### PR TITLE
Treat QUERY as a safe HTTP method for antiforgery and CSRF protection

### DIFF
--- a/src/Antiforgery/src/Internal/DefaultAntiforgery.cs
+++ b/src/Antiforgery/src/Internal/DefaultAntiforgery.cs
@@ -92,12 +92,9 @@ internal sealed class DefaultAntiforgery : IAntiforgery
         CheckSSLConfig(httpContext);
 
         var method = httpContext.Request.Method;
-        if (HttpMethods.IsGet(method) ||
-            HttpMethods.IsHead(method) ||
-            HttpMethods.IsOptions(method) ||
-            HttpMethods.IsTrace(method) ||
-            HttpMethods.IsQuery(method))
+        if (SafeHttpMethods.IsSafe(method))
         {
+            // Validation not needed for safe request types.
             return true;
         }
 

--- a/src/Antiforgery/src/Internal/DefaultAntiforgery.cs
+++ b/src/Antiforgery/src/Internal/DefaultAntiforgery.cs
@@ -94,7 +94,6 @@ internal sealed class DefaultAntiforgery : IAntiforgery
         var method = httpContext.Request.Method;
         if (SafeHttpMethods.IsSafe(method))
         {
-            // Validation not needed for safe request types.
             return true;
         }
 

--- a/src/Antiforgery/src/Internal/DefaultAntiforgery.cs
+++ b/src/Antiforgery/src/Internal/DefaultAntiforgery.cs
@@ -98,8 +98,6 @@ internal sealed class DefaultAntiforgery : IAntiforgery
             HttpMethods.IsTrace(method) ||
             HttpMethods.IsQuery(method))
         {
-            // Validation not needed for these request types.
-            // QUERY is a safe, idempotent method per RFC 10008.
             return true;
         }
 

--- a/src/Antiforgery/src/Internal/DefaultAntiforgery.cs
+++ b/src/Antiforgery/src/Internal/DefaultAntiforgery.cs
@@ -95,9 +95,11 @@ internal sealed class DefaultAntiforgery : IAntiforgery
         if (HttpMethods.IsGet(method) ||
             HttpMethods.IsHead(method) ||
             HttpMethods.IsOptions(method) ||
-            HttpMethods.IsTrace(method))
+            HttpMethods.IsTrace(method) ||
+            HttpMethods.IsQuery(method))
         {
             // Validation not needed for these request types.
+            // QUERY is a safe, idempotent method per RFC 10008.
             return true;
         }
 

--- a/src/Antiforgery/src/Microsoft.AspNetCore.Antiforgery.csproj
+++ b/src/Antiforgery/src/Microsoft.AspNetCore.Antiforgery.csproj
@@ -28,6 +28,7 @@
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)HttpExtensions.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)MiddlewareInvokedKeys.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)SafeHttpMethods.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)AntiforgeryValidationFeature.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)Buffers\RefPooledArrayBufferWriter.cs" Link="Shared\Buffers\%(Filename)%(Extension)" />
     <Compile Include="$(SharedSourceRoot)Encoding\Int7BitEncodingUtils.cs" Link="Shared\Encoding\%(Filename)%(Extension)" />

--- a/src/Antiforgery/test/DefaultAntiforgeryTest.cs
+++ b/src/Antiforgery/test/DefaultAntiforgeryTest.cs
@@ -709,6 +709,8 @@ public class DefaultAntiforgeryTest
     [InlineData("HEAD")]
     [InlineData("options")]
     [InlineData("TrAcE")]
