### PR TITLE
Obsolete UseWebAssemblyDebugging and remove it from Blazor templates

### DIFF
--- a/src/Components/Testing/testassets/TestApp/Program.cs
+++ b/src/Components/Testing/testassets/TestApp/Program.cs
@@ -15,7 +15,9 @@ var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
 {
+#pragma warning disable ASPDEPR011 // UseWebAssemblyDebugging is obsolete
     app.UseWebAssemblyDebugging();
+#pragma warning restore ASPDEPR011
 }
 
 app.UseAntiforgery();

--- a/src/Components/WebAssembly/DevServer/src/Server/Startup.cs
+++ b/src/Components/WebAssembly/DevServer/src/Server/Startup.cs
@@ -29,7 +29,9 @@ internal sealed class Startup
         app.UseDeveloperExceptionPage();
         EnableConfiguredPathbase(app, configuration);
 
+#pragma warning disable ASPDEPR011 // UseWebAssemblyDebugging is obsolete; the DevServer still hosts the legacy in-browser debug proxy endpoint.
         app.UseWebAssemblyDebugging();
+#pragma warning restore ASPDEPR011
 
         var webHostEnvironment = app.ApplicationServices.GetRequiredService<IWebHostEnvironment>();
         var applyCopHeaders = configuration.GetValue<bool>("ApplyCopHeaders");

