### PR TITLE
[Withdrawn] Pool MVC action-selection lookup key (CPU regression)

### DIFF
--- a/src/Mvc/Mvc.Core/src/Infrastructure/ActionSelectionTable.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/ActionSelectionTable.cs
@@ -3,6 +3,7 @@
 
 #nullable enable
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
@@ -36,6 +37,9 @@ namespace Microsoft.AspNetCore.Mvc.Infrastructure;
 // actions.
 internal sealed class ActionSelectionTable<TItem>
 {
+    private readonly Dictionary<string[], List<TItem>>.AlternateLookup<ReadOnlySpan<string>> _ordinalLookup;
+    private readonly Dictionary<string[], List<TItem>>.AlternateLookup<ReadOnlySpan<string>> _ordinalIgnoreCaseLookup;
+
     private ActionSelectionTable(
         int version,
         string[] routeKeys,
@@ -46,6 +50,8 @@ internal sealed class ActionSelectionTable<TItem>
         RouteKeys = routeKeys;
         OrdinalEntries = ordinalEntries;
         OrdinalIgnoreCaseEntries = ordinalIgnoreCaseEntries;
+        _ordinalLookup = ordinalEntries.GetAlternateLookup<ReadOnlySpan<string>>();
+        _ordinalIgnoreCaseLookup = ordinalIgnoreCaseEntries.GetAlternateLookup<ReadOnlySpan<string>>();
     }
 
     public int Version { get; }
@@ -162,24 +168,37 @@ internal sealed class ActionSelectionTable<TItem>
     public IReadOnlyList<TItem> Select(RouteValueDictionary values)
     {
         // Select works based on a string[] of the route values in a pre-calculated order. This code extracts
-        // those values in the correct order.
+        // those values in the correct order into a pooled buffer so we don't allocate a string[] per request.
         var routeKeys = RouteKeys;
-        var routeValues = new string[routeKeys.Length];
-        for (var i = 0; i < routeKeys.Length; i++)
+        var length = routeKeys.Length;
+        var routeValues = ArrayPool<string>.Shared.Rent(length);
+        try
         {
-            values.TryGetValue(routeKeys[i], out var value);
-            routeValues[i] = value as string ?? Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
-        }
+            for (var i = 0; i < length; i++)
+            {
+                values.TryGetValue(routeKeys[i], out var value);
+                routeValues[i] = value as string ?? Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+            }
 
-        // Now look up, first case-sensitive, then case-insensitive.
-        if (OrdinalEntries.TryGetValue(routeValues, out var matches) ||
-            OrdinalIgnoreCaseEntries.TryGetValue(routeValues, out matches))
+            // Slice to the exact length - the rented buffer may be longer than needed, and the lookup
+            // hashing/equality depends on the span length matching the stored keys' length.
+            var lookupKey = routeValues.AsSpan(0, length);
+
+            // Now look up, first case-sensitive, then case-insensitive.
+            if (_ordinalLookup.TryGetValue(lookupKey, out var matches) ||
+                _ordinalIgnoreCaseLookup.TryGetValue(lookupKey, out matches))
+            {
+                Debug.Assert(matches != null);
+                Debug.Assert(matches.Count >= 0);
+                return matches;
+            }
+
+            return Array.Empty<TItem>();
+        }
+        finally
         {
-            Debug.Assert(matches != null);
-            Debug.Assert(matches.Count >= 0);
-            return matches;
+            // Clear the buffer so we don't retain references to the route value strings.
+            ArrayPool<string>.Shared.Return(routeValues, clearArray: true);
         }
-
-        return Array.Empty<TItem>();
     }
 }

--- a/src/Mvc/Mvc.Core/src/Infrastructure/StringArrayComparer.cs
+++ b/src/Mvc/Mvc.Core/src/Infrastructure/StringArrayComparer.cs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.AspNetCore.Mvc.Infrastructure;
 
-internal sealed class StringArrayComparer : IEqualityComparer<string[]>
+internal sealed class StringArrayComparer : IEqualityComparer<string[]>, IAlternateEqualityComparer<ReadOnlySpan<string>, string[]>
 {
     public static readonly StringArrayComparer Ordinal = new StringArrayComparer(StringComparer.Ordinal);
 
@@ -70,4 +70,51 @@ internal sealed class StringArrayComparer : IEqualityComparer<string[]>
 
         return hash.ToHashCode();
     }
