### PR TITLE
[release/2.3] Add System.Security.Cryptography.Xml reference to affected projects

### DIFF
--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Microsoft.AspNetCore.Authentication.AzureAD.UI.csproj
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Microsoft.AspNetCore.Authentication.AzureAD.UI.csproj
@@ -14,6 +14,7 @@
     <Reference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <Reference Include="Microsoft.AspNetCore.Authentication.Cookies" />
     <Reference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
+    <Reference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
     <ItemGroup>

--- a/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Microsoft.AspNetCore.Authentication.AzureAD.UI.csproj
+++ b/src/Azure/AzureAD/Authentication.AzureAD.UI/src/Microsoft.AspNetCore.Authentication.AzureAD.UI.csproj
@@ -14,7 +14,7 @@
     <Reference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <Reference Include="Microsoft.AspNetCore.Authentication.Cookies" />
     <Reference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
     <ItemGroup>

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Microsoft.AspNetCore.Authentication.AzureADB2C.UI.csproj
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Microsoft.AspNetCore.Authentication.AzureADB2C.UI.csproj
@@ -14,6 +14,7 @@
     <Reference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <Reference Include="Microsoft.AspNetCore.Authentication.Cookies" />
     <Reference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
+    <Reference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
     <ItemGroup>

--- a/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Microsoft.AspNetCore.Authentication.AzureADB2C.UI.csproj
+++ b/src/Azure/AzureAD/Authentication.AzureADB2C.UI/src/Microsoft.AspNetCore.Authentication.AzureADB2C.UI.csproj
@@ -14,7 +14,7 @@
     <Reference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <Reference Include="Microsoft.AspNetCore.Authentication.Cookies" />
     <Reference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
     <ItemGroup>

--- a/src/Identity/Core/src/Microsoft.AspNetCore.Identity.csproj
+++ b/src/Identity/Core/src/Microsoft.AspNetCore.Identity.csproj
@@ -12,7 +12,7 @@
     <Reference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" />
     <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
     <Reference Include="Microsoft.Extensions.Identity.Core" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Identity/Core/src/Microsoft.AspNetCore.Identity.csproj
+++ b/src/Identity/Core/src/Microsoft.AspNetCore.Identity.csproj
@@ -12,6 +12,7 @@
     <Reference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" />
     <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
     <Reference Include="Microsoft.Extensions.Identity.Core" />
+    <Reference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
 </Project>

--- a/src/Identity/EntityFrameworkCore/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore.csproj
+++ b/src/Identity/EntityFrameworkCore/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore.csproj
@@ -11,6 +11,7 @@
     <Reference Include="Microsoft.AspNetCore.Identity" />
     <Reference Include="Microsoft.Extensions.Identity.Stores" />
     <Reference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <Reference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
 </Project>

--- a/src/Identity/EntityFrameworkCore/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore.csproj
+++ b/src/Identity/EntityFrameworkCore/src/Microsoft.AspNetCore.Identity.EntityFrameworkCore.csproj
@@ -11,7 +11,7 @@
     <Reference Include="Microsoft.AspNetCore.Identity" />
     <Reference Include="Microsoft.Extensions.Identity.Stores" />
     <Reference Include="Microsoft.EntityFrameworkCore.Relational" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Identity/Specification.Tests/src/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
+++ b/src/Identity/Specification.Tests/src/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
@@ -15,7 +15,7 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="xunit" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Identity/Specification.Tests/src/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
+++ b/src/Identity/Specification.Tests/src/Microsoft.AspNetCore.Identity.Specification.Tests.csproj
@@ -15,6 +15,7 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="xunit" />
+    <Reference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
 </Project>

--- a/src/Identity/UI/src/Microsoft.AspNetCore.Identity.UI.csproj
+++ b/src/Identity/UI/src/Microsoft.AspNetCore.Identity.UI.csproj
@@ -25,7 +25,7 @@
     <Reference Include="Microsoft.AspNetCore.StaticFiles" />
     <Reference Include="Microsoft.AspNetCore.Identity" />
     <Reference Include="Microsoft.Extensions.Identity.Stores" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Identity/UI/src/Microsoft.AspNetCore.Identity.UI.csproj
+++ b/src/Identity/UI/src/Microsoft.AspNetCore.Identity.UI.csproj
@@ -25,6 +25,7 @@
     <Reference Include="Microsoft.AspNetCore.StaticFiles" />
     <Reference Include="Microsoft.AspNetCore.Identity" />
     <Reference Include="Microsoft.Extensions.Identity.Stores" />
+    <Reference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Middleware/SpaServices.Extensions/src/Microsoft.AspNetCore.SpaServices.Extensions.csproj
+++ b/src/Middleware/SpaServices.Extensions/src/Microsoft.AspNetCore.SpaServices.Extensions.csproj
@@ -14,6 +14,7 @@
     <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.AspNetCore.WebSockets" />
