### PR TITLE
[release/8.0] improve CI flakiness

### DIFF
--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -1629,6 +1629,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/47967")]
     public void AnchorWithHrefToSameUrlWithQueryAndHash_ScrollsToElementOnTheSamePage()
     {
         SetUrlViaPushState("/");
@@ -1645,6 +1646,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/47967")]
     public void AnchorWithHrefToSameUrlWithParamAndHash_ScrollsToElementOnTheSamePage()
     {
         SetUrlViaPushState("/");
@@ -1711,6 +1713,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/47967")]
     public void NavigationManagerNavigateToSameUrlWithHash_ScrollsToElementOnTheSamePage()
     {
         SetUrlViaPushState("/");
@@ -1727,6 +1730,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/47967")]
     public void NavigationManagerNavigateToSameUrlWithQueryAndHash_ScrollsToElementOnTheSamePage()
     {
         SetUrlViaPushState("/");

--- a/src/Components/test/E2ETest/Tests/StatePersistenceTest.cs
+++ b/src/Components/test/E2ETest/Tests/StatePersistenceTest.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.Components.E2ETests.ServerRenderingTests;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.E2ETesting;
+using Microsoft.AspNetCore.Testing;
 using OpenQA.Selenium;
 using TestServer;
 using Xunit.Abstractions;
@@ -52,6 +53,7 @@ public class StatePersistenceTest : ServerTestBase<BasicTestAppServerSiteFixture
     [InlineData(false, typeof(InteractiveWebAssemblyRenderMode), "WebAssemblyStreaming")]
     // [InlineData(false, typeof(InteractiveAutoRenderMode), (string)null)] https://github.com/dotnet/aspnetcore/issues/50810
     // [InlineData(false, typeof(InteractiveAutoRenderMode), "AutoStreaming")] https://github.com/dotnet/aspnetcore/issues/50810
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/50810")]
     public void CanRenderComponentWithPersistedState(bool suppressEnhancedNavigation, Type renderMode, string streaming)
     {
         var mode = renderMode switch

--- a/src/SignalR/server/StackExchangeRedis/test/RedisEndToEnd.cs
+++ b/src/SignalR/server/StackExchangeRedis/test/RedisEndToEnd.cs
@@ -89,6 +89,7 @@ public class RedisEndToEndTests : VerifiableLoggedTest
     [ConditionalTheory]
     [SkipIfDockerNotPresent]
     [MemberData(nameof(TransportTypesAndProtocolTypes))]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/59991")]
     public async Task CanSendAndReceiveUserMessagesFromMultipleConnectionsWithSameUser(HttpTransportType transportType, string protocolName)
     {
         using (StartVerifiableLog())


### PR DESCRIPTION
Backporting quarantines for flaky tests that are already resolved (via quarantine or code fix) in `main`, to reduce release/8.0 CI flakiness. All reference existing tracking issues.

- `RedisEndToEndTests.CanSendAndReceiveUserMessagesFromMultipleConnectionsWithSameUser` — https://github.com/dotnet/aspnetcore/issues/59991 (quarantined in main)
- `StatePersistenceTest.CanRenderComponentWithPersistedState` — https://github.com/dotnet/aspnetcore/issues/50810 (fixed via code in main)
- `RoutingTest.NavigationManagerNavigateToSameUrlWithHash_ScrollsToElementOnTheSamePage` — https://github.com/dotnet/aspnetcore/issues/47967
- `RoutingTest.NavigationManagerNavigateToSameUrlWithQueryAndHash_ScrollsToElementOnTheSamePage` — https://github.com/dotnet/aspnetcore/issues/47967
- `RoutingTest.AnchorWithHrefToSameUrlWithQueryAndHash_ScrollsToElementOnTheSamePage` — https://github.com/dotnet/aspnetcore/issues/47967
- `RoutingTest.AnchorWithHrefToSameUrlWithParamAndHash_ScrollsToElementOnTheSamePage` — https://github.com/dotnet/aspnetcore/issues/47967