### PR TITLE
Use build identity (System.AccessToken) for internal feed creds instead of expired dn-bot-dnceng-artifact-feeds-rw PAT (release/8.0)

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -410,8 +410,22 @@ jobs:
 
       - ${{ parameters.beforeBuild }}
 
-      - task: NuGetAuthenticate@1
-        displayName: Authenticate to internal feeds (build identity)
+      - ${{ if eq(parameters.agentOs, 'Windows') }}:
+        - task: PowerShell@2
+          displayName: Setup Private Feeds Credentials
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
+            arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
+          env:
+            Token: $(System.AccessToken)
+      - ${{ if ne(parameters.agentOs, 'Windows') }}:
+        - task: Bash@3
+          displayName: Setup Private Feeds Credentials
+          inputs:
+            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
+            arguments: $(Build.SourcesDirectory)/NuGet.config $Token
+          env:
+            Token: $(System.AccessToken)
 
       # Populates internal runtime SAS tokens.
       - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -410,22 +410,8 @@ jobs:
 
       - ${{ parameters.beforeBuild }}
 
-      - ${{ if eq(parameters.agentOs, 'Windows') }}:
-        - task: PowerShell@2
-          displayName: Setup Private Feeds Credentials
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-            arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
-      - ${{ if ne(parameters.agentOs, 'Windows') }}:
-        - task: Bash@3
-          displayName: Setup Private Feeds Credentials
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-            arguments: $(Build.SourcesDirectory)/NuGet.config $Token
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
+      - task: NuGetAuthenticate@1
+        displayName: Authenticate to internal feeds (build identity)
 
       # Populates internal runtime SAS tokens.
       - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml


### PR DESCRIPTION
## Summary
Internal official builds fail restore with **HTTP 401 on `darc-int-*` / `dotnet-*-internal` feeds** because `dn-bot-dnceng-artifact-feeds-rw` was removed from the arcade secret manifest (arcade #17079) and **expired 2026-07-11**.

## Change
The 8.0 `SetupNugetSources.ps1` has a **mandatory** `-Password`, and it is also the step that **re-enables the `darc-int` sources** (which ship disabled in `NuGet.config` via `<disabledPackageSources>`). So dropping it and relying on `NuGetAuthenticate@1` alone would **not** work — the sources would stay disabled. Instead this keeps the `Setup Private Feeds Credentials` task and swaps the credential from the dead PAT to the pipeline's **build-service OAuth token** `$(System.AccessToken)`.

`$(System.AccessToken)` is the dnceng/internal **Project Build Service** identity, which has read access to all affected feeds — this is the intended "build identity instead of PAT" migration for feeds hosted in the same AzDO org.

## Validation
- `SetupNugetSources` still enables the disabled `darc-int` sources.
- Build-service identity has ≥reader on `darc-int-*` / `dotnet-*-internal`.

Tracking: dnceng/internal AB#11679.