### PR TITLE
fix: honor OpenAPI transformer registration order

### DIFF
--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -76,10 +76,9 @@ internal sealed class OpenApiDocumentService(
             Info = GetOpenApiInfo(),
             Servers = GetOpenApiServers(httpRequest)
         };
-        document.Paths = await GetOpenApiPathsAsync(document, scopedServiceProvider, operationTransformers, schemaTransformers, cancellationToken);
         try
         {
-            await ApplyTransformersAsync(document, scopedServiceProvider, schemaTransformers, cancellationToken);
+            await ApplyTransformersAndGeneratePathsAsync(document, scopedServiceProvider, operationTransformers, schemaTransformers, cancellationToken);
         }
 
         finally
@@ -101,7 +100,12 @@ internal sealed class OpenApiDocumentService(
         return document;
     }
 
-    private async Task ApplyTransformersAsync(OpenApiDocument document, IServiceProvider scopedServiceProvider, IOpenApiSchemaTransformer[] schemaTransformers, CancellationToken cancellationToken)
+    private async Task ApplyTransformersAndGeneratePathsAsync(
+        OpenApiDocument document,
+        IServiceProvider scopedServiceProvider,
+        IOpenApiOperationTransformer[] operationTransformers,
+        IOpenApiSchemaTransformer[] schemaTransformers,
+        CancellationToken cancellationToken)
     {
         var documentTransformerContext = new OpenApiDocumentTransformerContext
         {
@@ -111,11 +115,32 @@ internal sealed class OpenApiDocumentService(
             Document = document,
             SchemaTransformers = schemaTransformers
         };
-        // Use index-based for loop to avoid allocating an enumerator with a foreach.
-        for (var i = 0; i < _options.DocumentTransformers.Count; i++)
+        var pathsGenerated = false;
+        var hasGenerationTransformers = _options.Transformers.Any(static transformer => transformer is not IOpenApiDocumentTransformer);
+        if (!hasGenerationTransformers)
         {
-            var transformer = _options.DocumentTransformers[i];
-            await transformer.TransformAsync(document, documentTransformerContext, cancellationToken);
+            document.Paths = await GetOpenApiPathsAsync(document, scopedServiceProvider, operationTransformers, schemaTransformers, cancellationToken);
+            pathsGenerated = true;
+        }
+
+        // Use index-based for loop to avoid allocating an enumerator with a foreach.
+        for (var i = 0; i < _options.Transformers.Count; i++)
+        {
+            var transformer = _options.Transformers[i];
+            if (transformer is IOpenApiDocumentTransformer documentTransformer)
+            {
+                await documentTransformer.TransformAsync(document, documentTransformerContext, cancellationToken);
+            }
+            else if (!pathsGenerated)
+            {
+                document.Paths = await GetOpenApiPathsAsync(document, scopedServiceProvider, operationTransformers, schemaTransformers, cancellationToken);
+                pathsGenerated = true;
+            }
+        }
+
+        if (!pathsGenerated)
+        {
+            document.Paths = await GetOpenApiPathsAsync(document, scopedServiceProvider, operationTransformers, schemaTransformers, cancellationToken);
         }
     }
 

--- a/src/OpenApi/src/Services/OpenApiDocumentService.cs
+++ b/src/OpenApi/src/Services/OpenApiDocumentService.cs
@@ -116,7 +116,16 @@ internal sealed class OpenApiDocumentService(
             SchemaTransformers = schemaTransformers
         };
         var pathsGenerated = false;
-        var hasGenerationTransformers = _options.Transformers.Any(static transformer => transformer is not IOpenApiDocumentTransformer);
+        var hasGenerationTransformers = false;
+        for (var i = 0; i < _options.Transformers.Count; i++)
+        {
+            if (_options.Transformers[i].Kind is not OpenApiTransformerKind.Document)
+            {
+                hasGenerationTransformers = true;
+                break;
+            }
+        }
+
         if (!hasGenerationTransformers)
         {
             document.Paths = await GetOpenApiPathsAsync(document, scopedServiceProvider, operationTransformers, schemaTransformers, cancellationToken);
@@ -126,9 +135,10 @@ internal sealed class OpenApiDocumentService(
         // Use index-based for loop to avoid allocating an enumerator with a foreach.
         for (var i = 0; i < _options.Transformers.Count; i++)
         {
-            var transformer = _options.Transformers[i];
-            if (transformer is IOpenApiDocumentTransformer documentTransformer)
+            var transformerRegistration = _options.Transformers[i];
+            if (transformerRegistration.Kind is OpenApiTransformerKind.Document)
             {
+                var documentTransformer = (IOpenApiDocumentTransformer)transformerRegistration.Transformer;
                 await documentTransformer.TransformAsync(document, documentTransformerContext, cancellationToken);
             }
             else if (!pathsGenerated)

--- a/src/OpenApi/src/Services/OpenApiOptions.cs
+++ b/src/OpenApi/src/Services/OpenApiOptions.cs
@@ -12,6 +12,7 @@ namespace Microsoft.AspNetCore.OpenApi;
 /// </summary>
 public sealed class OpenApiOptions
 {
+    internal readonly List<object> Transformers = [];
     internal readonly List<IOpenApiDocumentTransformer> DocumentTransformers = [];
     internal readonly List<IOpenApiOperationTransformer> OperationTransformers = [];
     internal readonly List<IOpenApiSchemaTransformer> SchemaTransformers = [];
@@ -64,7 +65,9 @@ public sealed class OpenApiOptions
     public OpenApiOptions AddDocumentTransformer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TTransformerType>()
         where TTransformerType : IOpenApiDocumentTransformer
     {
-        DocumentTransformers.Add(new TypeBasedOpenApiDocumentTransformer(typeof(TTransformerType)));
+        var transformer = new TypeBasedOpenApiDocumentTransformer(typeof(TTransformerType));
+        DocumentTransformers.Add(transformer);
+        Transformers.Add(transformer);
         return this;
     }
 
@@ -78,6 +81,7 @@ public sealed class OpenApiOptions
         ArgumentNullException.ThrowIfNull(transformer);
 
         DocumentTransformers.Add(transformer);
+        Transformers.Add(transformer);
         return this;
     }
 
@@ -90,7 +94,9 @@ public sealed class OpenApiOptions
     {
         ArgumentNullException.ThrowIfNull(transformer);
 
-        DocumentTransformers.Add(new DelegateOpenApiDocumentTransformer(transformer));
+        var transformerInstance = new DelegateOpenApiDocumentTransformer(transformer);
+        DocumentTransformers.Add(transformerInstance);
+        Transformers.Add(transformerInstance);
         return this;
     }
 
@@ -102,7 +108,9 @@ public sealed class OpenApiOptions
     public OpenApiOptions AddOperationTransformer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TTransformerType>()
         where TTransformerType : IOpenApiOperationTransformer
     {
-        OperationTransformers.Add(new TypeBasedOpenApiOperationTransformer(typeof(TTransformerType)));
+        var transformer = new TypeBasedOpenApiOperationTransformer(typeof(TTransformerType));
+        OperationTransformers.Add(transformer);
+        Transformers.Add(transformer);
         return this;
     }
 
@@ -116,6 +124,7 @@ public sealed class OpenApiOptions
         ArgumentNullException.ThrowIfNull(transformer);
 
         OperationTransformers.Add(transformer);
+        Transformers.Add(transformer);
         return this;
     }
 
@@ -128,7 +137,9 @@ public sealed class OpenApiOptions
     {
         ArgumentNullException.ThrowIfNull(transformer);
 
-        OperationTransformers.Add(new DelegateOpenApiOperationTransformer(transformer));
+        var transformerInstance = new DelegateOpenApiOperationTransformer(transformer);
+        OperationTransformers.Add(transformerInstance);
+        Transformers.Add(transformerInstance);
         return this;
     }
 
@@ -140,7 +151,9 @@ public sealed class OpenApiOptions
     public OpenApiOptions AddSchemaTransformer<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TTransformerType>()
         where TTransformerType : IOpenApiSchemaTransformer
     {
-        SchemaTransformers.Add(new TypeBasedOpenApiSchemaTransformer(typeof(TTransformerType)));
+        var transformer = new TypeBasedOpenApiSchemaTransformer(typeof(TTransformerType));
+        SchemaTransformers.Add(transformer);
+        Transformers.Add(transformer);
         return this;
     }
 
@@ -154,6 +167,7 @@ public sealed class OpenApiOptions
         ArgumentNullException.ThrowIfNull(transformer);
 
         SchemaTransformers.Add(transformer);
+        Transformers.Add(transformer);
         return this;
     }
 
@@ -166,7 +180,9 @@ public sealed class OpenApiOptions
     {
         ArgumentNullException.ThrowIfNull(transformer);
 
-        SchemaTransformers.Add(new DelegateOpenApiSchemaTransformer(transformer));
+        var transformerInstance = new DelegateOpenApiSchemaTransformer(transformer);
+        SchemaTransformers.Add(transformerInstance);
+        Transformers.Add(transformerInstance);
         return this;
     }
 }

--- a/src/OpenApi/src/Services/OpenApiOptions.cs
+++ b/src/OpenApi/src/Services/OpenApiOptions.cs
@@ -12,7 +12,7 @@ namespace Microsoft.AspNetCore.OpenApi;
 /// </summary>
 public sealed class OpenApiOptions
 {
-    internal readonly List<object> Transformers = [];
+    internal readonly List<OpenApiTransformerRegistration> Transformers = [];
     internal readonly List<IOpenApiDocumentTransformer> DocumentTransformers = [];
     internal readonly List<IOpenApiOperationTransformer> OperationTransformers = [];
     internal readonly List<IOpenApiSchemaTransformer> SchemaTransformers = [];
@@ -67,7 +67,7 @@ public sealed class OpenApiOptions
     {
         var transformer = new TypeBasedOpenApiDocumentTransformer(typeof(TTransformerType));
         DocumentTransformers.Add(transformer);
-        Transformers.Add(transformer);
+        Transformers.Add(new(OpenApiTransformerKind.Document, transformer));
         return this;
     }
 
@@ -81,7 +81,7 @@ public sealed class OpenApiOptions
         ArgumentNullException.ThrowIfNull(transformer);
 
         DocumentTransformers.Add(transformer);
-        Transformers.Add(transformer);
+        Transformers.Add(new(OpenApiTransformerKind.Document, transformer));
         return this;
     }
 
@@ -96,7 +96,7 @@ public sealed class OpenApiOptions
 
         var transformerInstance = new DelegateOpenApiDocumentTransformer(transformer);
         DocumentTransformers.Add(transformerInstance);
-        Transformers.Add(transformerInstance);
+        Transformers.Add(new(OpenApiTransformerKind.Document, transformerInstance));
         return this;
     }
 
