### PR TITLE
Fix nullability handling in OpenApi

### DIFF
--- a/src/OpenApi/src/Extensions/TypeExtensions.cs
+++ b/src/OpenApi/src/Extensions/TypeExtensions.cs
@@ -40,8 +40,11 @@ internal static class TypeExtensions
 
     public static bool ShouldApplyNullableResponseSchema(this ApiResponseType apiResponseType, ApiDescription apiDescription)
     {
-        // Get the MethodInfo from the ActionDescriptor
-        var responseType = apiResponseType.Type;
+        if (apiResponseType.ModelMetadata?.IsNullableValueType == true)
+        {
+            return true;
+        }
+
         var methodInfo = apiDescription.ActionDescriptor is ControllerActionDescriptor controllerActionDescriptor
             ? controllerActionDescriptor.MethodInfo
             : apiDescription.ActionDescriptor.EndpointMetadata.OfType<MethodInfo>().SingleOrDefault();
@@ -51,24 +54,16 @@ internal static class TypeExtensions
             return false;
         }
 
+        var nullabilityInfoContext = new NullabilityInfoContext();
+        var nullabilityInfo = nullabilityInfoContext.Create(methodInfo.ReturnParameter);
+
         var returnType = methodInfo.ReturnType;
         if (returnType.IsGenericType &&
             (returnType.GetGenericTypeDefinition() == typeof(Task<>) || returnType.GetGenericTypeDefinition() == typeof(ValueTask<>)))
         {
-            returnType = returnType.GetGenericArguments()[0];
-        }
-        if (returnType != responseType)
-        {
-            return false;
+            nullabilityInfo = nullabilityInfo.GenericTypeArguments[0];
         }
 
-        if (returnType.IsValueType)
-        {
-            return apiResponseType.ModelMetadata?.IsNullableValueType ?? false;
-        }
-
-        var nullabilityInfoContext = new NullabilityInfoContext();
-        var nullabilityInfo = nullabilityInfoContext.Create(methodInfo.ReturnParameter);
         return nullabilityInfo.WriteState == NullabilityState.Nullable;
     }
 

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -559,6 +559,13 @@ internal sealed class OpenApiSchemaService(
 
     private JsonNode CreateSchema(Type type)
     {
+        // We always create a oneOf nullable wrapper. So we never want to include 'null' literal in the enum array.
+        var underlyingType = Nullable.GetUnderlyingType(type);
+        if (underlyingType?.IsEnum == true)
+        {
+            type = underlyingType;
+        }
+        
         var schema = JsonSchemaExporter.GetJsonSchemaAsNode(_jsonSerializerOptions, type, _configuration);
         return ResolveReferences(schema, schema);
     }

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -559,14 +559,10 @@ internal sealed class OpenApiSchemaService(
 
     private JsonNode CreateSchema(Type type)
     {
-        // We always create a oneOf nullable wrapper. So we never want to include 'null' literal in the enum array.
-        var underlyingType = Nullable.GetUnderlyingType(type);
-        if (underlyingType?.IsEnum == true)
-        {
-            type = underlyingType;
-        }
+        // We always create a oneOf nullable wrapper ourselves manually.
+        var underlyingType = Nullable.GetUnderlyingType(type) ?? type;
         
-        var schema = JsonSchemaExporter.GetJsonSchemaAsNode(_jsonSerializerOptions, type, _configuration);
+        var schema = JsonSchemaExporter.GetJsonSchemaAsNode(_jsonSerializerOptions, underlyingType, _configuration);
         return ResolveReferences(schema, schema);
     }
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nullable-body-direct.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nullable-body-direct.verified.txt
@@ -34,7 +34,16 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CamelCaseStatus"
+                  "oneOf": [
+                    {
+                      "enum": [
+                        null
+                      ]
+                    },
+                    {
+                      "$ref": "#/components/schemas/CamelCaseStatus"
+                    }
+                  ]
                 }
               }
             }
