### PR TITLE
Fix context leak in `RazorPageBase` causing attribute prefix pollution in TagHelpers

### DIFF
--- a/src/Mvc/Mvc.Razor/src/RazorPageBase.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorPageBase.cs
@@ -565,6 +565,8 @@ public abstract class RazorPageBase : IRazorPage
         {
             WritePositionTaggedLiteral(_attributeInfo.Suffix, _attributeInfo.SuffixOffset);
         }
+        
+        _attributeInfo = default;
     }
 
     /// <summary>

--- a/src/Mvc/Mvc.Razor/src/RazorPageBase.cs
+++ b/src/Mvc/Mvc.Razor/src/RazorPageBase.cs
@@ -565,7 +565,7 @@ public abstract class RazorPageBase : IRazorPage
         {
             WritePositionTaggedLiteral(_attributeInfo.Suffix, _attributeInfo.SuffixOffset);
         }
-        
+
         _attributeInfo = default;
     }
 

--- a/src/Mvc/Mvc.Razor/test/RazorPageTest.cs
+++ b/src/Mvc/Mvc.Razor/test/RazorPageTest.cs
@@ -1402,6 +1402,40 @@ public class RazorPageTest
         return view.Object;
     }
 
+    [Fact]
+    public void EndWriteAttribute_ClearsAttributeInfo_PreventingTagHelperPrefixPollution()
+    {
+        // Arrange
+        var page = CreatePage(p => { });
+        page.HtmlEncoder = new HtmlTestEncoder();
+        var writer = new StringWriter();
+
+        // Act
+        page.PushWriter(writer);
+
+        // 1. Simulate writing a normal dynamic HTML attribute (e.g. dir="@Model.Dir")
+        page.BeginWriteAttribute("dir", " dir=\"", 0, "\"", 0, 1);
+        page.WriteAttributeValue("", 0, "ltr", 0, 3, isLiteral: true);
+        page.EndWriteAttribute(); // <--- This clears _attributeInfo
+
+        // 2. Simulate Razor engine emitting a TagHelper attribute containing the @@ escape sequence
+        page.BeginWriteTagHelperAttribute();
+        
+        // If _attributeInfo was not cleared in EndWriteAttribute(), a state pollution occurs here.
+        // WriteAttributeValue would incorrectly inject the previous prefix (" dir=\"") into this buffer.
+        page.WriteAttributeValue("", 0, "~/node_modules/", 0, 15, isLiteral: true);
+        page.WriteLiteral("@");
+        page.WriteAttributeValue("", 0, "aiursoft", 0, 8, isLiteral: true);
+        
+        var tagHelperContent = page.EndWriteTagHelperAttribute();
+
+        page.PopWriter();
+
+        // Assert
+        Assert.Equal(" dir=\"ltr\"", writer.ToString());
+        Assert.Equal("~/node_modules/@aiursoft", tagHelperContent);
+    }
+
     private static ViewContext CreateViewContext(
         TextWriter writer = null,
         IViewBufferScope bufferScope = null,


### PR DESCRIPTION
Reset _attributeInfo to default after writing suffix. Fix #67891

Fix context leak in RazorPageBase causing attribute prefix pollution in TagHelpers

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

### Description

This PR fixes an edge-case bug in the Razor runtime where the internal `_attributeInfo` state is not cleared after writing an HTML attribute, leading to a "dirty read" (state pollution) when evaluating a subsequent TagHelper attribute.

### Steps to Reproduce & Symptoms

The bug manifests under a very specific combination of conditions:
1. An HTML tag with a dynamic attribute (e.g., `lang="@Model.Language"`).
2. Immediately followed by a tag that triggers a `TagHelper` (e.g., `<link href="~/[path]">`).
3. The `TagHelper` attribute contains an escaped `@` symbol (`@@`), forcing the Razor compiler to split the attribute and emit `WriteAttributeValue("", ...)` calls inside a `BeginWriteTagHelperAttribute()` block.

Because `EndWriteAttribute()` (from step 1) never clears the `_attributeInfo` state, `_attributeInfo.AttributeValuesCount` remains `1`. When `WriteAttributeValue` is subsequently called inside `BeginWriteTagHelperAttribute`, it mistakenly assumes it is still writing the previous attribute and prepends the **stale prefix** (e.g., ` lang="`) to the buffered TagHelper attribute.

This results in bizarre HTML output where the previous attribute's prefix is injected into the middle of the TagHelper attribute, corrupting the URL.

### Fix
Added `_attributeInfo = default;` to the end of `RazorPageBase.EndWriteAttribute()` to ensure that the attribute state is properly cleared when the writing scope ends. This prevents any subsequent `WriteAttributeValue` calls in buffered scopes from picking up stale prefixes.