### PR TITLE
ResponseCaching: avoid one-element string[] allocation on vary-by lookup

### DIFF
--- a/src/Middleware/ResponseCaching/src/Interfaces/IResponseCachingKeyProvider.cs
+++ b/src/Middleware/ResponseCaching/src/Interfaces/IResponseCachingKeyProvider.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Extensions.Primitives;
+
 namespace Microsoft.AspNetCore.ResponseCaching;
 
 internal interface IResponseCachingKeyProvider
@@ -23,6 +25,6 @@ internal interface IResponseCachingKeyProvider
     /// Create one or more vary keys for looking up cached responses.
     /// </summary>
     /// <param name="context">The <see cref="ResponseCachingContext"/>.</param>
-    /// <returns>An ordered <see cref="IEnumerable{T}"/> containing the vary keys to try when looking up items.</returns>
-    IEnumerable<string> CreateLookupVaryByKeys(ResponseCachingContext context);
+    /// <returns>An ordered <see cref="StringValues"/> containing the vary keys to try when looking up items.</returns>
+    StringValues CreateLookupVaryByKeys(ResponseCachingContext context);
 }

--- a/src/Middleware/ResponseCaching/src/Microsoft.AspNetCore.ResponseCaching.csproj
+++ b/src/Middleware/ResponseCaching/src/Microsoft.AspNetCore.ResponseCaching.csproj
@@ -27,5 +27,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.AspNetCore.ResponseCaching.Tests" />
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.ResponseCaching.Microbenchmarks" />
   </ItemGroup>
 </Project>

--- a/src/Middleware/ResponseCaching/src/ResponseCachingKeyProvider.cs
+++ b/src/Middleware/ResponseCaching/src/ResponseCachingKeyProvider.cs
@@ -28,9 +28,9 @@ internal sealed class ResponseCachingKeyProvider : IResponseCachingKeyProvider
         _options = options.Value;
     }
 
-    public IEnumerable<string> CreateLookupVaryByKeys(ResponseCachingContext context)
+    public StringValues CreateLookupVaryByKeys(ResponseCachingContext context)
     {
-        return new string[] { CreateStorageVaryByKey(context) };
+        return CreateStorageVaryByKey(context);
     }
 
     // GET<delimiter>SCHEME<delimiter>HOST:PORT/PATHBASE/PATH