+
+    // Alternate lookup support: allows probing the dictionary with a ReadOnlySpan<string> key
+    // (typically backed by a pooled buffer sliced to the exact length) without allocating a string[].
+    // The logic below mirrors the string[] overloads exactly, using the span length as the effective length.
+    public bool Equals(ReadOnlySpan<string> alternate, string[] other)
+    {
+        if (other == null)
+        {
+            return false;
+        }
+
+        if (alternate.Length != other.Length)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < alternate.Length; i++)
+        {
+            if (string.IsNullOrEmpty(alternate[i]) && string.IsNullOrEmpty(other[i]))
+            {
+                continue;
+            }
+
+            if (!_valueComparer.Equals(alternate[i], other[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public int GetHashCode(ReadOnlySpan<string> alternate)
+    {
+        var hash = new HashCode();
+        for (var i = 0; i < alternate.Length; i++)
+        {
+            // Route values define null and "" to be equivalent.
+            hash.Add(alternate[i] ?? string.Empty, _valueComparer);
+        }
+
+        return hash.ToHashCode();
+    }
+
+    // Only used when inserting via the alternate lookup. Action selection only reads, so this is
+    // never expected to be called, but it is required by the interface.
+    public string[] Create(ReadOnlySpan<string> alternate) => alternate.ToArray();
 }

--- a/src/Mvc/Mvc.Core/test/Infrastructure/ActionSelectionTableTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/ActionSelectionTableTest.cs
@@ -543,6 +543,131 @@ public class ActionSelectionTableTest
         Assert.Same(actions[0], action);
     }
 
+    [Fact]
+    public void Select_ManyRouteValues_MatchesAcrossOverLengthRentedBuffer()
+    {
+        // Select rents its lookup-key buffer from ArrayPool, whose Rent returns an array that is
+        // typically longer than requested. This exercises a table with several route keys to ensure
+        // the extra trailing slots in the rented buffer never affect hashing or matching.
+        var actions = new ActionDescriptor[]
+        {
+                new ActionDescriptor()
+                {
+                    DisplayName = "A1",
+                    RouteValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        { "area", "Admin" },
+                        { "controller", "Home" },
+                        { "action", "Index" },
+                        { "page", "1" },
+                        { "sort", "asc" },
+                    },
+                },
+                new ActionDescriptor()
+                {
+                    DisplayName = "A2",
+                    RouteValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        { "area", "Admin" },
+                        { "controller", "Home" },
+                        { "action", "Index" },
+                        { "page", "2" },
+                        { "sort", "asc" },
+                    },
+                },
+        };
+
+        var table = CreateTableWithActionDescriptors(actions);
+        var values = new RouteValueDictionary(new { area = "admin", controller = "home", action = "index", page = "2", sort = "ASC", });
+
+        var matches = table.Select(values);
+
+        Assert.Collection(matches, (a) => Assert.Same(actions[1], a));
+    }
+
+    [Fact]
+    public void Select_RepeatedCalls_ReturnConsistentResults()
+    {
+        // The rented buffer is cleared and returned to the pool after every call. Repeated calls must
+        // keep returning identical results, proving the buffer reuse does not retain or corrupt state.
+        var actions = new ActionDescriptor[]
+        {
+                new ActionDescriptor()
+                {
+                    DisplayName = "A1",
+                    RouteValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        { "controller", "Home" },
+                        { "action", "Index" }
+                    },
+                },
+                new ActionDescriptor()
+                {
+                    DisplayName = "A2",
+                    RouteValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        { "controller", "Home" },
+                        { "action", "About" }
+                    },
+                },
+        };
+
+        var table = CreateTableWithActionDescriptors(actions);
+        var values = new RouteValueDictionary(new { controller = "Home", action = "Index", });
+
+        for (var i = 0; i < 1000; i++)
+        {
+            var matches = table.Select(values);
+            Assert.Collection(matches, (a) => Assert.Same(actions[0], a));
+        }
+    }
+
+    [Fact]
+    public void Select_ConcurrentCalls_ReturnCorrectResults()
+    {
+        // Each Select call rents its own buffer, so concurrent lookups with different inputs must not
+        // interfere with each other.
+        var actions = new ActionDescriptor[]
+        {
+                new ActionDescriptor()
+                {
+                    DisplayName = "A1",
+                    RouteValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        { "controller", "Home" },
+                        { "action", "Index" }
+                    },
+                },
+                new ActionDescriptor()
+                {
+                    DisplayName = "A2",
+                    RouteValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        { "controller", "Home" },
+                        { "action", "About" }
+                    },
+                },
+        };
+
+        var table = CreateTableWithActionDescriptors(actions);
+        var index = new RouteValueDictionary(new { controller = "Home", action = "Index", });
+        var about = new RouteValueDictionary(new { controller = "Home", action = "About", });
+
+        Parallel.For(0, 2000, i =>
+        {
+            if (i % 2 == 0)
+            {
+                var matches = table.Select(index);
+                Assert.Collection(matches, (a) => Assert.Same(actions[0], a));
+            }
+            else
+            {
+                var matches = table.Select(about);
+                Assert.Collection(matches, (a) => Assert.Same(actions[1], a));
+            }
+        });
+    }
+
     private static ActionSelectionTable<ActionDescriptor> CreateTableWithActionDescriptors(IReadOnlyList<ActionDescriptor> actions)
     {
         return ActionSelectionTable<ActionDescriptor>.Create(new ActionDescriptorCollection(actions, 0));

--- a/src/Mvc/Mvc.Core/test/Infrastructure/StringArrayComparerTest.cs
+++ b/src/Mvc/Mvc.Core/test/Infrastructure/StringArrayComparerTest.cs
@@ -1,0 +1,189 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Mvc.Infrastructure;
+
+// StringArrayComparer backs the ActionSelectionTable lookups. It implements both the classic
+// IEqualityComparer<string[]> and the IAlternateEqualityComparer<ReadOnlySpan<string>, string[]>
+// used by the pooled-buffer fast path in ActionSelectionTable.Select. These tests assert the span
+// overloads are semantically identical to the array overloads so the allocation-free lookup cannot
+// change matching or hashing behavior.
+public class StringArrayComparerTest
+{
+    public static IEnumerable<object[]> Comparers =>
+        new[]
+        {
+            new object[] { false },
+            new object[] { true },
+        };
+
+    private static StringArrayComparer GetComparer(bool ignoreCase)
+        => ignoreCase ? StringArrayComparer.OrdinalIgnoreCase : StringArrayComparer.Ordinal;
+
+    [Theory]
+    [MemberData(nameof(Comparers))]
+    public void GetHashCode_SpanMatchesArray_ForEqualContents(bool ignoreCase)
+    {
+        var comparer = GetComparer(ignoreCase);
+        var array = new[] { "Home", "Index", "" };
+        ReadOnlySpan<string> span = array;
+
+        Assert.Equal(comparer.GetHashCode(array), comparer.GetHashCode(span));
+    }
+
+    [Theory]
+    [MemberData(nameof(Comparers))]
+    public void GetHashCode_NullAndEmpty_ProduceSameHash(bool ignoreCase)
+    {
+        var comparer = GetComparer(ignoreCase);
+        ReadOnlySpan<string> withNull = new[] { "Home", null! };
+        ReadOnlySpan<string> withEmpty = new[] { "Home", "" };
+
+        Assert.Equal(comparer.GetHashCode(withEmpty), comparer.GetHashCode(withNull));
+    }
+
+    [Theory]
+    [MemberData(nameof(Comparers))]
+    public void Equals_SpanAndArray_TrueForEqualContents(bool ignoreCase)
+    {
+        var comparer = GetComparer(ignoreCase);
+        ReadOnlySpan<string> span = new[] { "Home", "Index" };
+        var array = new[] { "Home", "Index" };
+
+        Assert.True(comparer.Equals(span, array));
+    }
+
+    [Theory]
+    [MemberData(nameof(Comparers))]
+    public void Equals_NullAndEmpty_AreEquivalent(bool ignoreCase)
+    {
+        var comparer = GetComparer(ignoreCase);
+        ReadOnlySpan<string> span = new[] { "Home", null! };
+        var array = new[] { "Home", "" };
+
+        Assert.True(comparer.Equals(span, array));
+    }
+
+    [Theory]
+    [MemberData(nameof(Comparers))]
+    public void Equals_DifferentLength_ReturnsFalse(bool ignoreCase)
+    {
+        var comparer = GetComparer(ignoreCase);
+        ReadOnlySpan<string> span = new[] { "Home", "Index" };
+        var array = new[] { "Home" };
+
+        Assert.False(comparer.Equals(span, array));
+    }
+
+    [Theory]
+    [MemberData(nameof(Comparers))]
+    public void Equals_OtherNull_ReturnsFalse(bool ignoreCase)
+    {
+        var comparer = GetComparer(ignoreCase);
+        ReadOnlySpan<string> span = new[] { "Home", "Index" };
+
+        Assert.False(comparer.Equals(span, null!));
+    }
+
+    [Fact]
+    public void Equals_Ordinal_IsCaseSensitive()
+    {
+        var comparer = StringArrayComparer.Ordinal;
+        ReadOnlySpan<string> span = new[] { "Home", "index" };
+        var array = new[] { "Home", "Index" };
+
+        Assert.False(comparer.Equals(span, array));
+    }
+
+    [Fact]
+    public void Equals_OrdinalIgnoreCase_IsCaseInsensitive()
+    {
+        var comparer = StringArrayComparer.OrdinalIgnoreCase;
+        ReadOnlySpan<string> span = new[] { "HOME", "iNDex" };
+        var array = new[] { "Home", "Index" };
+
+        Assert.True(comparer.Equals(span, array));
+    }
+
+    [Theory]
+    [MemberData(nameof(Comparers))]
+    public void GetHashCode_OverLengthBackingBuffer_UsesSpanLength(bool ignoreCase)
+    {
+        var comparer = GetComparer(ignoreCase);
+
+        // Mimics ArrayPool.Rent returning a buffer longer than needed - the extra trailing slots
+        // must not participate in hashing.
+        var backing = new[] { "Home", "Index", "GARBAGE", "MORE_GARBAGE" };
+        ReadOnlySpan<string> sliced = backing.AsSpan(0, 2);
+
+        Assert.Equal(comparer.GetHashCode(new[] { "Home", "Index" }), comparer.GetHashCode(sliced));
+    }
+
+    [Theory]
+    [MemberData(nameof(Comparers))]
+    public void Equals_OverLengthBackingBuffer_UsesSpanLength(bool ignoreCase)
+    {
+        var comparer = GetComparer(ignoreCase);
+        var backing = new[] { "Home", "Index", "GARBAGE", "MORE_GARBAGE" };
+        ReadOnlySpan<string> sliced = backing.AsSpan(0, 2);
+
+        Assert.True(comparer.Equals(sliced, new[] { "Home", "Index" }));
+    }
+
+    [Fact]
+    public void Create_ReturnsIndependentArrayCopy()
+    {
+        var comparer = StringArrayComparer.Ordinal;
+        var backing = new[] { "Home", "Index", "GARBAGE" };
+        ReadOnlySpan<string> sliced = backing.AsSpan(0, 2);
+
+        var created = ((IAlternateEqualityComparer<ReadOnlySpan<string>, string[]>)comparer).Create(sliced);
+
+        Assert.Equal(new[] { "Home", "Index" }, created);
+        backing[0] = "Mutated";
+        Assert.Equal("Home", created[0]);
+    }
+
+    [Theory]
+    [MemberData(nameof(Comparers))]
+    public void AlternateLookup_ProbesStoredKey_ViaOverLengthBuffer(bool ignoreCase)
+    {
+        var comparer = GetComparer(ignoreCase);
+        var dictionary = new Dictionary<string[], int>(comparer)
+        {
+            [new[] { "Home", "Index" }] = 1,
+        };
+        var lookup = dictionary.GetAlternateLookup<ReadOnlySpan<string>>();
+
+        var backing = new[] { "Home", "Index", "GARBAGE", "MORE_GARBAGE" };
+        Assert.True(lookup.TryGetValue(backing.AsSpan(0, 2), out var value));
+        Assert.Equal(1, value);
+    }
+
+    [Fact]
+    public void AlternateLookup_Ordinal_DoesNotMatchDifferentCasing()
+    {
+        var dictionary = new Dictionary<string[], int>(StringArrayComparer.Ordinal)
+        {
+            [new[] { "Home", "Index" }] = 1,
+        };
+        var lookup = dictionary.GetAlternateLookup<ReadOnlySpan<string>>();
+
+        ReadOnlySpan<string> differentCase = new[] { "home", "index" };
+        Assert.False(lookup.TryGetValue(differentCase, out _));
+    }
+
+    [Fact]
+    public void AlternateLookup_OrdinalIgnoreCase_MatchesDifferentCasing()
+    {
+        var dictionary = new Dictionary<string[], int>(StringArrayComparer.OrdinalIgnoreCase)
+        {
+            [new[] { "Home", "Index" }] = 1,
+        };
+        var lookup = dictionary.GetAlternateLookup<ReadOnlySpan<string>>();
+
+        ReadOnlySpan<string> differentCase = new[] { "home", "index" };
+        Assert.True(lookup.TryGetValue(differentCase, out var value));
+        Assert.Equal(1, value);
+    }
+}

--- a/src/Mvc/perf/Microbenchmarks/Microsoft.AspNetCore.Mvc/ConventionalActionSelectionBenchmark.cs
+++ b/src/Mvc/perf/Microbenchmarks/Microsoft.AspNetCore.Mvc/ConventionalActionSelectionBenchmark.cs
@@ -1,0 +1,99 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.AspNetCore.Mvc.Microbenchmarks;
+
+// Focused allocation benchmark for conventional (non-attribute) action selection. Each op performs a
+// single ActionSelector.SelectCandidates call against a pre-built RouteContext, so the only per-op
+// allocation is the lookup key materialized inside ActionSelectionTable.Select (the matched candidate
+// list returned on a hit is the shared cached instance, not a copy). This isolates the string[] key
+// allocation being eliminated, across a few/many route-value counts and exact/ignore-case/no-match
+// lookups (ordinal fast path vs. ordinal-ignore-case fallback).
+public class ConventionalActionSelectionBenchmark
+{
+    private static readonly string[] _keyNames =
+    {
+        "controller", "action", "area", "segment3", "segment4", "segment5", "segment6", "segment7",
+    };
+
+    private static readonly string[] _values =
+    {
+        "Home", "Index", "Admin", "v3", "v4", "v5", "v6", "v7",
+    };
+
+    [Params(1, 3, 8)]
+    public int RouteValueCount { get; set; }
+
+    private IActionSelector _actionSelector = default!;
+    private RouteContext _exactMatchContext = default!;
+    private RouteContext _ignoreCaseMatchContext = default!;
+    private RouteContext _noMatchContext = default!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var canonical = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < RouteValueCount; i++)
+        {
+            canonical.Add(_keyNames[i], _values[i]);
+        }
+
+        var action = new ActionDescriptor { RouteValues = canonical };
+        _actionSelector = CreateActionSelector(new[] { action });
+
+        _exactMatchContext = CreateContext(canonical, transform: static v => v);
+        _ignoreCaseMatchContext = CreateContext(canonical, transform: static v => v.ToLowerInvariant());
+        _noMatchContext = CreateContext(canonical, transform: static v => v + "-nomatch");
+    }
+
+    [Benchmark(Description = "exact-case match (ordinal fast path)")]
+    public IReadOnlyList<ActionDescriptor> ExactMatch()
+        => _actionSelector.SelectCandidates(_exactMatchContext);
+
+    [Benchmark(Description = "different-case match (ordinal-ignore-case fallback)")]
+    public IReadOnlyList<ActionDescriptor> IgnoreCaseMatch()
+        => _actionSelector.SelectCandidates(_ignoreCaseMatchContext);
+
+    [Benchmark(Description = "no match")]
+    public IReadOnlyList<ActionDescriptor> NoMatch()
+        => _actionSelector.SelectCandidates(_noMatchContext);
+
+    private static RouteContext CreateContext(Dictionary<string, string> canonical, Func<string, string> transform)
+    {
+        var context = new RouteContext(new DefaultHttpContext());
+        foreach (var kvp in canonical)
+        {
+            context.RouteData.Values[kvp.Key] = transform(kvp.Value);
+        }
+
+        return context;
+    }
+
+    private static IActionSelector CreateActionSelector(ActionDescriptor[] actions)
+    {
+        var actionCollection = new MockActionDescriptorCollectionProvider(actions);
+
+        return new ActionSelector(
+            actionCollection,
+            new ActionConstraintCache(actionCollection, Enumerable.Empty<IActionConstraintProvider>()),
+            NullLoggerFactory.Instance);
+    }
+
+    private sealed class MockActionDescriptorCollectionProvider : IActionDescriptorCollectionProvider
+    {
+        public MockActionDescriptorCollectionProvider(ActionDescriptor[] actions)
+        {
+            ActionDescriptors = new ActionDescriptorCollection(actions, 0);
+        }
+
+        public ActionDescriptorCollection ActionDescriptors { get; }
+    }
+}