@@ -49,8 +58,7 @@
         "enum": [
           "active",
           "inactive",
-          "pending",
-          null
+          "pending"
         ]
       }
     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nullable-param.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nullable-param.verified.txt
@@ -29,7 +29,16 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CamelCaseStatus"
+                  "oneOf": [
+                    {
+                      "enum": [
+                        null
+                      ]
+                    },
+                    {
+                      "$ref": "#/components/schemas/CamelCaseStatus"
+                    }
+                  ]
                 }
               }
             }
@@ -44,8 +53,7 @@
         "enum": [
           "active",
           "inactive",
-          "pending",
-          null
+          "pending"
         ]
       }
     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nullable-body-direct.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nullable-body-direct.verified.txt
@@ -34,7 +34,16 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PascalCaseStatus"
+                  "oneOf": [
+                    {
+                      "enum": [
+                        null
+                      ]
+                    },
+                    {
+                      "$ref": "#/components/schemas/PascalCaseStatus"
+                    }
+                  ]
                 }
               }
             }
@@ -49,8 +58,7 @@
         "enum": [
           "Active",
           "Inactive",
-          "Pending",
-          null
+          "Pending"
         ]
       }
     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nullable-param.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nullable-param.verified.txt
@@ -25,7 +25,16 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PascalCaseStatus"
+                  "oneOf": [
+                    {
+                      "enum": [
+                        null
+                      ]
+                    },
+                    {
+                      "$ref": "#/components/schemas/PascalCaseStatus"
+                    }
+                  ]
                 }
               }
             }
@@ -40,8 +49,7 @@
         "enum": [
           "Active",
           "Inactive",
-          "Pending",
-          null
+          "Pending"
         ]
       }
     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nullable-body-direct.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nullable-body-direct.verified.txt
@@ -32,7 +32,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CamelCaseStatus"
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/CamelCaseStatus"
+                    }
+                  ]
                 }
               }
             }
@@ -47,8 +54,7 @@
         "enum": [
           "active",
           "inactive",
-          "pending",
-          null
+          "pending"
         ]
       }
     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nullable-param.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nullable-param.verified.txt
@@ -29,7 +29,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CamelCaseStatus"
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/CamelCaseStatus"
+                    }
+                  ]
                 }
               }
             }
@@ -44,8 +51,7 @@
         "enum": [
           "active",
           "inactive",
-          "pending",
-          null
+          "pending"
         ]
       }
     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nullable-body-direct.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nullable-body-direct.verified.txt
@@ -32,7 +32,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PascalCaseStatus"
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/PascalCaseStatus"
+                    }
+                  ]
                 }
               }
             }
@@ -47,8 +54,7 @@
         "enum": [
           "Active",
           "Inactive",
-          "Pending",
-          null
+          "Pending"
         ]
       }
     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nullable-param.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nullable-param.verified.txt
@@ -25,7 +25,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PascalCaseStatus"
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/PascalCaseStatus"
+                    }
+                  ]
                 }
               }
             }
@@ -40,8 +47,7 @@
         "enum": [
           "Active",
           "Inactive",
-          "Pending",
-          null
+          "Pending"
         ]
       }
     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nullable-body-direct.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nullable-body-direct.verified.txt
@@ -32,7 +32,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CamelCaseStatus"
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/CamelCaseStatus"
+                    }
+                  ]
                 }
               }
             }
@@ -47,8 +54,7 @@
         "enum": [
           "active",
           "inactive",
-          "pending",
-          null
+          "pending"
         ]
       }
     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nullable-param.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nullable-param.verified.txt
@@ -29,7 +29,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CamelCaseStatus"
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/CamelCaseStatus"
+                    }
+                  ]
                 }
               }
             }
@@ -44,8 +51,7 @@
         "enum": [
           "active",
           "inactive",
-          "pending",
-          null
+          "pending"
         ]
       }
     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nullable-body-direct.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nullable-body-direct.verified.txt
@@ -32,7 +32,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PascalCaseStatus"
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/PascalCaseStatus"
+                    }
+                  ]
                 }
               }
             }
