### PR TITLE
Fix array type unwrapping in validation source generator

### DIFF
--- a/src/Validation/gen/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Validation/gen/Extensions/ITypeSymbolExtensions.cs
@@ -58,6 +58,12 @@ internal static class ITypeSymbolExtensions
             type = namedType.TypeArguments[0];
         }
 
+        if (type is IArrayTypeSymbol arrayType)
+        {
+            // Extract the T from an array type T[]
+            type = arrayType.ElementType;
+        }
+
         return type;
     }
 

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/ValidationsGenerator.IValidatableObject.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/ValidationsGenerator.IValidatableObject.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Http;
+
 namespace Microsoft.Extensions.Validation.GeneratorTests;
 
 public partial class ValidationsGeneratorTests : ValidationsGeneratorTestBase
@@ -188,6 +190,8 @@ WebApplication app = builder. Build();
 app.MapPost("/base", (BaseClass model) => Results.Ok(model));
 app.MapPost("/derived", (DerivedClass model) => Results.Ok(model));
 app.MapPost("/complex", (ComplexClass model) => Results.Ok(model));
+app.MapPost("/array", (BaseClass[] model) => Results.Ok(model)); 
+app.MapPost("/complex-array", (ComplexArrayClass model) => Results.Ok(model));
 
 app.Run();
 
@@ -211,6 +215,11 @@ public class DerivedClass : BaseClass
 public class ComplexClass
 {
     public NestedClass? NestedObject { get; set; }
+}
+
+public class ComplexArrayClass
+{
+    public NestedClass[]? NestedArray { get; set; }
 }
 
 public class NestedClass : IValidatableObject
@@ -299,6 +308,74 @@ public class NestedClass : IValidatableObject
                     error =>
                     {
                         Assert.Equal("NestedObject.Value", error.Key);
+                        Assert.Collection(error.Value,
+                            msg => Assert.Equal("Value cannot be null or empty.", msg));
+                    });
+            }
+        });
+
+        await VerifyEndpoint(compilation, "/array", async (endpoint, serviceProvider) =>
+        {
+            await ValidateArrayWithInvalidElement();
+            await ValidateArrayWithValidElement();
+            await ValidateEmptyArray();
+
+            async Task ValidateArrayWithInvalidElement()
+            {
+                var httpContext = CreateHttpContextWithPayload("""[ { "Value": "" } ]""", serviceProvider);
+
+                await endpoint.RequestDelegate(httpContext);
+
+                var problemDetails = await AssertBadRequest(httpContext);
+                Assert.Collection(problemDetails.Errors,
+                    error =>
+                    {
+                        Assert.Equal("model[0].Value", error.Key);
+                        Assert.Collection(error.Value,
+                            msg => Assert.Equal("Value cannot be null or empty.", msg));
+                    });
+            }
+
+            async Task ValidateArrayWithValidElement()
+            {
+                var httpContext = CreateHttpContextWithPayload("""[ { "Value": "valid" } ]""", serviceProvider);
+
+                await endpoint.RequestDelegate(httpContext);
+
+                Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
+            }
+
+            async Task ValidateEmptyArray()
+            {
+                var httpContext = CreateHttpContextWithPayload("[]", serviceProvider);
+
+                await endpoint.RequestDelegate(httpContext);
+
+                Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
+            }
+        });
+
+        await VerifyEndpoint(compilation, "/complex-array", async (endpoint, serviceProvider) =>
+        {
+            await ValidateComplexArrayWithInvalidElement();
+
+            async Task ValidateComplexArrayWithInvalidElement()
+            {
+                var httpContext = CreateHttpContextWithPayload("""
+                {
+                    "NestedArray": [
+                        { "Value": "" }
+                    ]
+                }
+                """, serviceProvider);
+
+                await endpoint.RequestDelegate(httpContext);
+
+                var problemDetails = await AssertBadRequest(httpContext);
+                Assert.Collection(problemDetails.Errors,
+                    error =>
+                    {
+                        Assert.Equal("NestedArray[0].Value", error.Key);
                         Assert.Collection(error.Value,
                             msg => Assert.Equal("Value cannot be null or empty.", msg));
                     });

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/ValidationsGenerator.IValidatableObject.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/ValidationsGenerator.IValidatableObject.cs
@@ -190,7 +190,7 @@ WebApplication app = builder. Build();
 app.MapPost("/base", (BaseClass model) => Results.Ok(model));
 app.MapPost("/derived", (DerivedClass model) => Results.Ok(model));
 app.MapPost("/complex", (ComplexClass model) => Results.Ok(model));
-app.MapPost("/array", (BaseClass[] model) => Results.Ok(model)); 
+app.MapPost("/array", (BaseClass[] model) => Results.Ok(model));
 app.MapPost("/complex-array", (ComplexArrayClass model) => Results.Ok(model));
 
 app.Run();

--- a/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateIValidatableObject_WithoutPropertyValidations#ValidatableInfoResolver.g.verified.cs
+++ b/src/Validation/test/Microsoft.Extensions.Validation.GeneratorTests/snapshots/ValidationsGeneratorTests.CanValidateIValidatableObject_WithoutPropertyValidations#ValidatableInfoResolver.g.verified.cs
@@ -115,6 +115,22 @@ namespace Microsoft.Extensions.Validation.Generated
                 );
                 return true;
             }
+            if (type == typeof(global::ComplexArrayClass))
+            {
+                validatableTypeInfo = new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatableTypeInfo(
+                    type: typeof(global::ComplexArrayClass),
+                    members: [
+                        new global::Microsoft.Extensions.Validation.Generated.GeneratedValidatablePropertyInfo(
+                            containingType: typeof(global::ComplexArrayClass),
+                            propertyType: typeof(global::NestedClass[]),
+                            name: "NestedArray",
+                            displayNameInfo: null
+                        ),
+                    ],
+                    displayNameInfo: null
+                );
+                return true;
+            }
 
             return false;
         }


### PR DESCRIPTION
# Fix array type unwrapping in validation source generator

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Fixes array type unwrapping for IValidatableObject in source generator.

## Description

The Validation source generator previously failed to recognize models implementing `IValidatableObject` or `IAsyncValidatableObject` when they were passed as arrays (either as endpoint parameters or nested properties). This occurred because the generator evaluated the `IArrayTypeSymbol` directly instead of unwrapping it to inspect its underlying element type.

This change updates the symbol processing logic to extract the element type from arrays, allowing the generator to discover and generate validation code for array elements. Added tests to cover direct array parameters, nested arrays, and empty array edge cases.

Fixes  #67412 