### PR TITLE
Fix QuickGrid None-mode async-provider prepend viewport drift 

### DIFF
--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -674,6 +674,10 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       el = el.nextElementSibling) {
       const rect = el.getBoundingClientRect();
       if (rect.bottom > containerTop) {
+        const existing = observersByDotNetObjectId[id].anchorSnapshot;
+        if (!useNativeAnchoring && anchorMode === 0 && existing && rect.top - containerTop > rect.height) {
+          return;
+        }
         observersByDotNetObjectId[id].anchorSnapshot = {
           anchorItemIndex,
           anchorOffset: rect.top - containerTop,

--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -485,12 +485,19 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
             // same viewport offset. Skip while a ScrollToItemAsync is in flight — we are
             // intentionally moving the viewport.
             var shouldRestore = _pendingAnchorRestore && !_pendingScrollToBottom && _currentScrollCts is null;
-            _pendingAnchorRestore = false;
+
+            var deferAnchorRestoreClear = shouldRestore && AnchorMode == VirtualizeAnchorMode.None;
+            if (!deferAnchorRestoreClear)
+            {
+                _pendingAnchorRestore = false;
+            }
 
             if (shouldRestore)
             {
                 await _jsInterop.RestoreAnchorAsync();
             }
+
+            _pendingAnchorRestore = false;
 
             await _jsInterop.RefreshObserversAsync();
         }

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -1992,8 +1992,8 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     [InlineData("0", false)]
     [InlineData("1", false)]
     [InlineData("2", false)]
-    // Disabled pending fix https://github.com/dotnet/aspnetcore/issues/67865:
-    // [InlineData("0", true)]
+    [InlineData("0", true)]
+    // Start/End async variants still disabled pending fix https://github.com/dotnet/aspnetcore/issues/67865:
     // [InlineData("1", true)]
     // [InlineData("2", true)]
     public void QuickGrid_AnchorMode_NearTop_PrependKeepsViewportStable(string anchorMode, bool useItemsProvider)
@@ -2120,8 +2120,8 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     [InlineData("0", false)]
     [InlineData("1", false)]
     [InlineData("2", false)]
-    // Disabled pending fix https://github.com/dotnet/aspnetcore/issues/67865:
-    // [InlineData("0", true)]
+    [InlineData("0", true)]
+    // Start/End async variants still disabled pending fix https://github.com/dotnet/aspnetcore/issues/67865:
     // [InlineData("1", true)]
     // [InlineData("2", true)]
     public void QuickGrid_AnchorMode_Bottom_PrependKeepsViewportStable(string anchorMode, bool useItemsProvider)
@@ -2153,8 +2153,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
 
     [Theory]
     [InlineData(false)]
-    // Disabled pending fix https://github.com/dotnet/aspnetcore/issues/67865:
-    // [InlineData(true)]
+    [InlineData(true)]
     public void QuickGrid_AnchorMode_None_PrependAtTop_ViewportStaysStable(bool useItemsProvider)
     {
         MountQuickGridAnchorModeComponent("0", useItemsProvider);
@@ -2244,7 +2243,6 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/67865")] // fails pre-fix
     public void QuickGrid_AnchorMode_None_AsyncProvider_PrependKeepsViewportStable()
     {
         MountQuickGridAnchorModeComponent("0", useItemsProvider: true);
@@ -2455,8 +2453,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
 
     [Theory]
     [InlineData(false)]
-    // Disabled pending fix https://github.com/dotnet/aspnetcore/issues/67865 (provider async-anchor race: index jumps 90->80):
-    // [InlineData(true)]
+    [InlineData(true)]
     public void QuickGrid_AnchorMode_None_MidList_ViewportStable(bool useItemsProvider)
     {
         MountQuickGridAnchorModeComponent("0", useItemsProvider);


### PR DESCRIPTION
Contributes to https://github.com/dotnet/aspnetcore/issues/67865.

`QuickGrid` renders a `<table>`, so Virtualize uses the manual (non-native) scroll-anchoring path because native one wouldn't work reliably in a table layout. On a prepend with an async `ItemsProvider`, the viewport drifted (top row jumped, e.g. 90->80) instead of staying stable.

Two things contributed to the problem:

1. Captured the anchor before the data arrived. While the provider was still fetching, the grid briefly showed a placeholder gap at the top. Virtualize captured that gap as its "keep this row in place" reference, so the follow-up scroll correction was computed against the wrong row.
2. Premature scroll callback undid the shift. On Server the scroll correction happens over an async round-trip. In that gap, a scroll observer fired and recalculated the window from a stale position, reverting the prepend before the correction landed.

Fixes, both scoped to `AnchorMode.None`:
- Ignore those mid-load snapshots and keep the last stable one.
- Hold the "restore in progress" flag across the round-trip so the stray callback is skipped.

<details><summary>New QuickGrid AnchorMode test coverage summary, updated after #67783</summary>

| Op · Position · Source | None | Start | End |
|---|---|---|---|
| ⬆️ · Exact top · Items          | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬆️ · Exact top · Prov           | V ✅ · QG ✅ 0/5 (fixed) | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ❌ 1/5 |
| ⬆️ · Exact top · Prov+delay     | V n/a · QG ✅ 0/5 (fixed) | V n/a · QG 🆕 ✅ 0/5 | V n/a · QG 🆕 ❌ 4/5 |
| ⬆️ · Near-top ~200px · Items     | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬆️ · Near-top ~200px · Prov      | V ✅ · QG ✅ 0/5 (fixed) | V ✅ · QG 🆕 ❌ 2/5 | V ✅ · QG 🆕 ❌ 1/5 |
| ⬆️ · Near-top ~200px · Prov+delay | V n/a · QG ✅ 0/5 (fixed) | V n/a · QG 🆕 ❌ 3/5 | V n/a · QG 🆕 ❌ 4/5 |
| ⬆️ · Mid-list · Items           | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬆️ · Mid-list · Prov            | V ✅ · QG ✅ 0/5 (fixed) | V ✅ · QG 🆕 ❌ 2/5 | V ✅ · QG 🆕 ❌ 4/5 |
| ⬆️ · Mid-list · Prov+delay      | V ✅ · QG ✅ 0/5 (fixed, `None_AsyncProvider` `[Fact]`) | — | — |
| ⬆️ · Bottom · Items              | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬆️ · Bottom · Prov               | V ✅ · QG ✅ 0/5 (fixed) | V ✅ · QG 🆕 ❌ 4/5 | V ✅ · QG 🆕 ❌ 1/5 |
| ⬆️ · After leaving top · Items   | — | V ✅ · QG 🆕 ✅ 0/5 | — |
| ⬆️ · After leaving top · Prov    | — | V ✅ · QG 🆕 ✅ 0/5 | — |
| ⬇️ · Near-top · Items             | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · Near-top · Prov              | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · Top · Items                  | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · Top · Prov                   | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ❌ 1/6 |
| ⬇️ · Mid-list · Items             | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · Mid-list · Prov              | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · Bottom · Items               | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · Bottom · Prov                | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · After leaving bottom · Items | — | — | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · After leaving bottom · Prov  | — | — | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ LARGE (100) · Bottom · Items   | — | V ✅ · QG 🆕 ❌ WASM | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ LARGE (100) · Bottom · Prov    | — | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⌨️ Home key → top · Items/Prov    | — · QG 🆕 ✅ 0/5 | — · QG 🆕 ✅ 0/5 | — · QG 🆕 ✅ 0/5 |
| ⌨️ End key → bottom · Items/Prov  | — · QG 🆕 ✅ 0/5 | — · QG 🆕 ✅ 0/5 | — · QG 🆕 ❌ 1/6 (CI/Mono) |
