### PR TITLE
Fix API for QuickGrid

### DIFF
--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
@@ -7,7 +7,7 @@ Microsoft.AspNetCore.Components.QuickGrid.QueryParameterNameOptions.Page.set -> 
 Microsoft.AspNetCore.Components.QuickGrid.QueryParameterNameOptions.QueryParameterNameOptions(string! prefix = "") -> void
 Microsoft.AspNetCore.Components.QuickGrid.QueryParameterNameOptions.Sort.get -> string!
 Microsoft.AspNetCore.Components.QuickGrid.QueryParameterNameOptions.Sort.set -> void
-Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.QueryParameterNameOptions.get -> Microsoft.AspNetCore.Components.QuickGrid.QueryParameterNameOptions?
+Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.QueryParameterNameOptions.get -> Microsoft.AspNetCore.Components.QuickGrid.QueryParameterNameOptions!
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.QueryParameterNameOptions.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.OnRowClick.get -> Microsoft.AspNetCore.Components.EventCallback<TGridItem>
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.OnRowClick.set -> void

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/PublicAPI.Unshipped.txt
@@ -1,6 +1,14 @@
 #nullable enable
-Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.QueryParameterNamePrefix.get -> string!
-Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.QueryParameterNamePrefix.set -> void
+Microsoft.AspNetCore.Components.QuickGrid.QueryParameterNameOptions
+Microsoft.AspNetCore.Components.QuickGrid.QueryParameterNameOptions.Direction.get -> string!
+Microsoft.AspNetCore.Components.QuickGrid.QueryParameterNameOptions.Direction.set -> void
+Microsoft.AspNetCore.Components.QuickGrid.QueryParameterNameOptions.Page.get -> string!
+Microsoft.AspNetCore.Components.QuickGrid.QueryParameterNameOptions.Page.set -> void
+Microsoft.AspNetCore.Components.QuickGrid.QueryParameterNameOptions.QueryParameterNameOptions(string! prefix = "") -> void
+Microsoft.AspNetCore.Components.QuickGrid.QueryParameterNameOptions.Sort.get -> string!
+Microsoft.AspNetCore.Components.QuickGrid.QueryParameterNameOptions.Sort.set -> void
+Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.QueryParameterNameOptions.get -> Microsoft.AspNetCore.Components.QuickGrid.QueryParameterNameOptions?
+Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.QueryParameterNameOptions.set -> void
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.OnRowClick.get -> Microsoft.AspNetCore.Components.EventCallback<TGridItem>
 Microsoft.AspNetCore.Components.QuickGrid.QuickGrid<TGridItem>.OnRowClick.set -> void
 override Microsoft.AspNetCore.Components.QuickGrid.Paginator.OnInitialized() -> void

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QueryParameterNameOptions.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QueryParameterNameOptions.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.QuickGrid;
+
+/// <summary>
+/// Specifies the query parameter names that a <see cref="QuickGrid{TGridItem}"/> uses to persist its
+/// sort column, sort direction, and page index in the URL.
+/// </summary>
+public sealed class QueryParameterNameOptions(string prefix = "")
+{
+    /// <summary>
+    /// Gets or sets the query parameter name used to persist the sort column. Defaults to <c>"{prefix}sort"</c>.
+    /// </summary>
+    public string Sort { get; set; } = $"{prefix}sort";
+
+    /// <summary>
+    /// Gets or sets the query parameter name used to persist the sort direction. Defaults to <c>"{prefix}direction"</c>.
+    /// </summary>
+    public string Direction { get; set; } = $"{prefix}direction";
+
+    /// <summary>
+    /// Gets or sets the query parameter name used to persist the page index. Defaults to <c>"{prefix}page"</c>.
+    /// </summary>
+    public string Page { get; set; } = $"{prefix}page";
+}

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
@@ -117,10 +117,12 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
     [Parameter] public EventCallback<TGridItem> OnRowClick { get; set; }
 
     /// <summary>