--- a/src/Middleware/ResponseCaching/src/ResponseCachingMiddleware.cs
+++ b/src/Middleware/ResponseCaching/src/ResponseCachingMiddleware.cs
@@ -224,7 +224,7 @@ public class ResponseCachingMiddleware
             {
                 foreach (var varyKey in _keyProvider.CreateLookupVaryByKeys(context))
                 {
-                    if (await TryServeCachedResponseAsync(context, _cache.Get(varyKey)))
+                    if (varyKey is not null && await TryServeCachedResponseAsync(context, _cache.Get(varyKey)))
                     {
                         return true;
                     }

--- a/src/Middleware/ResponseCaching/test/ResponseCachingKeyProviderTests.cs
+++ b/src/Middleware/ResponseCaching/test/ResponseCachingKeyProviderTests.cs
@@ -313,4 +313,116 @@ public class ResponseCachingKeyProviderTests
 
         Assert.Throws<CacheKeyDelimiterException>(() => cacheKeyProvider.CreateStorageVaryByKey(context));
     }
+
+    [Fact]
+    public void CreateLookupVaryByKeys_NoVaryRules_YieldsSinglePrefixKey()
+    {
+        var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
+        var context = TestUtils.CreateTestContext();
+        context.CachedVaryByRules = new CachedVaryByRules()
+        {
+            VaryByKeyPrefix = FastGuid.NewGuid().IdString
+        };
+
+        var keys = MaterializeLookupKeys(cacheKeyProvider, context);
+
+        Assert.Equal(new[] { cacheKeyProvider.CreateStorageVaryByKey(context) }, keys);
+        Assert.Equal(context.CachedVaryByRules.VaryByKeyPrefix, Assert.Single(keys));
+    }
+
+    [Fact]
+    public void CreateLookupVaryByKeys_VaryByHeader_YieldsSingleStorageKey()
+    {
+        var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
+        var context = TestUtils.CreateTestContext();
+        context.HttpContext.Request.Headers["HeaderA"] = "ValueA";
+        context.CachedVaryByRules = new CachedVaryByRules()
+        {
+            VaryByKeyPrefix = FastGuid.NewGuid().IdString,
+            Headers = new string[] { "HeaderA", "HeaderC" }
+        };
+
+        var keys = MaterializeLookupKeys(cacheKeyProvider, context);
+
+        Assert.Equal(new[] { cacheKeyProvider.CreateStorageVaryByKey(context) }, keys);
+    }
+
+    [Fact]
+    public void CreateLookupVaryByKeys_VaryByQueryKeys_YieldsSingleStorageKey()
+    {
+        var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
+        var context = TestUtils.CreateTestContext();
+        context.HttpContext.Request.QueryString = new QueryString("?QueryA=ValueA&QueryB=ValueB");
+        context.CachedVaryByRules = new CachedVaryByRules()
+        {
+            VaryByKeyPrefix = FastGuid.NewGuid().IdString,
+            QueryKeys = new string[] { "QueryA", "QueryC" }
+        };
+
+        var keys = MaterializeLookupKeys(cacheKeyProvider, context);
+
+        Assert.Equal(new[] { cacheKeyProvider.CreateStorageVaryByKey(context) }, keys);
+    }
+
+    [Fact]
+    public void CreateLookupVaryByKeys_VaryByQueryKeysWildcard_YieldsSingleStorageKey()
+    {
+        var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
+        var context = TestUtils.CreateTestContext();
+        context.HttpContext.Request.QueryString = new QueryString("?QueryA=ValueA&QueryB=ValueB");
+        context.CachedVaryByRules = new CachedVaryByRules()
+        {
+            VaryByKeyPrefix = FastGuid.NewGuid().IdString,
+            QueryKeys = new string[] { "*" }
+        };
+
+        var keys = MaterializeLookupKeys(cacheKeyProvider, context);
+
+        Assert.Equal(new[] { cacheKeyProvider.CreateStorageVaryByKey(context) }, keys);
+    }
+
+    [Fact]
+    public void CreateLookupVaryByKeys_VaryByHeadersAndQueryKeys_YieldsSingleStorageKey()
+    {
+        var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
+        var context = TestUtils.CreateTestContext();
+        context.HttpContext.Request.Headers["HeaderA"] = "ValueA";
+        context.HttpContext.Request.QueryString = new QueryString("?QueryA=ValueA");
+        context.CachedVaryByRules = new CachedVaryByRules()
+        {
+            VaryByKeyPrefix = FastGuid.NewGuid().IdString,
+            Headers = new string[] { "HeaderA", "HeaderC" },
+            QueryKeys = new string[] { "QueryA", "QueryC" }
+        };
+
+        var keys = MaterializeLookupKeys(cacheKeyProvider, context);
+
+        Assert.Equal(new[] { cacheKeyProvider.CreateStorageVaryByKey(context) }, keys);
+    }
+
+    [Fact]
+    public void CreateLookupVaryByKeys_Throws_IfHeaderValueContainsDelimiter()
+    {
+        var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
+        var context = TestUtils.CreateTestContext();
+        context.HttpContext.Request.Headers["HeaderA"] = "Value\u001eInjected";
+        context.CachedVaryByRules = new CachedVaryByRules()
+        {
+            VaryByKeyPrefix = FastGuid.NewGuid().IdString,
+            Headers = new string[] { "HeaderA" }
+        };
+
+        Assert.Throws<CacheKeyDelimiterException>(() => MaterializeLookupKeys(cacheKeyProvider, context));
+    }
+
+    private static List<string> MaterializeLookupKeys(IResponseCachingKeyProvider cacheKeyProvider, ResponseCachingContext context)
+    {
+        var keys = new List<string>();
+        foreach (var key in cacheKeyProvider.CreateLookupVaryByKeys(context))
+        {
+            keys.Add(key);
+        }
+
+        return keys;
+    }
 }

