### PR TITLE
Suppress false-positive CodeQL alerts

### DIFF
--- a/src/Http/Http.Features/src/IResponseCookies.cs
+++ b/src/Http/Http.Features/src/IResponseCookies.cs
@@ -32,6 +32,7 @@ public interface IResponseCookies
     {
         foreach (var keyValuePair in keyValuePairs)
         {
+            // codeql[SM02373] - This default interface method only forwards the caller's CookieOptions to the concrete Append; it applies no cookie policy itself.
             Append(keyValuePair.Key, keyValuePair.Value, options);
         }
     }

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Logout.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Logout.cshtml
@@ -9,6 +9,7 @@
     @{
         if (User.Identity!.IsAuthenticated)
         {
+            @* codeql[SM00430] - returnUrl is Url.Page with constant arguments (the app root), not user input, and Razor HTML-encodes the attribute value. codeql[SM02175] - returnUrl is Url.Page with constant arguments (the app root), not user input, and Razor HTML-encodes the attribute value. *@
             <form class="form-inline" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Page("/", new { area = "" })" method="post">
                 <button type="submit" class="nav-link btn btn-link text-dark">Click here to Logout</button>
             </form>

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Logout.cshtml
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Logout.cshtml
@@ -9,6 +9,7 @@
     @{
         if (User.Identity!.IsAuthenticated)
         {
+            @* codeql[SM00430] - returnUrl is Url.Page with constant arguments (the app root), not user input, and Razor HTML-encodes the attribute value. codeql[SM02175] - returnUrl is Url.Page with constant arguments (the app root), not user input, and Razor HTML-encodes the attribute value. *@
             <form class="form-inline" asp-area="Identity" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Page("/", new { area = "" })" method="post">
                 <button type="submit" class="nav-link btn btn-link text-dark">Click here to Logout</button>
             </form>

--- a/src/Razor/Razor/src/TagHelpers/DefaultTagHelperContent.cs
+++ b/src/Razor/Razor/src/TagHelpers/DefaultTagHelperContent.cs
@@ -89,6 +89,7 @@ public class DefaultTagHelperContent : TagHelperContent
             return AppendCore(null);
         }
 
+        // codeql[SM00430] - By contract the 'encoded' argument is already-encoded, trusted HTML; this is the HtmlString wrapping primitive, not an injection sink. codeql[SM02175] - By contract the 'encoded' argument is already-encoded, trusted HTML; this is the HtmlString wrapping primitive, not an injection sink. codeql[SM00431] - By contract the 'encoded' argument is already-encoded, trusted HTML; this is the HtmlString wrapping primitive, not an injection sink.
         return AppendCore(new HtmlString(encoded));
     }
 

--- a/src/Security/Authentication/Core/src/RemoteAuthenticationHandler.cs
+++ b/src/Security/Authentication/Core/src/RemoteAuthenticationHandler.cs
@@ -237,6 +237,7 @@ public abstract class RemoteAuthenticationHandler<TOptions> : AuthenticationHand
 
         var cookieName = Options.CorrelationCookie.Name + correlationId;
 
+        // codeql[SM02373] - The correlation cookie is always Secure: CorrelationCookie.SecurePolicy defaults to CookieSecurePolicy.Always.
         Response.Cookies.Append(cookieName, CorrelationMarker, cookieOptions);
     }
 

--- a/src/Security/Authentication/Core/src/RemoteAuthenticationHandler.cs
+++ b/src/Security/Authentication/Core/src/RemoteAuthenticationHandler.cs
@@ -237,7 +237,7 @@ public abstract class RemoteAuthenticationHandler<TOptions> : AuthenticationHand
 
         var cookieName = Options.CorrelationCookie.Name + correlationId;
 
-        // codeql[SM02373] - The correlation cookie is always Secure: CorrelationCookie.SecurePolicy defaults to CookieSecurePolicy.Always.
+        // codeql[SM02373] - The correlation cookie is Secure by default because CorrelationCookie.SecurePolicy defaults to CookieSecurePolicy.Always.
         Response.Cookies.Append(cookieName, CorrelationMarker, cookieOptions);
     }
 

--- a/src/Security/Authentication/JwtBearer/src/JwtBearerConfigureOptions.cs
+++ b/src/Security/Authentication/JwtBearer/src/JwtBearerConfigureOptions.cs
@@ -63,6 +63,7 @@ internal sealed class JwtBearerConfigureOptions : IConfigureNamedOptions<JwtBear
         options.RefreshOnIssuerKeyNotFound = StringHelpers.ParseValueOrDefault(configSection[nameof(options.RefreshOnIssuerKeyNotFound)], bool.Parse, options.RefreshOnIssuerKeyNotFound);
         options.RequireHttpsMetadata = StringHelpers.ParseValueOrDefault(configSection[nameof(options.RequireHttpsMetadata)], bool.Parse, options.RequireHttpsMetadata);
         options.SaveToken = StringHelpers.ParseValueOrDefault(configSection[nameof(options.SaveToken)], bool.Parse, options.SaveToken);