-    /// The parameter from which the page and sorting URL parameters are derived. The default value is an empty string, which results in query parameters named "page", "sort", and "order". If you provide a non-empty value, for example "products",
-    /// then the query parameters will be "products_page", "products_sort", and "products_order". This allows you to use multiple <see cref="QuickGrid{TGridItem}"/> components on the same page without their URL parameters conflicting with each other.
+    /// Optionally specifies the query parameter names used to persist the page, sort column, and sort direction in the URL.
+    /// When <see langword="null"/>, the query parameters are named "page", "sort", and "direction". Provide an instance with a
+    /// unique prefix, for example <c>new("products_")</c>, to use multiple <see cref="QuickGrid{TGridItem}"/> components on the
+    /// same page without their URL parameters conflicting with each other.
     /// </summary>
-    [Parameter] public string QueryParameterNamePrefix { get; set; } = "";
+    [Parameter] public QueryParameterNameOptions? QueryParameterNameOptions { get; set; }
 
     [Inject] private IServiceProvider Services { get; set; } = default!;
     [Inject] private IJSRuntime JS { get; set; } = default!;
@@ -175,9 +177,9 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
 
     private (string ColumnTitle, bool Ascending)? _cachedSortFromQuery;
 
-    private string SortQueryParameterNameBy => QueryParameterNamePrefix == "" ? "sort" : $"{QueryParameterNamePrefix}_sort";
-    private string SortQueryParameterNameOrder => QueryParameterNamePrefix == "" ? "order" : $"{QueryParameterNamePrefix}_order";
-    private string PageQueryParameterName => QueryParameterNamePrefix == "" ? "page" : $"{QueryParameterNamePrefix}_page";
+    private string SortQueryParameterNameBy => QueryParameterNameOptions?.Sort ?? "sort";
+    private string SortQueryParameterNameOrder => QueryParameterNameOptions?.Direction ?? "direction";
+    private string PageQueryParameterName => QueryParameterNameOptions?.Page ?? "page";
     private readonly QueryParameterValueSupplier _queryParameterValueSupplier;
 
     /// <summary>

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
@@ -117,12 +117,10 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
     [Parameter] public EventCallback<TGridItem> OnRowClick { get; set; }
 
     /// <summary>
-    /// Optionally specifies the query parameter names used to persist the page, sort column, and sort direction in the URL.
-    /// When <see langword="null"/>, the query parameters are named "page", "sort", and "direction". Provide an instance with a
-    /// unique prefix, for example <c>new("products_")</c>, to use multiple <see cref="QuickGrid{TGridItem}"/> components on the
-    /// same page without their URL parameters conflicting with each other.
+    /// Optionally specifies the <see cref="QueryParameterNameOptions"/> used to persist the page, sort column,
+    /// and sort direction in the URL. When <see langword="null"/>, the query parameters are named "page", "sort", and "direction".
     /// </summary>
-    [Parameter] public QueryParameterNameOptions? QueryParameterNameOptions { get; set; }
+    [Parameter] public QueryParameterNameOptions? QueryParameterNameOptions { get; set; } = new();
 
     [Inject] private IServiceProvider Services { get; set; } = default!;
     [Inject] private IJSRuntime JS { get; set; } = default!;