--- a/src/Middleware/ResponseCaching/test/TestUtils.cs
+++ b/src/Middleware/ResponseCaching/test/TestUtils.cs
@@ -346,12 +346,20 @@ internal class TestResponseCachingKeyProvider : IResponseCachingKeyProvider
         }
     }
 
-    public IEnumerable<string> CreateLookupVaryByKeys(ResponseCachingContext context)
+    public StringValues CreateLookupVaryByKeys(ResponseCachingContext context)
     {
-        foreach (var varyKey in _varyKey)
+        if (_varyKey.Count == 0)
         {
-            yield return _baseKey + varyKey;
+            return StringValues.Empty;
         }
+
+        var keys = new string[_varyKey.Count];
+        for (var i = 0; i < _varyKey.Count; i++)
+        {
+            keys[i] = _baseKey + _varyKey[i];
+        }
+
+        return new StringValues(keys);
     }
 
     public string CreateBaseKey(ResponseCachingContext context)

--- a/src/Middleware/perf/ResponseCaching.Microbenchmarks/ResponseCachingKeyProviderVaryBenchmark.cs
+++ b/src/Middleware/perf/ResponseCaching.Microbenchmarks/ResponseCachingKeyProviderVaryBenchmark.cs
@@ -1,0 +1,141 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.ObjectPool;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.ResponseCaching.Microbenchmarks;
+
+/// <summary>
+/// Measures allocations on the vary-by cache-lookup path. The middleware calls
+/// <see cref="IResponseCachingKeyProvider.CreateLookupVaryByKeys"/> and enumerates the result
+/// to probe the store for a cached vary-by response. The <c>Lookup</c> benchmark exercises that
+/// enumerated path; the <c>StorageKeyControl</c> benchmark builds the same underlying storage key
+/// without the enumeration wrapper, so the per-call difference is exactly the wrapper cost that
+/// this change removes.
+/// </summary>
+[MemoryDiagnoser]
+public class ResponseCachingKeyProviderVaryBenchmark
+{
+    public enum VaryScenario
+    {
+        NoVaryControl,
+        OneHeaderOneValue,
+        OneHeaderMultiValue,
+        OneHeaderAbsent,
+        ThreeHeaders,
+        OneQueryKey,
+        WildcardQueryStar,
+        HeaderPlusQuery,
+        LargeTwentyHeaders,
+    }
+
+    private ResponseCachingKeyProvider _keyProvider;
+    private ResponseCachingContext _context;
+
+    [Params(
+        VaryScenario.NoVaryControl,
+        VaryScenario.OneHeaderOneValue,
+        VaryScenario.OneHeaderMultiValue,
+        VaryScenario.OneHeaderAbsent,
+        VaryScenario.ThreeHeaders,
+        VaryScenario.OneQueryKey,
+        VaryScenario.WildcardQueryStar,
+        VaryScenario.HeaderPlusQuery,
+        VaryScenario.LargeTwentyHeaders)]
+    public VaryScenario Scenario { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _keyProvider = new ResponseCachingKeyProvider(new DefaultObjectPoolProvider(), Options.Create(new ResponseCachingOptions()));
+
+        var httpContext = new DefaultHttpContext();
+        var rules = new CachedVaryByRules
+        {
+            VaryByKeyPrefix = "0123456789abcdef0123456789abcdef"
+        };
+
+        switch (Scenario)
+        {
+            case VaryScenario.NoVaryControl:
+                break;
+
+            case VaryScenario.OneHeaderOneValue:
+                httpContext.Request.Headers["Accept-Encoding"] = "gzip";
+                rules.Headers = new[] { "Accept-Encoding" };
+                break;
+
+            case VaryScenario.OneHeaderMultiValue:
+                httpContext.Request.Headers["Accept-Encoding"] = new[] { "gzip", "br", "deflate" };
+                rules.Headers = new[] { "Accept-Encoding" };
+                break;
+
+            case VaryScenario.OneHeaderAbsent:
+                rules.Headers = new[] { "Accept-Encoding" };
+                break;
+
+            case VaryScenario.ThreeHeaders:
+                httpContext.Request.Headers["Accept-Encoding"] = "gzip";
+                httpContext.Request.Headers["Accept-Language"] = "en-US";
+                httpContext.Request.Headers["User-Agent"] = "benchmark";
+                rules.Headers = new[] { "Accept-Encoding", "Accept-Language", "User-Agent" };
+                break;
+
+            case VaryScenario.OneQueryKey:
+                httpContext.Request.QueryString = new QueryString("?culture=en-US");
+                rules.QueryKeys = new[] { "culture" };
+                break;
+
+            case VaryScenario.WildcardQueryStar:
+                httpContext.Request.QueryString = new QueryString("?culture=en-US&theme=dark");
+                rules.QueryKeys = new[] { "*" };
+                break;
+
+            case VaryScenario.HeaderPlusQuery:
+                httpContext.Request.Headers["Accept-Encoding"] = "gzip";
+                httpContext.Request.QueryString = new QueryString("?culture=en-US");
+                rules.Headers = new[] { "Accept-Encoding" };
+                rules.QueryKeys = new[] { "culture" };
+                break;
+
+            case VaryScenario.LargeTwentyHeaders:
+                var names = new string[20];
+                for (var i = 0; i < names.Length; i++)
+                {
+                    var name = "X-Vary-" + i;
+                    names[i] = name;
+                    httpContext.Request.Headers[name] = "v" + i;
+                }
+                rules.Headers = names;
+                break;
+        }
+
+        _context = new ResponseCachingContext(httpContext, NullLogger.Instance)
+        {
+            ResponseTime = DateTimeOffset.UtcNow,
+            CachedVaryByRules = rules
+        };
+    }
+
+    [Benchmark]
+    public int Lookup()
+    {
+        var total = 0;
+        foreach (var key in _keyProvider.CreateLookupVaryByKeys(_context))
+        {
+            total += key.Length;
+        }
+
+        return total;
+    }
+
+    [Benchmark(Baseline = true)]
+    public int StorageKeyControl()
+    {
+        return _keyProvider.CreateStorageVaryByKey(_context).Length;
+    }
+}

