### PR TITLE
API review changes for Blazor SSR client-side validation

### DIFF
--- a/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
+++ b/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Components.Endpoints;
 using Microsoft.AspNetCore.Components.Endpoints.DependencyInjection;
 using Microsoft.AspNetCore.Components.Endpoints.Forms;
 using Microsoft.AspNetCore.Components.Forms;
-using Microsoft.AspNetCore.Components.Forms.ClientValidation;
 using Microsoft.AspNetCore.Components.Forms.Mapping;
 using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Routing;

--- a/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceOptions.cs
+++ b/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceOptions.cs
@@ -23,6 +23,16 @@ public sealed class RazorComponentsServiceOptions
     public bool DetailedErrors { get; set; }
 
     /// <summary>
+    /// Gets or sets a value that determines whether client-side validation is disabled for all
+    /// forms rendered with static server-side rendering. When <see langword="false"/> (the default),
+    /// forms using <see cref="Microsoft.AspNetCore.Components.Forms.DataAnnotationsValidator"/> emit
+    /// client-side validation rules so user errors can be reported without a round trip to the
+    /// server. When <see langword="true"/>, no client-side validation rules are emitted and only
+    /// server-side validation runs.
+    /// </summary>
+    public bool DisableClientValidation { get; set; }
+
+    /// <summary>
     /// Gets or sets the maximum number of elements allowed in a form collection.
     /// </summary>
     public int MaxFormMappingCollectionSize

--- a/src/Components/Endpoints/src/Forms/ClientValidationRule.cs
+++ b/src/Components/Endpoints/src/Forms/ClientValidationRule.cs
@@ -1,13 +1,18 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.ObjectModel;
+
 namespace Microsoft.AspNetCore.Components.Forms;
 
 /// <summary>
-/// Describes a single client-side validation rule produced by an <see cref="IClientValidationAdapter"/>.
+/// Describes a single client-side validation rule produced by an <see cref="IClientValidationRuleProvider"/>.
 /// </summary>
 public sealed class ClientValidationRule
 {
+    private static readonly IReadOnlyDictionary<string, string> EmptyParameters =
+        ReadOnlyDictionary<string, string>.Empty;
+
     /// <summary>
     /// Creates a rule with the specified name and optional parameters.
     /// </summary>
@@ -28,7 +33,7 @@ public sealed class ClientValidationRule
         ArgumentException.ThrowIfNullOrEmpty(name);
 
         Name = name;
-        Parameters = parameters;
+        Parameters = parameters ?? EmptyParameters;
     }
 
     /// <summary>
@@ -37,8 +42,7 @@ public sealed class ClientValidationRule
     public string Name { get; }
 
     /// <summary>
-    /// Gets the parameters passed to the JS validator at runtime. <see langword="null"/> when
-    /// no parameters apply.
+    /// Gets the parameters passed to the JS validator at runtime. Empty when no parameters apply.
     /// </summary>
-    public IReadOnlyDictionary<string, string>? Parameters { get; }
+    public IReadOnlyDictionary<string, string> Parameters { get; }
 }

--- a/src/Components/Endpoints/src/Forms/DataAnnotationsClientValidationProvider.cs
+++ b/src/Components/Endpoints/src/Forms/DataAnnotationsClientValidationProvider.cs
@@ -6,7 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using Microsoft.AspNetCore.Components.Forms;
-using Microsoft.AspNetCore.Components.Forms.ClientValidation;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Validation;
 