@@ -344,10 +342,10 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
     private (string ColumnTitle, bool Ascending)? ReadSortFromQueryString()
     {
         var column = _queryParameterValueSupplier.GetQueryParameterValue(typeof(string), SortQueryParameterNameBy) as string;
-        var order = _queryParameterValueSupplier.GetQueryParameterValue(typeof(string), SortQueryParameterNameDirection) as string;
-        if (column is not null && order is not null)
+        var direction = _queryParameterValueSupplier.GetQueryParameterValue(typeof(string), SortQueryParameterNameDirection) as string;
+        if (column is not null && direction is not null)
         {
-            return order switch
+            return direction switch
             {
                 var d when d.Equals("asc", StringComparison.OrdinalIgnoreCase) => (column, true),
                 var d when d.Equals("desc", StringComparison.OrdinalIgnoreCase) => (column, false),

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
@@ -117,10 +117,10 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
     [Parameter] public EventCallback<TGridItem> OnRowClick { get; set; }
 
     /// <summary>
-    /// Optionally specifies the <see cref="QueryParameterNameOptions"/> used to persist the page, sort column,
-    /// and sort direction in the URL. When <see langword="null"/>, the query parameters are named "page", "sort", and "direction".
+    /// Specifies the <see cref="QueryParameterNameOptions"/> used to persist the page, sort column, and sort direction
+    /// in the URL. Defaults to an instance whose query parameters are named "page", "sort", and "direction".
     /// </summary>
-    [Parameter] public QueryParameterNameOptions? QueryParameterNameOptions { get; set; } = new();
+    [Parameter] public QueryParameterNameOptions QueryParameterNameOptions { get; set; } = new();
 
     [Inject] private IServiceProvider Services { get; set; } = default!;
     [Inject] private IJSRuntime JS { get; set; } = default!;
@@ -175,9 +175,9 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
 
     private (string ColumnTitle, bool Ascending)? _cachedSortFromQuery;
 
-    private string SortQueryParameterNameBy => QueryParameterNameOptions?.Sort ?? "sort";
-    private string SortQueryParameterNameDirection => QueryParameterNameOptions?.Direction ?? "direction";
-    private string PageQueryParameterName => QueryParameterNameOptions?.Page ?? "page";
+    private string SortQueryParameterNameBy => QueryParameterNameOptions.Sort;
+    private string SortQueryParameterNameDirection => QueryParameterNameOptions.Direction;
+    private string PageQueryParameterName => QueryParameterNameOptions.Page;
     private readonly QueryParameterValueSupplier _queryParameterValueSupplier;
 
     /// <summary>

--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
@@ -178,7 +178,7 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
     private (string ColumnTitle, bool Ascending)? _cachedSortFromQuery;
 
     private string SortQueryParameterNameBy => QueryParameterNameOptions?.Sort ?? "sort";
-    private string SortQueryParameterNameOrder => QueryParameterNameOptions?.Direction ?? "direction";
+    private string SortQueryParameterNameDirection => QueryParameterNameOptions?.Direction ?? "direction";
     private string PageQueryParameterName => QueryParameterNameOptions?.Page ?? "page";
     private readonly QueryParameterValueSupplier _queryParameterValueSupplier;
 
@@ -337,14 +337,14 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
         return NavigationManager.GetUriWithQueryParameters(new Dictionary<string, object?>
         {
             [SortQueryParameterNameBy] = column?.Title,
-            [SortQueryParameterNameOrder] = ascending ? "asc" : "desc",
+            [SortQueryParameterNameDirection] = ascending ? "asc" : "desc",
         });
     }
 
     private (string ColumnTitle, bool Ascending)? ReadSortFromQueryString()
     {
         var column = _queryParameterValueSupplier.GetQueryParameterValue(typeof(string), SortQueryParameterNameBy) as string;
-        var order = _queryParameterValueSupplier.GetQueryParameterValue(typeof(string), SortQueryParameterNameOrder) as string;
+        var order = _queryParameterValueSupplier.GetQueryParameterValue(typeof(string), SortQueryParameterNameDirection) as string;
         if (column is not null && order is not null)
         {
             return order switch

--- a/src/Components/test/E2ETest/Tests/QuickGridInteractiveCompatTest.cs
+++ b/src/Components/test/E2ETest/Tests/QuickGridInteractiveCompatTest.cs
@@ -47,7 +47,7 @@ public class QuickGridInteractiveCompatTest : ServerTestBase<BasicTestAppServerS
 
         // URL updates in both modes; only the rendered element differs
         Assert.Contains("sort=PersonId", Browser.Url);
-        Assert.Contains("order=asc", Browser.Url);
+        Assert.Contains("direction=asc", Browser.Url);
 
         // Click again to sort descending
         Browser.Click(By.CssSelector("#grid > table thead > tr > th:nth-child(1) > div > button.col-title"));
@@ -58,7 +58,7 @@ public class QuickGridInteractiveCompatTest : ServerTestBase<BasicTestAppServerS
         Browser.Equal("1981-06-04", () => Browser.FindElement(By.CssSelector("#grid > table tbody > tr:nth-child(1) > td:nth-child(4)")).Text);
 
         Assert.Contains("sort=PersonId", Browser.Url);
-        Assert.Contains("order=desc", Browser.Url);
+        Assert.Contains("direction=desc", Browser.Url);
     }
 
     [Fact]
@@ -71,7 +71,7 @@ public class QuickGridInteractiveCompatTest : ServerTestBase<BasicTestAppServerS
         Browser.Click(By.CssSelector("#grid > table thead > tr > th:nth-child(2) > div > button.col-title"));
         Browser.Equal("12372", () => Browser.FindElement(By.CssSelector("#grid > table tbody > tr:nth-child(1) > td:nth-child(1)")).Text);
         Assert.Contains("sort=FirstName", Browser.Url);
-        Assert.Contains("order=asc", Browser.Url);
+        Assert.Contains("direction=asc", Browser.Url);
 
         // Click again to sort descending
         Browser.Click(By.CssSelector("#grid > table thead > tr > th:nth-child(2) > div > button.col-title"));
@@ -81,7 +81,7 @@ public class QuickGridInteractiveCompatTest : ServerTestBase<BasicTestAppServerS
         Browser.Equal("Piestrzeniewicz", () => Browser.FindElement(By.CssSelector("#grid > table tbody > tr:nth-child(1) > td:nth-child(3)")).Text);
         Browser.Equal("1981-04-02", () => Browser.FindElement(By.CssSelector("#grid > table tbody > tr:nth-child(1) > td:nth-child(4)")).Text);
         Assert.Contains("sort=FirstName", Browser.Url);
-        Assert.Contains("order=desc", Browser.Url);
+        Assert.Contains("direction=desc", Browser.Url);
     }
 
     [Fact]
@@ -94,7 +94,7 @@ public class QuickGridInteractiveCompatTest : ServerTestBase<BasicTestAppServerS
         Browser.Click(By.CssSelector("#grid > table thead > tr > th:nth-child(4) > div > button.col-title"));
         Browser.Equal("11205", () => Browser.FindElement(By.CssSelector("#grid > table tbody > tr:nth-child(1) > td:nth-child(1)")).Text);
         Assert.Contains("sort=BirthDate", Browser.Url);
-        Assert.Contains("order=asc", Browser.Url);
+        Assert.Contains("direction=asc", Browser.Url);
 
         // Click again to sort descending
         Browser.Click(By.CssSelector("#grid > table thead > tr > th:nth-child(4) > div > button.col-title"));
@@ -104,7 +104,7 @@ public class QuickGridInteractiveCompatTest : ServerTestBase<BasicTestAppServerS
         Browser.Equal("Accorti", () => Browser.FindElement(By.CssSelector("#grid > table tbody > tr:nth-child(1) > td:nth-child(3)")).Text);
         Browser.Equal("2018-05-18", () => Browser.FindElement(By.CssSelector("#grid > table tbody > tr:nth-child(1) > td:nth-child(4)")).Text);
         Assert.Contains("sort=BirthDate", Browser.Url);
-        Assert.Contains("order=desc", Browser.Url);
+        Assert.Contains("direction=desc", Browser.Url);
     }
 
     [Fact]
@@ -146,6 +146,6 @@ public class QuickGridInteractiveCompatTest : ServerTestBase<BasicTestAppServerS
 
         // URL updates in both modes
         Assert.Contains("sort=PersonId", Browser.Url);
-        Assert.Contains("order=asc", Browser.Url);
+        Assert.Contains("direction=asc", Browser.Url);
     }
 }