@@ -110,7 +110,7 @@ public sealed class OpenApiOptions
     {
         var transformer = new TypeBasedOpenApiOperationTransformer(typeof(TTransformerType));
         OperationTransformers.Add(transformer);
-        Transformers.Add(transformer);
+        Transformers.Add(new(OpenApiTransformerKind.Operation, transformer));
         return this;
     }
 
@@ -124,7 +124,7 @@ public sealed class OpenApiOptions
         ArgumentNullException.ThrowIfNull(transformer);
 
         OperationTransformers.Add(transformer);
-        Transformers.Add(transformer);
+        Transformers.Add(new(OpenApiTransformerKind.Operation, transformer));
         return this;
     }
 
@@ -139,7 +139,7 @@ public sealed class OpenApiOptions
 
         var transformerInstance = new DelegateOpenApiOperationTransformer(transformer);
         OperationTransformers.Add(transformerInstance);
-        Transformers.Add(transformerInstance);
+        Transformers.Add(new(OpenApiTransformerKind.Operation, transformerInstance));
         return this;
     }
 
@@ -153,7 +153,7 @@ public sealed class OpenApiOptions
     {
         var transformer = new TypeBasedOpenApiSchemaTransformer(typeof(TTransformerType));
         SchemaTransformers.Add(transformer);
-        Transformers.Add(transformer);
+        Transformers.Add(new(OpenApiTransformerKind.Schema, transformer));
         return this;
     }
 
