### PR TITLE
Use System.AccessToken for internal feed auth on release/9.0

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -428,7 +428,8 @@ jobs:
 
       - template: /eng/common/templates-official/steps/enable-internal-sources.yml@self
         parameters:
-          legacyCredential: $(System.AccessToken)
+          ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+            legacyCredential: $(System.AccessToken)
       - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml@self
         parameters:
           expiryInHours: 3

--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -427,6 +427,8 @@ jobs:
       - ${{ parameters.beforeBuild }}
 
       - template: /eng/common/templates-official/steps/enable-internal-sources.yml@self
+        parameters:
+          legacyCredential: $(System.AccessToken)
       - template: /eng/common/templates-official/steps/enable-internal-runtimes.yml@self
         parameters:
           expiryInHours: 3


### PR DESCRIPTION
Restores internal feed authentication on `internal/release/9.0` after the `dn-bot-dnceng-artifact-feeds-rw` PAT was removed from arcade's vault manifest and expired (1ES PAT Disable Policy), causing fleet-wide 401s on `darc-int-*` / `dotnet-*-internal` feeds.

PR #67853 removed the `legacyCredential` PAT entirely, relying solely on the `NuGetAuthenticate@1` credential provider. That is **insufficient**: the Arcade toolset bootstrap restore (`build.cmd` -> `tools.ps1` -> `restore.proj`) reads credentials directly from `NuGet.config` and does not consume the credential provider. Build 3024337 (commit 7ea898fd, which contains #67853) still failed at toolset restore with all internal feeds unreachable.

This PR passes the build identity's OAuth token via `legacyCredential: $(System.AccessToken)`, which `SetupNugetSources.ps1` writes into `NuGet.config` as a live, permissioned credential. The `internal Build Service (dnceng)` identity has collaborator/contributor on the affected feeds. This matches the release/8.0 approach (#67854) and the mechanism that worked prior to PAT expiry (a cleartext credential in config).

Tracks AB#11679.