### PR TITLE
Reduce SignalR client/protocol allocations on stream-ID and header hot paths

### DIFF
--- a/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
+++ b/src/SignalR/clients/csharp/Client.Core/src/HubConnection.cs
@@ -868,7 +868,7 @@ public partial class HubConnection : IAsyncDisposable
 
             // I just want an excuse to use 'irq' as a variable name...
             var irq = InvocationRequest.Stream(cancellationToken, returnType, connectionState.GetNextId(), _loggerFactory, this, activity, out channel);
-            await InvokeStreamCore(connectionState, methodName, irq, args, streamIds?.ToArray(), cancellationToken).ConfigureAwait(false);
+            await InvokeStreamCore(connectionState, methodName, irq, args, streamIds, cancellationToken).ConfigureAwait(false);
 
             var streamTasks = LaunchStreams(connectionState, readers, cancellationToken);
 
@@ -890,7 +890,7 @@ public partial class HubConnection : IAsyncDisposable
         return channel;
     }
 
-    private Dictionary<string, object>? PackageStreamingParams(ConnectionState connectionState, ref object?[] args, out List<string>? streamIds)
+    private Dictionary<string, object>? PackageStreamingParams(ConnectionState connectionState, ref object?[] args, out string[]? streamIds)
     {
         Dictionary<string, object>? readers = null;
         streamIds = null;
@@ -899,6 +899,7 @@ public partial class HubConnection : IAsyncDisposable
         Span<bool> isStreaming = args.Length <= MaxStackSize
             ? stackalloc bool[MaxStackSize].Slice(0, args.Length)
             : new bool[args.Length];
+        var streamCount = 0;
         for (var i = 0; i < args.Length; i++)
         {
             var arg = args[i];
@@ -906,21 +907,26 @@ public partial class HubConnection : IAsyncDisposable
             {
                 isStreaming[i] = true;
                 newArgsCount--;
+                streamCount++;
+            }
+        }
 
-                if (readers is null)
+        if (streamCount > 0)
+        {
+            readers = new Dictionary<string, object>();
+            streamIds = new string[streamCount];
+            var streamIndex = 0;
+            for (var i = 0; i < args.Length; i++)
+            {
+                if (isStreaming[i])
                 {
-                    readers = new Dictionary<string, object>();
-                }
-                if (streamIds is null)
-                {
-                    streamIds = new List<string>();
-                }
+                    var id = connectionState.GetNextId();
+                    readers[id] = args[i]!;
+                    streamIds[streamIndex] = id;
+                    streamIndex++;
 
-                var id = connectionState.GetNextId();
-                readers[id] = arg;
-                streamIds.Add(id);
-
-                Log.StartingStream(_logger, id);
+                    Log.StartingStream(_logger, id);
+                }
             }
         }
 
@@ -1219,7 +1225,7 @@ public partial class HubConnection : IAsyncDisposable
             readers = PackageStreamingParams(connectionState, ref args, out var streamIds);
 
             var irq = InvocationRequest.Invoke(cancellationToken, returnType, connectionState.GetNextId(), _loggerFactory, this, activity, out invocationTask);
-            await InvokeCore(connectionState, methodName, irq, args, streamIds?.ToArray(), cancellationToken).ConfigureAwait(false);
+            await InvokeCore(connectionState, methodName, irq, args, streamIds, cancellationToken).ConfigureAwait(false);
 
             var streamTasks = LaunchStreams(connectionState, readers, cancellationToken);
 
@@ -1414,7 +1420,7 @@ public partial class HubConnection : IAsyncDisposable
             readers = PackageStreamingParams(connectionState, ref args, out var streamIds);
 
             Log.PreparingNonBlockingInvocation(_logger, methodName, args.Length);