+    [InlineData("QUERY")]
+    [InlineData("query")]
     public async Task IsRequestValidAsync_SkipsAntiforgery_ForSafeHttpMethods(string httpMethod)
     {
         // Arrange

--- a/src/DefaultBuilder/src/Internal/DefaultCsrfProtection.cs
+++ b/src/DefaultBuilder/src/Internal/DefaultCsrfProtection.cs
@@ -9,17 +9,6 @@ namespace Microsoft.AspNetCore.Antiforgery;
 
 internal sealed class DefaultCsrfProtection : ICsrfProtection
 {
-    // Safe HTTP methods that do not require cross-origin validation. GET, HEAD, OPTIONS,
-    // and TRACE are safe per RFC 9110; QUERY is defined as a safe, idempotent method by RFC 10008.
-    private static readonly HashSet<string> SafeMethods = new(StringComparer.OrdinalIgnoreCase)
-    {
-        HttpMethods.Get,
-        HttpMethods.Head,
-        HttpMethods.Options,
-        HttpMethods.Trace,
-        HttpMethods.Query,
-    };
-
     /// <inheritdoc />
     public async ValueTask<CsrfProtectionResult> ValidateAsync(HttpContext context)
     {
@@ -28,7 +17,7 @@ internal sealed class DefaultCsrfProtection : ICsrfProtection
         var request = context.Request;
 
         // Step 1: Safe methods are always allowed.
-        if (SafeMethods.Contains(request.Method))
+        if (SafeHttpMethods.IsSafe(request.Method))
         {
             return CsrfProtectionResult.Allowed();
         }

--- a/src/DefaultBuilder/src/Internal/DefaultCsrfProtection.cs
+++ b/src/DefaultBuilder/src/Internal/DefaultCsrfProtection.cs
@@ -9,13 +9,15 @@ namespace Microsoft.AspNetCore.Antiforgery;
 
 internal sealed class DefaultCsrfProtection : ICsrfProtection
 {
-    // Safe HTTP methods that do not require cross-origin validation (RFC 7231).
+    // Safe HTTP methods that do not require cross-origin validation. GET, HEAD, OPTIONS,
+    // and TRACE are safe per RFC 9110; QUERY is defined as a safe, idempotent method by RFC 10008.
     private static readonly HashSet<string> SafeMethods = new(StringComparer.OrdinalIgnoreCase)
     {
         HttpMethods.Get,
         HttpMethods.Head,
         HttpMethods.Options,
         HttpMethods.Trace,
+        HttpMethods.Query,
     };
 
     /// <inheritdoc />

--- a/src/DefaultBuilder/src/Microsoft.AspNetCore.csproj
+++ b/src/DefaultBuilder/src/Microsoft.AspNetCore.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)Obsoletions.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)MiddlewareInvokedKeys.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)SafeHttpMethods.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)AntiforgeryValidationFeature.cs" LinkBase="Shared" />
     <Compile Include="$(SharedSourceRoot)WebHostUtilities\WebHostUtilities.cs" LinkBase="Shared" />
   </ItemGroup>

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/DefaultCsrfProtectionTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/DefaultCsrfProtectionTests.cs
@@ -75,8 +75,10 @@ public class DefaultCsrfProtectionTests
     [InlineData("HEAD")]
     [InlineData("OPTIONS")]
     [InlineData("TRACE")]
+    [InlineData("QUERY")]
     [InlineData("get")]
     [InlineData("Get")]
+    [InlineData("query")]
     public async Task SafeMethods_AlwaysAllowed(string method)
     {
         var context = CreateContext(method: method, secFetchSite: "cross-site", origin: "https://evil.com");

--- a/src/Mvc/Mvc.ViewFeatures/src/Filters/AutoValidateAntiforgeryTokenAuthorizationFilter.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Filters/AutoValidateAntiforgeryTokenAuthorizationFilter.cs
@@ -23,7 +23,8 @@ internal sealed class AutoValidateAntiforgeryTokenAuthorizationFilter : Validate
         if (HttpMethods.IsGet(method) ||
             HttpMethods.IsHead(method) ||
             HttpMethods.IsTrace(method) ||
-            HttpMethods.IsOptions(method))
+            HttpMethods.IsOptions(method) ||
+            HttpMethods.IsQuery(method))
         {
             return false;
         }

--- a/src/Mvc/Mvc.ViewFeatures/src/Filters/AutoValidateAntiforgeryTokenAuthorizationFilter.cs
+++ b/src/Mvc/Mvc.ViewFeatures/src/Filters/AutoValidateAntiforgeryTokenAuthorizationFilter.cs
@@ -20,11 +20,7 @@ internal sealed class AutoValidateAntiforgeryTokenAuthorizationFilter : Validate
         ArgumentNullException.ThrowIfNull(context);
 
         var method = context.HttpContext.Request.Method;