@@ -167,7 +167,7 @@ public sealed class OpenApiOptions
         ArgumentNullException.ThrowIfNull(transformer);
 
         SchemaTransformers.Add(transformer);
-        Transformers.Add(transformer);
+        Transformers.Add(new(OpenApiTransformerKind.Schema, transformer));
         return this;
     }
 
@@ -182,7 +182,16 @@ public sealed class OpenApiOptions
 
         var transformerInstance = new DelegateOpenApiSchemaTransformer(transformer);
         SchemaTransformers.Add(transformerInstance);
-        Transformers.Add(transformerInstance);
+        Transformers.Add(new(OpenApiTransformerKind.Schema, transformerInstance));
         return this;
     }
+}
+
+internal readonly record struct OpenApiTransformerRegistration(OpenApiTransformerKind Kind, object Transformer);
+
+internal enum OpenApiTransformerKind
+{
+    Document,
+    Operation,
+    Schema
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/DocumentTransformerTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/DocumentTransformerTests.cs
@@ -107,6 +107,27 @@ public class DocumentTransformerTests : OpenApiDocumentServiceTestBase
     }
 
     [Fact]
+    public async Task TransformerRegisteredAsOperationTransformer_DoesNotRunAsDocumentTransformer()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/todo", () => { });
+
+        var transformer = new OperationAndDocumentTransformer();
+        var options = new OpenApiOptions();
+        options.AddOperationTransformer(transformer);
+
+        await VerifyOpenApiDocument(builder, options, document =>
+        {
+            Assert.Null(document.Info.Description);
+            Assert.Equal("Operation transformer ran.", document.Paths["/todo"].Operations[HttpMethod.Get].Description);
+        });
+
+        Assert.Equal(0, transformer.DocumentTransformCount);
+        Assert.Equal(1, transformer.OperationTransformCount);
+    }
+
+    [Fact]
     public async Task DocumentTransformer_SupportsActivatedTransformers()
     {
         var builder = CreateBuilder();
@@ -391,6 +412,27 @@ public class DocumentTransformerTests : OpenApiDocumentServiceTestBase
         await documentTask;
 
         Assert.Equal([1, 2, 3], transformerOrder);
+    }
+
+    private sealed class OperationAndDocumentTransformer : IOpenApiOperationTransformer, IOpenApiDocumentTransformer
+    {
+        public int OperationTransformCount { get; private set; }
+
+        public int DocumentTransformCount { get; private set; }
+
+        public Task TransformAsync(OpenApiOperation operation, OpenApiOperationTransformerContext context, CancellationToken cancellationToken)
+        {
+            OperationTransformCount++;
+            operation.Description = "Operation transformer ran.";
+            return Task.CompletedTask;
+        }
+
+        public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
+        {
+            DocumentTransformCount++;
+            document.Info.Description = "Document transformer ran.";
+            return Task.CompletedTask;
+        }
     }
 
     private class ActivatedTransformer : IOpenApiDocumentTransformer

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/DocumentTransformerTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/DocumentTransformerTests.cs
@@ -2,7 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Globalization;
+using System.Net.Http;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -32,6 +34,75 @@ public class DocumentTransformerTests : OpenApiDocumentServiceTestBase
         await VerifyOpenApiDocument(builder, options, document =>
         {
             Assert.Equal("2", document.Info.Description);
+        });
+    }
+
+    [Fact]
+    public async Task DocumentTransformer_RunsBeforeOperationGenerationToPreserveTagMetadata()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/todo", () => { }).WithTags("todos", "v1");
+
+        var options = new OpenApiOptions();
+        options.AddDocumentTransformer((document, context, cancellationToken) =>
+        {
+            document.Tags ??= new SortedSet<OpenApiTag>(Comparer<OpenApiTag>.Create(
+                static (left, right) => StringComparer.Ordinal.Compare(left.Name, right.Name)));
+            document.Tags.Add(new OpenApiTag
+            {
+                Name = "todos",
+                Description = "Operations for managing todo items."
+            });
+            document.Tags.Add(new OpenApiTag
+            {
+                Name = "v1",
+                Description = "Version 1 operations."
+            });
+            return Task.CompletedTask;
+        });
+        options.AddOperationTransformer((operation, context, cancellationToken) => Task.CompletedTask);
+
+        await VerifyOpenApiDocument(builder, options, document =>
+        {
+            Assert.Collection(document.Tags,
+                tag =>
+                {
+                    Assert.Equal("todos", tag.Name);
+                    Assert.Equal("Operations for managing todo items.", tag.Description);
+                },
+                tag =>
+                {
+                    Assert.Equal("v1", tag.Name);
+                    Assert.Equal("Version 1 operations.", tag.Description);
+                });
+        });
+    }
+
+    [Fact]
+    public async Task DocumentTransformer_RunsBeforeOperationTransformerWhenRegisteredFirst()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/todo", () => { });
+
+        var options = new OpenApiOptions();
+        options.AddDocumentTransformer((document, context, cancellationToken) =>
+        {
+            document.Info.Description = "Document transformer ran.";
+            return Task.CompletedTask;
+        });
+        options.AddOperationTransformer((operation, context, cancellationToken) =>
+        {
+            Assert.Equal("Document transformer ran.", context.Document.Info.Description);
+            operation.Description = "Operation transformer ran.";
+            return Task.CompletedTask;
+        });
+
+        await VerifyOpenApiDocument(builder, options, document =>
+        {
+            Assert.Equal("Document transformer ran.", document.Info.Description);
+            Assert.Equal("Operation transformer ran.", document.Paths["/todo"].Operations[HttpMethod.Get].Description);
         });
     }
 

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/OpenApiOptionsTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/OpenApiOptionsTests.cs
@@ -22,6 +22,7 @@ public class OpenApiOptionsTests
         // Assert
         var insertedTransformer = Assert.Single(options.DocumentTransformers);
         Assert.IsType<DelegateOpenApiDocumentTransformer>(insertedTransformer);
