### PR TITLE
Add more tests for OpenApi enums

### DIFF
--- a/src/OpenApi/sample/Endpoints/MapEnumsEndpoints.cs
+++ b/src/OpenApi/sample/Endpoints/MapEnumsEndpoints.cs
@@ -42,6 +42,16 @@ public static class EnumsEndpointsExtensions
         endpointRouteBuilder.MapPost("/enums/camelcase/nullable-body-direct", ([FromBody] CamelCaseStatus? status) => TypedResults.Ok(status))
             .WithGroupName("enum-camelcase-nullable-body-direct");
 
+        // Response where the enum is returned directly.
+        endpointRouteBuilder.MapPost("/enums/pascalcase/nonnullable-response", () => TypedResults.Ok<PascalCaseStatus>(PascalCaseStatus.Active))
+            .WithGroupName("enum-pascalcase-nonnullable-response");
+        endpointRouteBuilder.MapPost("/enums/pascalcase/nullable-response", () => TypedResults.Ok<PascalCaseStatus?>(PascalCaseStatus.Active))
+            .WithGroupName("enum-pascalcase-nullable-response");
+        endpointRouteBuilder.MapPost("/enums/camelcase/nonnullable-response", () => TypedResults.Ok<CamelCaseStatus>(CamelCaseStatus.Active))
+            .WithGroupName("enum-camelcase-nonnullable-response");
+        endpointRouteBuilder.MapPost("/enums/camelcase/nullable-response", () => TypedResults.Ok<CamelCaseStatus?>(CamelCaseStatus.Active))
+            .WithGroupName("enum-camelcase-nullable-response");
+
         return endpointRouteBuilder;
     }
 

--- a/src/OpenApi/sample/Program.cs
+++ b/src/OpenApi/sample/Program.cs
@@ -58,6 +58,10 @@ builder.Services.AddOpenApi("enum-pascalcase-nonnullable-body-direct");
 builder.Services.AddOpenApi("enum-pascalcase-nullable-body-direct");
 builder.Services.AddOpenApi("enum-camelcase-nonnullable-body-direct");
 builder.Services.AddOpenApi("enum-camelcase-nullable-body-direct");