-            var invocationMessage = new InvocationMessage(null, methodName, args, streamIds?.ToArray());
+            var invocationMessage = new InvocationMessage(null, methodName, args, streamIds);
             if (activity is not null)
             {
                 InjectHeaders(activity, invocationMessage);
@@ -2357,14 +2363,19 @@ public partial class HubConnection : IAsyncDisposable
         {
             lock (_lock)
             {
-                if (_pendingCalls.ContainsKey(irq.InvocationId))
+#if NETSTANDARD2_0 || NETFRAMEWORK
+                var added = !_pendingCalls.ContainsKey(irq.InvocationId);
+                if (added)
+                {
+                    _pendingCalls.Add(irq.InvocationId, irq);
+                }
+#else
+                var added = _pendingCalls.TryAdd(irq.InvocationId, irq);
+#endif
+                if (!added)
                 {
                     Log.InvocationAlreadyInUse(_logger, irq.InvocationId);
                     throw new InvalidOperationException($"Invocation ID '{irq.InvocationId}' is already in use.");
-                }
-                else
-                {
-                    _pendingCalls.Add(irq.InvocationId, irq);
                 }
             }
         }

--- a/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocolWorker.cs
+++ b/src/SignalR/common/Protocols.MessagePack/src/Protocol/MessagePackHubProtocolWorker.cs
@@ -243,7 +243,7 @@ internal abstract class MessagePackHubProtocolWorker
         var headerCount = ReadMapLength(ref reader, "headers");
         if (headerCount > 0)
         {
-            var headers = new Dictionary<string, string>(StringComparer.Ordinal);
+            var headers = new Dictionary<string, string>((int)headerCount, StringComparer.Ordinal);
 
             for (var i = 0; i < headerCount; i++)
             {
@@ -266,21 +266,22 @@ internal abstract class MessagePackHubProtocolWorker
     private static string[]? ReadStreamIds(ref MessagePackReader reader)
     {
         var streamIdCount = ReadArrayLength(ref reader, "streamIds");
-        List<string>? streams = null;
 
         if (streamIdCount > 0)
         {
-            streams = new List<string>();
+            var streams = new string[streamIdCount];
             for (var i = 0; i < streamIdCount; i++)
             {
                 var id = reader.ReadString();
                 ThrowIfNullOrEmpty(id, "value in streamIds received");
 
-                streams.Add(id);
+                streams[i] = id;
             }
+
+            return streams;
         }
 
-        return streams?.ToArray();
+        return null;
     }
 
     private static AckMessage CreateAckMessage(ref MessagePackReader reader)

--- a/src/SignalR/perf/Microbenchmarks/HubConnectionSendBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/HubConnectionSendBenchmark.cs
@@ -3,6 +3,7 @@
 
 using System.Buffers;
 using System.IO.Pipelines;
+using System.Threading.Channels;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
@@ -21,6 +22,7 @@ public class HubConnectionSendBenchmark
     private TestDuplexPipe _pipe;
     private TaskCompletionSource<ReadResult> _tcs;
     private object[] _arguments;
+    private object[] _streamingArguments;
 
     [GlobalSetup]
     public void GlobalSetup()
@@ -72,6 +74,12 @@ public class HubConnectionSendBenchmark
         {
             _arguments[i] = "Hello world!";
         }
+
+        // A single completed stream reader plus a few normal args, to exercise
+        // PackageStreamingParams' stream-id packaging without any live streaming work.
+        var streamChannel = Channel.CreateUnbounded<int>();
+        streamChannel.Writer.Complete();
+        _streamingArguments = new object[] { "Hello world!", streamChannel.Reader, "Hello world!" };
     }
 
     [Params(0, 1, 10, 100)]
@@ -91,5 +99,11 @@ public class HubConnectionSendBenchmark
     public Task SendAsync()
     {
         return _hubConnection.SendCoreAsync("Dummy", _arguments);
+    }
+
+    [Benchmark]
+    public Task SendStreamingAsync()
+    {
+        return _hubConnection.SendCoreAsync("Dummy", _streamingArguments);
     }
 }

--- a/src/SignalR/perf/Microbenchmarks/HubProtocolBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/HubProtocolBenchmark.cs
@@ -14,7 +14,7 @@ public class HubProtocolBenchmark
     private TestBinder _binder;
     private HubMessage _hubMessage;
 
-    [Params(Message.NoArguments, Message.FewArguments, Message.ManyArguments, Message.LargeArguments)]
+    [Params(Message.NoArguments, Message.FewArguments, Message.ManyArguments, Message.LargeArguments, Message.WithStreams)]
     public Message Input { get; set; }
 
     [Params(Protocol.MsgPack, Protocol.Json, Protocol.NewtonsoftJson)]
@@ -49,6 +49,10 @@ public class HubProtocolBenchmark
                 break;
             case Message.LargeArguments:
                 _hubMessage = new InvocationMessage("Target", new object[] { new string('F', 10240), new byte[10240] });
+                break;
+            case Message.WithStreams:
+                _hubMessage = new InvocationMessage(invocationId: null, "Target", new object[] { 1, "Foo", 2.0f },
+                    new[] { "stream-id-0", "stream-id-1", "stream-id-2", "stream-id-3" });
                 break;
         }
 
@@ -88,6 +92,7 @@ public class HubProtocolBenchmark
         NoArguments = 0,
         FewArguments = 1,
         ManyArguments = 2,
-        LargeArguments = 3
+        LargeArguments = 3,
+        WithStreams = 4
     }
 }