### PR DESCRIPTION
I am running an experiment - full analysis to follow. Contact @artl93

---

**⚠️ WIP EXPERIMENT — DO NOT REVIEW OR MERGE.** This is a documented performance experiment with a **negative net result**. Recommendation: **do not merge** (see the pinned decision comment). Kept as a draft for the record.

## What this does

`ActionSelectionTable<TItem>.Select(RouteValueDictionary)` allocated a fresh `string[]` lookup key on every call to probe its route-value dictionaries. This change rents the key buffer from `ArrayPool<string>.Shared` and probes via `Dictionary<,>.AlternateLookup<ReadOnlySpan<string>>`, so the per-call `string[]` is never heap-allocated.

## Result (why it's not for merge)

- **Allocation: eliminated.** 32 / 48 / 88 B → **0 B** per call for 1 / 3 / 8 route values; Gen0 → 0. Deterministic.
- **CPU: regresses.** On the isolated `Select` op, mean time grows ~**+21–30%** at 1–3 route values (the common case) and ~+2–5% at 8, from `ArrayPool.Shared.Rent`/`Return(clearArray:true)` overhead. Error bars are tight — real, not noise.
- **Net: marginal-to-negative.** The removed 48 B and the added ~few ns are both negligible inside a full MVC request (µs–ms). There is **no** end-to-end throughput/latency evidence that the reduced Gen0 pressure outweighs the added CPU. The dotnet/aspnetcore bar for hot-path changes is *no throughput regression*, which this fails.