+builder.Services.AddOpenApi("enum-pascalcase-nonnullable-response");
+builder.Services.AddOpenApi("enum-pascalcase-nullable-response");
+builder.Services.AddOpenApi("enum-camelcase-nonnullable-response");
+builder.Services.AddOpenApi("enum-camelcase-nullable-response");
 builder.Services.AddOpenApi("localized", options =>
 {
     options.ShouldInclude = _ => true;

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentIntegrationTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/OpenApiDocumentIntegrationTests.cs
@@ -57,6 +57,10 @@ public sealed class OpenApiDocumentIntegrationTests(SampleAppFixture fixture) : 
         "enum-pascalcase-nullable-body-direct",
         "enum-camelcase-nonnullable-body-direct",
         "enum-camelcase-nullable-body-direct",
+        "enum-pascalcase-nonnullable-response",
+        "enum-pascalcase-nullable-response",
+        "enum-camelcase-nonnullable-response",
+        "enum-camelcase-nullable-response",
     ];
 
     public static TheoryData<string> EnumDocumentNames()

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nonnullable-response.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nonnullable-response.verified.txt
@@ -1,0 +1,44 @@
+﻿{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "Sample | enum-camelcase-nonnullable-response",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/enums/camelcase/nonnullable-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CamelCaseStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CamelCaseStatus": {
+        "enum": [
+          "active",
+          "inactive",
+          "pending"
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Sample"
+    }
+  ]
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nullable-response.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nullable-response.verified.txt
@@ -1,0 +1,45 @@
+﻿{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "Sample | enum-camelcase-nullable-response",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/enums/camelcase/nullable-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CamelCaseStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CamelCaseStatus": {
+        "enum": [
+          "active",
+          "inactive",
+          "pending",
+          null
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Sample"
+    }
+  ]
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nonnullable-response.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nonnullable-response.verified.txt
@@ -1,0 +1,44 @@
+﻿{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "Sample | enum-pascalcase-nonnullable-response",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/enums/pascalcase/nonnullable-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PascalCaseStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PascalCaseStatus": {
+        "enum": [
+          "Active",
+          "Inactive",
+          "Pending"
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Sample"
+    }
+  ]
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nullable-response.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nullable-response.verified.txt
@@ -1,0 +1,45 @@
+﻿{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "Sample | enum-pascalcase-nullable-response",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/enums/pascalcase/nullable-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PascalCaseStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PascalCaseStatus": {
+        "enum": [
+          "Active",
+          "Inactive",
+          "Pending",
+          null
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Sample"
+    }
+  ]
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nonnullable-response.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nonnullable-response.verified.txt
@@ -1,0 +1,44 @@
+﻿{
+  "openapi": "3.1.2",
+  "info": {
+    "title": "Sample | enum-camelcase-nonnullable-response",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/enums/camelcase/nonnullable-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CamelCaseStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CamelCaseStatus": {
+        "enum": [
+          "active",
+          "inactive",
+          "pending"
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Sample"
+    }
+  ]
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nullable-response.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nullable-response.verified.txt
@@ -1,0 +1,45 @@
+﻿{
+  "openapi": "3.1.2",
+  "info": {
+    "title": "Sample | enum-camelcase-nullable-response",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/enums/camelcase/nullable-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CamelCaseStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CamelCaseStatus": {
+        "enum": [
+          "active",
+          "inactive",
+          "pending",
+          null
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Sample"
+    }
+  ]
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nonnullable-response.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nonnullable-response.verified.txt
@@ -1,0 +1,44 @@
+﻿{
+  "openapi": "3.1.2",
+  "info": {
+    "title": "Sample | enum-pascalcase-nonnullable-response",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/enums/pascalcase/nonnullable-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PascalCaseStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PascalCaseStatus": {
+        "enum": [
+          "Active",
+          "Inactive",
+          "Pending"
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Sample"
+    }
+  ]
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nullable-response.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nullable-response.verified.txt
@@ -1,0 +1,45 @@
+﻿{
+  "openapi": "3.1.2",
+  "info": {
+    "title": "Sample | enum-pascalcase-nullable-response",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/enums/pascalcase/nullable-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PascalCaseStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PascalCaseStatus": {
+        "enum": [
+          "Active",
+          "Inactive",
+          "Pending",
+          null
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Sample"
+    }
+  ]
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nonnullable-response.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nonnullable-response.verified.txt
@@ -1,0 +1,44 @@
+﻿{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "Sample | enum-camelcase-nonnullable-response",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/enums/camelcase/nonnullable-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CamelCaseStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CamelCaseStatus": {
+        "enum": [
+          "active",
+          "inactive",
+          "pending"
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Sample"
+    }
+  ]
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nullable-response.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-camelcase-nullable-response.verified.txt
@@ -1,0 +1,45 @@
+﻿{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "Sample | enum-camelcase-nullable-response",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/enums/camelcase/nullable-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CamelCaseStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CamelCaseStatus": {
+        "enum": [
+          "active",
+          "inactive",
+          "pending",
+          null
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Sample"
+    }
+  ]
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nonnullable-response.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nonnullable-response.verified.txt
@@ -1,0 +1,44 @@
+﻿{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "Sample | enum-pascalcase-nonnullable-response",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/enums/pascalcase/nonnullable-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PascalCaseStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PascalCaseStatus": {
+        "enum": [
+          "Active",
+          "Inactive",
+          "Pending"
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Sample"
+    }
+  ]
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nullable-response.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=enum-pascalcase-nullable-response.verified.txt
@@ -1,0 +1,45 @@
+﻿{
+  "openapi": "3.2.0",
+  "info": {
+    "title": "Sample | enum-pascalcase-nullable-response",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/enums/pascalcase/nullable-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PascalCaseStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PascalCaseStatus": {
+        "enum": [
+          "Active",
+          "Inactive",
+          "Pending",
+          null
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Sample"
+    }
+  ]
+}

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
@@ -377,6 +377,82 @@
         }
       }
     },
+    "/enums/pascalcase/nonnullable-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PascalCaseStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/enums/pascalcase/nullable-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PascalCaseStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/enums/camelcase/nonnullable-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CamelCaseStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/enums/camelcase/nullable-response": {
+      "post": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CamelCaseStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/first-doc/get1": {
       "get": {
         "tags": [


### PR DESCRIPTION
Follow-up to #67485

This only adds tests catching the current behavior.