### PR TITLE
Skip macOS quarantined-test job on PRs

### DIFF
--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -110,39 +110,45 @@ jobs:
       publishOnError: true
       includeForks: true
 
-- template: jobs/default-build.yml
-  parameters:
-    jobName: MacOS_Quarantined_Test
-    jobDisplayName: "Tests: macOS"
-    agentOs: macOS
-    timeoutInMinutes: 150
-    isAzDOTestingJob: true
-    enablePublishTestResults: false
-    steps:
-    - bash: ./eng/build.sh --ci --nobl --all --no-build-java --pack
-      displayName: Build
-    - bash: ./eng/build.sh --ci --nobl --all --no-build --no-build-java --test
-            -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
-      displayName: Run Quarantined Tests
-      continueOnError: true
-    - task: PublishTestResults@2
-      displayName: Publish Quarantined Test Results
-      inputs:
-        testResultsFormat: 'xUnit'
-        testResultsFiles: '*.xml'
-        searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)/Quarantined'
-        testRunTitle: Quarantine-$(AgentOsName)-$(BuildConfiguration)-xunit
-        mergeTestResults: true
-      condition: always()
-    artifacts:
-    - name: MacOS_Quarantined_Test_Logs
-      path: artifacts/log/
-      publishOnError: true
-      includeForks: true
-    - name: MacOS_Quarantined_Test_Results
-      path: artifacts/TestResults/
-      publishOnError: true
-      includeForks: true
+# The macOS quarantined-test job is skipped on PRs: the agent hangs and hits the
+# 150-minute timeout on roughly half of runs (a fork/exec deadlock in the
+# ServerComparison functional-test deploy path, not a test failure), which only
+# runs ~6-7 quarantined tests when it does complete. It still runs on main via
+# the scheduled and batched CI triggers so we retain macOS quarantine coverage.
+- ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
+  - template: jobs/default-build.yml
+    parameters:
+      jobName: MacOS_Quarantined_Test
+      jobDisplayName: "Tests: macOS"
+      agentOs: macOS
+      timeoutInMinutes: 150
+      isAzDOTestingJob: true
+      enablePublishTestResults: false
+      steps:
+      - bash: ./eng/build.sh --ci --nobl --all --no-build-java --pack
+        displayName: Build
+      - bash: ./eng/build.sh --ci --nobl --all --no-build --no-build-java --test
+              -p:RunQuarantinedTests=true -p:SkipHelixReadyTests=true
+        displayName: Run Quarantined Tests
+        continueOnError: true
+      - task: PublishTestResults@2
+        displayName: Publish Quarantined Test Results
+        inputs:
+          testResultsFormat: 'xUnit'
+          testResultsFiles: '*.xml'
+          searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)/Quarantined'
+          testRunTitle: Quarantine-$(AgentOsName)-$(BuildConfiguration)-xunit
+          mergeTestResults: true
+        condition: always()
+      artifacts:
+      - name: MacOS_Quarantined_Test_Logs
+        path: artifacts/log/
+        publishOnError: true
+        includeForks: true
+      - name: MacOS_Quarantined_Test_Results
+        path: artifacts/TestResults/
+        publishOnError: true
+        includeForks: true
 
 - template: jobs/default-build.yml
   parameters:


### PR DESCRIPTION
## Summary

Skips the **`Tests: macOS`** quarantined-test job on **PR** builds of the quarantine pipeline (`.azure/pipelines/quarantined-pr.yml`). It still runs on `main` via the scheduled (every-4-hours) and batched CI triggers, so we keep macOS quarantine coverage on the branch.

## Why

Over the last 7 days of [def 86](https://dev.azure.com/dnceng-public/public/_build?definitionId=86), the macOS job was by far the dominant failure:

- **72** failed builds had `Tests: macOS` fail; **59** of those were the *"ran longer than the maximum time of 150 minutes"* timeout.
- Every failed **rolling** build (**18/18**) failed *only* on macOS, all via the 150-min timeout — i.e. ~half of all main builds hard-fail on this hang.
- The hang is a **fork()/exec() deadlock** in the ServerComparison functional-test deploy path (`MSBuild → Process.Start → Interop.Sys.ForkAndExecProcess`), not a test failure. It reproduces on native Intel hosted `macos-15` agents.
- When the job *does* complete, the macOS agent leg only runs **~6–7 quarantined tests** — so blocking PRs for up to 150 minutes on it is a poor tradeoff.

Given the low test yield and the high failure/timeout rate, skipping it on PRs removes a frequent 150-minute drag on PR validation while preserving macOS coverage on `main`.

## Change

Wraps the macOS job in `- ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:` (an established pattern in this repo, e.g. `ci-public.yml`, `ci-unofficial.yml`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Related: https://github.com/dotnet/runtime/issues/89272