--- a/src/SignalR/perf/Microbenchmarks/HubProtocolBenchmark.cs
+++ b/src/SignalR/perf/Microbenchmarks/HubProtocolBenchmark.cs
@@ -14,7 +14,7 @@ public class HubProtocolBenchmark
     private TestBinder _binder;
     private HubMessage _hubMessage;
 
-    [Params(Message.NoArguments, Message.FewArguments, Message.ManyArguments, Message.LargeArguments, Message.WithStreams)]
+    [Params(Message.NoArguments, Message.FewArguments, Message.ManyArguments, Message.LargeArguments, Message.WithStreams, Message.WithHeaders)]
     public Message Input { get; set; }
 
     [Params(Protocol.MsgPack, Protocol.Json, Protocol.NewtonsoftJson)]
@@ -53,6 +53,22 @@ public class HubProtocolBenchmark
             case Message.WithStreams:
                 _hubMessage = new InvocationMessage(invocationId: null, "Target", new object[] { 1, "Foo", 2.0f },
                     new[] { "stream-id-0", "stream-id-1", "stream-id-2", "stream-id-3" });
+                break;
+            case Message.WithHeaders:
+                _hubMessage = new InvocationMessage("Target", new object[] { 1, "Foo", 2.0f })
+                {
+                    Headers = new Dictionary<string, string>
+                    {
+                        { "header-1", "value-1" },
+                        { "header-2", "value-2" },
+                        { "header-3", "value-3" },
+                        { "header-4", "value-4" },
+                        { "header-5", "value-5" },
+                        { "header-6", "value-6" },
+                        { "header-7", "value-7" },
+                        { "header-8", "value-8" },
+                    }
+                };
                 break;
         }
 
@@ -93,6 +109,7 @@ public class HubProtocolBenchmark
         FewArguments = 1,
         ManyArguments = 2,
         LargeArguments = 3,
-        WithStreams = 4
+        WithStreams = 4,
+        WithHeaders = 5
     }
 }


### PR DESCRIPTION
> **Draft / experiment — not for review yet.** Contact @artl93. This is an allocation-reduction experiment on SignalR hot paths, published as a draft while the analysis is finalized.

## Summary

Three low-risk SignalR allocation cleanups on hot parse/send paths. No public API or wire-format changes; behavior (ordering, exception type/message, validation, header comparer) is preserved.

1. **MessagePack `ReadStreamIds`** — fill a right-sized `string[]` directly instead of `List<string>` + `ToArray()`, removing the list object, its backing array, and the extra `ToArray()` copy per stream-carrying message.
2. **MessagePack `ReadHeaders`** — pre-size the headers `Dictionary` from the wire map count (`StringComparer.Ordinal` preserved), avoiding rehash/regrowth.
3. **Client `HubConnection`** — `PackageStreamingParams` returns the final `string[]?` directly (no intermediate `List<string>` + `ToArray()`), and `AddInvocation` uses a single `TryAdd` probe instead of a `ContainsKey` + `Add` double dictionary lookup (duplicate-ID exception type/message preserved).

## Before / after (allocations, paired A/B)

Baseline = parent `f297235c48`; candidate = this branch. Only the two product files differ between the two builds; same machine, SDK, BDN config. Allocation is deterministic per operation.

**MessagePack protocol read (out-of-process BDN):**

| Scenario | Before | After | Δ |
|---|---|---|---|
| Read — WithStreams (4 stream IDs) | 560 B | 472 B | −88 B (−15.7%) |
| Read — WithHeaders (8 headers) | 3,136 B | 2,584 B | −552 B (−17.6%) |
| Read — ManyArguments (control) | 400 B | 400 B | 0 |

**Client send (out-of-process BDN, standalone harness):**

| Scenario | Before | After | Δ |
|---|---|---|---|
| SendStreamingAsync — json (1 stream) | 2,041 B | 1,955 B | −86 B (−4.2%) |
| SendStreamingAsync — messagepack (1 stream) | 2,041 B | 1,953 B | −88 B (−4.3%) |
| SendAsync — control (non-streaming) | no change | no change | 0 |

Controls confirm no regression on unaffected paths. Non-streaming, header-less messages are unaffected (both `ReadHeaders`/`ReadStreamIds` early-return on count 0). Fix #3 `TryAdd` is CPU-only (single vs. double dictionary probe, zero allocation delta); the client-side guard is defensive since client invocation IDs are generated internally and monotonically, and the change preserves the exact `InvalidOperationException` message (`Invocation ID '{id}' is already in use.`).

## Tests

SignalR Common protocol tests and Client tests pass with no regression (MessagePack parse/write, streaming-parameter, and pending-invocation paths). Full commands and raw benchmark artifacts are in the analysis comment.