--- a/src/Components/test/E2ETest/Tests/QuickGridInteractiveTest.cs
+++ b/src/Components/test/E2ETest/Tests/QuickGridInteractiveTest.cs
@@ -34,7 +34,7 @@ public class QuickGridInteractiveTest : ServerTestBase<BasicTestAppServerSiteFix
         Browser.Click(By.CssSelector("#grid > table thead > tr > th:nth-child(1) > div > a"));
         Browser.Equal("10895", () => Browser.FindElement(By.CssSelector("#grid > table tbody > tr:nth-child(1) > td:nth-child(1)")).Text);
         Assert.Contains("sort=PersonId", Browser.Url);
-        Assert.Contains("order=asc", Browser.Url);
+        Assert.Contains("direction=asc", Browser.Url);
 
         // Click again to sort descending
         Browser.Click(By.CssSelector("#grid > table thead > tr > th:nth-child(1) > div > a"));
@@ -45,7 +45,7 @@ public class QuickGridInteractiveTest : ServerTestBase<BasicTestAppServerSiteFix
         Browser.Equal("Karttunen", () => Browser.FindElement(By.CssSelector("#grid > table tbody > tr:nth-child(1) > td:nth-child(3)")).Text);
         Browser.Equal("1981-06-04", () => Browser.FindElement(By.CssSelector("#grid > table tbody > tr:nth-child(1) > td:nth-child(4)")).Text);
         Assert.Contains("sort=PersonId", Browser.Url);
