### PR TITLE
Improve CreateTwoFactorRecoveryCode in .NET 8+

### DIFF
--- a/src/Identity/Extensions.Core/src/UserManager.cs
+++ b/src/Identity/Extensions.Core/src/UserManager.cs
@@ -2522,8 +2522,7 @@ public class UserManager<TUser> : IDisposable where TUser : class
     private static ReadOnlySpan<char> AllowedChars =>
     [
         '2', '3', '4', '5', '6', '7', '8', '9',
-        'B', 'C', 'D', 'F', 'G', 'H', 'J', 'K',
-        'M', 'N', 'P', 'Q', 'R', 'T', 'V', 'W', 'X', 'Y'
+        'B', 'C', 'D', 'F', 'G', 'H', 'J', 'K', 'M', 'N', 'P', 'Q', 'R', 'T', 'V', 'W', 'X', 'Y'
     ];
 #else
     // We don't want to use any confusing characters like 0/O 1/I/L/l

--- a/src/Identity/Extensions.Core/src/UserManager.cs
+++ b/src/Identity/Extensions.Core/src/UserManager.cs
@@ -2478,7 +2478,16 @@ public class UserManager<TUser> : IDisposable where TUser : class
     /// <returns></returns>
     protected virtual string CreateTwoFactorRecoveryCode()
     {
-#if NET6_0_OR_GREATER
+#if NET8_0_OR_GREATER
+        return string.Create(11, 0, static (buffer, _) =>
+        {
+            Span<char> temp = stackalloc char[10];
+            RandomNumberGenerator.GetItems(AllowedChars, temp);
+            temp[..5].CopyTo(buffer);
+            temp[5..].CopyTo(buffer[6..]);
+            buffer[5] = '-';
+        });
+#elif NET6_0_OR_GREATER
         return string.Create(11, 0, static (buffer, _) =>
         {
             buffer[10] = GetRandomRecoveryCodeChar();
@@ -2510,6 +2519,16 @@ public class UserManager<TUser> : IDisposable where TUser : class
 #endif
     }
 
+#if NET8_0_OR_GREATER
+    // We don't want to use any confusing characters like 0/O 1/I/L/l
+    // Taken from windows valid product key source
+    private static ReadOnlySpan<char> AllowedChars =>
+    [
+        '2', '3', '4', '5', '6', '7', '8', '9',
+        'B', 'C', 'D', 'F', 'G', 'H', 'J', 'K',
+        'M', 'N', 'P', 'Q', 'R', 'T', 'V', 'W', 'X', 'Y'
+    ];
+#else
     // We don't want to use any confusing characters like 0/O 1/I/L/l
     // Taken from windows valid product key source
     private static readonly char[] AllowedChars = "23456789BCDFGHJKMNPQRTVWXY".ToCharArray();
@@ -2547,6 +2566,7 @@ public class UserManager<TUser> : IDisposable where TUser : class
 
         return AllowedChars[(int)result];
     }
+#endif
 
     /// <summary>
     /// Returns whether a recovery code is valid for a user. Note: recovery codes are only valid

--- a/src/Identity/Extensions.Core/src/UserManager.cs
+++ b/src/Identity/Extensions.Core/src/UserManager.cs
@@ -2481,10 +2481,7 @@ public class UserManager<TUser> : IDisposable where TUser : class
 #if NET8_0_OR_GREATER
         return string.Create(11, 0, static (buffer, _) =>
         {
-            Span<char> temp = stackalloc char[10];
-            RandomNumberGenerator.GetItems(AllowedChars, temp);
-            temp[..5].CopyTo(buffer);
-            temp[5..].CopyTo(buffer[6..]);
+            RandomNumberGenerator.GetItems(AllowedChars, buffer);
             buffer[5] = '-';
         });
 #elif NET6_0_OR_GREATER


### PR DESCRIPTION
# Improve CreateTwoFactorRecoveryCode in .NET 8 or higher

Changes the `CreateTwoFactorRecoveryCode` method to use the new `RandomNumberGenerator.GetItems` method in .NET 8 or higher.

## Description

Changes the `CreateTwoFactorRecoveryCode` method to use [the `RandomNumberGenerator.GetItems` method](https://learn.microsoft.com/en-gb/dotnet/api/system.security.cryptography.randomnumbergenerator.getitems?view=net-10.0) added in .NET 8, rather than repeatedly calling `RNG.Fill` to generate a single index into the `AllowedChars` array. 

This reduces the complexity of the code in modern frameworks, and means it can take advantage of any performance improvements in the `GetItems` method.

The `AllowedChars` field is also replaced with a span-returning property. This avoids the array allocation, as the array data will be embedded within the assembly's metadata.

Fixes #67668.
