### PR TITLE
[release/10.0] Limit Microsoft.OpenApi to disallow next major

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -179,8 +179,8 @@
     <XunitExtensibilityExecutionVersion>$(XunitVersion)</XunitExtensibilityExecutionVersion>
     <XUnitRunnerVisualStudioVersion>3.1.3</XUnitRunnerVisualStudioVersion>
     <MicrosoftDataSqlClientVersion>5.2.2</MicrosoftDataSqlClientVersion>
-    <MicrosoftOpenApiVersion>[2.7.5)</MicrosoftOpenApiVersion>
-    <MicrosoftOpenApiYamlReaderVersion>[2.7.5)</MicrosoftOpenApiYamlReaderVersion>
+    <MicrosoftOpenApiVersion>[2.7.5,3.0.0)</MicrosoftOpenApiVersion>
+    <MicrosoftOpenApiYamlReaderVersion>[2.7.5,3.0.0)</MicrosoftOpenApiYamlReaderVersion>
     <!-- dotnet tool versions (see also auto-updated DotnetEfVersion property). -->
     <DotnetDumpVersion>6.0.322601</DotnetDumpVersion>
     <DotnetServeVersion>1.10.93</DotnetServeVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -179,8 +179,8 @@
     <XunitExtensibilityExecutionVersion>$(XunitVersion)</XunitExtensibilityExecutionVersion>
     <XUnitRunnerVisualStudioVersion>3.1.3</XUnitRunnerVisualStudioVersion>
     <MicrosoftDataSqlClientVersion>5.2.2</MicrosoftDataSqlClientVersion>
-    <MicrosoftOpenApiVersion>2.7.5</MicrosoftOpenApiVersion>
-    <MicrosoftOpenApiYamlReaderVersion>2.7.5</MicrosoftOpenApiYamlReaderVersion>
+    <MicrosoftOpenApiVersion>[2.7.5)</MicrosoftOpenApiVersion>
+    <MicrosoftOpenApiYamlReaderVersion>[2.7.5)</MicrosoftOpenApiYamlReaderVersion>
     <!-- dotnet tool versions (see also auto-updated DotnetEfVersion property). -->
     <DotnetDumpVersion>6.0.322601</DotnetDumpVersion>
     <DotnetServeVersion>1.10.93</DotnetServeVersion>


### PR DESCRIPTION
This mirrors #67771 in release/10.0.

# Limit Microsoft.OpenApi to disallow next major

This PR adjusts the dependency on Microsoft.OpenApi to be `< 3.0.0` and `>= 2.7.5`.

## Description

Microsoft.OpenApi 2.x and 3.x are **not** binary compatible. Attempting to update Microsoft.OpenApi in user applications to 3.x while using .NET 10 will fail with errors that are hard to interpret by users. This could either be that the Xml comments source generator producing code with compilation errors, or fail due to other binary incompatibilities at runtime.

Fixes #64317

## Customer Impact

Customers will get a more clear error from NuGet that they should keep the dependency on 2.x as 3.0.0+ isn't supported. This is better than failing with cryptic errors in source-generated code.

## Regression?

No

## Risk

Low

This is a failure case already today.

## Verification

From CI artifacts:

<img width="1491" height="813" alt="image" src="https://github.com/user-attachments/assets/97d716de-c717-4885-b925-eb5ac36b321f" />

<img width="450" height="223" alt="image" src="https://github.com/user-attachments/assets/af38a651-c5a3-4fd8-a338-2b1f45d71dfc" />


## Packaging changes reviewed?

- [x] Yes
- [ ] No
- [ ] N/A
