### PR TITLE
Cap Zstandard request decompression window at 8 MB

### DIFF
--- a/src/Middleware/RequestDecompression/src/ZstandardDecompressionProvider.cs
+++ b/src/Middleware/RequestDecompression/src/ZstandardDecompressionProvider.cs
@@ -10,9 +10,19 @@ namespace Microsoft.AspNetCore.RequestDecompression;
 /// </summary>
 internal sealed class ZstandardDecompressionProvider : IDecompressionProvider
 {
+    // Cap the decompression window at 8 MB (2^23). RFC 9659 requires the "zstd" HTTP content
+    // coding to use a window no larger than 8 MB, and browsers such as Chromium reject larger
+    // windows for the same reason. Payloads produced with a larger window (for example,
+    // "zstd --long") will fail to decompress; default streaming compression uses a window of at
+    // most 2 MB and is unaffected.
+    private static readonly ZstandardDecompressionOptions s_decompressionOptions = new()
+    {
+        MaxWindowLog = 23,
+    };
+
     /// <inheritdoc />
     public Stream GetDecompressionStream(Stream stream)
     {
-        return new ZstandardStream(stream, CompressionMode.Decompress, leaveOpen: true);
+        return new ZstandardStream(stream, s_decompressionOptions, leaveOpen: true);
     }
 }

--- a/src/Middleware/RequestDecompression/test/RequestDecompressionMiddlewareTests.cs
+++ b/src/Middleware/RequestDecompression/test/RequestDecompressionMiddlewareTests.cs
@@ -83,6 +83,14 @@ public class RequestDecompressionMiddlewareTests
         return await GetCompressedContent(compressorDelegate, uncompressedBytes);
     }
 
+    private static async Task<byte[]> GetZstdCompressedContentWithWindowLog(byte[] uncompressedBytes, int windowLog)
+    {
+        Stream compressorDelegate(Stream compressedContent) =>
+            new ZstandardStream(compressedContent, new ZstandardCompressionOptions { WindowLog = windowLog });
+
+        return await GetCompressedContent(compressorDelegate, uncompressedBytes);
+    }
+
     [Fact]
     public async Task Request_ContentEncodingBrotli_Decompressed()
     {
@@ -161,6 +169,21 @@ public class RequestDecompressionMiddlewareTests
         // Assert
         AssertDecompressedWithLog(logMessages, contentEncoding.ToLowerInvariant());
         Assert.Equal(uncompressedBytes, decompressedBytes);
+    }
+
+    [Fact]
+    public async Task Request_ContentEncodingZstd_WindowExceedsMaxWindowLog_Throws()
+    {
+        // The middleware caps the Zstandard decompression window at 8 MB (windowLog 23) as
+        // required by RFC 9659, so a payload advertising a larger window must be rejected.
+
+        // Arrange
+        var contentEncoding = "zstd";
+        var uncompressedBytes = GetUncompressedContent();
+        var compressedBytes = await GetZstdCompressedContentWithWindowLog(uncompressedBytes, windowLog: 24);
+
+        // Act/Assert
+        await Assert.ThrowsAsync<IOException>(async () => await InvokeMiddleware(compressedBytes, new[] { contentEncoding }));
     }
 
     [Fact]


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Cap the Zstandard request decompression window at 8 MB (windowLog 23).

## Description

The request decompression middleware decodes `zstd` request bodies from untrusted clients. The zstd decoder sizes its window buffer from the frame header, and the native default allows windows up to 128 MB. That lets a small compressed request force a large decoder allocation, which is a decompression-bomb style DoS vector.

This wires up the new `System.IO.Compression.ZstandardDecompressionOptions.MaxWindowLog` (from dotnet/runtime#129768) and sets it to 23 (8 MB) internally on the request decompression provider. 8 MB is the maximum window RFC 9659 permits for the HTTP `zstd` content coding, and it matches what browsers such as Chromium enforce. A request that advertises a larger window now fails to decompress.

This is intentionally an internal change with no new public API. The related API proposal (#67476) to expose these options was not approved, so the window is capped at the RFC-mandated value with no configuration knob for now.

Notes for reviewers:
- No effect on well-behaved clients: default streaming zstd emits a window of at most ~2 MB (windowLog 21). Only payloads built with a larger window (for example `zstd --long`, ultra levels, or an explicit `WindowLog > 23`) are rejected.
- The compression side is unchanged. A decoder cap costs nothing, whereas pinning the encoder would waste memory for no benefit, and ResponseCompression already emits compliant windows.
- When the window is too large the runtime decoder throws `IOException` ("Data requires too much memory for decoding..."). The middleware lets it propagate, matching how it already surfaces other decode failures. The added test asserts this.

Related to #67476