### PR TITLE
HttpSys: fail startup when Strict hardening cannot be applied

### DIFF
--- a/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
+++ b/src/Servers/HttpSys/src/NativeInterop/UrlGroup.cs
@@ -66,7 +66,11 @@ internal sealed partial class UrlGroup : IDisposable
                 : HTTP_CHANNEL_BIND_SECURE_CHANNEL_TOKEN,
         };
 
-        SetProperty(HTTP_SERVER_PROPERTY.HttpServerChannelBindProperty, new IntPtr(&info), (uint)ChannelBindInfoSize, throwOnError: false);
+        SetProperty(
+            HTTP_SERVER_PROPERTY.HttpServerChannelBindProperty,
+            new IntPtr(&info),
+            (uint)ChannelBindInfoSize,
+            throwOnError: level == HttpAuthenticationHardeningLevel.Strict);
     }
 
     internal ulong Id { get; private set; }


### PR DESCRIPTION
Follow-up to #67436 addressing https://github.com/dotnet/aspnetcore/pull/67436#discussion_r3555698908.

When `HttpAuthenticationHardeningLevel.Strict` is configured, the caller is asking for a hard security guarantee (reject authenticated requests that lack a valid channel binding token). Silently degrading to the OS default hardening on a `SetProperty` failure is misleading, so throw and fail startup instead.

`Legacy`/`Medium` continue to log-and-continue via `Log.SetUrlPropertyError`, matching the previous behavior.

## Change

`UrlGroup.SetChannelBindingProperty` now calls `SetProperty(..., throwOnError: level == HttpAuthenticationHardeningLevel.Strict)`.

## Notes

- The OS floor for `HttpServerChannelBindProperty` is Windows 7 / Server 2008 R2, so failure on a supported OS realistically only happens under kernel policy/ACL restrictions or test shims.
- No behavior change for the default `Medium` level.