+    <Reference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
 </Project>

--- a/src/Middleware/SpaServices.Extensions/src/Microsoft.AspNetCore.SpaServices.Extensions.csproj
+++ b/src/Middleware/SpaServices.Extensions/src/Microsoft.AspNetCore.SpaServices.Extensions.csproj
@@ -14,7 +14,7 @@
     <Reference Include="Microsoft.Extensions.FileProviders.Physical" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.AspNetCore.WebSockets" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj
+++ b/src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Mvc.TagHelpers" />
     <Reference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" />
+    <Reference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish" Condition=" '$(IsCrossTargetingBuild)' != 'true' ">

--- a/src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj
+++ b/src/Middleware/SpaServices/src/Microsoft.AspNetCore.SpaServices.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Mvc.TagHelpers" />
     <Reference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
   <Target Name="PrepublishScript" BeforeTargets="PrepareForPublish" Condition=" '$(IsCrossTargetingBuild)' != 'true' ">

--- a/src/Mvc/Mvc.Localization/src/Microsoft.AspNetCore.Mvc.Localization.csproj
+++ b/src/Mvc/Mvc.Localization/src/Microsoft.AspNetCore.Mvc.Localization.csproj
@@ -21,6 +21,7 @@ Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer</Description>
     <Reference Include="Microsoft.AspNetCore.Localization" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
     <Reference Include="Microsoft.Extensions.Localization" />
+    <Reference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
 </Project>

--- a/src/Mvc/Mvc.Localization/src/Microsoft.AspNetCore.Mvc.Localization.csproj
+++ b/src/Mvc/Mvc.Localization/src/Microsoft.AspNetCore.Mvc.Localization.csproj
@@ -21,7 +21,7 @@ Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer</Description>
     <Reference Include="Microsoft.AspNetCore.Localization" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
     <Reference Include="Microsoft.Extensions.Localization" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Mvc/Mvc.Razor/src/Microsoft.AspNetCore.Mvc.Razor.csproj
+++ b/src/Mvc/Mvc.Razor/src/Microsoft.AspNetCore.Mvc.Razor.csproj
@@ -25,6 +25,7 @@
     <Reference Include="Microsoft.Extensions.Caching.Memory" />
     <Reference Include="Microsoft.Extensions.FileProviders.Composite" />
     <Reference Include="Microsoft.Extensions.HashCodeCombiner.Sources" PrivateAssets="All" />
+    <Reference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mvc/Mvc.Razor/src/Microsoft.AspNetCore.Mvc.Razor.csproj
+++ b/src/Mvc/Mvc.Razor/src/Microsoft.AspNetCore.Mvc.Razor.csproj
@@ -25,7 +25,7 @@
     <Reference Include="Microsoft.Extensions.Caching.Memory" />
     <Reference Include="Microsoft.Extensions.FileProviders.Composite" />
     <Reference Include="Microsoft.Extensions.HashCodeCombiner.Sources" PrivateAssets="All" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mvc/Mvc.RazorPages/src/Microsoft.AspNetCore.Mvc.RazorPages.csproj
+++ b/src/Mvc/Mvc.RazorPages/src/Microsoft.AspNetCore.Mvc.RazorPages.csproj
@@ -19,6 +19,7 @@
     <Reference Include="Microsoft.AspNetCore.Mvc.Razor" />
 
     <Reference Include="Microsoft.Extensions.ParameterDefaultValue.Sources" PrivateAssets="All" />
+    <Reference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mvc/Mvc.RazorPages/src/Microsoft.AspNetCore.Mvc.RazorPages.csproj
+++ b/src/Mvc/Mvc.RazorPages/src/Microsoft.AspNetCore.Mvc.RazorPages.csproj
@@ -19,7 +19,7 @@
     <Reference Include="Microsoft.AspNetCore.Mvc.Razor" />
 
     <Reference Include="Microsoft.Extensions.ParameterDefaultValue.Sources" PrivateAssets="All" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mvc/Mvc.TagHelpers/src/Microsoft.AspNetCore.Mvc.TagHelpers.csproj
+++ b/src/Mvc/Mvc.TagHelpers/src/Microsoft.AspNetCore.Mvc.TagHelpers.csproj
@@ -22,5 +22,6 @@
     <Reference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <Reference Include="Microsoft.Extensions.HashCodeCombiner.Sources" PrivateAssets="All" />
     <Reference Include="Microsoft.Extensions.Primitives" />
+    <Reference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 </Project>