-        Assert.Contains("order=desc", Browser.Url);
+        Assert.Contains("direction=desc", Browser.Url);
     }
 
     [Fact]
@@ -58,7 +58,7 @@ public class QuickGridInteractiveTest : ServerTestBase<BasicTestAppServerSiteFix
         Browser.Click(By.CssSelector("#grid > table thead > tr > th:nth-child(2) > div > a.col-title"));
         Browser.Equal("12372", () => Browser.FindElement(By.CssSelector("#grid > table tbody > tr:nth-child(1) > td:nth-child(1)")).Text);
         Assert.Contains("sort=FirstName", Browser.Url);
-        Assert.Contains("order=asc", Browser.Url);
+        Assert.Contains("direction=asc", Browser.Url);
 
         // Click again to sort descending
         Browser.Click(By.CssSelector("#grid > table thead > tr > th:nth-child(2) > div > a.col-title"));
@@ -69,7 +69,7 @@ public class QuickGridInteractiveTest : ServerTestBase<BasicTestAppServerSiteFix
         Browser.Equal("Piestrzeniewicz", () => Browser.FindElement(By.CssSelector("#grid > table tbody > tr:nth-child(1) > td:nth-child(3)")).Text);
         Browser.Equal("1981-04-02", () => Browser.FindElement(By.CssSelector("#grid > table tbody > tr:nth-child(1) > td:nth-child(4)")).Text);
         Assert.Contains("sort=FirstName", Browser.Url);
-        Assert.Contains("order=desc", Browser.Url);
+        Assert.Contains("direction=desc", Browser.Url);
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public class QuickGridInteractiveTest : ServerTestBase<BasicTestAppServerSiteFix
         Browser.Click(By.CssSelector("#grid > table thead > tr > th:nth-child(4) > div > a"));
         Browser.Equal("11205", () => Browser.FindElement(By.CssSelector("#grid > table tbody > tr:nth-child(1) > td:nth-child(1)")).Text);
         Assert.Contains("sort=BirthDate", Browser.Url);
-        Assert.Contains("order=asc", Browser.Url);
+        Assert.Contains("direction=asc", Browser.Url);
 
         // Click again to sort descending
         Browser.Click(By.CssSelector("#grid > table thead > tr > th:nth-child(4) > div > a"));
