### PR TITLE
Use build identity for internal feeds instead of expired dn-bot-dnceng-artifact-feeds-rw PAT (release/9.0)

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -427,8 +427,6 @@ jobs:
       - ${{ parameters.beforeBuild }}
 
       - template: /eng/common/templates-official/steps/enable-internal-sources.yml@self
-        parameters:
-          legacyCredential: $(dn-bot-dnceng-artifact-feeds-rw)
       - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml@self
         parameters:
           expiryInHours: 3


### PR DESCRIPTION
## Summary
Internal official builds on this servicing branch are failing package restore with **HTTP 401 on all `darc-int-*` and `dotnet-*-internal` feeds** (e.g. build 3022753). Root cause: the `dn-bot-dnceng-artifact-feeds-rw` PAT was removed from the arcade secret manifest (arcade PR #17079, 2026-07-08) and **expired 2026-07-11**; rotation had stopped, so `legacyCredential: $(dn-bot-dnceng-artifact-feeds-rw)` now injects an expired/empty token.

## Change
Remove the `legacyCredential` PAT parameter from the `enable-internal-sources` step. For the `internal` project the template then takes the build-identity path (`SetupNugetSources` without a password + `NuGetAuthenticate@1`), authenticating internal feeds via the pipeline's build service identity. This matches how `main` already works.

## Validation
- dnceng/internal **Project Build Service** has ≥reader on the affected feeds: `contributor` on `darc-int-*`, `collaborator` on `dotnet9-internal`, `contributor` on `dotnet8-internal`.
- aspnetcore `main` builds restore internal feeds successfully with no PAT.

Tracking: dnceng/internal AB#11679 (live-site AB#11678).