### PR TITLE
Delete dead code in DelegateOpenApiDocumentTransformer

### DIFF
--- a/src/OpenApi/src/Transformers/DelegateOpenApiDocumentTransformer.cs
+++ b/src/OpenApi/src/Transformers/DelegateOpenApiDocumentTransformer.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.DependencyInjection;
-
 namespace Microsoft.AspNetCore.OpenApi;
 
 internal sealed class DelegateOpenApiDocumentTransformer : IOpenApiDocumentTransformer

--- a/src/OpenApi/src/Transformers/DelegateOpenApiDocumentTransformer.cs
+++ b/src/OpenApi/src/Transformers/DelegateOpenApiDocumentTransformer.cs
@@ -7,33 +7,13 @@ namespace Microsoft.AspNetCore.OpenApi;
 
 internal sealed class DelegateOpenApiDocumentTransformer : IOpenApiDocumentTransformer
 {
-    private readonly Func<OpenApiDocument, OpenApiDocumentTransformerContext, CancellationToken, Task>? _documentTransformer;
-    private readonly Func<OpenApiOperation, OpenApiOperationTransformerContext, CancellationToken, Task>? _operationTransformer;
+    private readonly Func<OpenApiDocument, OpenApiDocumentTransformerContext, CancellationToken, Task> _documentTransformer;
 
     public DelegateOpenApiDocumentTransformer(Func<OpenApiDocument, OpenApiDocumentTransformerContext, CancellationToken, Task> transformer)
-    {
-        _documentTransformer = transformer;
-    }
-
-    public DelegateOpenApiDocumentTransformer(Func<OpenApiOperation, OpenApiOperationTransformerContext, CancellationToken, Task> transformer)
-    {
-        _operationTransformer = transformer;
-    }
+        => _documentTransformer = transformer;
 
     public async Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
     {
-        if (_documentTransformer != null)
-        {
-            await _documentTransformer(document, context, cancellationToken);
-        }
-
-        if (_operationTransformer != null)
-        {
-            var documentService = context.ApplicationServices.GetRequiredKeyedService<OpenApiDocumentService>(context.DocumentName);
-            await documentService.ForEachOperationAsync(
-                document,
-                async (operation, operationContext, token) => await _operationTransformer(operation, operationContext, token),
-                cancellationToken);
-        }
+        await _documentTransformer(document, context, cancellationToken);
     }
 }


### PR DESCRIPTION
Deleted unused internal constructor and cleaned up `DelegateOpenApiDocumentTransformer`

The only single usage of this class is:

https://github.com/dotnet/aspnetcore/blob/346fa53dcc2f96afd375cbb681cd690c3de1e37c/src/OpenApi/src/Services/OpenApiOptions.cs#L93

which is `Func<OpenApiDocument, OpenApiDocumentTransformerContext, CancellationToken, Task>`.

So, the class never holds an operation transformer.