### PR TITLE
Suppress by-design CodeQL alerts

### DIFF
--- a/src/DataProtection/DataProtection/src/Managed/AesGcmAuthenticatedEncryptor.cs
+++ b/src/DataProtection/DataProtection/src/Managed/AesGcmAuthenticatedEncryptor.cs
@@ -131,6 +131,7 @@ internal sealed unsafe class AesGcmAuthenticatedEncryptor : IOptimizedAuthentica
                         validationSubkey: Span<byte>.Empty /* filling in derivedKey only */);
 
                     // Perform the decryption operation directly into destination
+                    // codeql[SM04193] - By design: reviewed and signed off by the Crypto Board; AES-GCM is enabled by default only in dev/non-prod and requires explicit opt-in in production, so there is no default prod exposure.
                     using var aes = new AesGcm(derivedKey, TAG_SIZE_IN_BYTES);
                     aes.Decrypt(nonce, encrypted, tag, plaintext);
 

--- a/src/DataProtection/DataProtection/src/Managed/AesGcmAuthenticatedEncryptor.cs
+++ b/src/DataProtection/DataProtection/src/Managed/AesGcmAuthenticatedEncryptor.cs
@@ -131,7 +131,7 @@ internal sealed unsafe class AesGcmAuthenticatedEncryptor : IOptimizedAuthentica
                         validationSubkey: Span<byte>.Empty /* filling in derivedKey only */);
 
                     // Perform the decryption operation directly into destination
-                    // codeql[SM04193] - By design: reviewed and signed off by the Crypto Board; AES-GCM is enabled by default only in dev/non-prod and requires explicit opt-in in production, so there is no default prod exposure.
+                    // codeql[SM04193] - By design: reviewed and signed off by the Crypto Board; managed AES-GCM is not the Data Protection default (AES-256-CBC is) and is only used when an app explicitly opts into GCM.
                     using var aes = new AesGcm(derivedKey, TAG_SIZE_IN_BYTES);
                     aes.Decrypt(nonce, encrypted, tag, plaintext);
 

--- a/src/Middleware/Rewrite/src/UrlActions/ChangeCookieAction.cs
+++ b/src/Middleware/Rewrite/src/UrlActions/ChangeCookieAction.cs
@@ -35,6 +35,7 @@ internal sealed class ChangeCookieAction : UrlAction
     public override void ApplyAction(RewriteContext context, BackReferenceCollection? ruleBackReferences, BackReferenceCollection? conditionBackReferences)
     {
         var options = GetOrCreateOptions();
+        // codeql[SM02373] - By design this emits the cookie exactly as the mod_rewrite rule author specified, including their chosen Secure flag.
         context.HttpContext.Response.Cookies.Append(Name, Value ?? string.Empty, options);
     }
 

--- a/src/Middleware/Session/src/SessionMiddleware.cs
+++ b/src/Middleware/Session/src/SessionMiddleware.cs
@@ -141,6 +141,7 @@ public class SessionMiddleware
             var cookieOptions = _options.Cookie.Build(_context);
 
             var response = _context.Response;
+            // codeql[SM02373] - By design the session cookie's SecurePolicy defaults to None so sessions work over HTTP; apps set CookiePolicy or SecurePolicy.Always to require Secure.
             response.Cookies.Append(_options.Cookie.Name!, _cookieValue, cookieOptions);
 
             var responseHeaders = response.Headers;

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -841,6 +841,7 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
 
                 // no need to validate signature when token is received using "code flow" as per spec
                 // [http://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation].
+                // codeql[SM04387] - By design: in code flow the ID token is fetched from the token endpoint over the TLS back-channel, so OIDC Core 1.0 does not require signature validation.
                 validationParameters.RequireSignedTokens = false;
 
                 // At least a cursory validation is required on the new IdToken, even if we've already validated the one from the authorization response.

--- a/src/Security/Authentication/Twitter/src/TwitterHandler.cs
+++ b/src/Security/Authentication/Twitter/src/TwitterHandler.cs
@@ -174,6 +174,7 @@ public partial class TwitterHandler : RemoteAuthenticationHandler<TwitterOptions
 
         var cookieOptions = Options.StateCookie.Build(Context, TimeProvider.GetUtcNow());
 
