### PR TITLE
Fix flaky WebApplicationFactory Kestrel port race

### DIFF
--- a/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
+++ b/src/Mvc/Mvc.Testing/src/WebApplicationFactory.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Text.Json;
@@ -216,32 +217,25 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
 
         var host = builder.Build();
 
-        TryConfigureServerPort(() => GetServerAddressFeature(host));
-
         host.Start();
         return host;
     }
 #pragma warning restore ASPDEPR008 // IWebHost is obsolete
-
-    private void TryConfigureServerPort(Func<IServerAddressesFeature?> serverAddressFeatureAccessor)
-    {
-        if (_kestrelPort.HasValue)
-        {
-            var saf = serverAddressFeatureAccessor();
-            if (saf is not null)
-            {
-                saf.Addresses.Clear();
-                saf.Addresses.Add($"http://127.0.0.1:{_kestrelPort}");
-                saf.PreferHostingUrls = true;
-            }
-        }
-    }
 
     private void ConfigureBuilderToUseKestrel(IWebHostBuilder builder)
     {
         if (_configureKestrelOptions is not null)
         {
             builder.UseKestrel(_configureKestrelOptions);
+        }
+        else if (_kestrelPort is int port)
+        {
+            // Configure the endpoint here (during the app's own startup) instead of mutating
+            // IServerAddressesFeature after the host is built. Apps that start themselves
+            // (e.g. minimal apps run via DeferredHostBuilder) bind Kestrel on their own thread
+            // and can make the addresses collection read-only before the factory could update it,
+            // causing an intermittent InvalidOperationException.
+            builder.UseKestrel(options => options.Listen(IPAddress.Loopback, port));
         }
         else
         {
@@ -655,7 +649,6 @@ public partial class WebApplicationFactory<TEntryPoint> : IDisposable, IAsyncDis
     protected virtual IHost CreateHost(IHostBuilder builder)
     {
         var host = builder.Build();
-        TryConfigureServerPort(() => GetServerAddressFeature(host));
         host.Start();
         return host;
     }

--- a/src/Mvc/test/Mvc.FunctionalTests/RealServerUsingMinimalBackedIntegrationTests.cs
+++ b/src/Mvc/test/Mvc.FunctionalTests/RealServerUsingMinimalBackedIntegrationTests.cs
@@ -5,7 +5,6 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Hosting.Server;
-using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Mvc.FunctionalTests;
@@ -51,7 +50,6 @@ public class RealServerUsingMinimalBackedIntegrationTests : IClassFixture<Kestre
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/67340")]
     public void CanResolveServices()
     {
         // Act


### PR DESCRIPTION
Fix a flaky WebApplicationFactory Kestrel port race

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making.

## Description

`RealServerUsingMinimalBackedIntegrationTests` intermittently fails with:

```
System.InvalidOperationException : IServerAddressesFeature.Addresses cannot be modified after the server has started.
```

### Root cause

When `WebApplicationFactory` is configured with `UseKestrel(port)`, it called `TryConfigureServerPort`, which cleared and re-added entries in `IServerAddressesFeature.Addresses` *after* `builder.Build()`. For minimal / `WebApplication` apps the app owns its own lifecycle: `DeferredHostBuilder.Build()` runs the entry point via `HostFactoryResolver`, and the app starts Kestrel on its own thread. Kestrel's `BindAsync` calls `PreventPublicMutation()`, making the addresses collection read-only. That bind races with the factory's `Addresses.Clear()` on the test thread; when Kestrel wins the race, `Clear()` throws.

### Fix

Instead of mutating the addresses after the host is built, configure the Kestrel endpoint directly via `KestrelServerOptions.Listen(IPAddress.Loopback, port)` in `ConfigureBuilderToUseKestrel`. This runs during the app's own startup, before binding, so there is no post-start mutation and no race. With `PreferHostingUrls == false` (the default), `AddressBinder` uses `OverrideWithEndpointsStrategy`, so the configured endpoint overrides any addresses the app set via `app.Urls`, and the resolved (possibly dynamic) port is written back into the addresses feature so `TryExtractHostAddress` still reads the real bound port. `TryConfigureServerPort` is removed.

This also un-quarantines `RealServerUsingMinimalBackedIntegrationTests.CanResolveServices`, which was quarantined for the same exception.

### Verification

- `Microsoft.AspNetCore.Mvc.Testing` builds clean.
- Confirmed at runtime that a `Listen(Loopback, 0)` endpoint overrides a non-empty `app.Urls` and reports the real dynamically assigned port (the semantics the factory relies on). The full `Mvc.FunctionalTests` project requires the native IIS/ANCM build, so the real-server tests will be validated in CI.

Fixes #67340