### PR TITLE
Remove dead CODEOWNERS rule for non-existent BlazorServerWeb-CSharp template path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,7 +26,6 @@
 /src/Mvc/                                                                         @dotnet/minimal-apis
 /src/Mvc/Mvc.ApiExplorer                                                          @halter73
 /src/OpenApi                                                                      @dotnet/minimal-apis
-/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/        @dotnet/aspnet-blazor-eng
 /src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/  @dotnet/aspnet-blazor-eng
 /src/Security/                                                                    @halter73
 /src/Servers/                                                                     @halter73 @BrennanConroy @mgravell

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,9 @@
 /src/Mvc/                                                                         @dotnet/minimal-apis
 /src/Mvc/Mvc.ApiExplorer                                                          @halter73
 /src/OpenApi                                                                      @dotnet/minimal-apis
+/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWasmServiceDefaults-CSharp/ @dotnet/aspnet-blazor-eng
+/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/              @dotnet/aspnet-blazor-eng
+/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWebWorker-CSharp/        @dotnet/aspnet-blazor-eng
 /src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/  @dotnet/aspnet-blazor-eng
 /src/Security/                                                                    @halter73
 /src/Servers/                                                                     @halter73 @BrennanConroy @mgravell


### PR DESCRIPTION
Hi, and thank you for ASP.NET Core.

`.github/CODEOWNERS` (line 29) assigns `@dotnet/aspnet-blazor-eng` to `/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp/`, but that directory no longer exists:

```
$ gh api repos/dotnet/aspnetcore/contents/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorServerWeb-CSharp  # → 404
```

Since the path doesn't exist, the rule matches nothing. This removes the dead line.

For transparency: I used AI assistance to spot and draft this; I verified the 404 myself.