@@ -47,8 +54,7 @@
         "enum": [
           "Active",
           "Inactive",
-          "Pending",
-          null
+          "Pending"
         ]
       }
     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nullable-param.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nullable-param.verified.txt
@@ -25,7 +25,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PascalCaseStatus"
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/PascalCaseStatus"
+                    }
+                  ]
                 }
               }
             }
@@ -40,8 +47,7 @@
         "enum": [
           "Active",
           "Inactive",
-          "Pending",
-          null
+          "Pending"
         ]
       }
     }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
@@ -60,7 +60,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PascalCaseStatus"
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/PascalCaseStatus"
+                    }
+                  ]
                 }
               }
             }
@@ -125,7 +132,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CamelCaseStatus"
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/CamelCaseStatus"
+                    }
+                  ]
                 }
               }
             }
@@ -305,7 +319,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PascalCaseStatus"
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/PascalCaseStatus"
+                    }
+                  ]
                 }
               }
             }
@@ -369,7 +390,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CamelCaseStatus"
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/CamelCaseStatus"
+                    }
+                  ]
                 }
               }
             }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ResponseSchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ResponseSchemas.cs
@@ -244,7 +244,11 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var responses = Assert.Single(operation.Responses);
             var response = responses.Value;
             Assert.True(response.Content.TryGetValue("application/json", out var mediaType));
-            var schema = mediaType.Schema;
+            var wrapper = mediaType.Schema;
+            Assert.NotNull(wrapper.OneOf);
+            Assert.Equal(2, wrapper.OneOf.Count);
+            Assert.Equal(JsonSchemaType.Null, wrapper.OneOf[0].Type);
+            var schema = wrapper.OneOf[1];
             Assert.Equal(JsonSchemaType.Object, schema.Type);
             Assert.Collection(schema.Properties,
                 property =>
@@ -291,7 +295,11 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             var responses = Assert.Single(operation.Responses);
             var response = responses.Value;
             Assert.True(response.Content.TryGetValue("application/json", out var mediaType));
-            var schema = mediaType.Schema;
+            var wrapper = mediaType.Schema;
+            Assert.NotNull(wrapper.OneOf);
+            Assert.Equal(2, wrapper.OneOf.Count);
+            Assert.Equal(JsonSchemaType.Null, wrapper.OneOf[0].Type);
+            var schema = wrapper.OneOf[1];
             Assert.Equal(JsonSchemaType.Object, schema.Type);
             Assert.Collection(schema.Properties,
                 property =>


### PR DESCRIPTION
- `ShouldApplyNullableResponseSchema` implementation was not accurate. It previously compared equality of `MethodInfo.ReturnType` and `ApiResponseType.Type`, and returned false immediately if they were not equal. That means that APIs that use typed results (e.g, `Ok<T>`) will always be considered non-nullable, because `Ok<T>` isn't equal to `T`. The only "unwrapping" that used to exist is for `Task<T>` and `ValueTask<T>`. The new implementation first does a quick and accurate check for value types, using `ModelMetadata.IsNullableValueType`. If it's true, we know for sure we have a nullable response. The tricky part is for reference types, which is still not handled very well in this PR and I'll leave it as a follow-up (it's existing bug anyways).
- For nullable types, we always create `oneOf` nullable wrapper today. That means that the schema itself should never match null. Imagine the following:

    ```json
    "oneOf": [
      { "type": "null" },
      { SOME_SCHEMA_OR_REF_GOES_HERE }
    ]
    ```

    If the `SOME_SCHEMA_OR_REF_GOES_HERE` matches null. Then the `oneOf` constrained isn't satisfies because it expects **one and exactly one** schema to match. So, when we hand off work to STJ, we always pass it non-nullable type. This also helps with ensuring that we don't end up with two componentized schema of the same name where one wants to be nullable and the other doesn't want to be nullable (the nullable wrapper is always inlined).

I expect there could be more changes and improvements needed in this area, so this likely won't be the only PR to touch things around nullability here, but this is a good improvement so far.