### PR TITLE
Fix overflow in AccessFailedAsync when DefaultLockoutTimeSpan is large

### DIFF
--- a/src/Identity/Extensions.Core/src/UserManager.cs
+++ b/src/Identity/Extensions.Core/src/UserManager.cs
@@ -2222,7 +2222,13 @@ public class UserManager<TUser> : IDisposable where TUser : class
                 return await UpdateUserAndRecordMetricAsync(user, UserUpdateType.IncrementAccessFailed, startTimestamp).ConfigureAwait(false);
             }
             Logger.LogDebug(LoggerEventIds.UserLockedOut, "User is locked out.");
-            await store.SetLockoutEndDateAsync(user, UtcNow().Add(Options.Lockout.DefaultLockoutTimeSpan),
+            var now = UtcNow();
+            // Guard against overflow when DefaultLockoutTimeSpan is large enough to push the lockout end
+            // date past DateTimeOffset.MaxValue (e.g. TimeSpan.MaxValue is used to lock out indefinitely).
+            var lockoutEndDate = Options.Lockout.DefaultLockoutTimeSpan < DateTimeOffset.MaxValue - now
+                ? now.Add(Options.Lockout.DefaultLockoutTimeSpan)
+                : DateTimeOffset.MaxValue;
+            await store.SetLockoutEndDateAsync(user, lockoutEndDate,
                 CancellationToken).ConfigureAwait(false);
             await store.ResetAccessFailedCountAsync(user, CancellationToken).ConfigureAwait(false);
             return await UpdateUserAndRecordMetricAsync(user, UserUpdateType.IncrementAccessFailed, startTimestamp).ConfigureAwait(false);

--- a/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
+++ b/src/Identity/Specification.Tests/src/UserManagerSpecificationTests.cs
@@ -1169,6 +1169,27 @@ public abstract class UserManagerSpecificationTestBase<TUser, TKey>
     /// </summary>
     /// <returns>Task</returns>
     [Fact]
+    public async Task LockoutWithMaxTimeSpanDoesNotOverflow()
+    {
+        var mgr = CreateManager();
+        mgr.Options.Lockout.DefaultLockoutTimeSpan = TimeSpan.MaxValue;
+        mgr.Options.Lockout.MaxFailedAccessAttempts = 0;
+        var user = CreateTestUser();
+        IdentityResultAssert.IsSuccess(await mgr.CreateAsync(user));
+        Assert.True(await mgr.GetLockoutEnabledAsync(user));
+        Assert.False(await mgr.IsLockedOutAsync(user));
+        IdentityResultAssert.IsSuccess(await mgr.AccessFailedAsync(user));
+        Assert.True(await mgr.IsLockedOutAsync(user));
+        Assert.Equal(DateTimeOffset.MaxValue, await mgr.GetLockoutEndDateAsync(user));
+        IdentityResultAssert.VerifyLogMessage(mgr.Logger, $"User is locked out.");
+        Assert.Equal(0, await mgr.GetAccessFailedCountAsync(user));
+    }
+
+    /// <summary>
+    /// Test.
+    /// </summary>
+    /// <returns>Task</returns>
+    [Fact]
     public async Task TwoFailureLockout()
     {
         var mgr = CreateManager();


### PR DESCRIPTION
## Summary

Fixes #60181.

`UserManager.AccessFailedAsync` sets the lockout end date with:

```csharp
UtcNow().Add(Options.Lockout.DefaultLockoutTimeSpan)
```

When `DefaultLockoutTimeSpan` is large enough that the result exceeds `DateTimeOffset.MaxValue`, this throws `ArgumentOutOfRangeException`. A legitimate scenario is setting `DefaultLockoutTimeSpan = TimeSpan.MaxValue` to lock an account out indefinitely (e.g. after repeated failed MFA attempts). Today that crashes instead of locking the user out.

## Change

Clamp the computed lockout end date to `DateTimeOffset.MaxValue` when the configured timespan would overflow:

```csharp
var now = UtcNow();
var lockoutEndDate = Options.Lockout.DefaultLockoutTimeSpan < DateTimeOffset.MaxValue - now
    ? now.Add(Options.Lockout.DefaultLockoutTimeSpan)
    : DateTimeOffset.MaxValue;
```

The overflow check computes headroom as `DateTimeOffset.MaxValue - now` (always a valid `TimeSpan`), so the check itself cannot overflow.

## Tests

Adds `LockoutWithMaxTimeSpanDoesNotOverflow` to the shared `UserManagerSpecificationTestBase` suite, so every store implementation (in-memory, EF Core) is covered. It sets `DefaultLockoutTimeSpan = TimeSpan.MaxValue`, triggers a lockout via `AccessFailedAsync`, and asserts the call succeeds and the lockout end date is `DateTimeOffset.MaxValue`.
