### PR TITLE
Http: avoid boxing StringValues when promoting duplicate query keys

### DIFF
--- a/src/Http/Http/perf/Microbenchmarks/QueryCollectionBenchmarks.cs
+++ b/src/Http/Http/perf/Microbenchmarks/QueryCollectionBenchmarks.cs
@@ -17,6 +17,7 @@ public class QueryCollectionBenchmarks
     private const string _singleValue = "?key1=value1";
     private const string _singleValueWithPlus = "?key1=value1+value2+value3";
     private const string _encoded = "?key1=value%231";
+    private const string _duplicateKeys = "?key1=value1&key1=value2&key1=value3&key2=value1&key2=value2";
 
     [Benchmark(Description = "ParseNew")]
     [BenchmarkCategory("QueryString")]
@@ -44,6 +45,20 @@ public class QueryCollectionBenchmarks
     public void ParseNewEncoded()
     {
         _ = QueryFeature.ParseNullableQueryInternal(_encoded);
+    }
+
+    [Benchmark(Description = "ParseNew")]
+    [BenchmarkCategory("DuplicateKeys")]
+    public void ParseNewDuplicateKeys()
+    {
+        _ = QueryFeature.ParseNullableQueryInternal(_duplicateKeys);
+    }
+
+    [Benchmark(Description = "QueryHelpersParse")]
+    [BenchmarkCategory("DuplicateKeys")]
+    public void QueryHelpersParseDuplicateKeys()
+    {
+        _ = QueryHelpers.ParseNullableQuery(_duplicateKeys);
     }
 
     [Benchmark(Description = "QueryHelpersParse")]

--- a/src/Http/Http/perf/Microbenchmarks/QueryDuplicateKeyScalingBenchmarks.cs
+++ b/src/Http/Http/perf/Microbenchmarks/QueryDuplicateKeyScalingBenchmarks.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Http;
 /// Characterizes allocation/timing of <c>QueryFeature</c> parsing as the number of
 /// repeated (duplicate) query keys grows. Exercises the <c>KvpAccumulator</c> path that
 /// promotes repeated keys into a <see cref="System.Collections.Generic.List{T}"/>, which is
-/// the code path affected by the duplicate-key list pre-sizing change.
+/// the code path affected by the duplicate-key list promotion change.
 /// </summary>
 [MemoryDiagnoser]
 public class QueryDuplicateKeyScalingBenchmarks
@@ -24,8 +24,9 @@ public class QueryDuplicateKeyScalingBenchmarks
 
     /// <summary>
     /// Total number of occurrences of a single repeated key. 1 == no duplicate (control,
-    /// no promotion); 2+ triggers promotion to a backing list with (Occurrences-1) growth
-    /// events on the un-optimized path.
+    /// no promotion); 2+ triggers a single promotion to a backing list, after which each
+    /// further occurrence appends to that list (the list grows through its normal capacity
+    /// doubling as more values are added).
     /// </summary>
     [Params(1, 2, 3, 4, 8, 16, 32)]
     public int Occurrences { get; set; }

