### PR TITLE
[Quarantine] AddValidationIntegrationTest.FormWithNestedValidation_Works

### DIFF
--- a/src/Components/test/E2ETest/ServerRenderingTests/AddValidationIntegrationTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/AddValidationIntegrationTest.cs
@@ -8,6 +8,7 @@ using Components.TestServer.RazorComponents;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
+using Microsoft.AspNetCore.InternalTesting;
 using OpenQA.Selenium;
 using TestServer;
 using Xunit.Abstractions;
@@ -27,6 +28,7 @@ public class AddValidationIntegrationTest : ServerTestBase<BasicTestAppServerSit
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/67699")]
     public void FormWithNestedValidation_Works()
     {
         Browser.Exists(By.Id("submit-form")).Click();


### PR DESCRIPTION
Quarantines the flaky Blazor E2E test `AddValidationIntegrationTest.FormWithNestedValidation_Works`.

## Failure rate

Analyzing the last 80 `aspnetcore-components-e2e` builds (~24 hours):

- Failed in **24 builds (~30%)**
- **4 failures on `refs/heads/main`** (~33% of main runs in the window)
- Spread across 20 different unrelated PRs — not caused by any specific change

## Failure signature

```
Assert.Equal() Failure: Collections differ
Expected: ["Email is required.", "Full Name is required.", "Order Name is required.", "Product Name is required.", "Street is required.", "Zip Code is required."]
Actual:   ["Order Name is required."]
```

The test submits a form and asserts the validation summary contains 6 required-field messages, but only the first one is present. Looks like a Selenium/Blazor race between the submit click and the summary rendering.

## Example failing builds

- [Build 1500125](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1500125) (on PR #67635)
- [Build 1500081](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1500081) (main)
- [Build 1499768](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1499768) (main)

## Tracking

- Issue: #67699

/cc @dotnet/aspnetcore-blazor