--- a/src/Mvc/Mvc.TagHelpers/src/Microsoft.AspNetCore.Mvc.TagHelpers.csproj
+++ b/src/Mvc/Mvc.TagHelpers/src/Microsoft.AspNetCore.Mvc.TagHelpers.csproj
@@ -22,6 +22,6 @@
     <Reference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <Reference Include="Microsoft.Extensions.HashCodeCombiner.Sources" PrivateAssets="All" />
     <Reference Include="Microsoft.Extensions.Primitives" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Mvc/Mvc/src/Microsoft.AspNetCore.Mvc.csproj
+++ b/src/Mvc/Mvc/src/Microsoft.AspNetCore.Mvc.csproj
@@ -24,6 +24,7 @@
     <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" PrivateAssets="None" />
     <Reference Include="Microsoft.Extensions.Caching.Memory" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <Reference Include="System.Security.Cryptography.Xml" />
 
   </ItemGroup>
 

--- a/src/Mvc/Mvc/src/Microsoft.AspNetCore.Mvc.csproj
+++ b/src/Mvc/Mvc/src/Microsoft.AspNetCore.Mvc.csproj
@@ -24,7 +24,7 @@
     <Reference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" PrivateAssets="None" />
     <Reference Include="Microsoft.Extensions.Caching.Memory" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
 
   </ItemGroup>
 

--- a/src/Mvc/ViewCompilation/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.csproj
+++ b/src/Mvc/ViewCompilation/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.csproj
@@ -30,6 +30,7 @@
     <Reference Include="Microsoft.AspNetCore.Hosting" />
     <Reference Include="Microsoft.AspNetCore.Mvc.RazorPages" />
     <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" />
+    <Reference Include="System.Security.Cryptography.Xml" />
 
     <PackageReference Update="Microsoft.NETCore.App" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Mvc/ViewCompilation/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.csproj
+++ b/src/Mvc/ViewCompilation/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.csproj
@@ -30,7 +30,7 @@
     <Reference Include="Microsoft.AspNetCore.Hosting" />
     <Reference Include="Microsoft.AspNetCore.Mvc.RazorPages" />
     <Reference Include="Microsoft.Extensions.CommandLineUtils.Sources" PrivateAssets="All" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
 
     <PackageReference Update="Microsoft.NETCore.App" PrivateAssets="All" />
   </ItemGroup>

--- a/src/Security/Authentication/Facebook/src/Microsoft.AspNetCore.Authentication.Facebook.csproj
+++ b/src/Security/Authentication/Facebook/src/Microsoft.AspNetCore.Authentication.Facebook.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Authentication.OAuth" />
+    <Reference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authentication/Facebook/src/Microsoft.AspNetCore.Authentication.Facebook.csproj
+++ b/src/Security/Authentication/Facebook/src/Microsoft.AspNetCore.Authentication.Facebook.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Authentication.OAuth" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authentication/Google/src/Microsoft.AspNetCore.Authentication.Google.csproj
+++ b/src/Security/Authentication/Google/src/Microsoft.AspNetCore.Authentication.Google.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Authentication.OAuth" />
+    <Reference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authentication/Google/src/Microsoft.AspNetCore.Authentication.Google.csproj
+++ b/src/Security/Authentication/Google/src/Microsoft.AspNetCore.Authentication.Google.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Authentication.OAuth" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authentication/MicrosoftAccount/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount.csproj
+++ b/src/Security/Authentication/MicrosoftAccount/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Authentication.OAuth" />
+    <Reference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authentication/MicrosoftAccount/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount.csproj
+++ b/src/Security/Authentication/MicrosoftAccount/src/Microsoft.AspNetCore.Authentication.MicrosoftAccount.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Authentication.OAuth" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authentication/OpenIdConnect/src/Microsoft.AspNetCore.Authentication.OpenIdConnect.csproj
+++ b/src/Security/Authentication/OpenIdConnect/src/Microsoft.AspNetCore.Authentication.OpenIdConnect.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Authentication.OAuth" />
     <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
+    <Reference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authentication/OpenIdConnect/src/Microsoft.AspNetCore.Authentication.OpenIdConnect.csproj
+++ b/src/Security/Authentication/OpenIdConnect/src/Microsoft.AspNetCore.Authentication.OpenIdConnect.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Authentication.OAuth" />
     <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authentication/Twitter/src/Microsoft.AspNetCore.Authentication.Twitter.csproj
+++ b/src/Security/Authentication/Twitter/src/Microsoft.AspNetCore.Authentication.Twitter.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Authentication.OAuth" />
+    <Reference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authentication/Twitter/src/Microsoft.AspNetCore.Authentication.Twitter.csproj
+++ b/src/Security/Authentication/Twitter/src/Microsoft.AspNetCore.Authentication.Twitter.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Authentication.OAuth" />
-    <Reference Include="System.Security.Cryptography.Xml" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds an explicit `<Reference Include="System.Security.Cryptography.Xml" />` to each project that depends (directly or transitively) on `System.Security.Cryptography.Xml`, so the patched package version flows into these assemblies.

Fixes a CG alert