--- a/src/Components/WebAssembly/Samples/HostedBlazorWebassemblyApp/Server/Startup.cs
+++ b/src/Components/WebAssembly/Samples/HostedBlazorWebassemblyApp/Server/Startup.cs
@@ -39,7 +39,9 @@ public class Startup
         if (env.IsDevelopment())
         {
             app.UseDeveloperExceptionPage();
+#pragma warning disable ASPDEPR011 // UseWebAssemblyDebugging is obsolete
             app.UseWebAssemblyDebugging();
+#pragma warning restore ASPDEPR011
         }
         else
         {

--- a/src/Components/WebAssembly/Server/src/Microsoft.AspNetCore.Components.WebAssembly.Server.csproj
+++ b/src/Components/WebAssembly/Server/src/Microsoft.AspNetCore.Components.WebAssembly.Server.csproj
@@ -35,6 +35,7 @@
     <Compile Include="$(ComponentsSharedSourceRoot)\src\CacheHeaderSettings.cs" Link="Shared\CacheHeaderSettings.cs" />
     <Compile Include="$(SharedSourceRoot)\CommandLineUtils\Utilities\DotNetMuxer.cs" Link="Shared\DotNetMuxer.cs" />
     <Compile Include="$(ComponentsSharedSourceRoot)src\CultureStateProvider.cs" Link="Shared\CultureStateProvider.cs" />
+    <Compile Include="$(SharedSourceRoot)Obsoletions.cs" LinkBase="Shared" />
     <Content Include="build\**" Pack="true" PackagePath="build\%(RecursiveDir)%(FileName)%(Extension)" />
   </ItemGroup>
 

--- a/src/Components/WebAssembly/Server/src/PACKAGE.md
+++ b/src/Components/WebAssembly/Server/src/PACKAGE.md
@@ -28,11 +28,6 @@ builder.Services.AddRazorComponents()
 
 var app = builder.Build();
 
-if (app.Environment.IsDevelopment())
-{
-    app.UseWebAssemblyDebugging();
-}
-
 app.UseAntiforgery();
 app.MapStaticAssets();
 app.MapRazorComponents<App>()

--- a/src/Components/WebAssembly/Server/src/WebAssemblyNetDebugProxyAppBuilderExtensions.cs
+++ b/src/Components/WebAssembly/Server/src/WebAssemblyNetDebugProxyAppBuilderExtensions.cs
@@ -4,6 +4,7 @@
 using System.Net;
 using System.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Server;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.AspNetCore.Builder;
 
@@ -16,6 +17,7 @@ public static class WebAssemblyNetDebugProxyAppBuilderExtensions
     /// Adds middleware needed for debugging Blazor WebAssembly applications
     /// inside Chromium dev tools.
     /// </summary>
+    [Obsolete(Obsoletions.UseWebAssemblyDebuggingMessage, DiagnosticId = Obsoletions.UseWebAssemblyDebuggingDiagId, UrlFormat = Obsoletions.AspNetCoreDeprecate011Url)]
     public static void UseWebAssemblyDebugging(this IApplicationBuilder app)
     {
         app.Map("/_framework/debug", app =>

--- a/src/Components/WebAssembly/testassets/HostedInAspNet.Server/Startup.cs
+++ b/src/Components/WebAssembly/testassets/HostedInAspNet.Server/Startup.cs
@@ -41,7 +41,9 @@ public class Startup
         if (env.IsDevelopment())
         {
             app.UseDeveloperExceptionPage();
+#pragma warning disable ASPDEPR011 // UseWebAssemblyDebugging is obsolete
             app.UseWebAssemblyDebugging();
+#pragma warning restore ASPDEPR011
         }
 
         if (mapAllApps || mapAlternativePathApp)

--- a/src/Components/WebAssembly/testassets/Wasm.Prerendered.Server/Startup.cs
+++ b/src/Components/WebAssembly/testassets/Wasm.Prerendered.Server/Startup.cs
@@ -22,7 +22,9 @@ public class Startup
         if (env.IsDevelopment())
         {
             app.UseDeveloperExceptionPage();
+#pragma warning disable ASPDEPR011 // UseWebAssemblyDebugging is obsolete
             app.UseWebAssemblyDebugging();
+#pragma warning restore ASPDEPR011
         }
 
         app.UseHttpsRedirection();

--- a/src/Framework/App.Runtime/src/CompatibilitySuppressions.xml
+++ b/src/Framework/App.Runtime/src/CompatibilitySuppressions.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Program.Main.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Program.Main.cs
@@ -85,15 +85,10 @@ public class Program
         var app = builder.Build();
 
         // Configure the HTTP request pipeline.
-#if (UseWebAssembly || IndividualLocalAuth)
+#if (IndividualLocalAuth)
         if (app.Environment.IsDevelopment())
         {
-#if (UseWebAssembly)
-            app.UseWebAssemblyDebugging();
-#endif
-#if (IndividualLocalAuth)
             app.UseMigrationsEndPoint();
-#endif
         }
         else
 #else

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Program.cs
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Program.cs
@@ -79,15 +79,10 @@ builder.Services.AddSingleton<IEmailSender<ApplicationUser>, IdentityNoOpEmailSe
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
-#if (UseWebAssembly || IndividualLocalAuth)
+#if (IndividualLocalAuth)
 if (app.Environment.IsDevelopment())
 {
-#if (UseWebAssembly)
-    app.UseWebAssemblyDebugging();
-#endif
-#if (IndividualLocalAuth)
     app.UseMigrationsEndPoint();
-#endif
 }
 else
 #else

--- a/src/Shared/Obsoletions.cs
+++ b/src/Shared/Obsoletions.cs
@@ -22,8 +22,13 @@ internal sealed class Obsoletions
     internal const string AspNetCoreDeprecate008Url = "https://aka.ms/aspnet/deprecate/008";
     internal const string AspNetCoreDeprecate009Url = "https://aka.ms/aspnet/deprecate/009";
     internal const string AspNetCoreDeprecate010Url = "https://aka.ms/aspnet/deprecate/010";
+    internal const string AspNetCoreDeprecate011Url = "https://aka.ms/aspnet/deprecate/011";
 
     // ITlsTokenBindingFeature (RFC 8471 TLS Token Binding) has been abandoned by browsers (Chrome/Edge) and IETF work has stalled.
     internal const string TlsTokenBindingFeatureMessage = "ITlsTokenBindingFeature is deprecated. TLS Token Binding (RFC 8471) has not been adopted by browsers.";
     internal const string TlsTokenBindingFeatureDiagId = "ASPDEPR010";
+
+    // UseWebAssemblyDebugging is deprecated. Blazor WebAssembly debugging is now launched directly by Visual Studio and Visual Studio Code.
+    internal const string UseWebAssemblyDebuggingMessage = "UseWebAssemblyDebugging is obsolete and should be removed along with any inspectUri configurations. Blazor WebAssembly debugging is now launched directly by Visual Studio and Visual Studio Code.";
+    internal const string UseWebAssemblyDebuggingDiagId = "ASPDEPR011";
 }


### PR DESCRIPTION
## Why

Blazor WebAssembly debugging is now launched directly by Visual Studio and Visual Studio Code, which start the debug proxy themselves. The legacy `UseWebAssemblyDebugging()` middleware only exists to support the old in-browser (Ctrl+Alt+D) experience, and usage of that path is very low. This deprecates the API and stops emitting it from our shipping templates.

Note: this means the legacy in-browser debugging path (including Firefox / non-VS scenarios) is no longer supported going forward.

## What changed

- **Obsoleted the API** as `ASPDEPR011`. Added the message, diagnostic id, and a new `AspNetCoreDeprecate011Url` entry to the shared `Obsoletions.cs`, applied `[Obsolete(...)]` to `WebAssemblyNetDebugProxyAppBuilderExtensions.UseWebAssemblyDebugging`, and wired the shared source into the WebAssembly.Server project.
- **Removed it from the Blazor Web App template** (`Program.cs` and `Program.Main.cs`) and collapsed the now-redundant `#if (UseWebAssembly || IndividualLocalAuth)` / `#if (UseWebAssembly)` conditionals down to `#if (IndividualLocalAuth)`.
- **Kept the repo building** by suppressing `ASPDEPR011` (with justifying comments) at the internal callers that still host the legacy proxy: the DevServer `Startup.cs`, plus the `HostedInAspNet.Server`, `Wasm.Prerendered.Server`, `HostedBlazorWebassemblyApp`, and Components `TestApp` assets.
- **Updated the WebAssembly.Server `PACKAGE.md`** sample so the docs match the templates.

## Notes for reviewers

- No `PublicAPI.*.txt` changes are needed. Marking a member `[Obsolete]` does not change the API signature text, consistent with the recent `ITlsTokenBindingFeature` deprecation (`ASPDEPR010`).
- The standalone Blazor WebAssembly template (`ComponentsWebAssembly-CSharp`) is client-only and needed no change.
- Verified locally: `Microsoft.AspNetCore.Components.WebAssembly.Server` and `...DevServer` both build with 0 warnings / 0 errors under warnings-as-errors, confirming the obsoletion and suppressions are correct.

Fixes #67858