### PR TITLE
Fix url normalizer backslashes

### DIFF
--- a/src/Middleware/Rewrite/src/UrlNormalizer.cs
+++ b/src/Middleware/Rewrite/src/UrlNormalizer.cs
@@ -9,17 +9,24 @@ internal static class UrlNormalizer
     // scheme-relative authority. Mirrors the rejection predicate in SharedUrlHelper.IsLocalUrl.
     public static string CollapseLeadingSlashes(string url)
     {
-        if (url.Length < 2 || url[0] != '/' || (url[1] != '/' && url[1] != '\\'))
+        if (string.IsNullOrEmpty(url))
         {
             return url;
         }
 
-        var i = 1;
-        while (i < url.Length && (url[i] == '/' || url[i] == '\\'))
+        if ((url[0] != '/' && url[0] != '\\') ||
+            (url[0] == '/' && (url.Length == 1 || (url[1] != '/' && url[1] != '\\'))))
         {
-            i++;
+            return url;
         }
 
-        return i == url.Length ? "/" : string.Concat("/", url.AsSpan(i));
+        var firstNonSlash = url.AsSpan().IndexOfAnyExcept('/', '\\');
+
+        if (firstNonSlash < 0)
+        {
+            return "/";
+        }
+
+        return string.Concat("/", url.AsSpan(firstNonSlash));
     }
 }

--- a/src/Middleware/Rewrite/test/MiddlewareTests.cs
+++ b/src/Middleware/Rewrite/test/MiddlewareTests.cs
@@ -182,6 +182,10 @@ public class MiddlewareTests
     [InlineData("legacy/(.*)", "/$1", "legacy//example.com")]
     [InlineData("legacy/(.*)", "/$1", "legacy///example.com")]
     [InlineData("legacy/(.*)", "/$1", @"legacy/\example.com")]
+    [InlineData("(.*)", @"\example.com", "anything")]
+    [InlineData("(.*)", @"\\example.com", "anything")]
+    [InlineData("(.*)", @"\/\example.com", "anything")]
+    [InlineData("legacy/(.*)", "/$1", @"legacy\\example.com")]
     public async Task CheckRedirect_CollapsesSchemeRelativeTarget(string pattern, string replacement, string requestUrl)
     {
         var options = new RewriteOptions().AddRedirect(pattern, replacement, statusCode: StatusCodes.Status302Found);


### PR DESCRIPTION
# Fix url normalizer backslashes

UrlNormalizer.CollapseLeadingSlashes (introduced in #66961) was intended to prevent rewrite/redirect targets from resolving as scheme-relative URLs (//host, /\host). However, it only triggered when the string already started with /

## Description

`CollapseLeadingSlashes` now treats a leading `\` the same as a leading `/` for the purposes of triggering normalization, closing the bypass regardless of which character (or combination of `/` and `\`) starts the string:

```csharp
if ((url[0] != '/' && url[0] != '\\') ||
    (url[0] == '/' && (url.Length == 1 || (url[1] != '/' && url[1] != '\\'))))
{
    return url;
}

var firstNonSlash = url.AsSpan().IndexOfAnyExcept('/', '\\');
if (firstNonSlash < 0)
{
    return "/";
}
return string.Concat("/", url.AsSpan(firstNonSlash));
```

The fast-path condition returns early only when:

there's no leading `/` or `\` at all, or
the string already starts with exactly one / (i.e. it's already normalized).

Any other case, including a bare leading `\`, or multiple leading slashes/backslashes in any combination falls through to the collapsing logic.

Why a hybrid (if-path + IndexOfAnyExcept) approach instead of a plain scalar loop

The original implementation used a simple manual scan with a `while` loop checking `url[i] == '/' || url[i] == '\\'` one character at a time. I benchmarked three approaches

A pure if-based scalar scan (closest to the original code, extended to also catch `\`). 
A pure `Span<char>.IndexOfAnyExcept('/', '\\')` call with no fast path.
The hybrid version above: fast-path checks for the 0/1-leading-slash case, falling back to `IndexOfAnyExcept` otherwise.

Results (ns/op, representative rows):

| Input | Scalar `if` | Pure `IndexOfAnyExcept` | Hybrid |
| :--- | :--- | :--- | :--- |
| `""` / `already normalized` / | ~0.2–0.5 ns | ~0.06–0.2 ns | ~0.07–0.3 ns |
| `///` (short run) | ~2.9 ns | ~4.1 ns | ~3.1 ns |
| Long string, long leading slash run (54 chars) | ~40.2 ns | ~12.5 ns | ~13.2 ns |
| `/////site.com/path` | ~12.1 ns | ~13.0 ns | ~13.5 ns |

Given that this method sits on the rewrite/redirect request path and its inputs are influenced by external clients, I prioritized keeping the common case cheap while making the worst case resilient rather than linear.

Fixes #67812 