### PR TITLE
Implement RFC 9931 §8 for HTTP/1.1 CONNECT in Kestrel

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -1253,6 +1253,15 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
             }
         }
 
+        // Close the connection when rejecting an HTTP/1.1 CONNECT request.
+        // See https://www.rfc-editor.org/rfc/rfc9931#section-8.
+        if (_httpVersion == Http.HttpVersion.Http11 &&
+            Method == HttpMethod.Connect &&
+            StatusCode >= StatusCodes.Status300MultipleChoices)
+        {
+            DisableKeepAlive(ConnectionEndReason.ResponseNoKeepAlive);
+        }
+
         responseHeaders.SetReadOnly();
 
         if (!hasConnection && _httpVersion < Http.HttpVersion.Http2)

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -667,6 +667,123 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
     public async Task AttemptingToWriteZeroContentLengthFor2xxResponsesOnConnect_ContentLengthRemoved(int statusCode)
         => await AttemptingToWriteZeroContentLength_ContentLengthRemoved(statusCode, HttpMethod.Connect).ConfigureAwait(true);
 
+    // RFC 9931 Section 8: In HTTP/1.1, a server that rejects a CONNECT request MUST close the
+    // underlying connection, regardless of whether the request carried "Connection: close".
+    [Theory]
+    [InlineData(StatusCodes.Status400BadRequest)]
+    [InlineData(StatusCodes.Status407ProxyAuthenticationRequired)]
+    [InlineData(StatusCodes.Status500InternalServerError)]
+    [InlineData(StatusCodes.Status502BadGateway)]
+    public async Task RejectedConnectRequestClosesHttp11Connection(int statusCode)
+    {
+        await using (var server = new TestServer(httpContext =>
+        {
+            httpContext.Response.StatusCode = statusCode;
+            return Task.CompletedTask;
+        }, new TestServiceContext(LoggerFactory)))
+        {
+            using (var connection = server.CreateConnection())
+            {
+                await connection.Send(
+                    "CONNECT no-such-destination.example:443 HTTP/1.1",
+                    "Host: no-such-destination.example:443",
+                    "",
+                    "");
+
+                await connection.ReceiveEnd(
+                    $"HTTP/1.1 {Encoding.ASCII.GetString(ReasonPhrases.ToStatusBytes(statusCode))}",
+                    "Content-Length: 0",
+                    "Connection: close",
+                    $"Date: {server.Context.DateHeaderValue}",
+                    "",
+                    "");
+            }
+        }
+    }
+
+    // A CONNECT rejected with a keep-alive-carrying request header must still result in the
+    // connection being closed. RFC 9931 Section 8 explicitly overrides any "keep-alive" hint
+    // from the request.
+    [Fact]
+    public async Task RejectedConnectRequestWithKeepAliveRequestHeaderClosesHttp11Connection()
+    {
+        await using (var server = new TestServer(httpContext =>
+        {
+            httpContext.Response.StatusCode = StatusCodes.Status407ProxyAuthenticationRequired;
+            return Task.CompletedTask;
+        }, new TestServiceContext(LoggerFactory)))
+        {
+            using (var connection = server.CreateConnection())
+            {
+                await connection.Send(
+                    "CONNECT no-such-destination.example:443 HTTP/1.1",
+                    "Host: no-such-destination.example:443",
+                    "Connection: keep-alive",
+                    "",
+                    "");
+
+                await connection.ReceiveEnd(
+                    "HTTP/1.1 407 Proxy Authentication Required",
+                    "Content-Length: 0",
+                    "Connection: close",
+                    $"Date: {server.Context.DateHeaderValue}",
+                    "",
+                    "");
+            }
+        }
+    }
+
+    // A 2xx CONNECT response accepts the tunnel. RFC 9931 Section 8's mandatory-close rule
+    // only applies to rejections, so keep-alive should not be forced off. Verify by sending a
+    // follow-up request on the same connection and confirming it is processed.
+    [Fact]
+    public async Task AcceptedConnectRequestDoesNotForceConnectionClose()
+    {
+        await using (var server = new TestServer(httpContext =>
+        {
+            if (httpContext.Request.Method == "CONNECT")
+            {
+                httpContext.Response.StatusCode = StatusCodes.Status200OK;
+            }
+            else
+            {
+                httpContext.Response.StatusCode = StatusCodes.Status204NoContent;
+            }
+            return Task.CompletedTask;
+        }, new TestServiceContext(LoggerFactory)))
+        {
+            using (var connection = server.CreateConnection())
+            {
+                await connection.Send(
+                    "CONNECT server.example:443 HTTP/1.1",
+                    "Host: server.example:443",
+                    "",
+                    "");
+
+                // A 2xx response to CONNECT must not include Content-Length and must not
+                // carry a "Connection: close" header added by Kestrel.
+                await connection.Receive(
+                    "HTTP/1.1 200 OK",
+                    $"Date: {server.Context.DateHeaderValue}",
+                    "",
+                    "");
+
+                // The connection should still be usable for subsequent requests.
+                await connection.Send(
+                    "GET / HTTP/1.1",
+                    "Host:",
+                    "",
+                    "");
+
+                await connection.Receive(
+                    "HTTP/1.1 204 No Content",
+                    $"Date: {server.Context.DateHeaderValue}",
+                    "",
+                    "");
+            }
+        }
+    }
+
     private async Task AttemptingToWriteNonzeroContentLengthFails(int statusCode, HttpMethod method)
     {
         var testMeterFactory = new TestMeterFactory();


### PR DESCRIPTION
Per [RFC 9931 §8](https://www.rfc-editor.org/rfc/rfc9931#section-8), an HTTP/1.1 server that rejects a `CONNECT` request must close the connection. Kestrel currently keeps it open. This change disables keep-alive when the method is `CONNECT`, the version is HTTP/1.1, and the final status is ≥ 300. HTTP/2, HTTP/3, and accepted (2xx) CONNECTs are unaffected.