+        Assert.Same(insertedTransformer, Assert.Single(options.Transformers));
         Assert.IsType<OpenApiOptions>(result);
         Assert.Empty(options.OperationTransformers);
         Assert.Empty(options.SchemaTransformers);
@@ -40,6 +41,7 @@ public class OpenApiOptionsTests
         // Assert
         var insertedTransformer = Assert.Single(options.DocumentTransformers);
         Assert.Same(transformer, insertedTransformer);
+        Assert.Same(insertedTransformer, Assert.Single(options.Transformers));
         Assert.IsType<OpenApiOptions>(result);
         Assert.Empty(options.OperationTransformers);
         Assert.Empty(options.SchemaTransformers);
@@ -57,6 +59,7 @@ public class OpenApiOptionsTests
         // Assert
         var insertedTransformer = Assert.Single(options.DocumentTransformers);
         Assert.IsType<TypeBasedOpenApiDocumentTransformer>(insertedTransformer);
+        Assert.Same(insertedTransformer, Assert.Single(options.Transformers));
         Assert.IsType<OpenApiOptions>(result);
         Assert.Empty(options.OperationTransformers);
         Assert.Empty(options.SchemaTransformers);
@@ -79,6 +82,7 @@ public class OpenApiOptionsTests
         // Assert
         var insertedTransformer = Assert.Single(options.OperationTransformers);
         Assert.IsType<DelegateOpenApiOperationTransformer>(insertedTransformer);
