### PR TITLE
[release/10.0] Fix flaky CanElevateEffectiveMaxItemCount_WhenOverscanExceedsMax

### DIFF
--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -578,9 +578,14 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     {
         Browser.MountTestComponent<VirtualizationLargeOverscan>();
         var container = Browser.Exists(By.Id("virtualize-large-overscan"));
-        // Ensure we have an initial contiguous batch and the elevated effective max has kicked in (>= OverscanCount)
-        var indices = GetVisibleItemIndices();
-        Browser.True(() => indices.Count >= 200);
+        // Wait for the elevated effective max to kick in (>= OverscanCount).
+        // Re-query inside the retry loop so we see new items as they render.
+        List<int> indices = null;
+        Browser.True(() =>
+        {
+            indices = GetVisibleItemIndices();
+            return indices.Count >= 200;
+        });
 
         // Give focus so PageDown works
         container.Click();
@@ -595,8 +600,13 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var scrollTop = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
         while (scrollTop + clientHeight < scrollHeight)
         {
-            // Validate contiguity on the current page
-            Browser.True(() => IsCurrentViewContiguous(indices));
+            // Re-query visible items after each scroll so contiguity and
+            // progress checks reflect the current DOM state.
+            Browser.True(() =>
+            {
+                indices = GetVisibleItemIndices();
+                return IsCurrentViewContiguous(indices);
+            });
 
             // Track progress in indices
             var currentMax = indices.Max();


### PR DESCRIPTION
Backport of #66291 to release/10.0.

## Why

The Blazor E2E test `VirtualizationTest.CanElevateEffectiveMaxItemCount_WhenOverscanExceedsMax` (and its `ServerVirtualizationTest` subclass) is flaking in the `components-e2e` pipeline on release/10.0. In a scan of the last 30 days of components-e2e builds tied to release/10.0 (direct rolling builds + PRs targeting release/10.0), it failed in 2 distinct builds (PR #67464 on 7/3 and a rolling release/10.0 build on 7/8). It is the only 2+-failure test in that window not already quarantined on the branch.

## Root cause

This is the exact issue already fixed on `main` by #66291 (closing #65962), which was **never backported to release/10.0**:

> The test was flaky because `GetVisibleItemIndices()` was called once and the result was reused in all `Browser.True()` retry loops and across PageDown iterations. In server mode, the async virtualization update had not finished yet when the snapshot was taken, so the retry loops kept checking a stale list that never reached 200 items.

## Fix

Re-query `GetVisibleItemIndices()` inside each `Browser.True()` loop so retries see the current DOM state. This is a clean cherry-pick of the `VirtualizationTest.cs` change from #66291 (the `TestSubclasses.cs` portion of that PR was a quarantine-attribute removal that does not apply on release/10.0, since the test is not quarantined there).

Rather than quarantine the test on release/10.0, this backports the real fix so we retain coverage and match `main`.