+        // codeql[SM02373] - By design the short-lived Twitter OAuth state cookie uses SameAsRequest, so it is Secure whenever the request is HTTPS.
         Response.Cookies.Append(Options.StateCookie.Name!, Options.StateDataFormat.Protect(requestToken), cookieOptions);
 
         var redirectContext = new RedirectContext<TwitterOptions>(Context, Scheme, Options, properties, twitterAuthenticationEndpoint);

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/Startup.cs
@@ -58,8 +58,10 @@ public class Startup
                 .AddJwtBearer(options =>
                 {
                     options.TokenValidationParameters =
+                        // codeql[SM04554] - By design: this functional-test host validates self-issued test tokens, so no external issuer is configured. codeql[SM04555] - By design: issuer validation is intentionally disabled in the test host.
                         new TokenValidationParameters
                         {
+                            // codeql[SM04387] - By design: functional-test host signs tokens with a test key, so disabling audience/issuer validation is safe.
                             ValidateAudience = false,
                             ValidateIssuer = false,
                             ValidateActor = false,

--- a/src/SignalR/clients/ts/FunctionalTests/Startup.cs
+++ b/src/SignalR/clients/ts/FunctionalTests/Startup.cs
@@ -57,8 +57,10 @@ public class Startup
             .AddJwtBearer(options =>
             {
                 options.TokenValidationParameters =
+                // codeql[SM04554] - By design: this functional-test host validates self-issued test tokens, so no external issuer is configured. codeql[SM04555] - By design: issuer validation is intentionally disabled in the test host.
                 new TokenValidationParameters
                 {
+                    // codeql[SM04387] - By design: functional-test host signs tokens with a test key, so disabling audience/issuer validation is safe.
                     ValidateAudience = false,
                     ValidateIssuer = false,
                     ValidateActor = false,

--- a/src/SignalR/samples/JwtSample/Startup.cs
+++ b/src/SignalR/samples/JwtSample/Startup.cs
@@ -30,9 +30,11 @@ public class Startup
             .AddJwtBearer(options =>
             {
                 options.TokenValidationParameters =
+                // codeql[SM04554] - By design: this SignalR sample validates tokens signed with its own demo key, so no external issuer is configured. codeql[SM04555] - By design: issuer validation is intentionally disabled in the sample.
                 new TokenValidationParameters
                 {
                     LifetimeValidator = (before, expires, token, parameters) => expires > DateTime.UtcNow,
+                    // codeql[SM04387] - By design: the sample signs tokens with a hardcoded demo key, so disabling audience/issuer validation is safe. codeql[SM04284] - By design: the sample intentionally disables audience/issuer validation for its demo-key tokens.
                     ValidateAudience = false,
                     ValidateIssuer = false,
                     ValidateActor = false,

--- a/src/Tools/dotnet-user-jwts/src/Helpers/JwtIssuer.cs
+++ b/src/Tools/dotnet-user-jwts/src/Helpers/JwtIssuer.cs
@@ -72,9 +72,11 @@ internal sealed class JwtIssuer
     public bool IsValid(string encodedToken)
     {
         var handler = new JwtSecurityTokenHandler();
+        // codeql[SM04554] - By design: this local dev tool validates only its own self-minted tokens, so no external issuer is configured. codeql[SM04555] - By design: issuer validation is intentionally disabled for the dev tool.
         var tokenValidationParameters = new TokenValidationParameters
         {
             IssuerSigningKey = _signingKey,
+            // codeql[SM04387] - By design: dotnet-user-jwts mints and validates its own tokens with a key it owns, so this override is safe. codeql[SM04284] - By design: the dev tool intentionally disables audience/issuer validation for its self-issued tokens.
             ValidateAudience = false,
             ValidateIssuer = false,
             ValidateIssuerSigningKey = true


### PR DESCRIPTION
Suppresses a set of **by-design / accepted-risk** CodeQL security alerts across ASP.NET Core authentication, cookies, dev tooling, and data protection by adding inline `codeql[<ruleId>]` justifications (same mechanism as #67710, which handled the false positives). All 19 alerts here are intentional, reviewed behavior — not defects.

### Categories (all "by design")

**Cookie `SecurePolicy` (SM02373)**
- `SessionMiddleware` — the session cookie's `SecurePolicy` defaults to `None` so sessions work over HTTP; apps opt into Secure via `CookiePolicy`/`SecurePolicy.Always`.
- `TwitterHandler` — the short-lived OAuth state cookie uses `SameAsRequest`, so it is Secure over HTTPS.
- Rewrite `ChangeCookieAction` — emits the cookie exactly as the mod_rewrite rule author specified, including their chosen Secure flag.

**OIDC code-flow signature validation (SM04387)**
- `OpenIdConnectHandler` — in code flow the ID token is fetched from the token endpoint over the TLS back-channel, so OIDC Core 1.0 does not require signature validation.

**Dev-tool / sample / test JWT validation (SM04554 / SM04555 / SM04284 / SM04387)**
- `dotnet-user-jwts` (`JwtIssuer`), the SignalR `JwtSample`, and the SignalR C#/TS functional-test hosts each mint and validate their own tokens with a key they own, so audience/issuer validation is intentionally disabled in that closed loop (`ValidateIssuerSigningKey` stays `true`).

**Managed AES-GCM encryptor (SM04193)**
- `AesGcmAuthenticatedEncryptor` — reviewed and signed off by the Crypto Board. AES-GCM is enabled by default only in dev/non-prod; production apps must explicitly opt in, so there is no default production exposure.

### Notes
- One accepted-risk alert (Rewrite `Internal/UrlActions/ChangeCookieAction.cs`) has no suppression because that file no longer exists in `main`.
- The AES-GCM `Encrypt` path uses the same signed-off `AesGcm` construction; only the single flagged (`Decrypt`) site is annotated to match the one alert.
- Justification wording incorporates the doc-comment/accuracy feedback from #67710 (no suppressions are placed between an XML doc comment and a public member).
