### PR TITLE
Unify null session behaviour for TempData and SupplyParameterFromTempData

### DIFF
--- a/src/Components/Endpoints/src/SessionCascadingValueSupplier.cs
+++ b/src/Components/Endpoints/src/SessionCascadingValueSupplier.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Components.Reflection;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
@@ -61,7 +60,11 @@ internal partial class SessionCascadingValueSupplier
         return new PropertyGetter(type, propertyInfo);
     }
 
-    internal ISession? GetSession() => _httpContext?.Features.Get<ISessionFeature>()?.Session;
+    // A null HttpContext means we're rendering interactively (Server circuit or WebAssembly),
+    // where the session isn't available; yield null instead of failing. When an HttpContext is
+    // present (static SSR) an unavailable session is a misconfiguration and fails fast.
+    internal ISession? GetSession()
+        => _httpContext is null ? null : SessionResolver.GetRequiredSession(_httpContext);
 
     internal void RegisterValueCallback(string sessionKey, Func<object?> valueGetter)
     {
@@ -81,6 +84,7 @@ internal partial class SessionCascadingValueSupplier
         var session = GetSession();
         if (session is null)
         {
+            Log.SessionUnavailable(_logger);
             return Task.CompletedTask;
         }
 
@@ -120,6 +124,9 @@ internal partial class SessionCascadingValueSupplier
 
         [LoggerMessage(2, LogLevel.Warning, "Deserialization of the element from session failed.", EventName = "SessionDeserializeFail")]
         public static partial void SessionDeserializeFail(ILogger logger, Exception exception);
+
+        [LoggerMessage(3, LogLevel.Warning, "No active HttpContext is available (interactive rendering); [SupplyParameterFromSession] is skipped.", EventName = "SessionUnavailable")]
+        public static partial void SessionUnavailable(ILogger logger);
     }
 
     internal partial class SessionSubscription : CascadingParameterSubscription
@@ -153,6 +160,7 @@ internal partial class SessionCascadingValueSupplier
             var session = _owner.GetSession();
             if (session is null)
             {
+                Log.SessionUnavailable(_owner._logger);
                 return null;
             }
 

--- a/src/Components/Endpoints/src/SessionResolver.cs
+++ b/src/Components/Endpoints/src/SessionResolver.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Components.Endpoints;
+
+internal static class SessionResolver
+{
+    // Matches the message thrown by HttpContext.Session so both session-consuming
+    // features surface the same InvalidOperationException when the session is unavailable.
+    internal const string SessionNotConfiguredMessage = "Session has not been configured for this application or request.";
+
+    // Fails fast the first time the session is touched and found unavailable, whether
+    // session middleware isn't configured or the feature exposes a null session.
+    // Callers that legitimately have no HttpContext (interactive rendering) must not call this.
+    internal static ISession GetRequiredSession(HttpContext httpContext)
+    {
+        var session = httpContext.Session;
+        if (session is null)
+        {
+            throw new InvalidOperationException(SessionNotConfiguredMessage);
+        }
+
+        return session;
+    }
+}

--- a/src/Components/Endpoints/src/SessionResolver.cs
+++ b/src/Components/Endpoints/src/SessionResolver.cs
@@ -11,9 +11,6 @@ internal static class SessionResolver
     // features surface the same InvalidOperationException when the session is unavailable.
     internal const string SessionNotConfiguredMessage = "Session has not been configured for this application or request.";
 
