### PR TITLE
Set up a one-off publishing pipeline for npm packages using ESRP

### DIFF
--- a/.azure/pipelines/publish-npm-esrp.yml
+++ b/.azure/pipelines/publish-npm-esrp.yml
@@ -1,0 +1,166 @@
+#
+# See https://learn.microsoft.com/azure/devops/pipelines/yaml-schema for details on this file.
+#
+# Ad-hoc pipeline to (re)publish the npm packages produced by an aspnetcore build to npmjs.org
+# using ESRP Package Release.
+#
+# The pipeline takes the BAR (Build Asset Registry / "darc") build ID of an aspnetcore build as
+# input, uses `darc gather-drop` to download that build's BlobArtifacts (the npm *.tgz packages are
+# published as blob assets under `npm/`), stages the *.tgz files, and hands them to the ESRP Release
+# task which signs and publishes them to https://registry.npmjs.org/.
+#
+# This is intended to be run *manually* (queue the pipeline and supply the build ID). It does not
+# run on CI or PR triggers.
+#
+# Find the BAR build ID with `darc get-build` (see
+# https://github.com/dotnet/arcade-services/blob/main/docs/Darc.md).
+#
+# NOTE: The ESRP identity/onboarding values (service connection, managed-identity client id,
+# key vault, signing certificate, main publisher) are exposed as parameters with clearly-marked
+# TODO placeholder defaults. They must be filled in with the values assigned to aspnetcore during
+# ESRP Package Release onboarding before this pipeline can publish. See:
+#   https://microsoft.sharepoint.com/teams/prss/esrp/info/SitePages/Integrating-the-ESRP-Package-Release-ADO-task-into-your-ADO-Pipeline(1).aspx
+
+trigger: none
+pr: none
+
+parameters:
+# The BAR (Build Asset Registry / darc) build ID whose npm packages should be published.
+- name: barBuildId
+  displayName: 'BAR (darc) build ID to publish npm packages from'
+  type: string
+
+# The npm dist-tag to publish under (e.g. 'latest', 'next', 'beta').
+- name: npmDistTag
+  displayName: 'npm dist-tag'
+  type: string
+  default: latest
+
+# ---------------------------------------------------------------------------------------------
+# ESRP Package Release onboarding values. TODO: replace the placeholder defaults with the values
+# assigned to aspnetcore during ESRP onboarding.
+# ---------------------------------------------------------------------------------------------
+- name: esrpConnectedServiceName
+  displayName: 'ESRP: managed-identity service connection name'
+  type: string
+  default: 'TODO-AspNetCore-ESRP-Release-ManagedIdentity'
+- name: esrpClientId
+  displayName: 'ESRP: managed-identity client id'
+  type: string
+  default: 'TODO-esrp-managed-identity-client-id'
+- name: esrpDomainTenantId
+  displayName: 'ESRP: domain tenant id'
+  type: string
+  # Microsoft (microsoft.onmicrosoft.com) tenant. TODO: confirm the tenant expected by aspnetcore's ESRP onboarding.
+  default: '72f988bf-86f1-41af-91ab-2d7cd011db47'
+- name: esrpKeyVaultName
+  displayName: 'ESRP: key vault name (holds the release signing certificate)'
+  type: string
+  default: 'TODO-aspnetcore-esrp-keyvault'
+- name: esrpSignCertName
+  displayName: 'ESRP: signing certificate name'
+  type: string
+  default: 'TODO-aspnetcore-esrp-release-certificate'
+- name: esrpMainPublisher
+  displayName: 'ESRP: main publisher id'
+  type: string
+  default: 'TODO-aspnetcore-esrp-main-publisher'
+
+variables:
+- name: _TeamName
+  value: AspNetCore
+- name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+  value: true
+# Publish-Build-Assets provides: MaestroAccessToken (used as the BAR token for `darc gather-drop`).
+- group: Publish-Build-Assets
+- template: /eng/common/templates-official/variables/pool-providers.yml@self
+
+resources:
+  repositories:
+  # Repo: 1ESPipelineTemplates/1ESPipelineTemplates
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
+  parameters:
+    pool:
+      name: NetCore1ESPool-Svc-Internal
+      image: windows.vs2022.amd64
+      os: windows
+    sdl:
+      sourceAnalysisPool:
+        name: NetCore1ESPool-Svc-Internal
+        image: windows.vs2022.amd64
+        os: windows
+    stages:
+    - stage: publish
+      displayName: Publish npm packages
+      jobs:
+      - job: PublishNpm
+        displayName: 'Publish npm packages from BAR build ${{ parameters.barBuildId }}'
+        timeoutInMinutes: 120
+        templateContext:
+          outputs:
+          # Publish the exact set of packages that were sent to ESRP, for auditing/traceability.
+          - output: pipelineArtifact
+            displayName: 'Publish staged npm packages (audit)'
+            targetPath: $(Build.ArtifactStagingDirectory)/npm-to-publish
+            artifactName: npm-packages
+        steps:
+        - checkout: self
+
+        - powershell: ./eng/common/darc-init.ps1
+          displayName: Install darc
+
+        - powershell: |
+            $ErrorActionPreference = 'Stop'
+            $drop = Join-Path '$(Agent.TempDirectory)' 'drop'
+            $stage = Join-Path '$(Build.ArtifactStagingDirectory)' 'npm-to-publish'
+            New-Item -ItemType Directory -Force -Path $drop | Out-Null
+            New-Item -ItemType Directory -Force -Path $stage | Out-Null
+
+            # Download only the outputs of the specified (root) build. npm packages are published as
+            # blob assets, so they land under <drop>\shipping\assets\...\npm\<version>\*.tgz.
+            darc gather-drop `
+              --id ${{ parameters.barBuildId }} `
+              --output-dir $drop `
+              --bar-uri https://maestro.dot.net/ `
+              --password $env:BAR_TOKEN `
+              --azdev-pat $env:AZDO_TOKEN `
+              --verbose
+            if ($LASTEXITCODE -ne 0) { throw "darc gather-drop failed with exit code $LASTEXITCODE" }
+
+            # Stage only the npm *.tgz packages into a flat folder for ESRP.
+            $tgz = @(Get-ChildItem -Path $drop -Recurse -Filter *.tgz)
+            if ($tgz.Count -eq 0) {
+              throw "No npm (*.tgz) packages were found in the drop for BAR build ${{ parameters.barBuildId }}."
+            }
+            $tgz | ForEach-Object { Copy-Item -LiteralPath $_.FullName -Destination $stage }
+
+            Write-Host "Staged $($tgz.Count) npm package(s) for publishing:"
+            Get-ChildItem -Path $stage -Filter *.tgz | ForEach-Object { Write-Host "  $($_.Name)" }
+          displayName: 'Gather npm packages from BAR build ${{ parameters.barBuildId }}'
+          env:
+            BAR_TOKEN: $(MaestroAccessToken)
+            AZDO_TOKEN: $(System.AccessToken)
+
+        - task: EsrpRelease@11
+          displayName: 'Publish npm packages to npmjs.org via ESRP'
+          inputs:
+            ConnectedServiceName: ${{ parameters.esrpConnectedServiceName }}
+            ClientId: ${{ parameters.esrpClientId }}
+            DomainTenantId: ${{ parameters.esrpDomainTenantId }}
+            UseManagedIdentity: true
+            KeyVaultName: ${{ parameters.esrpKeyVaultName }}
+            SignCertName: ${{ parameters.esrpSignCertName }}
+            Intent: 'PackageDistribution'
+            ContentType: 'npm'
+            FolderLocation: $(Build.ArtifactStagingDirectory)/npm-to-publish
+            Owners: $(Build.RequestedForEmail)
+            Approvers: $(Build.RequestedForEmail)
+            ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
+            MainPublisher: ${{ parameters.esrpMainPublisher }}
+            ProductState: ${{ parameters.npmDistTag }}


