### PR TITLE
[release/10.0] Move Linux CI jobs off Microsoft-hosted pools (backport #64842, #65867)

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -295,7 +295,6 @@ stages:
       jobName: Linux_x64_build
       jobDisplayName: "Build: Linux x64"
       agentOs: Linux
-      useHostedUbuntu: false
       steps:
       - script: ./eng/build.sh
             --ci
@@ -327,6 +326,7 @@ stages:
       jobName: Linux_arm_build
       jobDisplayName: "Build: Linux ARM"
       agentOs: Linux
+      use1ESUbuntu: true
       buildArgs:
         --arch arm
         --pack
@@ -357,6 +357,7 @@ stages:
       jobName: Linux_arm64_build
       jobDisplayName: "Build: Linux ARM64"
       agentOs: Linux
+      use1ESUbuntu: true
       steps:
       - script: ./eng/build.sh
             --ci
@@ -421,7 +422,6 @@ stages:
       jobName: Linux_musl_arm_build
       jobDisplayName: "Build: Linux Musl ARM"
       agentOs: Linux
-      useHostedUbuntu: false
       container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-build-amd64
       buildArgs:
         --arch arm
@@ -454,7 +454,6 @@ stages:
       jobName: Linux_musl_arm64_build
       jobDisplayName: "Build: Linux Musl ARM64"
       agentOs: Linux
-      useHostedUbuntu: false
       container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-build-amd64
       buildArgs:
         --arch arm64
@@ -538,7 +537,6 @@ stages:
         jobDisplayName: "Test: Ubuntu x64"
         agentOs: Linux
         isAzDOTestingJob: true
-        useHostedUbuntu: false
         buildArgs: --all --test --binaryLog /p:RunTemplateTests=false /p:SkipHelixReadyTests=true $(_InternalRuntimeDownloadArgs)
         beforeBuild:
         - bash: "./eng/scripts/install-nginx.sh"

--- a/.azure/pipelines/ci-unofficial.yml
+++ b/.azure/pipelines/ci-unofficial.yml
@@ -314,7 +314,6 @@ extends:
           jobName: Linux_x64_build
           jobDisplayName: "Build: Linux x64"
           agentOs: Linux
-          useHostedUbuntu: false
           beforeBuild:
           - script: git submodule update --init
             displayName: Update submodules
@@ -349,6 +348,7 @@ extends:
           jobName: Linux_arm_build
           jobDisplayName: "Build: Linux ARM"
           agentOs: Linux
+          use1ESUbuntu: true
           beforeBuild:
           - script: git submodule update --init
             displayName: Update submodules
@@ -382,6 +382,7 @@ extends:
           jobName: Linux_arm64_build
           jobDisplayName: "Build: Linux ARM64"
           agentOs: Linux
+          use1ESUbuntu: true
           beforeBuild:
           - script: git submodule update --init
             displayName: Update submodules
@@ -452,7 +453,6 @@ extends:
           jobName: Linux_musl_arm_build
           jobDisplayName: "Build: Linux Musl ARM"
           agentOs: Linux
-          useHostedUbuntu: false
           container: azureLinux30Net10BuildAmd64
           beforeBuild:
           - script: git submodule update --init
@@ -488,7 +488,6 @@ extends:
           jobName: Linux_musl_arm64_build
           jobDisplayName: "Build: Linux Musl ARM64"
           agentOs: Linux
-          useHostedUbuntu: false
           container: azureLinux30Net10BuildAmd64
           beforeBuild:
           - script: git submodule update --init
@@ -576,7 +575,6 @@ extends:
             jobDisplayName: "Test: Ubuntu x64"
             agentOs: Linux
             isAzDOTestingJob: true
-            useHostedUbuntu: false
             buildArgs: --all --test --binaryLog /p:RunTemplateTests=false /p:SkipHelixReadyTests=true $(_InternalRuntimeDownloadArgs)
             beforeBuild:
             - script: git submodule update --init

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -330,7 +330,6 @@ extends:
           jobName: Linux_x64_build
           jobDisplayName: "Build: Linux x64"
           agentOs: Linux
-          useHostedUbuntu: false
           buildArgs:
             --arch x64
             --pack
@@ -362,6 +361,7 @@ extends:
           jobName: Linux_arm_build
           jobDisplayName: "Build: Linux ARM"
           agentOs: Linux
+          use1ESUbuntu: true
           buildArgs:
             --arch arm
             --pack
@@ -392,6 +392,7 @@ extends:
           jobName: Linux_arm64_build
           jobDisplayName: "Build: Linux ARM64"
           agentOs: Linux
+          use1ESUbuntu: true
           buildArgs:
             --arch arm64
             --pack
@@ -456,7 +457,6 @@ extends:
           jobName: Linux_musl_arm_build
           jobDisplayName: "Build: Linux Musl ARM"
           agentOs: Linux
-          useHostedUbuntu: false
           container: azureLinux30Net10BuildAmd64
           buildArgs:
             --arch arm
@@ -489,7 +489,6 @@ extends:
           jobName: Linux_musl_arm64_build
           jobDisplayName: "Build: Linux Musl ARM64"
           agentOs: Linux
-          useHostedUbuntu: false
           container: azureLinux30Net10BuildAmd64
           buildArgs:
             --arch arm64
@@ -570,7 +569,6 @@ extends:
             jobDisplayName: "Test: Ubuntu x64"
             agentOs: Linux
             isAzDOTestingJob: true
-            useHostedUbuntu: false
             buildArgs: --all --test --binaryLog /p:RunTemplateTests=false /p:SkipHelixReadyTests=true $(_InternalRuntimeDownloadArgs)
             beforeBuild:
             - bash: "./eng/scripts/install-nginx.sh"

--- a/.azure/pipelines/jobs/components-e2e-test-job.yml
+++ b/.azure/pipelines/jobs/components-e2e-test-job.yml
@@ -8,6 +8,7 @@ jobs:
     jobName: Components_E2E_Test
     jobDisplayName: "Test: Blazor E2E tests on Linux"
     agentOs: Linux
+    use1ESUbuntu: true
     isAzDOTestingJob: true
     enablePublishTestResults: false
     timeoutInMinutes: 120

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -70,7 +70,7 @@ parameters:
   installNodeJs: true
   timeoutInMinutes: 180
   testRunTitle: $(AgentOsName)-$(BuildConfiguration)
-  useHostedUbuntu: true
+  use1ESUbuntu: false
   # Checkout optimization parameters
   fetchDepth: 1
   fetchTags: false
@@ -108,8 +108,9 @@ jobs:
         ${{ if eq(parameters.agentOs, 'macOS') }}:
           vmImage: macOS-15
         ${{ if eq(parameters.agentOs, 'Linux') }}:
-          ${{ if eq(parameters.useHostedUbuntu, true) }}:
-            vmImage: ubuntu-22.04
+          ${{ if eq(parameters.use1ESUbuntu, true) }}:
+            name: $(DncEngPublicBuildPool)
+            demands: ImageOverride -equals 1es-ubuntu-2204-open
           ${{ else }}:
             name: $(DncEngPublicBuildPool)
             demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
@@ -328,9 +329,14 @@ jobs:
           image: macOS-15
           os: macOS
         ${{ if eq(parameters.agentOs, 'Linux') }}:
-          name: $(DncEngInternalBuildPool)
-          image: 1es-ubuntu-2204
-          os: linux
+          ${{ if eq(parameters.use1ESUbuntu, true) }}:
+            name: $(DncEngInternalBuildPool)
+            image: 1es-ubuntu-2204
+            os: linux
+          ${{ else }}:
+            name: $(DncEngInternalBuildPool)
+            image: Build.Ubuntu.2204.Amd64
+            os: linux
         ${{ if eq(parameters.agentOs, 'Windows') }}:
           name: $(DncEngInternalBuildPool)
           # Visual Studio Enterprise - contains some stuff, like SQL Server and IIS Express, that we use for testing

--- a/.azure/pipelines/quarantined-pr.yml
+++ b/.azure/pipelines/quarantined-pr.yml
@@ -151,7 +151,6 @@ jobs:
     timeoutInMinutes: 60
     isAzDOTestingJob: true
     enablePublishTestResults: false
-    useHostedUbuntu: false
     steps:
     - bash: ./eng/build.sh --ci --nobl --all --no-build-java --pack
       displayName: Build


### PR DESCRIPTION
## Summary

Backport of #64842 and #65867 to `release/10.0`.

`release/10.0` predates these PRs, so its `default-build.yml` still uses the old
`useHostedUbuntu: true` default, which routes Linux CI/PR jobs to the
**Microsoft-hosted** `vmImage: ubuntu-22.04` pool. This includes the queue-bound
Components E2E ("Test: Blazor E2E tests on Linux") job and the Linux cross-build
legs, which incur multi-hour agent-queue waits on the finite hosted pool.

This change brings `release/10.0` in line with `main`: it renames the parameter
to `use1ESUbuntu` (default `false`) and routes Linux jobs to the .NET-owned
dnceng pool (`$(DncEngPublicBuildPool)` / `$(DncEngInternalBuildPool)`) with the
`1es-ubuntu-2204(-open)` or `Build.Ubuntu.2204.Amd64(.Open)` images.

## Backported PRs

- **#64842** — Switch default for `useHostedUbuntu` to false and use dnceng pool
- **#65867** — Fix Ubuntu build image (`Build.Ubuntu.2204` → `Build.Ubuntu.2204.Amd64`)

## Changes

| File | Change |
|------|--------|
| `jobs/default-build.yml` | Rename `useHostedUbuntu` (default `true`) → `use1ESUbuntu` (default `false`); route public/internal Linux to the dnceng pool with `1es-ubuntu-2204(-open)` (when `use1ESUbuntu: true`) or `Build.Ubuntu.2204.Amd64(.Open)` (else) |
| `jobs/components-e2e-test-job.yml` | Set `use1ESUbuntu: true` (Blazor E2E) |
| `ci.yml`, `ci-public.yml`, `ci-unofficial.yml` | Remove `useHostedUbuntu: false`; add `use1ESUbuntu: true` to Linux ARM + ARM64 |
| `quarantined-pr.yml` | Remove `useHostedUbuntu: false` |

## Notes

- The change was applied semantically (not a literal cherry-pick) because
  `release/10.0` has diverged from the PRs' base (the Components E2E job is split
  into `jobs/components-e2e-test-job.yml`, and the Linux cross legs are structured
  differently). The resulting pool logic matches `main`.
- `release/10.0`'s Windows images (`windows.vs2022.amd64[.open]`) are intentionally
  left unchanged — the Windows image bump on `main` was a separate PR, not part of
  #64842/#65867.
- After the parameter rename, any lingering `useHostedUbuntu` reference would be an
  undeclared-parameter error, so every pipeline that passed it was updated. Verified
  no `useHostedUbuntu` remains and all changed YAML files parse.

Relates to dnceng AB#11633.