@@ -16,17 +15,27 @@ internal sealed class DataAnnotationsClientValidationProvider : ClientValidation
 {
     private readonly ClientValidationCache _clientValidationCache;
     private readonly IValidationLocalizer? _validationLocalizer;
+    private readonly bool _clientValidationDisabled;
 
     [UnconditionalSuppressMessage("Trimming", "IL2066", Justification = "Preserves ValidationOptions's parameterless constructor used by Microsoft.Extensions.Options to materialize IOptions<ValidationOptions>.")]
     [DynamicDependency(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(ValidationOptions))]
-    public DataAnnotationsClientValidationProvider(ClientValidationCache clientValidationCache, IOptions<ValidationOptions> validationOptions)
+    public DataAnnotationsClientValidationProvider(
+        ClientValidationCache clientValidationCache,
+        IOptions<ValidationOptions> validationOptions,
+        IOptions<RazorComponentsServiceOptions> razorComponentsOptions)
     {
         _clientValidationCache = clientValidationCache;
         _validationLocalizer = validationOptions.Value.Localizer;
+        _clientValidationDisabled = razorComponentsOptions.Value.DisableClientValidation;
     }
 
     public override RenderFragment? RenderClientValidationRules(EditContext editContext, IReadOnlyDictionary<FieldIdentifier, string> renderedFields)
     {
+        if (_clientValidationDisabled)
+        {
+            return null;
+        }
+
         var json = SerializeClientValidationData(editContext, renderedFields);
         if (json is null)
         {
@@ -79,9 +88,9 @@ internal sealed class DataAnnotationsClientValidationProvider : ClientValidation
                 continue;
             }
 
-            if (attribute is IClientValidationAdapter adapter)
+            if (attribute is IClientValidationRuleProvider ruleProvider)
             {
-                foreach (var customRule in adapter.GetClientValidationRules())
+                foreach (var customRule in ruleProvider.GetClientValidationRules())
                 {
                     writer.BeginRule(customRule.Name, errorMessage);
                     if (customRule.Parameters is { Count: > 0 } parameters)

--- a/src/Components/Endpoints/src/Forms/IClientValidationRuleProvider.cs
+++ b/src/Components/Endpoints/src/Forms/IClientValidationRuleProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.Components.Forms;
 /// for forms rendered server-side. Rule names must match a validator registered on the JS side via
 /// <c>Blazor.formValidation.addValidator(name, ...)</c>.
 /// </remarks>
-public interface IClientValidationAdapter
+public interface IClientValidationRuleProvider
 {
     /// <summary>
     /// Produces the client-side validation rules for this attribute.

--- a/src/Components/Endpoints/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Endpoints/src/PublicAPI.Unshipped.txt
@@ -3,6 +3,8 @@ Microsoft.AspNetCore.Components.Endpoints.BasePath
 Microsoft.AspNetCore.Components.Endpoints.BasePath.BasePath() -> void
 Microsoft.AspNetCore.Components.Endpoints.RazorComponentsServiceOptions.CacheViewSizeLimit.get -> long
 Microsoft.AspNetCore.Components.Endpoints.RazorComponentsServiceOptions.CacheViewSizeLimit.set -> void
+Microsoft.AspNetCore.Components.Endpoints.RazorComponentsServiceOptions.DisableClientValidation.get -> bool
+Microsoft.AspNetCore.Components.Endpoints.RazorComponentsServiceOptions.DisableClientValidation.set -> void
 Microsoft.AspNetCore.Components.Endpoints.RazorComponentsServiceOptions.CacheViewHybridCache.get -> Microsoft.Extensions.Caching.Hybrid.HybridCache?
 Microsoft.AspNetCore.Components.Endpoints.RazorComponentsServiceOptions.CacheViewHybridCache.set -> void
 Microsoft.AspNetCore.Components.CacheView
@@ -86,7 +88,7 @@ Microsoft.AspNetCore.Components.WebAssemblyBrowserOptions.EnvironmentName.set ->
 Microsoft.AspNetCore.Components.WebAssemblyBrowserOptions.EnvironmentVariables.get -> System.Collections.Generic.IDictionary<string!, string!>!
 Microsoft.AspNetCore.Components.Forms.ClientValidationRule
 Microsoft.AspNetCore.Components.Forms.ClientValidationRule.Name.get -> string!
-Microsoft.AspNetCore.Components.Forms.ClientValidationRule.Parameters.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>?
+Microsoft.AspNetCore.Components.Forms.ClientValidationRule.Parameters.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
 Microsoft.AspNetCore.Components.Forms.ClientValidationRule.ClientValidationRule(string! name, System.Collections.Generic.IReadOnlyDictionary<string!, string!>? parameters = null) -> void
-Microsoft.AspNetCore.Components.Forms.IClientValidationAdapter
-Microsoft.AspNetCore.Components.Forms.IClientValidationAdapter.GetClientValidationRules() -> System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Components.Forms.ClientValidationRule!>!
+Microsoft.AspNetCore.Components.Forms.IClientValidationRuleProvider
+Microsoft.AspNetCore.Components.Forms.IClientValidationRuleProvider.GetClientValidationRules() -> System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Components.Forms.ClientValidationRule!>!

--- a/src/Components/Endpoints/test/FormValidation/ClientValidationProviderTests.cs
+++ b/src/Components/Endpoints/test/FormValidation/ClientValidationProviderTests.cs
@@ -148,9 +148,9 @@ public class ClientValidationProviderTests
     }
 
     [Fact]
-    public void CustomAdapterAttribute_ContributesItsRules()
+    public void CustomRuleProviderAttribute_ContributesItsRules()
     {
-        var rule = SingleRule(GetData<CustomAdapterModel>(nameof(CustomAdapterModel.Value))!, nameof(CustomAdapterModel.Value));
+        var rule = SingleRule(GetData<CustomRuleProviderModel>(nameof(CustomRuleProviderModel.Value))!, nameof(CustomRuleProviderModel.Value));
 
         Assert.Equal("custom", rule.Name);
         Assert.Equal("custom message", rule.Message);
@@ -288,15 +288,34 @@ public class ClientValidationProviderTests
         Assert.Equal(new[] { "OrderName", "ShippingAddress.Street" }, clientPaths);
     }
 
+    [Fact]
+    public void GlobalDisableClientValidation_EmitsNoCarrier()
+    {
+        var model = new TwoFieldModel();
+        var editContext = new EditContext(model);
+        var fields = new Dictionary<FieldIdentifier, string>
+        {
+            [new FieldIdentifier(model, nameof(TwoFieldModel.First))] = "First",
+        };
+
+        // Sanity: with client validation enabled, the provider produces a carrier fragment.
+        Assert.NotNull(CreateProvider().RenderClientValidationRules(editContext, fields));
+
+        // With the global opt-out (RazorComponentsServiceOptions.DisableClientValidation), the
+        // provider emits nothing so the JS engine never activates for any form.
+        Assert.Null(CreateProvider(disableClientValidation: true).RenderClientValidationRules(editContext, fields));
+    }
+
     // ---- Helpers ----
 
     private static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web);
 
-    private static DataAnnotationsClientValidationProvider CreateProvider(ValidationOptions? options = null)
+    private static DataAnnotationsClientValidationProvider CreateProvider(ValidationOptions? options = null, bool disableClientValidation = false)
     {
         var opts = Options.Create(options ?? new ValidationOptions());
         var cache = new ClientValidationCache(opts);
-        return new DataAnnotationsClientValidationProvider(cache, opts);
+        var razorOptions = Options.Create(new RazorComponentsServiceOptions { DisableClientValidation = disableClientValidation });
+        return new DataAnnotationsClientValidationProvider(cache, opts, razorOptions);
     }
 
     private static FormData? GetData<TModel>(params string[] fieldNames)
@@ -482,13 +501,13 @@ public class ClientValidationProviderTests
         public string Field { get; set; } = "";
     }
 
-    private sealed class CustomAdapterModel
+    private sealed class CustomRuleProviderModel
     {
-        [CustomAdapter(ErrorMessage = "custom message")]
+        [CustomRuleProvider(ErrorMessage = "custom message")]
         public string Value { get; set; } = "";
     }
 
-    private sealed class CustomAdapterAttribute : ValidationAttribute, IClientValidationAdapter
+    private sealed class CustomRuleProviderAttribute : ValidationAttribute, IClientValidationRuleProvider
     {
         public IEnumerable<ClientValidationRule> GetClientValidationRules()
         {

--- a/src/Components/Forms/src/DataAnnotationsValidator.cs
+++ b/src/Components/Forms/src/DataAnnotationsValidator.cs
@@ -16,12 +16,12 @@ public class DataAnnotationsValidator : ComponentBase, IDisposable
     [Inject] private IServiceProvider ServiceProvider { get; set; } = default!;
 
     /// <summary>
-    /// Gets or sets whether client-side validation rules are emitted to the browser for this form.
-    /// When <see langword="true"/> (the default), the framework includes the validation rules for
+    /// Gets or sets whether client-side validation rules are suppressed for this form.
+    /// When <see langword="false"/> (the default), the framework includes the validation rules for
     /// the form's model in the rendered HTML so user errors can be reported without a round trip
-    /// to the server. When <see langword="false"/>, only server-side validation runs.
+    /// to the server. When <see langword="true"/>, only server-side validation runs.
     /// </summary>
-    [Parameter] public bool EnableClientValidation { get; set; } = true;
+    [Parameter] public bool DisableClientValidation { get; set; }
 
     /// <inheritdoc />
     protected override void OnInitialized()
@@ -36,7 +36,7 @@ public class DataAnnotationsValidator : ComponentBase, IDisposable
         _subscriptions = CurrentEditContext.EnableDataAnnotationsValidation(ServiceProvider);
         _originalEditContext = CurrentEditContext;
 
-        if (EnableClientValidation)
+        if (!DisableClientValidation)
         {
             CurrentEditContext.Properties[typeof(DataAnnotationsValidator)] = true;
         }

--- a/src/Components/Forms/src/Microsoft.AspNetCore.Components.Forms.WarningSuppressions.xml
+++ b/src/Components/Forms/src/Microsoft.AspNetCore.Components.Forms.WarningSuppressions.xml
@@ -19,11 +19,5 @@
       <property name="Scope">member</property>
       <property name="Target">M:Microsoft.AspNetCore.Components.Forms.EditContextDataAnnotationsExtensions.DataAnnotationsEventSubscriptions.TryGetValidatableProperty(Microsoft.AspNetCore.Components.Forms.FieldIdentifier@,System.Reflection.PropertyInfo@)</property>
     </attribute>
-    <attribute fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute">
-      <argument>ILLink</argument>
-      <argument>IL2036</argument>
-      <property name="Scope">member</property>
-      <property name="Target">M:Microsoft.AspNetCore.Components.Forms.ClientValidation.DefaultClientValidationService.#ctor(System.IServiceProvider)</property>
-    </attribute>
   </assembly>
 </linker>

--- a/src/Components/Forms/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Forms/src/PublicAPI.Unshipped.txt
@@ -2,8 +2,8 @@
 Microsoft.AspNetCore.Components.Forms.ValidationRequestedEventArgs.AddAsyncValidator(System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! validator) -> void
 *REMOVED*static Microsoft.AspNetCore.Components.Forms.EditContextDataAnnotationsExtensions.AddDataAnnotationsValidation(this Microsoft.AspNetCore.Components.Forms.EditContext! editContext) -> Microsoft.AspNetCore.Components.Forms.EditContext!
 *REMOVED*static Microsoft.AspNetCore.Components.Forms.EditContextDataAnnotationsExtensions.EnableDataAnnotationsValidation(this Microsoft.AspNetCore.Components.Forms.EditContext! editContext) -> System.IDisposable!
-Microsoft.AspNetCore.Components.Forms.DataAnnotationsValidator.EnableClientValidation.get -> bool
-Microsoft.AspNetCore.Components.Forms.DataAnnotationsValidator.EnableClientValidation.set -> void
+Microsoft.AspNetCore.Components.Forms.DataAnnotationsValidator.DisableClientValidation.get -> bool
+Microsoft.AspNetCore.Components.Forms.DataAnnotationsValidator.DisableClientValidation.set -> void
 Microsoft.AspNetCore.Components.Forms.EditContext.ValidateAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
 Microsoft.AspNetCore.Components.Forms.EditContext.RegisterAsyncFieldValidator(in Microsoft.AspNetCore.Components.Forms.FieldIdentifier fieldIdentifier, System.Func<System.Threading.CancellationToken, System.Threading.Tasks.Task!>! validator) -> void
 Microsoft.AspNetCore.Components.Forms.EditContext.IsValidationPending(in Microsoft.AspNetCore.Components.Forms.FieldIdentifier fieldIdentifier) -> bool

--- a/src/Components/Web/src/Forms/ClientValidation/ClientValidationData.cs
+++ b/src/Components/Web/src/Forms/ClientValidation/ClientValidationData.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.AspNetCore.Components.Forms.ClientValidation;
+namespace Microsoft.AspNetCore.Components.Forms;
 
 /// <summary>
 /// Renders the per-form client-side validation carrier when client-side validation is activated

--- a/src/Components/Web/src/Forms/ClientValidation/ClientValidationProvider.cs
+++ b/src/Components/Web/src/Forms/ClientValidation/ClientValidationProvider.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.AspNetCore.Components.Forms.ClientValidation;
+namespace Microsoft.AspNetCore.Components.Forms;
 
 /// <summary>
 /// Provides client-side validation metadata for a form's model.

--- a/src/Components/Web/src/Forms/ClientValidation/RenderedFieldRegistry.cs
+++ b/src/Components/Web/src/Forms/ClientValidation/RenderedFieldRegistry.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.AspNetCore.Components.Forms.ClientValidation;
+namespace Microsoft.AspNetCore.Components.Forms;
 
 /// <summary>
 /// Per-form registry of the inputs that rendered under an <see cref="EditContext"/> in static

--- a/src/Components/Web/src/Forms/EditForm.cs
+++ b/src/Components/Web/src/Forms/EditForm.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using Microsoft.AspNetCore.Components.Forms.ClientValidation;
 using Microsoft.AspNetCore.Components.Forms.Mapping;
 using Microsoft.AspNetCore.Components.Rendering;
 

--- a/src/Components/Web/src/Forms/InputBase.cs
+++ b/src/Components/Web/src/Forms/InputBase.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
-using Microsoft.AspNetCore.Components.Forms.ClientValidation;
 using Microsoft.AspNetCore.Components.Forms.Mapping;
 
 namespace Microsoft.AspNetCore.Components.Forms;

--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -7,9 +7,9 @@ Microsoft.AspNetCore.Components.Web.EnvironmentView.Exclude.get -> string?
 Microsoft.AspNetCore.Components.Web.EnvironmentView.Exclude.set -> void
 Microsoft.AspNetCore.Components.Web.EnvironmentView.Include.get -> string?
 Microsoft.AspNetCore.Components.Web.EnvironmentView.Include.set -> void
-abstract Microsoft.AspNetCore.Components.Forms.ClientValidation.ClientValidationProvider.RenderClientValidationRules(Microsoft.AspNetCore.Components.Forms.EditContext! editContext, System.Collections.Generic.IReadOnlyDictionary<Microsoft.AspNetCore.Components.Forms.FieldIdentifier, string!>! renderedFields) -> Microsoft.AspNetCore.Components.RenderFragment?
-Microsoft.AspNetCore.Components.Forms.ClientValidation.ClientValidationProvider
-Microsoft.AspNetCore.Components.Forms.ClientValidation.ClientValidationProvider.ClientValidationProvider() -> void
+abstract Microsoft.AspNetCore.Components.Forms.ClientValidationProvider.RenderClientValidationRules(Microsoft.AspNetCore.Components.Forms.EditContext! editContext, System.Collections.Generic.IReadOnlyDictionary<Microsoft.AspNetCore.Components.Forms.FieldIdentifier, string!>! renderedFields) -> Microsoft.AspNetCore.Components.RenderFragment?
+Microsoft.AspNetCore.Components.Forms.ClientValidationProvider
+Microsoft.AspNetCore.Components.Forms.ClientValidationProvider.ClientValidationProvider() -> void
 Microsoft.AspNetCore.Components.Routing.NavLink.RelativeToCurrentUri.get -> bool
 Microsoft.AspNetCore.Components.Routing.NavLink.RelativeToCurrentUri.set -> void
 *REMOVED*Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions

--- a/src/Components/test/E2ETest/ServerRenderingTests/ClientValidation/ClientValidationTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/ClientValidation/ClientValidationTest.cs
@@ -272,7 +272,7 @@ public class ClientValidationTest : ClientValidationTestBase
     }
 
     [Fact]
-    public void EnableClientValidationFalse_EmitsNoCarrier()
+    public void DisableClientValidationTrue_EmitsNoCarrier()
     {
         // The page is reachable but emits no carrier: the JS engine never activates.
         NavigateToClientValidationPage(

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/ClientValidation/BasicValidation.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/ClientValidation/BasicValidation.razor
@@ -13,7 +13,7 @@
 </style>
 
 <EditForm Model="Form" FormName="basic-validation" method="post">
-    <DataAnnotationsValidator EnableClientValidation="@(!DisableClientValidation)" />
+    <DataAnnotationsValidator DisableClientValidation="@DisableClientValidation" />
     <ValidationSummary />
 
     <div>

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/ClientValidation/CustomValidator.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/ClientValidation/CustomValidator.razor
@@ -53,9 +53,9 @@
     }
 
     // A custom ValidationAttribute that also contributes a client-side rule by implementing
-    // IClientValidationAdapter. The framework emits its rule into the carrier payload; the
+    // IClientValidationRuleProvider. The framework emits its rule into the carrier payload; the
     // matching JS validator is registered above via Blazor.formValidation.addValidator.
-    private sealed class StartsWithAttribute : ValidationAttribute, IClientValidationAdapter
+    private sealed class StartsWithAttribute : ValidationAttribute, IClientValidationRuleProvider
     {
         private readonly string _prefix;
 

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/DefaultFormBoundParameterAnnotations.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/Forms/DefaultFormBoundParameterAnnotations.razor
@@ -6,7 +6,7 @@
 <h2>Default form with bound parameter using data annotations for validation and data member to tweak the binding.</h2>
 
 <EditForm Model="Parameter" method="POST" OnValidSubmit="() => _submitted = true" FormName="someform" Enhance>
-    <DataAnnotationsValidator EnableClientValidation="false" />
+    <DataAnnotationsValidator DisableClientValidation="true" />
     <ValidationSummary/>
     <p>
         <label>


### PR DESCRIPTION
Fixes #67800

Applies the changes requested during API review of the Blazor SSR client-side validation proposal.

- Renamed `DataAnnotationsValidator.EnableClientValidation` to `DisableClientValidation` (polarity flipped, default `false`)
- Added a global `RazorComponentsServiceOptions.DisableClientValidation` opt-out that is read by the `ClientValidationProvider` and suppresses rule emission for all forms
- Renamed `IClientValidationAdapter` to `IClientValidationRuleProvider`
- Made `ClientValidationRule.Parameters` non-nullable (empty dictionary when unset)
- Moved types from `Microsoft.AspNetCore.Components.Forms.ClientValidation` into the `Microsoft.AspNetCore.Components.Forms` namespace
- Updated doc comment references, and removed a stale trimmer warning suppression