### PR DESCRIPTION
Set up a one-off, manually-triggered pipeline to (re)publish the npm packages produced by an aspnetcore build to npmjs.org using ESRP Package Release.

The pipeline takes the BAR (Build Asset Registry / `darc`) build ID of an aspnetcore build as input, uses `darc gather-drop` to download that build's blob artifacts (npm `.tgz` packages are published as blob assets under `npm/`), stages the `.tgz` files, and hands them to the ESRP Release task (`EsrpRelease@11`, `Intent: PackageDistribution`, `ContentType: npm`) which signs and publishes them to `https://registry.npmjs.org/`. It extends the 1ES Official pipeline template, matching the pattern in `.azure/pipelines/ci.yml`.

There is no existing ESRP-based npm publishing precedent in the dotnet org (npm publishing to npmjs is currently a manual `npm publish` step per `dotnet/aspnetcore-internal/docs/release/AspNetSignalRBuildAndRelease.md`); the task schema is modeled on the Azure SDK / microsoft-mcp ESRP npm templates.

## TODOs before this can publish

The ESRP identity/onboarding values are exposed as pipeline parameters with clearly-marked `TODO-…` placeholder defaults. They must be filled in with the values assigned to aspnetcore during **ESRP Package Release onboarding** before the pipeline can publish:

- [ ] `esrpConnectedServiceName` — ESRP managed-identity ADO service connection name
- [ ] `esrpClientId` — managed-identity client id
- [ ] `esrpDomainTenantId` — domain tenant id (defaulted to the Microsoft tenant; confirm)
- [ ] `esrpKeyVaultName` — Key Vault holding the release signing certificate
- [ ] `esrpSignCertName` — signing certificate name
- [ ] `esrpMainPublisher` — ESRP main publisher id (start with the PPE/test publisher, then switch to prod)

Onboarding steps that produce these values (see the PRSS/ESRP SharePoint docs "Steps for onboarding to ESRP Release & Secure Origin" and "Integrating the ESRP Package Release ADO task"):

- [ ] File the ESRP onboarding request; loop in dnceng/DDFUN (may already have a managed identity + Key Vault from ESRP code signing that can be reused).
- [ ] Designate/allow-list a User-Assigned Managed Identity and create the ADO service connection bound to it.
- [ ] Register/point to the signing certificate + Key Vault and grant the identity read access.
- [ ] Get a publisher id assigned (test first, then prod).
- [ ] Complete "Secure Origin" registration for `registry.npmjs.org` and add ESRP's automation identity as an owner on the `@microsoft`/`@dotnet` npm orgs (coordinate with `aspnetnpmers`).
- [ ] Validate against ESRP PPE with a throwaway build, then flip to the production publisher.

Also worth confirming during review: whether ESRP prefers this modeled as a 1ES `releaseJob` deployment (as the Azure SDK examples do for production npmjs pushes) vs. the plain job used here, and whether `System.AccessToken` on the internal pool can reach the target build's artifacts if it's a cross-project build.

Opening as **draft** to preserve the work while onboarding is completed. No PRs/issues are otherwise affected.
