### PR TITLE
Fix agentic workflow detection job missing pat_pool dependency (stopgap; prefer gh-aw ≥ v0.82.6 recompile)

### DIFF
--- a/.github/workflows/browsertesting-deps-update.lock.yml
+++ b/.github/workflows/browsertesting-deps-update.lock.yml
@@ -1358,6 +1358,7 @@ jobs:
     needs:
       - activation
       - agent
+      - pat_pool
     if: always() && needs.agent.result != 'skipped'
     runs-on: ubuntu-latest
     environment: copilot-pat-pool

--- a/.github/workflows/community-pr-issue-check.lock.yml
+++ b/.github/workflows/community-pr-issue-check.lock.yml
@@ -1273,6 +1273,7 @@ jobs:
     needs:
       - activation
       - agent
+      - pat_pool
     if: always() && needs.agent.result != 'skipped'
     runs-on: ubuntu-latest
     environment: copilot-pat-pool

--- a/.github/workflows/cswin32-update.lock.yml
+++ b/.github/workflows/cswin32-update.lock.yml
@@ -1364,6 +1364,7 @@ jobs:
     needs:
       - activation
       - agent
+      - pat_pool
     if: always() && needs.agent.result != 'skipped'
     runs-on: ubuntu-latest
     environment: copilot-pat-pool

--- a/.github/workflows/issue-triage-agent.lock.yml
+++ b/.github/workflows/issue-triage-agent.lock.yml
@@ -1423,6 +1423,7 @@ jobs:
     needs:
       - activation
       - agent
+      - pat_pool
     if: always() && needs.agent.result != 'skipped'
     runs-on: ubuntu-latest
     environment: copilot-pat-pool

--- a/.github/workflows/test-quarantine.lock.yml
+++ b/.github/workflows/test-quarantine.lock.yml
@@ -2482,6 +2482,7 @@ jobs:
     needs:
       - activation
       - agent
+      - pat_pool
     if: always() && needs.agent.result != 'skipped'
     runs-on: ubuntu-latest
     environment: copilot-pat-pool

--- a/.github/workflows/triage-comment-reviewer.lock.yml
+++ b/.github/workflows/triage-comment-reviewer.lock.yml
@@ -1352,6 +1352,7 @@ jobs:
     needs:
       - activation
       - agent
+      - pat_pool
     if: always() && needs.agent.result != 'skipped'
     runs-on: ubuntu-latest
     environment: copilot-pat-pool


### PR DESCRIPTION
> [!WARNING]
> **Stopgap on generated files — probably should NOT be merged as-is.** These `*.lock.yml` files are compiler-generated by `gh aw compile` (see the `# DO NOT EDIT` headers). The durable fix is to **regenerate them with gh-aw ≥ v0.82.6**, which already contains the compiler fix (see below). This hand-edit just mirrors what that recompile produces, and any future recompile with an older CLI would revert it. Opened as **draft** for visibility/discussion.

## Symptom

Every agentic workflow's compiler-generated **threat-detection** (`detection`) job fails at runtime with:

```
CAPIError: 503 Credentials for GitHub Copilot (port 10002) are not configured.
Set COPILOT_GITHUB_TOKEN or COPILOT_PROVIDER_API_KEY
```

The top-level run still reports **green**, so it fails silently. Because detection produces no `THREAT_DETECTION_RESULT`, its conclusion becomes `warning`, and the WTD3 warn policy aborts all non-reviewable safe outputs (`add_labels`, `set_issue_type`, `call_workflow`).

## Root cause

The `detection` job selects its Copilot token via:

```yaml
COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0, ...) }}
```

but its generated `needs:` list is `[activation, agent]` — **`pat_pool` is missing**. So `needs.pat_pool.outputs.pat_number` resolves to an empty string, every `case()` branch is false, and the token becomes the literal fallback `'NO COPILOT PAT AVAILABLE'`, which the api-proxy sidecar rejects → 503. The sibling `agent` job works because it correctly declares `needs: [activation, pat_pool]`.

## This was a gh-aw compiler bug — already fixed upstream

- The bug: the compiler generated the detection job's `needs:` without scanning its effective `engine.env` for `needs.<importedJob>.outputs.*` references.
- Fixed upstream in **github/gh-aw PR #44202** ("fix: detection job missing engine.env job dependencies in needs list", 2026-07-08) — see ADR-44202. `buildDetectionJob` now scans the detection engine env via `getReferencedCustomJobs(...)` and appends referenced custom jobs (e.g. `pat_pool`) to `needs`.
- First released in **gh-aw v0.82.6** (2026-07-08).
- These lock files were compiled with **gh-aw v0.81.6** (2026-06-27), which predates the fix.

## Recommended durable fix (instead of / superseding this PR)

Upgrade the local `gh aw` CLI to **≥ v0.82.6** (latest v0.82.8) and recompile:

```
gh extension upgrade gh-aw        # or install the v0.82.6+ tag
gh aw compile
```

then commit the regenerated `*.lock.yml`. That produces the same `- pat_pool` addition this PR makes by hand, but durably.

## Introduced by

#67411 "Adopt the PAT pool for agentic workflows" — broken continuously since (only surfaces when the `detection` job actually runs, i.e. when the agent emits safe outputs / a patch).

## Affected workflows (all 6)

`issue-triage-agent`, `browsertesting-deps-update`, `community-pr-issue-check`, `cswin32-update`, `test-quarantine`, `triage-comment-reviewer`.

## This change

Adds `- pat_pool` to each `detection` job's `needs:` list (6 files, one line each).