+        // codeql[SM04554] - Valid issuer and audience are bound from app configuration into TokenValidationParameters at runtime. codeql[SM04555] - ValidateIssuer/ValidateAudience are enabled here whenever configured issuers/audiences are supplied.
         options.TokenValidationParameters = new()
         {
             ValidateIssuer = validateIssuer,

--- a/src/Security/Authentication/JwtBearer/src/JwtBearerConfigureOptions.cs
+++ b/src/Security/Authentication/JwtBearer/src/JwtBearerConfigureOptions.cs
@@ -63,7 +63,7 @@ internal sealed class JwtBearerConfigureOptions : IConfigureNamedOptions<JwtBear
         options.RefreshOnIssuerKeyNotFound = StringHelpers.ParseValueOrDefault(configSection[nameof(options.RefreshOnIssuerKeyNotFound)], bool.Parse, options.RefreshOnIssuerKeyNotFound);
         options.RequireHttpsMetadata = StringHelpers.ParseValueOrDefault(configSection[nameof(options.RequireHttpsMetadata)], bool.Parse, options.RequireHttpsMetadata);
         options.SaveToken = StringHelpers.ParseValueOrDefault(configSection[nameof(options.SaveToken)], bool.Parse, options.SaveToken);
-        // codeql[SM04554] - Valid issuer and audience are bound from app configuration into TokenValidationParameters at runtime. codeql[SM04555] - ValidateIssuer/ValidateAudience are enabled here whenever configured issuers/audiences are supplied.
+        // codeql[SM04554] - Valid issuer and audience are bound from app configuration into TokenValidationParameters at runtime. codeql[SM04555] - ValidateIssuer/ValidateAudience are bound from configuration (defaulting to the existing option values); the handler still validates at runtime.
         options.TokenValidationParameters = new()
         {
             ValidateIssuer = validateIssuer,

--- a/src/Security/Authentication/JwtBearer/src/JwtBearerOptions.cs
+++ b/src/Security/Authentication/JwtBearer/src/JwtBearerOptions.cs
@@ -127,6 +127,7 @@ public class JwtBearerOptions : AuthenticationSchemeOptions
     /// </summary>
     /// <remarks>Contains the types and definitions required for validating a token.</remarks>
     /// <exception cref="ArgumentNullException">if 'value' is null.</exception>
+    // codeql[SM04554] - Valid issuer is populated at runtime by the handler from the authority's discovery metadata, not statically here. codeql[SM04555] - Issuer validation runs in the handler; ValidateIssuer defaults to true in Microsoft.IdentityModel.
     public TokenValidationParameters TokenValidationParameters { get; set; } = new TokenValidationParameters();
 
     /// <summary>

--- a/src/Security/Authentication/JwtBearer/src/JwtBearerOptions.cs
+++ b/src/Security/Authentication/JwtBearer/src/JwtBearerOptions.cs
@@ -127,8 +127,7 @@ public class JwtBearerOptions : AuthenticationSchemeOptions
     /// </summary>
     /// <remarks>Contains the types and definitions required for validating a token.</remarks>
     /// <exception cref="ArgumentNullException">if 'value' is null.</exception>
-    // codeql[SM04554] - Valid issuer is populated at runtime by the handler from the authority's discovery metadata, not statically here. codeql[SM04555] - Issuer validation runs in the handler; ValidateIssuer defaults to true in Microsoft.IdentityModel.
-    public TokenValidationParameters TokenValidationParameters { get; set; } = new TokenValidationParameters();
+    public TokenValidationParameters TokenValidationParameters { get; set; } = new TokenValidationParameters(); // codeql[SM04554] - Valid issuer is populated at runtime by the handler from the authority's discovery metadata, not statically here. codeql[SM04555] - Issuer validation runs in the handler; ValidateIssuer defaults to true in Microsoft.IdentityModel.
 
     /// <summary>
     /// Defines whether the bearer token should be stored in the

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -1162,6 +1162,7 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
 
         var cookieOptions = Options.NonceCookie.Build(Context, TimeProvider.GetUtcNow());
 
+        // codeql[SM02373] - The nonce cookie is always Secure: NonceCookie.SecurePolicy defaults to CookieSecurePolicy.Always.
         Response.Cookies.Append(
             Options.NonceCookie.Name + Options.StringDataFormat.Protect(nonce),
             NonceProperty,

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -1162,7 +1162,7 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
 
         var cookieOptions = Options.NonceCookie.Build(Context, TimeProvider.GetUtcNow());
 
-        // codeql[SM02373] - The nonce cookie is always Secure: NonceCookie.SecurePolicy defaults to CookieSecurePolicy.Always.
+        // codeql[SM02373] - The nonce cookie is Secure by default because NonceCookie.SecurePolicy defaults to CookieSecurePolicy.Always.
         Response.Cookies.Append(
             Options.NonceCookie.Name + Options.StringDataFormat.Protect(nonce),
             NonceProperty,

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs
@@ -285,6 +285,7 @@ public class OpenIdConnectOptions : RemoteAuthenticationOptions
     /// Gets or sets the parameters used to validate identity tokens.
     /// </summary>
     /// <remarks>Contains the types and definitions required for validating a token.</remarks>
+    // codeql[SM04554] - Valid issuer is populated at runtime by the handler from the authority's discovery metadata, not statically here. codeql[SM04555] - Issuer validation runs in the handler; ValidateIssuer defaults to true in Microsoft.IdentityModel.
     public TokenValidationParameters TokenValidationParameters { get; set; } = new TokenValidationParameters();
 
     /// <summary>

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectOptions.cs
@@ -285,8 +285,7 @@ public class OpenIdConnectOptions : RemoteAuthenticationOptions
     /// Gets or sets the parameters used to validate identity tokens.
     /// </summary>
     /// <remarks>Contains the types and definitions required for validating a token.</remarks>
-    // codeql[SM04554] - Valid issuer is populated at runtime by the handler from the authority's discovery metadata, not statically here. codeql[SM04555] - Issuer validation runs in the handler; ValidateIssuer defaults to true in Microsoft.IdentityModel.
-    public TokenValidationParameters TokenValidationParameters { get; set; } = new TokenValidationParameters();
+    public TokenValidationParameters TokenValidationParameters { get; set; } = new TokenValidationParameters(); // codeql[SM04554] - Valid issuer is populated at runtime by the handler from the authority's discovery metadata, not statically here. codeql[SM04555] - Issuer validation runs in the handler; ValidateIssuer defaults to true in Microsoft.IdentityModel.
 
     /// <summary>
     /// Indicates that the authentication session lifetime (e.g. cookies) should match that of the authentication token.

--- a/src/Security/Authentication/WsFederation/src/WsFederationOptions.cs
+++ b/src/Security/Authentication/WsFederation/src/WsFederationOptions.cs
@@ -26,6 +26,7 @@ public class WsFederationOptions : RemoteAuthenticationOptions
             new JwtSecurityTokenHandler()
         };
 
+    // codeql[SM04554] - Valid issuer is populated at runtime by the handler from the authority's discovery metadata, not statically here. codeql[SM04555] - Issuer validation runs in the handler; ValidateIssuer defaults to true in Microsoft.IdentityModel.
     private TokenValidationParameters _tokenValidationParameters = new TokenValidationParameters();
 
     /// <summary>

--- a/src/Security/Authentication/WsFederation/src/WsFederationOptions.cs
+++ b/src/Security/Authentication/WsFederation/src/WsFederationOptions.cs
@@ -26,7 +26,7 @@ public class WsFederationOptions : RemoteAuthenticationOptions
             new JwtSecurityTokenHandler()
         };
 
-    // codeql[SM04554] - Valid issuer is populated at runtime by the handler from the authority's discovery metadata, not statically here. codeql[SM04555] - Issuer validation runs in the handler; ValidateIssuer defaults to true in Microsoft.IdentityModel.
+    // codeql[SM04554] - Valid issuer is populated at runtime by the handler from the federation metadata (MetadataAddress/ConfigurationManager), not statically here. codeql[SM04555] - Issuer validation runs in the handler; ValidateIssuer defaults to true in Microsoft.IdentityModel.
     private TokenValidationParameters _tokenValidationParameters = new TokenValidationParameters();
 
     /// <summary>

--- a/src/Servers/IIS/AspNetCoreModuleV2/IISLib/percpu.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/IISLib/percpu.h
@@ -200,6 +200,7 @@ PER_CPU<T>::ForEach(
     FunctionForEach Function
 )
 {
+    // codeql[SM02323] - Loop is counter-bounded: Index starts at 0, increments monotonically, and exits at m_VariablesCount.
     for(DWORD Index = 0; Index < m_VariablesCount; ++Index)
     {
         T * pObject = GetObject(Index);


### PR DESCRIPTION
Suppresses 19 CodeQL alerts that are confirmed **false positives** (the flagged security control is demonstrably present, or the flagged construct isn't a real sink). Each suppression is an inline `codeql[<ruleId>]` comment with a justification, per the SDL guidance. By-design / accepted-risk alerts are intentionally **not** included here and will be handled separately.

| Rule | Alerts | Sites | Why it's a false positive |
|------|:-----:|-------|---------------------------|
| SM04554 / SM04555 | 8 | JwtBearer/OIDC/WsFed options + JwtBearer config binding | Valid issuer is wired at runtime by the handler from the authority's discovery metadata (or bound from config); `ValidateIssuer` defaults to `true`. |
| SM02373 | 3 | `IResponseCookies` default method, OIDC nonce & correlation cookies | Forwarding helper sets no policy; nonce/correlation cookies default `SecurePolicy = Always`. |
| SM00430 / SM02175 / SM00431 | 7 | `DefaultTagHelperContent.AppendHtml`, Identity V4/V5 `Logout.cshtml` | `AppendHtml(encoded)` wraps by-contract trusted HTML; `returnUrl` is a constant `Url.Page`, Razor-encoded. |
| SM02323 | 1 | `AspNetCoreModuleV2/IISLib/percpu.h` | Counter-bounded loop that exits at `m_VariablesCount`. |

Note: the SM02323 alert on `AspNetCoreModuleV1/IISLib/percpu.h` is omitted — that module no longer exists in `main`.
