### PR TITLE
[Kestrel] Deflake HTTP/2 connection closing tests

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2ConnectionTests.cs
@@ -5369,9 +5369,15 @@ public class Http2ConnectionTests : Http2TestBase
     [Fact]
     public async Task StopProcessingNextRequestSendsGracefulGOAWAYThenFinalGOAWAYWhenAllStreamsComplete()
     {
-        await InitializeConnectionAsync(_echoApplication);
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await InitializeConnectionAsync(context =>
+        {
+            requestStarted.TrySetResult();
+            return _echoApplication(context);
+        });
 
         await StartStreamAsync(1, _browserRequestHeaders, endStream: false);
+        await requestStarted.Task.DefaultTimeout();
 
         _connection.StopProcessingNextRequest(ConnectionEndReason.AppShutdownTimeout);
         await _closingStateReached.Task.DefaultTimeout();
@@ -5402,9 +5408,15 @@ public class Http2ConnectionTests : Http2TestBase
     [Fact]
     public async Task AcceptNewStreamsDuringClosingConnection()
     {
-        await InitializeConnectionAsync(_echoApplication);
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await InitializeConnectionAsync(context =>
+        {
+            requestStarted.TrySetResult();
+            return _echoApplication(context);
+        });
 
         await StartStreamAsync(1, _browserRequestHeaders, endStream: false);
+        await requestStarted.Task.DefaultTimeout();
 
         _connection.StopProcessingNextRequest(ConnectionEndReason.AppShutdownTimeout);
         VerifyGoAway(await ReceiveFrameAsync(), Int32.MaxValue, Http2ErrorCode.NO_ERROR);
@@ -5453,9 +5465,15 @@ public class Http2ConnectionTests : Http2TestBase
         // Remove callback that completes _pair.Application.Output on abort.
         _mockConnectionContext.Reset();
 
-        await InitializeConnectionAsync(_echoApplication);
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await InitializeConnectionAsync(context =>
+        {
+            requestStarted.TrySetResult();
+            return _echoApplication(context);
+        });
 
         await StartStreamAsync(1, _browserRequestHeaders, endStream: false);
+        await requestStarted.Task.DefaultTimeout();
 
         _connection.OnInputOrOutputCompleted();
         await _closedStateReached.Task.DefaultTimeout();


### PR DESCRIPTION
## Summary

- wait for the initial request to reach the application before directly initiating graceful shutdown or closing the HTTP/2 connection
- make the active-stream and GOAWAY expectations deterministic in all three affected lifecycle tests
- keep the fix local to these tests instead of changing shared scheduling behavior

`StartStreamAsync` guarantees that the HEADERS frame was flushed, but not that the connection loop has processed it. A direct `StopProcessingNextRequest` or `OnInputOrOutputCompleted` call can therefore observe zero active streams and take a different shutdown path.

## Tests

The three affected tests passed 100 iterations each (300 executions).

## Related

- Failed CI: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1507529&view=ms.vss-test-web.build-test-results-tab&runId=41548186&resultId=110922&paneView=debug
- Related closed issues: #39479, #41172
- Prior broader synchronization-context attempt: #41181