-    // Fails fast the first time the session is touched and found unavailable, whether
-    // session middleware isn't configured or the feature exposes a null session.
-    // Callers that legitimately have no HttpContext (interactive rendering) must not call this.
     internal static ISession GetRequiredSession(HttpContext httpContext)
     {
         var session = httpContext.Session;

--- a/src/Components/Endpoints/src/TempData/CookieTempDataProvider.cs
+++ b/src/Components/Endpoints/src/TempData/CookieTempDataProvider.cs
@@ -43,19 +43,22 @@ internal sealed partial class CookieTempDataProvider : ITempDataProvider
         ArgumentNullException.ThrowIfNull(context);
         var cookieName = _options.TempDataCookie.Name ?? CookieName;
 
+        if (!context.Request.Cookies.ContainsKey(cookieName))
+        {
+            Log.TempDataCookieNotFound(_logger, cookieName);
+            return ReadOnlyDictionary<string, object?>.Empty;
+        }
+
+        var serializedDataFromCookie = _chunkingCookieManager.GetRequestCookie(context, cookieName);
+        if (serializedDataFromCookie is null)
+        {
+            return ReadOnlyDictionary<string, object?>.Empty;
+        }
+
+        // Only the decode/unprotect/deserialize of untrusted cookie data is guarded: data errors
+        // fall back to empty, while unexpected errors surface instead of being silently swallowed.
         try
         {
-            if (!context.Request.Cookies.ContainsKey(cookieName))
-            {
-                Log.TempDataCookieNotFound(_logger, cookieName);
-                return ReadOnlyDictionary<string, object?>.Empty;
-            }
-            var serializedDataFromCookie = _chunkingCookieManager.GetRequestCookie(context, cookieName);
-            if (serializedDataFromCookie is null)
-            {
-                return ReadOnlyDictionary<string, object?>.Empty;
-            }
-
             byte[]? rentedDecodeBuffer = null;
             var maxDecodedSize = Base64Url.GetMaxDecodedLength(serializedDataFromCookie.Length);
             var decodeBuffer = maxDecodedSize <= 256

--- a/src/Components/Endpoints/src/TempData/CookieTempDataProvider.cs
+++ b/src/Components/Endpoints/src/TempData/CookieTempDataProvider.cs
@@ -68,6 +68,10 @@ internal sealed partial class CookieTempDataProvider : ITempDataProvider
             try
             {
                 var decodeStatus = Base64Url.DecodeFromChars(serializedDataFromCookie, decodeBuffer, out _, out var bytesWritten);
+                if (decodeStatus != OperationStatus.Done)
+                {
+                    throw new FormatException("The TempData cookie did not contain valid Base64Url-encoded data.");
+                }
                 var protectedBytes = decodeBuffer[..bytesWritten];
                 Dictionary<string, JsonElement>? dataFromCookie;
 

--- a/src/Components/Endpoints/src/TempData/CookieTempDataProvider.cs
+++ b/src/Components/Endpoints/src/TempData/CookieTempDataProvider.cs
@@ -55,8 +55,6 @@ internal sealed partial class CookieTempDataProvider : ITempDataProvider
             return ReadOnlyDictionary<string, object?>.Empty;
         }
 
-        // Only the decode/unprotect/deserialize of untrusted cookie data is guarded: data errors
-        // fall back to empty, while unexpected errors surface instead of being silently swallowed.
         try
         {
             byte[]? rentedDecodeBuffer = null;

--- a/src/Components/Endpoints/src/TempData/SessionStorageTempDataProvider.cs
+++ b/src/Components/Endpoints/src/TempData/SessionStorageTempDataProvider.cs
@@ -25,10 +25,10 @@ internal sealed partial class SessionStorageTempDataProvider : ITempDataProvider
     {
         ArgumentNullException.ThrowIfNull(context);
 
+        var session = SessionResolver.GetRequiredSession(context);
+
         try
         {
-            var session = context.Session;
-
             if (session.TryGetValue(TempDataSessionStateKey, out var value))
             {
                 var dataFromSession = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(value);
@@ -63,7 +63,7 @@ internal sealed partial class SessionStorageTempDataProvider : ITempDataProvider
             }
         }
 
-        var session = context.Session;
+        var session = SessionResolver.GetRequiredSession(context);
         if (values.Count == 0)
         {
             session.Remove(TempDataSessionStateKey);

--- a/src/Components/Endpoints/src/TempData/TempDataCascadingValueSupplier.cs
+++ b/src/Components/Endpoints/src/TempData/TempDataCascadingValueSupplier.cs
@@ -99,6 +99,9 @@ internal partial class TempDataCascadingValueSupplier
 
         [LoggerMessage(2, LogLevel.Warning, "Deserialization of the element from TempData failed.", EventName = "TempDataDeserializeFail")]
         public static partial void TempDataDeserializeFail(ILogger logger, Exception exception);
+
+        [LoggerMessage(3, LogLevel.Warning, "No active HttpContext is available (interactive rendering); the [SupplyParameterFromTempData] value is skipped and will be null.", EventName = "TempDataUnavailableForRead")]
+        public static partial void TempDataUnavailableForRead(ILogger logger);
     }
 
     internal partial class TempDataSubscription : CascadingParameterSubscription
@@ -137,6 +140,7 @@ internal partial class TempDataCascadingValueSupplier
             var tempData = _owner.GetTempData();
             if (tempData is null)
             {
+                Log.TempDataUnavailableForRead(_owner._logger);
                 return null;
             }
 

--- a/src/Components/Endpoints/test/Session/SessionCascadingValueSupplierTest.cs
+++ b/src/Components/Endpoints/test/Session/SessionCascadingValueSupplierTest.cs
@@ -5,7 +5,9 @@
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
 
@@ -140,7 +142,23 @@ public class SessionCascadingValueSupplierTest
     }
 
     [Fact]
-    public async Task PersistAllValues_NoOp_WhenSessionUnavailable()
+    public async Task PersistAllValues_LogsWarningAndSkips_WhenHttpContextNotSet()
+    {
+        var sink = new TestSink();
+        var supplier = new SessionCascadingValueSupplier(
+            new TestLoggerFactory(sink, enabled: true).CreateLogger<SessionCascadingValueSupplier>());
+        supplier.RegisterValueCallback("key", () => "value");
+
+        // No SetRequestContext: mimics interactive rendering where no HttpContext is available.
+        await supplier.PersistAllValues();
+
+        var write = Assert.Single(sink.Writes);
+        Assert.Equal(LogLevel.Warning, write.LogLevel);
+        Assert.Equal("SessionUnavailable", write.EventId.Name);
+    }
+
+    [Fact]
+    public async Task PersistAllValues_Throws_WhenSessionUnavailable()
     {
         _supplier.RegisterValueCallback("key", () => "value");
 
@@ -148,7 +166,19 @@ public class SessionCascadingValueSupplierTest
         httpContext.Features.Set<IHttpResponseFeature>(new TestHttpResponseFeature());
         _supplier.SetRequestContext(httpContext);
 
-        await _supplier.PersistAllValues();
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _supplier.PersistAllValues());
+    }
+
+    [Fact]
+    public async Task PersistAllValues_Throws_WhenSessionIsNull()
+    {
+        _supplier.RegisterValueCallback("key", () => "value");
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set<ISessionFeature>(new TestSessionFeature(null!));
+        _supplier.SetRequestContext(httpContext);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => _supplier.PersistAllValues());
     }
 
     [Fact]

--- a/src/Components/Endpoints/test/Session/SessionSubscriptionTest.cs
+++ b/src/Components/Endpoints/test/Session/SessionSubscriptionTest.cs
@@ -8,7 +8,9 @@ using Microsoft.AspNetCore.Components.Test.Helpers;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 using static Microsoft.AspNetCore.Components.Endpoints.SessionCascadingValueSupplierTest;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
@@ -41,6 +43,35 @@ public class SessionSubscriptionTest
         var result = subscription.GetCurrentValue();
 
         Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetValue_LogsWarning_WhenHttpContextNotSet()
+    {
+        var sink = new TestSink();
+        var supplier = new SessionCascadingValueSupplier(
+            new TestLoggerFactory(sink, enabled: true).CreateLogger<SessionCascadingValueSupplier>());
+        var subscription = new SessionCascadingValueSupplier.SessionSubscription(
+            supplier, "key", typeof(string), () => _component.Value);
+
+        var result = subscription.GetCurrentValue();
+
+        Assert.Null(result);
+        var write = Assert.Single(sink.Writes);
+        Assert.Equal(LogLevel.Warning, write.LogLevel);
+        Assert.Equal("SessionUnavailable", write.EventId.Name);
+    }
+
+    [Fact]
+    public void GetValue_Throws_WhenSessionIsNull()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set<Microsoft.AspNetCore.Http.Features.ISessionFeature>(new TestSessionFeature(null!));
+        _supplier.SetRequestContext(httpContext);
+
+        var subscription = CreateSubscription("key", typeof(string));
+
+        Assert.Throws<InvalidOperationException>(() => subscription.GetCurrentValue());
     }
 
     [Fact]