--- a/src/Middleware/perf/ResponseCaching.Microbenchmarks/ResponseCachingKeyProviderVaryBenchmark.cs
+++ b/src/Middleware/perf/ResponseCaching.Microbenchmarks/ResponseCachingKeyProviderVaryBenchmark.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.ObjectPool;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.AspNetCore.ResponseCaching.Microbenchmarks;
 
@@ -14,8 +15,15 @@ namespace Microsoft.AspNetCore.ResponseCaching.Microbenchmarks;
 /// <see cref="IResponseCachingKeyProvider.CreateLookupVaryByKeys"/> and enumerates the result
 /// to probe the store for a cached vary-by response. The <c>Lookup</c> benchmark exercises that
 /// enumerated path; the <c>StorageKeyControl</c> benchmark builds the same underlying storage key
-/// without the enumeration wrapper, so the per-call difference is exactly the wrapper cost that
-/// this change removes.
+/// without the enumeration wrapper.
+/// <para>
+/// Run the same benchmark at both product revisions to see the effect: at the pre-change revision
+/// (where the provider returned a one-element <c>string[]</c> as <c>IEnumerable&lt;string&gt;</c>)
+/// <c>Lookup</c> allocates a fixed amount more than <c>StorageKeyControl</c> — the array plus the
+/// heap enumerator. After the change (the provider returns a <see cref="StringValues"/> struct)
+/// <c>Lookup</c> allocates exactly what <c>StorageKeyControl</c> does, so the per-call difference
+/// collapses to zero. That before/after delta is the wrapper cost this change removes.
+/// </para>
 /// </summary>
 [MemoryDiagnoser]
 public class ResponseCachingKeyProviderVaryBenchmark


### PR DESCRIPTION
## Summary

On the response-caching vary-by lookup path, `ResponseCachingMiddleware` calls the **internal** `IResponseCachingKeyProvider.CreateLookupVaryByKeys(context)` and `foreach`-es the result to probe the store for a cached vary-by response. The implementation wrapped a single computed storage key in a one-element array:

```csharp
public IEnumerable<string> CreateLookupVaryByKeys(ResponseCachingContext context)
    => new string[] { CreateStorageVaryByKey(context) };
```

