### PR TITLE
Allow `null` on `UserOptions.AllowedUserNameCharacters`

### DIFF
--- a/src/Identity/Extensions.Core/src/PublicAPI.Unshipped.txt
+++ b/src/Identity/Extensions.Core/src/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
+*REMOVED*Microsoft.AspNetCore.Identity.UserOptions.AllowedUserNameCharacters.get -> string!
+Microsoft.AspNetCore.Identity.UserOptions.AllowedUserNameCharacters.get -> string?
 Microsoft.AspNetCore.Identity.UserPasskeyInfo.Aaguid.get -> byte[]?
 Microsoft.AspNetCore.Identity.UserPasskeyInfo.Aaguid.set -> void

--- a/src/Identity/Extensions.Core/src/UserOptions.cs
+++ b/src/Identity/Extensions.Core/src/UserOptions.cs
@@ -12,7 +12,7 @@ public class UserOptions
     /// Gets or sets the list of allowed characters in the username used to validate user names. Defaults to abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+
     /// </summary>
     /// <remarks>
-    /// When set to <c>null</c> there is no restrictions on the characters that can be used in user names.
+    /// When set to <c>null</c> or empty, there are no restrictions on the characters that can be used in user names.
     /// </remarks>
     /// <value>
     /// The list of allowed characters in the username used to validate user names.

--- a/src/Identity/Extensions.Core/src/UserOptions.cs
+++ b/src/Identity/Extensions.Core/src/UserOptions.cs
@@ -11,10 +11,13 @@ public class UserOptions
     /// <summary>
     /// Gets or sets the list of allowed characters in the username used to validate user names. Defaults to abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+
     /// </summary>
+    /// <remarks>
+    /// When set to <c>null</c> there is no restrictions on the characters that can be used in user names.
+    /// </remarks>
     /// <value>
     /// The list of allowed characters in the username used to validate user names.
     /// </value>
-    public string AllowedUserNameCharacters { get; set; } = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+";
+    public string? AllowedUserNameCharacters { get; set; } = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+";
 
     /// <summary>
     /// Gets or sets a flag indicating whether the application requires unique emails for its users. Defaults to false.


### PR DESCRIPTION
# Allow `null` on `UserOptions.AllowedUserNameCharacters`

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Allow `null` on `UserOptions.AllowedUserNameCharacters` to denote that all characters are allowed in a user name.

## Description

There are already tests validating that when null is set to this option that non-alphanumeric characters are allowed in user names. This just makes it clear from the type system that `null` is allowed here and has a meaning.

https://github.com/dotnet/aspnetcore/blob/b50ab865ec4dcd3d6ac30221288cc36bf189d300/src/Identity/test/Identity.Test/UserValidatorTest.cs#L77

Fixes #64078