--- a/src/Components/Endpoints/test/TempData/SessionStorageTempDataProviderTest.cs
+++ b/src/Components/Endpoints/test/TempData/SessionStorageTempDataProviderTest.cs
@@ -71,13 +71,30 @@ public class SessionStorageTempDataProviderTest
     }
 
     [Fact]
-    public void Load_ReturnsEmptyTempData_WhenSessionThrows()
+    public void Load_Throws_WhenSessionNotConfigured()
     {
         var httpContext = CreateHttpContext(throwOnSessionAccess: true);
-        var tempData = _sessionStateTempDataProvider.LoadTempData(httpContext);
 
-        Assert.NotNull(tempData);
-        Assert.Empty(tempData);
+        Assert.Throws<InvalidOperationException>(() => _sessionStateTempDataProvider.LoadTempData(httpContext));
+    }
+
+    [Fact]
+    public void Load_Throws_WhenSessionIsNull()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set<ISessionFeature>(new TestSessionFeature { Session = null });
+
+        Assert.Throws<InvalidOperationException>(() => _sessionStateTempDataProvider.LoadTempData(httpContext));
+    }
+
+    [Fact]
+    public void Save_Throws_WhenSessionNotConfigured()
+    {
+        var httpContext = CreateHttpContext(throwOnSessionAccess: true);
+        var tempData = CreateTempData();
+        tempData["Key1"] = "Value1";
+
+        Assert.Throws<InvalidOperationException>(() => _sessionStateTempDataProvider.SaveTempData(httpContext, tempData.Save()));
     }
 
     [Fact]