+        Assert.Same(insertedTransformer, Assert.Single(options.Transformers));
         Assert.IsType<OpenApiOptions>(result);
         Assert.Empty(options.DocumentTransformers);
         Assert.Empty(options.SchemaTransformers);
@@ -97,6 +101,7 @@ public class OpenApiOptionsTests
         // Assert
         var insertedTransformer = Assert.Single(options.OperationTransformers);
         Assert.Same(transformer, insertedTransformer);
+        Assert.Same(insertedTransformer, Assert.Single(options.Transformers));
         Assert.IsType<OpenApiOptions>(result);
         Assert.Empty(options.DocumentTransformers);
         Assert.Empty(options.SchemaTransformers);
@@ -114,6 +119,7 @@ public class OpenApiOptionsTests
         // Assert
         var insertedTransformer = Assert.Single(options.OperationTransformers);
         Assert.IsType<TypeBasedOpenApiOperationTransformer>(insertedTransformer);
+        Assert.Same(insertedTransformer, Assert.Single(options.Transformers));
         Assert.IsType<OpenApiOptions>(result);
         Assert.Empty(options.DocumentTransformers);
         Assert.Empty(options.SchemaTransformers);
@@ -136,6 +142,7 @@ public class OpenApiOptionsTests
         // Assert
         var insertedTransformer = Assert.Single(options.SchemaTransformers);
         Assert.IsType<DelegateOpenApiSchemaTransformer>(insertedTransformer);
+        Assert.Same(insertedTransformer, Assert.Single(options.Transformers));
         Assert.IsType<OpenApiOptions>(result);
         Assert.Empty(options.DocumentTransformers);
         Assert.Empty(options.OperationTransformers);
@@ -154,6 +161,7 @@ public class OpenApiOptionsTests
         // Assert
         var insertedTransformer = Assert.Single(options.SchemaTransformers);
         Assert.Same(transformer, insertedTransformer);
