### PR TITLE
[release/10.0] Update Microsoft.Data.SqlClient reference version to 6.1.1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -130,7 +130,7 @@
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension90x64Version>$(MicrosoftAspNetCoreAzureAppServicesSiteExtension90Version)</MicrosoftAspNetCoreAzureAppServicesSiteExtension90x64Version>
     <MicrosoftAspNetCoreAzureAppServicesSiteExtension90x86Version>$(MicrosoftAspNetCoreAzureAppServicesSiteExtension90Version)</MicrosoftAspNetCoreAzureAppServicesSiteExtension90x86Version>
     <!-- 3rd party dependencies -->
-    <AzureIdentityVersion>1.11.4</AzureIdentityVersion>
+    <AzureIdentityVersion>1.14.2</AzureIdentityVersion>
     <AngleSharpVersion>0.9.9</AngleSharpVersion>
     <BenchmarkDotNetVersion>0.13.0</BenchmarkDotNetVersion>
     <CastleCoreVersion>4.2.1</CastleCoreVersion>
@@ -178,7 +178,7 @@
     <XunitExtensibilityCoreVersion>$(XunitVersion)</XunitExtensibilityCoreVersion>
     <XunitExtensibilityExecutionVersion>$(XunitVersion)</XunitExtensibilityExecutionVersion>
     <XUnitRunnerVisualStudioVersion>3.1.3</XUnitRunnerVisualStudioVersion>
-    <MicrosoftDataSqlClientVersion>5.2.2</MicrosoftDataSqlClientVersion>
+    <MicrosoftDataSqlClientVersion>6.1.1</MicrosoftDataSqlClientVersion>
     <MicrosoftOpenApiVersion>2.7.5</MicrosoftOpenApiVersion>
     <MicrosoftOpenApiYamlReaderVersion>2.7.5</MicrosoftOpenApiYamlReaderVersion>
     <!-- dotnet tool versions (see also auto-updated DotnetEfVersion property). -->


### PR DESCRIPTION
Fixes #66636

Updates Microsoft.Data.SqlClient dependency version to 6.1.1 on release/10.0 branch, matching the version used by EF Core 10.0. This prevents FileNotFoundException for Microsoft.Data.SqlClient version 5.0.0.0 at runtime when EF Core resolves to version 6.x.