--- a/src/Components/Endpoints/test/TempData/TempDataSubscriptionTest.cs
+++ b/src/Components/Endpoints/test/TempData/TempDataSubscriptionTest.cs
@@ -5,7 +5,9 @@ using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Test.Helpers;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging.Testing;
 using Moq;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
@@ -45,6 +47,23 @@ public class TempDataSubscriptionTest
         var result = subscription.GetCurrentValue();
 
         Assert.Null(result);
+    }
+
+    [Fact]
+    public void GetValue_LogsWarning_WhenHttpContextNotSet()
+    {
+        var sink = new TestSink();
+        var supplier = new TempDataCascadingValueSupplier(
+            new TestLoggerFactory(sink, enabled: true).CreateLogger<TempDataCascadingValueSupplier>());
+        var subscription = new TempDataCascadingValueSupplier.TempDataSubscription(
+            supplier, "key", typeof(string), () => _component.Value);
+
+        var result = subscription.GetCurrentValue();
+
+        Assert.Null(result);
+        var write = Assert.Single(sink.Writes);
+        Assert.Equal(LogLevel.Warning, write.LogLevel);
+        Assert.Equal("TempDataUnavailableForRead", write.EventId.Name);
     }
 
     [Fact]

--- a/src/Components/test/E2ETest/Tests/TempDataCookieTest.cs
+++ b/src/Components/test/E2ETest/Tests/TempDataCookieTest.cs
@@ -160,7 +160,7 @@ public class TempDataCookieTest : ServerTestBase<BasicTestAppServerSiteFixture<R
     [Fact]
     public void StreamingSSR_CookieTempData_DoesNotPersistValuesWrittenAfterFirstFlush()
     {
-        Navigate($"{ServerPathBase}/streaming-session-persistence");
+        Navigate($"{ServerPathBase}/streaming-cookie-tempdata-persistence");
         Browser.Exists(By.Id("streaming-complete"));
 
         Navigate($"{ServerPathBase}/tempdata");

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/StreamingRendering/StreamingCookieTempDataPersistence.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/StreamingRendering/StreamingCookieTempDataPersistence.razor
@@ -1,4 +1,4 @@
-@page "/streaming-cookie-tempdata-persistence"
+﻿@page "/streaming-cookie-tempdata-persistence"
 @attribute [StreamRendering]
 
 <h1>Streaming Cookie TempData Persistence Test</h1>
@@ -23,10 +23,7 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        // The await is critical: it causes the component to enter the streaming phase.
-        // Values set AFTER the await are written once the response has already started,
-        // which the cookie TempData provider cannot persist.
-        await Task.Delay(100);
+        await EnterStreamingPhaseAsync();
 
         SupplyParameterFromTempDataValue = "tempdata-set-during-streaming";
         if (TempData is not null)
@@ -35,4 +32,6 @@ else
         }
         _done = true;
     }