--- a/src/Http/Http/perf/Microbenchmarks/QueryDuplicateKeyScalingBenchmarks.cs
+++ b/src/Http/Http/perf/Microbenchmarks/QueryDuplicateKeyScalingBenchmarks.cs
@@ -1,0 +1,141 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace Microsoft.AspNetCore.Http;
+
+/// <summary>
+/// Characterizes allocation/timing of <c>QueryFeature</c> parsing as the number of
+/// repeated (duplicate) query keys grows. Exercises the <c>KvpAccumulator</c> path that
+/// promotes repeated keys into a <see cref="System.Collections.Generic.List{T}"/>, which is
+/// the code path affected by the duplicate-key list pre-sizing change.
+/// </summary>
+[MemoryDiagnoser]
+public class QueryDuplicateKeyScalingBenchmarks
+{
+    private string _repeatedSingleKey = string.Empty;
+    private string _uniqueKeys = string.Empty;
+    private string _multipleDuplicatedKeys = string.Empty;
+    private string _encodedDuplicates = string.Empty;
+    private string _longValueDuplicates = string.Empty;
+
+    /// <summary>
+    /// Total number of occurrences of a single repeated key. 1 == no duplicate (control,
+    /// no promotion); 2+ triggers promotion to a backing list with (Occurrences-1) growth
+    /// events on the un-optimized path.
+    /// </summary>
+    [Params(1, 2, 3, 4, 8, 16, 32)]
+    public int Occurrences { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // One key repeated <Occurrences> times: ?k=v0&k=v1&...
+        var sb = new StringBuilder("?");
+        for (var i = 0; i < Occurrences; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append('&');
+            }
+            sb.Append("key=value").Append(i);
+        }
+        _repeatedSingleKey = sb.ToString();
+
+        // Unique-keys control: <Occurrences> DISTINCT keys, no duplicates, no promotion.
+        sb.Clear();
+        sb.Append('?');
+        for (var i = 0; i < Occurrences; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append('&');
+            }
+            sb.Append("key").Append(i).Append("=value").Append(i);
+        }
+        _uniqueKeys = sb.ToString();
+
+        // Multiple duplicated keys: <Occurrences> distinct keys each duplicated 3x.
+        sb.Clear();
+        sb.Append('?');
+        var first = true;
+        for (var k = 0; k < Occurrences; k++)
+        {
+            for (var d = 0; d < 3; d++)
+            {
+                if (!first)
+                {
+                    sb.Append('&');
+                }
+                first = false;
+                sb.Append('k').Append(k).Append("=v").Append(d);
+            }
+        }
+        _multipleDuplicatedKeys = sb.ToString();
+
+        // Percent-encoded duplicate values (decoding path + promotion).
+        sb.Clear();
+        sb.Append('?');
+        for (var i = 0; i < Occurrences; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append('&');
+            }
+            sb.Append("key=value%23").Append(i);
+        }
+        _encodedDuplicates = sb.ToString();
+
+        // Long-value duplicates (larger strings, same promotion shape).
+        var longVal = new string('x', 128);
+        sb.Clear();
+        sb.Append('?');
+        for (var i = 0; i < Occurrences; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append('&');
+            }
+            sb.Append("key=").Append(longVal).Append(i);
+        }
+        _longValueDuplicates = sb.ToString();
+    }
+
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("RepeatedSingleKey")]
+    public void RepeatedSingleKey()
+    {
+        _ = QueryFeature.ParseNullableQueryInternal(_repeatedSingleKey);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("UniqueKeysControl")]
+    public void UniqueKeysControl()
+    {
+        _ = QueryFeature.ParseNullableQueryInternal(_uniqueKeys);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("MultipleDuplicatedKeys")]
+    public void MultipleDuplicatedKeys()
+    {
+        _ = QueryFeature.ParseNullableQueryInternal(_multipleDuplicatedKeys);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("EncodedDuplicates")]
+    public void EncodedDuplicates()
+    {
+        _ = QueryFeature.ParseNullableQueryInternal(_encodedDuplicates);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("LongValueDuplicates")]
+    public void LongValueDuplicates()
+    {
+        _ = QueryFeature.ParseNullableQueryInternal(_longValueDuplicates);
+    }
+}

--- a/src/Http/Http/src/Features/QueryFeature.cs
+++ b/src/Http/Http/src/Features/QueryFeature.cs
@@ -163,10 +163,15 @@ public class QueryFeature : IQueryFeature
                     _expandingAccumulator = new AdaptiveCapacityDictionary<string, List<string>>(capacity: 5, StringComparer.OrdinalIgnoreCase);
                 }
 
-                // Already 2 (1 existing + the new one) entries so use List's expansion mechanism for more
-                var list = new List<string>();
+                // Already 2 (1 existing + the new one) entries, so pre-size the list to avoid an
+                // immediate growth/copy when the second value is added.
+                var list = new List<string>(values.Count + 1);
 
-                list.AddRange(values);
+                for (var i = 0; i < values.Count; i++)
+                {
+                    list.Add(values[i]!);
+                }
+
                 list.Add(value);
 
                 _expandingAccumulator[key] = list;

--- a/src/Http/Http/src/Features/QueryFeature.cs
+++ b/src/Http/Http/src/Features/QueryFeature.cs
@@ -163,10 +163,11 @@ public class QueryFeature : IQueryFeature
                     _expandingAccumulator = new AdaptiveCapacityDictionary<string, List<string>>(capacity: 5, StringComparer.OrdinalIgnoreCase);
                 }
 
-                // Copy the existing values by index rather than AddRange(values): passing the
-                // StringValues struct through IEnumerable<string> boxes it. Indexed adds avoid that
-                // boxing allocation while still letting the list grow to its default capacity in a
-                // single step, so keys that repeat three or more times incur no extra reallocation.
+                // Copy the existing value(s) by index rather than calling AddRange(values):
+                // AddRange takes IEnumerable<string>, which boxes the StringValues struct.
+                // Indexed Add avoids that boxing allocation. List growth and capacity behavior
+                // are unchanged from AddRange, so this is a strict allocation reduction that
+                // preserves ordering and contents exactly.
                 var list = new List<string>();
 
                 for (var i = 0; i < values.Count; i++)

--- a/src/Http/Http/src/Features/QueryFeature.cs
+++ b/src/Http/Http/src/Features/QueryFeature.cs
@@ -163,9 +163,11 @@ public class QueryFeature : IQueryFeature
                     _expandingAccumulator = new AdaptiveCapacityDictionary<string, List<string>>(capacity: 5, StringComparer.OrdinalIgnoreCase);
                 }
 