@@ -93,7 +93,7 @@ public class QuickGridInteractiveTest : ServerTestBase<BasicTestAppServerSiteFix
         Browser.Equal("Accorti", () => Browser.FindElement(By.CssSelector("#grid > table tbody > tr:nth-child(1) > td:nth-child(3)")).Text);
         Browser.Equal("2018-05-18", () => Browser.FindElement(By.CssSelector("#grid > table tbody > tr:nth-child(1) > td:nth-child(4)")).Text);
         Assert.Contains("sort=BirthDate", Browser.Url);
-        Assert.Contains("order=desc", Browser.Url);
+        Assert.Contains("direction=desc", Browser.Url);
     }
 
     [Fact]
@@ -140,7 +140,7 @@ public class QuickGridInteractiveTest : ServerTestBase<BasicTestAppServerSiteFix
         Browser.Click(By.CssSelector("#grid > table thead > tr > th:nth-child(1) > div > a"));
         Browser.Equal("10895", () => Browser.FindElement(By.CssSelector("#grid > table tbody > tr:nth-child(1) > td:nth-child(1)")).Text);
 
-        // Sort second grid by FirstName ascending (uses QueryParameterNamePrefix="people" prefix)
+        // Sort second grid by FirstName ascending (uses QueryParameterNameOptions with "people_" prefix)
         Browser.Click(By.CssSelector("#grid2 > table thead > tr > th:nth-child(2) > div > a.col-title"));
         Browser.Equal("12372", () => Browser.FindElement(By.CssSelector("#grid2 > table tbody > tr:nth-child(1) > td:nth-child(1)")).Text);
 
@@ -149,9 +149,9 @@ public class QuickGridInteractiveTest : ServerTestBase<BasicTestAppServerSiteFix
 
         // Verify URL contains both unprefixed and prefixed sort parameters
         Assert.Contains("sort=PersonId", Browser.Url);
-        Assert.Contains("order=asc", Browser.Url);
+        Assert.Contains("direction=asc", Browser.Url);
         Assert.Contains("people_sort=FirstName", Browser.Url);
-        Assert.Contains("people_order=asc", Browser.Url);
+        Assert.Contains("people_direction=asc", Browser.Url);
     }
 
     [Fact]

--- a/src/Components/test/E2ETest/Tests/QuickGridNoInteractivityTest.cs
+++ b/src/Components/test/E2ETest/Tests/QuickGridNoInteractivityTest.cs
@@ -144,12 +144,12 @@ public class QuickGridNoInteractivityTest : ServerTestBase<BasicTestAppServerSit
         Browser.FindElement(By.CssSelector("#grid table thead > tr > th:nth-child(1) a.col-title")).Click();
         Browser.Equal("10895", () => Browser.FindElement(By.CssSelector("#grid table tbody > tr:nth-child(1) > td:nth-child(1)")).Text);
         Assert.Contains("sort=PersonId", Browser.Url);
-        Assert.Contains("order=asc", Browser.Url);
+        Assert.Contains("direction=asc", Browser.Url);
         Browser.FindElement(By.CssSelector("#grid table thead > tr > th:nth-child(1) a.col-title")).Click();
 
         Browser.Equal("12381", () => Browser.FindElement(By.CssSelector("#grid table tbody > tr:nth-child(1) > td:nth-child(1)")).Text);
         Assert.Contains("sort=PersonId", Browser.Url);
-        Assert.Contains("order=desc", Browser.Url);
+        Assert.Contains("direction=desc", Browser.Url);
 
         var firstRow = Browser.FindElement(By.CssSelector("#grid table tbody > tr:nth-child(1)"));
         Assert.Equal("Matti", firstRow.FindElement(By.CssSelector("td:nth-child(2)")).Text);