+
+    private static Task EnterStreamingPhaseAsync() => Task.Delay(100);
 }

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/StreamingRendering/StreamingCookieTempDataPersistence.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/StreamingRendering/StreamingCookieTempDataPersistence.razor
@@ -1,0 +1,38 @@
+@page "/streaming-cookie-tempdata-persistence"
+@attribute [StreamRendering]
+
+<h1>Streaming Cookie TempData Persistence Test</h1>
+
+@if (_done)
+{
+    <p id="streaming-complete">Done</p>
+}
+else
+{
+    <p id="streaming-status">Waiting for streaming...</p>
+}
+
+@code {
+    private bool _done;
+
+    [SupplyParameterFromTempData]
+    private string SupplyParameterFromTempDataValue { get; set; } = string.Empty;
+
+    [CascadingParameter]
+    public ITempData? TempData { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        // The await is critical: it causes the component to enter the streaming phase.
+        // Values set AFTER the await are written once the response has already started,
+        // which the cookie TempData provider cannot persist.
+        await Task.Delay(100);
+
+        SupplyParameterFromTempDataValue = "tempdata-set-during-streaming";
+        if (TempData is not null)
+        {
+            TempData["Message"] = "streaming-tempdata-message";
+        }
+        _done = true;
+    }
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/StreamingRendering/StreamingSessionPersistence.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/StreamingRendering/StreamingSessionPersistence.razor
@@ -26,10 +26,7 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        // The await is critical: it causes the component to enter the streaming phase.
-        // Values set AFTER the await are the ones that were silently lost with the old
-        // OnStarting-based persistence, because OnStarting fires before streaming begins.
-        await Task.Delay(100);
+        await EnterStreamingPhaseAsync();
 
         Email = "set-during-streaming";
         SupplyParameterFromTempDataValue = "tempdata-set-during-streaming";
@@ -39,4 +36,6 @@ else
         }
         _done = true;
     }
+
+    private static Task EnterStreamingPhaseAsync() => Task.Delay(100);
 }


### PR DESCRIPTION
# Unify null/unavailable session handling for Session and TempData

## Summary

The Blazor Endpoints session and TempData features handled a missing/unavailable session inconsistently — some paths threw, some silently returned empty, and some returned `null`. This PR unifies the behavior across all of them:

- **A session is expected but unavailable while an `HttpContext` is present (static SSR misconfiguration)** → fail fast with `InvalidOperationException`.
- **No `HttpContext` at all (interactive Server circuit / WebAssembly)** → yield `null`/empty gracefully and log a single warning.
- **Untrusted/corrupt stored data** → swallowed, falling back to empty (unchanged).

## Changes