-                // Already 2 (1 existing + the new one) entries, so pre-size the list to avoid an
-                // immediate growth/copy when the second value is added.
-                var list = new List<string>(values.Count + 1);
+                // Copy the existing values by index rather than AddRange(values): passing the
+                // StringValues struct through IEnumerable<string> boxes it. Indexed adds avoid that
+                // boxing allocation while still letting the list grow to its default capacity in a
+                // single step, so keys that repeat three or more times incur no extra reallocation.
+                var list = new List<string>();
 
                 for (var i = 0; i < values.Count; i++)
                 {


### PR DESCRIPTION
## Summary

`QueryFeature` parses request query strings. When a key appears more than once, `KvpAccumulator` promotes the accumulated values into a `List<string>`. The previous code populated that list with `List<string>.AddRange(values)`, where `values` is a `StringValues` **struct**. Passing a struct to `AddRange(IEnumerable<string>)` **boxes it on the heap** (~24 bytes), even though `AddRange` then takes its `ICollection<T>` fast path.

This change replaces `AddRange(values)` with a small indexed copy loop, which reads directly off the struct and avoids the box:

```csharp
var list = new List<string>();
for (var i = 0; i < values.Count; i++)
{
    list.Add(values[i]!);
}
list.Add(value);
```

Result: **−24 bytes per duplicate-key promotion**, with identical list contents/order/capacity and no extra reallocation.

## Motivation

Query strings with repeated keys are common (`?id=1&id=2`, checkbox groups, array-style params, etc.). Every such promotion boxed the `StringValues` struct. The boxed object is discarded immediately after the copy, so it is pure GC pressure on a hot request-parsing path. Removing it costs nothing on the common single-value path (that branch is unchanged and never runs for non-duplicate keys).

## Measured allocation

Deterministic bytes/op (`GC.GetAllocatedBytesForCurrentThread`), A/B between the exact parent and this head. Two independent methods agree to the byte: a BenchmarkDotNet `[MemoryDiagnoser]` crossover (whole `QueryFeature.cs` swapped and rebuilt per arm) and a direct A/B harness that loads each arm's built `Microsoft.AspNetCore.Http.dll` and drives the real `QueryFeature.ParseNullableQueryInternal` through a zero-allocation delegate.

**One key repeated N times** (exactly one promotion):

| Occurrences | before | after | delta |
|------------:|-------:|------:|------:|
| 1 (no duplicate) |  304 |  304 | **0** |
| 2  |  680 |  656 | **−24** |
| 3  |  760 |  736 | **−24** |
| 4  |  840 |  816 | **−24** |
| 8  | 1248 | 1224 | **−24** |
| 16 | 2040 | 2016 | **−24** |
| 32 | 3600 | 3576 | **−24** |

**Savings scale with the number of promotions, not occurrence count.** With N distinct keys each duplicated (so N promotions in one parse), the saving is exactly −24 B × N:

| Distinct duplicated keys | before | after | delta |
|------------:|-------:|------:|------:|
| 1  |   736 |   712 | **−24** |
| 2  |  1088 |  1040 | **−48** |
| 4  |  1792 |  1696 | **−96** |
| 8  |  3384 |  3192 | **−192** |
| 16 |  8472 |  8088 | **−384** |
| 32 | 16840 | 16072 | **−768** |

Controls confirm the delta is exactly the single 24-byte box and nothing else:
- **Unique keys, no duplicates: 0 B change** at every size (the promotion branch is never taken) — this is the overwhelmingly common request shape.
- **Percent-encoded duplicate values: −24 B** (decode path unaffected).
- **128-char duplicate values: −24 B** (the box is fixed-size; independent of value length).
- Allocation-only improvement; no throughput change is claimed (timing deltas are within run-to-run noise).

The −24 B delta is architecture-invariant. A focused allocation probe using the real `Microsoft.Extensions.Primitives.StringValues` measured **exactly −24.00 B/op on both Linux x64 and macOS ARM64** (identical absolute allocations), confirming the box is the sole difference.

## Correctness

Value ordering through promotion, empty values, percent-encoded keys/values, and the `OrdinalIgnoreCase` comparer are preserved exactly (`KvpAccumulator` is internal; `values[i]!` is a compile-time-only null-forgiving on `StringValues`' `string?` indexer). Existing `QueryFeatureTests` cover these; the full Query test set passes (28/28 locally).

> CI note: the current red X is an unrelated repo-wide `NU1902` build break (AngleSharp 0.9.9 advisory treated as error in Identity/Security/Mvc functional-test projects); this change touches no packages and `Microsoft.AspNetCore.Http` builds clean.

## Benchmarks

Committed under `src/Http/Http/perf/Microbenchmarks/`:
- `QueryCollectionBenchmarks.ParseNewDuplicateKeys`
- `QueryDuplicateKeyScalingBenchmarks` (repeated-key scaling plus unique-key, multi-duplicate, encoded, and long-value controls)

```
dotnet run -c Release --project src/Http/Http/perf/Microbenchmarks \
  -- --filter "*QueryDuplicateKeyScalingBenchmarks*" --memory
```

---

<sub>Draft: opened as a performance experiment. Kept as a draft pending maintainer interest — allocation-only, low-risk, zero behavioral change. Contact @artl93.</sub>