Enumerating that `IEnumerable<string>` allocates two heap objects per lookup — the `string[1]` and the `IEnumerator<string>` the runtime materializes for it — purely to hand a **single** key to the `foreach`. This change makes the internal API return `Microsoft.Extensions.Primitives.StringValues`, a struct that holds the one key and enumerates through a struct enumerator, so the lookup path adds **zero** heap allocations over building the key itself. There was only ever one key, so lookup order and equality are unchanged.

## Canonical A/B — BenchmarkDotNet (MemoryDiagnoser)

This PR adds `ResponseCachingKeyProviderVaryBenchmark`, run at the exact before/after product revisions with a byte-identical harness. `Lookup` enumerates `CreateLookupVaryByKeys`; `StorageKeyControl` builds the same underlying key **without** the enumeration wrapper, so `Lookup − Control` isolates exactly the wrapper cost removed here.

| Scenario | Before `Lookup` | After `Lookup` | Control (before = after) | Saved |
|---|--:|--:|--:|--:|
| NoVaryControl        | 54 B    | 0 B     | 0 B     | **54 B** |
| OneHeaderOneValue    | 222 B   | 168 B   | 168 B   | **54 B** |
| OneHeaderMultiValue  | 278 B   | 224 B   | 224 B   | **54 B** |
| OneHeaderAbsent      | 182 B   | 128 B   | 128 B   | **54 B** |
| ThreeHeaders         | 374 B   | 320 B   | 320 B   | **54 B** |
| OneQueryKey          | 206 B   | 152 B   | 152 B   | **54 B** |
| WildcardQueryStar    | 382 B   | 328 B   | 328 B   | **54 B** |
| HeaderPlusQuery      | 286 B   | 232 B   | 232 B   | **54 B** |
| LargeTwentyHeaders   | 1,310 B | 1,256 B | 1,256 B | **54 B** |

**Result:** a fixed **~54 B per lookup** is eliminated in every scenario — independent of vary-rule size, because those bytes live in the storage-key string, which is unchanged (identical `Control` column, before vs after). After the change, `Lookup` allocates **exactly** what `StorageKeyControl` allocates (0 B wrapper delta) in all nine scenarios. An independent `GC.GetAllocatedBytesForCurrentThread` probe measured the constant at ~64 B; both methods agree it is a small **fixed per-lookup** cost fully removed with no behavioral change (the ~10 B difference is measurement-method variance; the BDN MemoryDiagnoser figures above are canonical).

- Before: `f297235c48` · After: `5765da25e9` (+ unit tests `7162e16188`) · harness sha256 `6fbad7ee…db90` (identical bytes at both revisions).
- Env: BenchmarkDotNet v0.13.0; Apple M5 Pro, macOS 26.5.2 arm64; .NET SDK `11.0.100-preview.6.26318.108`; net11.0; Server GC; Toolchain .NET Core 11.0 (out-of-process). Reduced iteration counts were used because the host was under heavy concurrent load, so wall-clock `Mean` values are noisy and are **not** the metric — `Allocated` is deterministic and load-independent.

## Why it's safe

- Return type changed on the **internal** `IResponseCachingKeyProvider` only — no public API surface changes.
- The yielded value is byte-for-byte the same `CreateStorageVaryByKey(context)` string, so enumeration order and equality are identical.
- Vary-by semantics unchanged: vary-by-header names preserve case and values are sorted ordinally; vary-by-query-key names normalize upper-invariant with ordinal values; `VaryByQueryKeys = ["*"]` varies by all query keys; empty Headers **and** QueryKeys → the key is just the `VaryByKeyPrefix`.
- New unit tests assert the exact key and order across: no-vary (prefix-only), single/multi header values, absent header, multiple headers, single query key, wildcard `*`, and header+query combined.

## Applicability

`CreateLookupVaryByKeys` runs once per request that reaches a cached resource carrying vary-by rules (a `Vary` header and/or `VaryByQueryKeys`) — the vary-resolution step for both eventual hits and vary-misses. Non-vary cached responses take a different branch. The absolute saving is small; the value is zero-allocation determinism on a genuinely per-request path for endpoints that vary their cache, at no behavioral cost.

---

_This remains a draft experiment; I am not marking it ready for review._