+        Assert.Same(insertedTransformer, Assert.Single(options.Transformers));
         Assert.IsType<OpenApiOptions>(result);
         Assert.Empty(options.DocumentTransformers);
         Assert.Empty(options.OperationTransformers);
@@ -171,6 +179,7 @@ public class OpenApiOptionsTests
         // Assert
         var insertedTransformer = Assert.Single(options.SchemaTransformers);
         Assert.IsType<TypeBasedOpenApiSchemaTransformer>(insertedTransformer);
+        Assert.Same(insertedTransformer, Assert.Single(options.Transformers));
         Assert.IsType<OpenApiOptions>(result);
         Assert.Empty(options.DocumentTransformers);
         Assert.Empty(options.OperationTransformers);

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/OpenApiOptionsTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/OpenApiOptionsTests.cs
@@ -22,7 +22,7 @@ public class OpenApiOptionsTests
         // Assert
         var insertedTransformer = Assert.Single(options.DocumentTransformers);
         Assert.IsType<DelegateOpenApiDocumentTransformer>(insertedTransformer);
-        Assert.Same(insertedTransformer, Assert.Single(options.Transformers));
+        AssertRegistration(insertedTransformer, OpenApiTransformerKind.Document, Assert.Single(options.Transformers));
         Assert.IsType<OpenApiOptions>(result);
         Assert.Empty(options.OperationTransformers);
         Assert.Empty(options.SchemaTransformers);
@@ -41,7 +41,7 @@ public class OpenApiOptionsTests
         // Assert
         var insertedTransformer = Assert.Single(options.DocumentTransformers);
         Assert.Same(transformer, insertedTransformer);
-        Assert.Same(insertedTransformer, Assert.Single(options.Transformers));
+        AssertRegistration(insertedTransformer, OpenApiTransformerKind.Document, Assert.Single(options.Transformers));
         Assert.IsType<OpenApiOptions>(result);
         Assert.Empty(options.OperationTransformers);
         Assert.Empty(options.SchemaTransformers);
@@ -59,7 +59,7 @@ public class OpenApiOptionsTests
         // Assert
         var insertedTransformer = Assert.Single(options.DocumentTransformers);
         Assert.IsType<TypeBasedOpenApiDocumentTransformer>(insertedTransformer);
-        Assert.Same(insertedTransformer, Assert.Single(options.Transformers));
+        AssertRegistration(insertedTransformer, OpenApiTransformerKind.Document, Assert.Single(options.Transformers));
         Assert.IsType<OpenApiOptions>(result);
         Assert.Empty(options.OperationTransformers);
         Assert.Empty(options.SchemaTransformers);
@@ -82,7 +82,7 @@ public class OpenApiOptionsTests
         // Assert
         var insertedTransformer = Assert.Single(options.OperationTransformers);
         Assert.IsType<DelegateOpenApiOperationTransformer>(insertedTransformer);
-        Assert.Same(insertedTransformer, Assert.Single(options.Transformers));
+        AssertRegistration(insertedTransformer, OpenApiTransformerKind.Operation, Assert.Single(options.Transformers));
         Assert.IsType<OpenApiOptions>(result);
         Assert.Empty(options.DocumentTransformers);
         Assert.Empty(options.SchemaTransformers);
@@ -101,7 +101,7 @@ public class OpenApiOptionsTests
         // Assert
         var insertedTransformer = Assert.Single(options.OperationTransformers);
         Assert.Same(transformer, insertedTransformer);
-        Assert.Same(insertedTransformer, Assert.Single(options.Transformers));
+        AssertRegistration(insertedTransformer, OpenApiTransformerKind.Operation, Assert.Single(options.Transformers));
         Assert.IsType<OpenApiOptions>(result);
         Assert.Empty(options.DocumentTransformers);
         Assert.Empty(options.SchemaTransformers);
@@ -119,7 +119,7 @@ public class OpenApiOptionsTests
         // Assert
         var insertedTransformer = Assert.Single(options.OperationTransformers);
         Assert.IsType<TypeBasedOpenApiOperationTransformer>(insertedTransformer);
-        Assert.Same(insertedTransformer, Assert.Single(options.Transformers));
+        AssertRegistration(insertedTransformer, OpenApiTransformerKind.Operation, Assert.Single(options.Transformers));
         Assert.IsType<OpenApiOptions>(result);
         Assert.Empty(options.DocumentTransformers);
         Assert.Empty(options.SchemaTransformers);