Full canonical before/after tables, environment, commands, SHAs and hashes are in the comments.

## Where it runs

`Select` is reached by three call sites: `ActionSelector` (conventional action selection, via the legacy `MvcRouteHandler`), `DynamicControllerEndpointSelector` (`MapDynamicControllerRoute`), and `DynamicPageEndpointSelector` (`MapDynamicPageRoute`). Statically attribute-routed / endpoint-routed controllers and Minimal APIs do not use this path.

## Correctness (verified, tests pass)

The `StringArrayComparer` span overloads mirror the array overloads exactly (null/empty route-value equivalence; effective length = span length), ordinal-first then ordinal-ignore-case fallback preserved, the rented buffer is sliced to the exact length (over-sizing invisible to hashing/equality), and it is cleared + returned on both success and exception paths (no route-value retention). Non-string values still go through `Convert.ToString(value, InvariantCulture)` exactly as before. Added `StringArrayComparerTest` plus `ActionSelectionTableTest` cases (over-length buffer, repeated calls, concurrency); 100/100 pass.

## Why the allocation can't be trivially removed for free

The allocation *is* the dictionary key — you cannot probe the map without one, and `string[]` can't be `stackalloc`'d (managed refs). Pooling + a span `AlternateLookup` is the natural zero-alloc route, but it trades the allocation for pool bookkeeping CPU. Alternatives (a per-thread cached buffer, or clearing only `[0,length)` and returning with `clearArray:false`) shift or slightly reduce the cost but do not turn the op-level regression into a win, and a fundamentally different lookup structure would be a much larger change with its own risks.

cc @artl93 — **still a work in progress; not for review or merge.**
