### PR TITLE
Fix antiforgery/CSRF middleware lost on primary path when using re-execution

### DIFF
--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/CsrfProtectionIntegrationTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/CsrfProtectionIntegrationTests.cs
@@ -1203,6 +1203,94 @@ public class CsrfProtectionIntegrationTests
     }
 
     [Fact]
+    public async Task CsrfProtection_ImplicitRouting_WithReExecute_NormalRequestToAntiforgeryEndpoint_Succeeds()
+    {
+        // Regression test for https://github.com/dotnet/aspnetcore/issues/67628 (the Blazor Web template shape).
+        // UseStatusCodePagesWithReExecute builds a re-execution branch whose routing consumes the framework's
+        // single-use post-routing (auth/authz/CSRF) block. Before the fix, the re-execution branch stole that block
+        // from the primary pipeline, so a normal request to an antiforgery-required endpoint threw
+        // "a middleware was not found that supports anti-forgery" (HTTP 500).
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        using var app = builder.Build();
+
+        app.UseStatusCodePagesWithReExecute("/not-found");
+
+        app.MapGet("/", () => "home").WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapGet("/not-found", (HttpContext ctx) =>
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return ctx.Response.WriteAsync("not found");
+        }).WithMetadata(new RequireAntiforgeryTokenAttribute());
+
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var response = await client.GetAsync("/");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("home", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task CsrfProtection_ExplicitRouting_WithReExecute_NormalRequestToAntiforgeryEndpoint_Succeeds()
+    {
+        // Companion to the implicit-routing regression test above: the same block-stealing bug also affects apps that
+        // call UseRouting() explicitly (the framework defers auth/authz/CSRF into the same single-use slot).
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        using var app = builder.Build();
+
+        app.UseRouting();
+        app.UseStatusCodePagesWithReExecute("/not-found");
+
+        app.MapGet("/", () => "home").WithMetadata(new RequireAntiforgeryTokenAttribute());
+        app.MapGet("/not-found", (HttpContext ctx) =>
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return ctx.Response.WriteAsync("not found");
+        }).WithMetadata(new RequireAntiforgeryTokenAttribute());
+
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var response = await client.GetAsync("/");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("home", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task CsrfProtection_ImplicitRouting_WithReExecute_StillProtectsNormalCrossOriginPost()
+    {
+        // Ensures restoring the post-routing block for the primary pipeline does not weaken protection: a cross-origin
+        // POST to an antiforgery-required endpoint must still be rejected when re-execution is configured.
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        using var app = builder.Build();
+
+        app.UseStatusCodePagesWithReExecute("/not-found");
+
+        app.MapPost("/protected", EnforceCsrfProtected);
+        app.MapGet("/not-found", (HttpContext ctx) =>
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return ctx.Response.WriteAsync("not found");
+        }).WithMetadata(new RequireAntiforgeryTokenAttribute());
+
+        await app.StartAsync();
+
+        var client = app.GetTestClient();
+        var request = new HttpRequestMessage(HttpMethod.Post, "/protected");
+        request.Headers.Add("Sec-Fetch-Site", "cross-site");
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("protected", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
     public async Task CsrfProtection_NotAutoInjected_WhenAppHasNoEndpointDataSources()
     {
         // Regression guard for the aspnet/Benchmarks-style perf regression (companion to #67119

--- a/src/Shared/Reroute.cs
+++ b/src/Shared/Reroute.cs
@@ -11,6 +11,11 @@ internal static class RerouteHelper
     internal const string GlobalRouteBuilderKey = "__GlobalEndpointRouteBuilder";
     internal const string UseRoutingKey = "__UseRouting";
 
+    // Keep in sync with Microsoft.AspNetCore.Http.MiddlewareInvokedKeys.PostRoutingPipeline. It is duplicated as a
+    // literal here because this shared source file is compiled into assemblies that don't all include
+    // MiddlewareInvokedKeys.cs (matching how GlobalRouteBuilderKey/UseRoutingKey are duplicated above).
+    private const string PostRoutingPipelineKey = "__Internal_PostRoutingPipeline";
+
     internal static RequestDelegate Reroute(IApplicationBuilder app, object routeBuilder, RequestDelegate next)
     {
         if (app.Properties.TryGetValue(UseRoutingKey, out var useRouting) && useRouting is Func<IApplicationBuilder, IApplicationBuilder> useRoutingFunc)
@@ -26,7 +31,25 @@ internal static class RerouteHelper
             // apply the next middleware
             builder.Run(next);
 
-            return builder.Build();
+            // Building this re-execution branch composes an EndpointRoutingMiddleware that consumes the framework's
+            // single-use post-routing middleware slot (the implicit authentication/authorization/CSRF pipeline added
+            // by WebApplicationBuilder) from the shared global route builder's properties. Capture it beforehand and
+            // restore it afterwards so the primary request pipeline's routing still runs that implicit middleware.
+            // Without this, a normal request to an antiforgery-required endpoint in an app that also re-executes
+            // (e.g. UseStatusCodePagesWithReExecute in the Blazor Web template) fails with
+            // "a middleware was not found that supports anti-forgery". See https://github.com/dotnet/aspnetcore/issues/67628.
+            var routeBuilderProperties = (routeBuilder as IApplicationBuilder)?.Properties;
+            object? postRoutingBlock = null;
+            routeBuilderProperties?.TryGetValue(PostRoutingPipelineKey, out postRoutingBlock);
+
+            var reroutePipeline = builder.Build();
+
+            if (postRoutingBlock is not null && routeBuilderProperties is not null)
+            {
+                routeBuilderProperties[PostRoutingPipelineKey] = postRoutingBlock;
+            }
+
+            return reroutePipeline;
         }
 
         return next;


### PR DESCRIPTION
## Summary

Fixes #67628. A newly created Blazor Web App (`dotnet new blazor` + `dotnet run`) returns HTTP 500 on every page on 11.0 Preview 7 (regression from Preview 6), failing with `Endpoint / (/) contains anti-forgery metadata, but a middleware was not found that supports anti-forgery`. This also turned the `Templates.Mvc.Test.BlazorTemplateTest` CI leg red on essentially every run.

## Analysis

The Blazor Web template no longer calls `app.UseAntiforgery()` explicitly (removed in #67119); it relies on the framework auto-injecting the antiforgery/CSRF middleware. `WebApplicationBuilder` stores that implicit post-routing middleware (authentication/authorization/CSRF) in a single-use application-property slot, `__Internal_PostRoutingPipeline`, which `EndpointRoutingMiddleware` consumes (and removes) so it runs right after routing and stamps the marker that `EndpointMiddleware` checks for.

The template also calls `app.UseStatusCodePagesWithReExecute(...)`. In the `WebApplication` case this goes through `RerouteHelper.Reroute`, which builds a re-execution branch that itself calls `UseRouting()`. Because the user pipeline (containing the re-execution middleware) is composed before the primary routing middleware, that branch's `EndpointRoutingMiddleware` consumes and removes the single-use slot from the shared global route builder first. The primary request pipeline's routing is then built without the block, so a normal request to an antiforgery-required endpoint (the Blazor root `/`) finds no antiforgery/CSRF marker and `EndpointMiddleware` throws.

The bug affects all `RerouteHelper.Reroute` callers: `UseStatusCodePagesWithReExecute`, `UseExceptionHandler`, `UsePathBase`, and `UseRewriter`. Existing tests only exercised the re-executed path (which received the stolen block), so the normal-request regression went uncovered.

## Fix

Capture the `__Internal_PostRoutingPipeline` slot from the shared global route builder before building the re-execution branch and restore it afterwards, in `RerouteHelper.Reroute` (`src/Shared/Reroute.cs`). This lets the re-execution branch keep its own copy of the implicit middleware (preserving CSRF on re-executed paths) while leaving the slot in place for the primary pipeline's routing. The single-use semantics for the main pipeline are unchanged, so repeated `UseRouting()` calls still cannot double-apply the block.

## Tests

Added three regression tests to `CsrfProtectionIntegrationTests` covering the previously-untested shape (a normal request to an antiforgery-required endpoint when re-execution is configured), for both implicit and explicit routing, plus a guard that cross-origin POSTs are still rejected.

Verified locally (all green):

- `CsrfProtectionIntegrationTests` (61)
- `WebApplicationTests` (299)
- Diagnostics `StatusCode`/`ExceptionHandler` (54)
- Http.Abstractions `UsePathBase` (52)
- Rewrite (473)
- Routing `EndpointMiddleware`/`EndpointRoutingMiddleware` (37)

## Notes

Draft for review. The `app.UseAntiforgery()` workaround from the issue remains valid; this change removes the need for it.