@@ -142,7 +142,7 @@ public class OpenApiOptionsTests
         // Assert
         var insertedTransformer = Assert.Single(options.SchemaTransformers);
         Assert.IsType<DelegateOpenApiSchemaTransformer>(insertedTransformer);
-        Assert.Same(insertedTransformer, Assert.Single(options.Transformers));
+        AssertRegistration(insertedTransformer, OpenApiTransformerKind.Schema, Assert.Single(options.Transformers));
         Assert.IsType<OpenApiOptions>(result);
         Assert.Empty(options.DocumentTransformers);
         Assert.Empty(options.OperationTransformers);
@@ -161,7 +161,7 @@ public class OpenApiOptionsTests
         // Assert
         var insertedTransformer = Assert.Single(options.SchemaTransformers);
         Assert.Same(transformer, insertedTransformer);
-        Assert.Same(insertedTransformer, Assert.Single(options.Transformers));
+        AssertRegistration(insertedTransformer, OpenApiTransformerKind.Schema, Assert.Single(options.Transformers));
         Assert.IsType<OpenApiOptions>(result);
         Assert.Empty(options.DocumentTransformers);
         Assert.Empty(options.OperationTransformers);
@@ -179,10 +179,16 @@ public class OpenApiOptionsTests
         // Assert
         var insertedTransformer = Assert.Single(options.SchemaTransformers);
         Assert.IsType<TypeBasedOpenApiSchemaTransformer>(insertedTransformer);
-        Assert.Same(insertedTransformer, Assert.Single(options.Transformers));
+        AssertRegistration(insertedTransformer, OpenApiTransformerKind.Schema, Assert.Single(options.Transformers));
         Assert.IsType<OpenApiOptions>(result);
         Assert.Empty(options.DocumentTransformers);
         Assert.Empty(options.OperationTransformers);
+    }
+
+    private static void AssertRegistration(object transformer, OpenApiTransformerKind kind, OpenApiTransformerRegistration registration)
+    {
+        Assert.Same(transformer, registration.Transformer);
+        Assert.Equal(kind, registration.Kind);
     }
 
     private class TestOpenApiDocumentTransformer : IOpenApiDocumentTransformer

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/OperationTransformerTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Transformers/OperationTransformerTests.cs
@@ -52,14 +52,6 @@ public class OperationTransformerTests : OpenApiDocumentServiceTestBase
 
         var options = new OpenApiOptions();
 
-        // While added first, document transformers should run after the operation transformers
-        options.AddDocumentTransformer<MyDocumentationTransformer>();
-        options.AddDocumentTransformer((document, context, cancellationToken) =>
-        {
-            Assert.All(document.Paths.Values.SelectMany(p => p.Operations).Select(p => p.Value), o => Assert.Equal("6", o.Description));
-            return Task.CompletedTask;
-        });
-
         // Operation transforms should run FIFO regardless of which kind of transformer is used
         options.AddOperationTransformer((operation, context, cancellationToken) =>
         {
@@ -85,6 +77,12 @@ public class OperationTransformerTests : OpenApiDocumentServiceTestBase
         {
             Assert.Equal("5", operation.Description);
             operation.Description = "6";
+            return Task.CompletedTask;
+        });
+        options.AddDocumentTransformer<MyDocumentationTransformer>();
+        options.AddDocumentTransformer((document, context, cancellationToken) =>
+        {
+            Assert.All(document.Paths.Values.SelectMany(p => p.Operations).Select(p => p.Value), o => Assert.Equal("6", o.Description));
             return Task.CompletedTask;
         });
 


### PR DESCRIPTION
Fixes the OpenAPI transformer ordering issue discussed in https://github.com/dotnet/aspnetcore/issues/65723#issuecomment-5025789850.\n\nThis keeps the existing per-transformer-type lists while tracking registrations in a unified internal list so document transformers registered before operation/schema transformers can run before operation generation. This allows document transformers to pre-populate document-level tag metadata without operation tag discovery replacing it.\n\nValidation:\n- Docker: dotnet test src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Microsoft.AspNetCore.OpenApi.Tests.csproj --filter 'FullyQualifiedName~DocumentTransformerTests|FullyQualifiedName~OperationTransformerTests'

fixes #65723
closes #67457