### PR TITLE
[release/9.0] improve CI flakiness

### DIFF
--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -1711,6 +1711,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/47967")]
     public void NavigationManagerNavigateToSameUrlWithHash_ScrollsToElementOnTheSamePage()
     {
         SetUrlViaPushState("/");
@@ -1727,6 +1728,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/47967")]
     public void NavigationManagerNavigateToSameUrlWithQueryAndHash_ScrollsToElementOnTheSamePage()
     {
         SetUrlViaPushState("/");
@@ -1743,6 +1745,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/47967")]
     public void NavigationManagerNavigateToSameUrlWithParamAndHash_ScrollsToElementOnTheSamePage()
     {
         SetUrlViaPushState("/");


### PR DESCRIPTION
Backporting quarantines for flaky scroll tests that are already resolved in `main`, to reduce release/9.0 CI flakiness. All reference existing tracking issue https://github.com/dotnet/aspnetcore/issues/47967.

- `RoutingTest.NavigationManagerNavigateToSameUrlWithHash_ScrollsToElementOnTheSamePage`
- `RoutingTest.NavigationManagerNavigateToSameUrlWithQueryAndHash_ScrollsToElementOnTheSamePage`
- `RoutingTest.NavigationManagerNavigateToSameUrlWithParamAndHash_ScrollsToElementOnTheSamePage`