- **New `SessionResolver` helper** — one place that resolves `HttpContext.Session` and throws `InvalidOperationException` when session middleware isn't configured or the feature exposes a `null` session. Uses the same message as `HttpContext.Session` so every path surfaces an identical exception.
- **`SessionCascadingValueSupplier` (`[SupplyParameterFromSession]`)** — `GetSession()` returns `null` only when there is no `HttpContext` (interactive rendering); otherwise it routes through `SessionResolver` and fails fast. A single `SessionUnavailable` warning is logged when the parameter is skipped on read or persist (previously silent).
- **`SessionStorageTempDataProvider`** — load and save now resolve the session via `SessionResolver.GetRequiredSession`. On load, session access moved outside the `try` so a missing/unconfigured session fails fast instead of being swallowed into empty TempData; only deserialization errors remain swallowed.
- **`TempDataCascadingValueSupplier` (`[SupplyParameterFromTempData]`)** — logs a `TempDataUnavailableForRead` warning when the parameter is skipped during interactive rendering (previously silent), matching the session supplier.
- **`CookieTempDataProvider`** — narrowed the load `try/catch` to wrap only the decode/unprotect/deserialize of untrusted cookie data. Cookie retrieval and not-found checks now sit outside the `try`, so unexpected errors surface instead of being silently swallowed as "no TempData". Corrupt/tampered cookie data still degrades gracefully to empty and clears the cookie.

## Resulting behavior

| Class | Store unavailable (SSR, context present) | Interactive (no `HttpContext`) | Corrupt/unreadable data |
|---|---|---|---|
| `SessionCascadingValueSupplier` | throws `InvalidOperationException` | warns + `null` | deserialization swallowed → `null` |
| `TempDataCascadingValueSupplier` | n/a (uses `ITempData`) | warns + `null` | deserialization swallowed → `null` |
| `SessionStorageTempDataProvider` | throws `InvalidOperationException` | n/a (SSR-only) | deserialization swallowed → empty |
| `CookieTempDataProvider` | n/a (cookies always available) | n/a (SSR-only) | decode/deserialize swallowed → empty + clears cookie |

## Testing

Unit tests updated/added across the affected classes:

- `SessionCascadingValueSupplierTest` — persist throws when a context is present but the session is unconfigured/`null`; logs `SessionUnavailable` and skips when no `HttpContext`.
- `SessionSubscriptionTest` — read throws when the session is `null` with a context present; returns `null` and logs `SessionUnavailable` when no `HttpContext`.
- `SessionStorageTempDataProviderTest` — load and save throw when the session is unconfigured/`null`; corrupt session data still returns empty.
- `TempDataSubscriptionTest` — read returns `null` and logs `TempDataUnavailableForRead` when no `HttpContext`.

E2E test assets:

- Added `StreamingCookieTempDataPersistence.razor` (`/streaming-cookie-tempdata-persistence`) — a cookie-only streaming page that mirrors the existing streaming scenario without `[SupplyParameterFromSession]`. `TempDataCookieTest.StreamingSSR_CookieTempData_DoesNotPersistValuesWrittenAfterFirstFlush` now targets this page. Because `[SupplyParameterFromSession]` now fails fast when session middleware isn't configured, the cookie test app (which does not call `UseSession`) can no longer share the session-based streaming page. The session tests continue to use the original `StreamingSessionPersistence.razor` under `--UseSession=true`.

## Breaking changes

No public API changes — all affected types are `internal`. There is an intentional **runtime behavior change** for misconfigured apps: paths that previously swallowed an unconfigured/unavailable session and returned empty/`null` during static SSR now throw `InvalidOperationException` to surface the misconfiguration early. Concretely, using `[SupplyParameterFromSession]` (or the session-backed `TempData` provider) on a page rendered by an app that has not configured session middleware (`AddSession`/`UseSession`) now throws during SSR instead of silently yielding `null`/empty. Interactive rendering behavior is unchanged (no `HttpContext` → still yields `null`/empty, now with a warning log).

Fixes #67175