@@ -160,7 +160,7 @@ public class QuickGridNoInteractivityTest : ServerTestBase<BasicTestAppServerSit
     [Fact]
     public void SortLinkLoadsCorrectOrder()
     {
-        Navigate($"{ServerPathBase}/quickgrid?sort=PersonId&order=desc");
+        Navigate($"{ServerPathBase}/quickgrid?sort=PersonId&direction=desc");
 
         Browser.Equal("12381", () => Browser.FindElement(By.CssSelector("#grid table tbody > tr:nth-child(1) > td:nth-child(1)")).Text);
         Assert.Equal("Matti", Browser.FindElement(By.CssSelector("#grid table tbody > tr:nth-child(1) > td:nth-child(2)")).Text);
@@ -174,7 +174,7 @@ public class QuickGridNoInteractivityTest : ServerTestBase<BasicTestAppServerSit
         Browser.Equal("2", () => Browser.FindElement(By.CssSelector(".first-paginator .paginator nav > div > strong:nth-child(1)")).Text);
         Browser.FindElement(By.CssSelector("#grid table thead > tr > th:nth-child(1) a.col-title")).Click();
         Browser.True(() => Browser.Url.Contains("sort=PersonId"));
-        Browser.True(() => Browser.Url.Contains("order=asc"));
+        Browser.True(() => Browser.Url.Contains("direction=asc"));
         var firstRow = Browser.FindElement(By.CssSelector("#grid table tbody > tr:nth-child(1)"));
         Assert.NotNull(firstRow);
     }
@@ -194,9 +194,9 @@ public class QuickGridNoInteractivityTest : ServerTestBase<BasicTestAppServerSit
         Assert.Equal("10895", Browser.FindElement(By.CssSelector("#grid table tbody > tr:nth-child(1) > td:nth-child(1)")).Text);
 
         Assert.Contains("sort=PersonId", Browser.Url);
-        Assert.Contains("order=asc", Browser.Url);
+        Assert.Contains("direction=asc", Browser.Url);
         Assert.Contains("QuickGrid2_sort=Name", Browser.Url);
-        Assert.Contains("QuickGrid2_order=asc", Browser.Url);
+        Assert.Contains("QuickGrid2_direction=asc", Browser.Url);
 
         // Sort second grid by Name descending
         Browser.FindElement(By.CssSelector("#grid2 table thead > tr > th:nth-child(2) a.col-title")).Click();
@@ -205,9 +205,9 @@ public class QuickGridNoInteractivityTest : ServerTestBase<BasicTestAppServerSit
         // First grid should remain unchanged
         Assert.Equal("10895", Browser.FindElement(By.CssSelector("#grid table tbody > tr:nth-child(1) > td:nth-child(1)")).Text);
         Assert.Contains("sort=PersonId", Browser.Url);
-        Assert.Contains("order=asc", Browser.Url);
+        Assert.Contains("direction=asc", Browser.Url);
         Assert.Contains("QuickGrid2_sort=Name", Browser.Url);
-        Assert.Contains("QuickGrid2_order=desc", Browser.Url);
+        Assert.Contains("QuickGrid2_direction=desc", Browser.Url);
     }
 
     [Fact]

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/QuickGrid/QuickGridComponent.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/QuickGrid/QuickGridComponent.razor
@@ -15,7 +15,7 @@
 </div>
 
 <div id="grid2">
-    <QuickGrid ItemsProvider="@cityProvider" Pagination="@pagination2" QueryParameterNamePrefix="QuickGrid2">
+    <QuickGrid ItemsProvider="@cityProvider" Pagination="@pagination2" QueryParameterNameOptions="@(new QueryParameterNameOptions("QuickGrid2_"))">
         <PropertyColumn Property="@(c => c.CityId)" />
         <PropertyColumn Property="@(c => c.Name)" Sortable="true" />
         <PropertyColumn Property="@(c => c.Country)" Sortable="true" />
@@ -31,7 +31,7 @@
     </div>
 </FormMappingScope>
 <div id="grid3">