-        if (HttpMethods.IsGet(method) ||
-            HttpMethods.IsHead(method) ||
-            HttpMethods.IsTrace(method) ||
-            HttpMethods.IsOptions(method) ||
-            HttpMethods.IsQuery(method))
+        if (SafeHttpMethods.IsSafe(method))
         {
             return false;
         }

--- a/src/Mvc/Mvc.ViewFeatures/src/Microsoft.AspNetCore.Mvc.ViewFeatures.csproj
+++ b/src/Mvc/Mvc.ViewFeatures/src/Microsoft.AspNetCore.Mvc.ViewFeatures.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)\AntiforgeryMetadata.cs" LinkBase="Infrastructure" />
     <Compile Include="$(SharedSourceRoot)MiddlewareInvokedKeys.cs" LinkBase="Infrastructure" />
+    <Compile Include="$(SharedSourceRoot)SafeHttpMethods.cs" LinkBase="Infrastructure" />
     <Compile Include="$(SharedSourceRoot)\PooledArrayBufferWriter.cs" LinkBase="Infrastructure" />
     <Compile Include="$(SharedSourceRoot)\Components\ResourceCollectionResolver.cs" LinkBase="Infrastructure" />
   </ItemGroup>

--- a/src/Mvc/Mvc.ViewFeatures/test/Filters/AutoValidateAntiforgeryTokenAuthorizationFilterTest.cs
+++ b/src/Mvc/Mvc.ViewFeatures/test/Filters/AutoValidateAntiforgeryTokenAuthorizationFilterTest.cs
@@ -45,6 +45,8 @@ public class AutoValidateAntiforgeryTokenAuthorizationFilterTest
     [InlineData("HEAD")]
     [InlineData("TracE")]
     [InlineData("OPTIONs")]
+    [InlineData("QUERY")]
+    [InlineData("query")]
     public async Task Filter_SkipsAntiforgeryVerification_ForSafeMethod(string httpMethod)
     {
         // Arrange

--- a/src/Shared/SafeHttpMethods.cs
+++ b/src/Shared/SafeHttpMethods.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Http;
+
+/// <summary>
+/// Helpers for identifying HTTP methods that are "safe" and therefore do not require
+/// antiforgery/CSRF validation. GET, HEAD, OPTIONS, and TRACE are safe per RFC 9110;
+/// QUERY is defined as a safe, idempotent method by RFC 10008.
+/// </summary>
+internal static class SafeHttpMethods
+{
+    /// <summary>
+    /// Returns <see langword="true"/> when <paramref name="method"/> is a safe HTTP method
+    /// that does not require antiforgery/CSRF validation.
+    /// </summary>
+    /// <param name="method">The HTTP method name.</param>
+    public static bool IsSafe(string method) =>
+        HttpMethods.IsGet(method) ||
+        HttpMethods.IsHead(method) ||
+        HttpMethods.IsOptions(method) ||
+        HttpMethods.IsTrace(method) ||
+        HttpMethods.IsQuery(method);
+}


### PR DESCRIPTION
Fixes #67825

## Summary

The CSRF protection middleware (new in .NET 11) and the antiforgery middleware only treat the classic safe methods (GET/HEAD/OPTIONS/TRACE) as exempt from cross-origin / antiforgery validation. The `QUERY` HTTP method — added to `HttpMethods` in #63260 — was missing from both lists, so it was incorrectly treated as unsafe.

`QUERY` is defined as a **safe, idempotent** method by [RFC 10008 (The HTTP QUERY Method)](https://www.rfc-editor.org/rfc/rfc10008.html), so per its defined semantics it does not request any state change and belongs alongside GET/HEAD.

## Changes

- `DefaultCsrfProtection`: add `HttpMethods.Query` to the `SafeMethods` set.
- `DefaultAntiforgery.IsRequestValidAsync`: skip validation for `QUERY`.
- Added `QUERY` (and lowercase) cases to both existing safe-method test theories.

## Verification

- `DefaultCsrfProtectionTests.SafeMethods_AlwaysAllowed`: 8/8 passing.
- `DefaultAntiforgeryTest.IsRequestValidAsync_SkipsAntiforgery_ForSafeHttpMethods`: 6/6 passing.

## Note

For reference, Go's `net/http.CrossOriginProtection` (Go 1.25) currently exempts only GET/HEAD/OPTIONS and has not yet added QUERY.