-    <QuickGrid Items="@people" Pagination="@pagination3" QueryParameterNamePrefix="QuickGrid3">
+    <QuickGrid Items="@people" Pagination="@pagination3" QueryParameterNameOptions="@(new QueryParameterNameOptions("QuickGrid3_"))">
         <PropertyColumn Property="@(p => p.PersonId)" Sortable="true" />
         <PropertyColumn Property="@(p => p.FirstName)" Sortable="true" />
         <PropertyColumn Property="@(p => p.LastName)" Sortable="true" />

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/QuickGrid/QuickGridInteractive.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/QuickGrid/QuickGridInteractive.razor
@@ -28,7 +28,7 @@
     <Paginator State="@pagination2" />
 </div>
 <div id="grid2">
-    <QuickGrid Items="@people" Pagination="@pagination2" QueryParameterNamePrefix="people">
+    <QuickGrid Items="@people" Pagination="@pagination2" QueryParameterNameOptions="@(new QueryParameterNameOptions("people_"))">
         <PropertyColumn Property="@(p => p.PersonId)" Sortable="true" />
         <PropertyColumn Property="@(p => p.FirstName)" Sortable="true" />
         <PropertyColumn Property="@(p => p.LastName)" Sortable="true" />


### PR DESCRIPTION
# Fix API for QuickGrid

## Summary

Adjusts the unshipped QuickGrid URL-state API to match what was approved in API review for #66830: the `QueryParameterNamePrefix` string parameter is replaced with a new sealed `QueryParameterNameOptions` class that lets callers control each query parameter name independently.

## Changes

- **New `QueryParameterNameOptions` type** — a sealed class with a primary constructor `QueryParameterNameOptions(string prefix = "")` and three settable properties: `Sort`, `Direction`, and `Page`, defaulting to `"{prefix}sort"`, `"{prefix}direction"`, and `"{prefix}page"`.
- **`QuickGrid<TGridItem>` parameter changed** — `[Parameter] public string QueryParameterNamePrefix` is replaced by `[Parameter] public QueryParameterNameOptions? QueryParameterNameOptions`. When `null`, the query parameters default to `sort`, `direction`, and `page`.
- **Direction query parameter renamed** — the sort-direction parameter changed from `order` to `direction` (the default for `QueryParameterNameOptions.Direction`).
- **`PublicAPI.Unshipped.txt`** updated to remove the `QueryParameterNamePrefix` entries and add the new type and parameter.
- **Test assets and E2E tests** updated to the new API and parameter names.

## Details

Previously the component owned the naming scheme: an empty prefix produced `sort`/`order`/`page`, and a non-empty prefix such as `"products"` produced `products_sort`/`products_order`/`products_page` (the component inserted the `_` separator). The approved design moves that control to the caller — the prefix now includes its own separator (e.g. `new("products_")` produces `products_sort`, `products_direction`, `products_page`), and each name can also be set individually via the `Sort`/`Direction`/`Page` properties. This keeps the multi-grid scenario working (unique names per grid to avoid URL conflicts) while giving callers full control over each parameter name.

## Testing

Existing QuickGrid E2E suites were updated to the new API:
- `QuickGridNoInteractivityTest`, `QuickGridInteractiveTest`, and `QuickGridInteractiveCompatTest` — updated sort-direction URL assertions from `order=` to `direction=`.
- Test asset pages (`QuickGridComponent.razor`, `QuickGridInteractive.razor`) — updated to pass `QueryParameterNameOptions` with an explicit prefix (e.g. `new("QuickGrid2_")`, `new("people_")`) in place of `QueryParameterNamePrefix`.

## Breaking Changes

These affect the **unshipped** (preview) API introduced in #65451, not a released API:
- `QuickGrid<TGridItem>.QueryParameterNamePrefix` is removed; use `QueryParameterNameOptions` instead.
- The default sort-direction query parameter name changed from `order` to `direction`.

Fixes #66830
