### PR TITLE
Fix QuickGrid Start-mode async-provider prepend viewport drift.

### DIFF
--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -677,7 +677,8 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       const rect = el.getBoundingClientRect();
       if (rect.bottom > containerTop) {
         const existing = observersByDotNetObjectId[id].anchorSnapshot;
-        if (!useNativeAnchoring && anchorMode === 0 && existing && rect.top - containerTop > rect.height) {
+        const startAnchoring = (anchorMode & 1) !== 0 && !convergingToTop;
+        if (!useNativeAnchoring && (anchorMode === 0 || startAnchoring) && existing && rect.top - containerTop > rect.height) {
           return;
         }
         observersByDotNetObjectId[id].anchorSnapshot = {

--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -88,6 +88,8 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
     // so the viewport stays stable after a prepend or append.
     private bool _pendingAnchorRestore;
 
+    private bool _deferPrependAnchorClear;
+
     [Inject]
     private IJSRuntime JSRuntime { get; set; } = default!;
 
@@ -480,7 +482,9 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
             // intentionally moving the viewport.
             var shouldRestore = _pendingAnchorRestore && !_pendingScrollToBottom && _currentScrollCts is null;
 
-            var deferAnchorRestoreClear = shouldRestore && AnchorMode == VirtualizeAnchorMode.None;
+            var deferAnchorRestoreClear = shouldRestore
+                && (AnchorMode == VirtualizeAnchorMode.None
+                    || ((AnchorMode & VirtualizeAnchorMode.Start) != 0 && _deferPrependAnchorClear));
             if (!deferAnchorRestoreClear)
             {
                 _pendingAnchorRestore = false;
@@ -492,6 +496,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
             }
 
             _pendingAnchorRestore = false;
+            _deferPrependAnchorClear = false;
 
             await _jsInterop.RefreshObserversAsync();
         }
@@ -953,8 +958,10 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
     private async ValueTask<ItemsProviderResult<TItem>> AdjustForPrependAsync(
         int countDelta, int newTotalCount, CancellationToken cancellationToken)
     {
+        var wasAtTop = _itemsBefore == 0;
         _itemsBefore = Math.Min(_itemsBefore + countDelta, Math.Max(0, newTotalCount - _visibleItemCapacity));
         _pendingAnchorRestore = true;
+        _deferPrependAnchorClear = !wasAtTop;
 
         var adjustedRequest = new ItemsProviderRequest(_itemsBefore, _visibleItemCapacity, cancellationToken);
         return await _itemsProvider(adjustedRequest);

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -1997,8 +1997,8 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     [InlineData("1", false)]
     [InlineData("2", false)]
     [InlineData("0", true)]
-    // Start/End async variants still disabled pending fix https://github.com/dotnet/aspnetcore/issues/67865:
-    // [InlineData("1", true)]
+    [InlineData("1", true)]
+    // End async variant still disabled pending fix https://github.com/dotnet/aspnetcore/issues/67865:
     // [InlineData("2", true)]
     public void QuickGrid_AnchorMode_NearTop_PrependKeepsViewportStable(string anchorMode, bool useItemsProvider)
     {
@@ -2126,8 +2126,8 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     [InlineData("1", false)]
     [InlineData("2", false)]
     [InlineData("0", true)]
-    // Start/End async variants still disabled pending fix https://github.com/dotnet/aspnetcore/issues/67865:
-    // [InlineData("1", true)]
+    [InlineData("1", true)]
+    // End async variant still disabled pending fix https://github.com/dotnet/aspnetcore/issues/67865:
     // [InlineData("2", true)]
     public void QuickGrid_AnchorMode_Bottom_PrependKeepsViewportStable(string anchorMode, bool useItemsProvider)
     {
@@ -2488,8 +2488,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
 
     [Theory]
     [InlineData(false)]
-    // Disabled pending fix https://github.com/dotnet/aspnetcore/issues/67865 (provider async-anchor race: index jumps 90->80):
-    // [InlineData(true)]
+    [InlineData(true)]
     public void QuickGrid_AnchorMode_Start_MidList_ViewportStable(bool useItemsProvider)
     {
         MountQuickGridAnchorModeComponent("1", useItemsProvider);


### PR DESCRIPTION
Follow-up to #67931 (which fixed the same problem in  AnchorMode.None ). Extends the fix to `AnchorMode.Start` when items are prepended to `QuickGrid` with async `ItemsProvider`. Contributes to https://github.com/dotnet/aspnetcore/issues/67865.

## The problem

`QuickGrid` renders as a `<table>`, and browser-native scroll anchoring is unreliable inside table layout, so `Virtualize` falls back to manual JS scroll compensation. On Blazor Server, restoring that anchor is an async round-trip. During the latency after a prepend, two things went wrong in Start mode:

1. An anchor was captured while data was still loading. The topmost rendered row was sitting in a placeholder gap below the container top, so the restore computed the wrong scroll offset.
2. Premature scroll callback undid the shift.. The reserved height had already grown but the compensating scroll had not landed yet, so a stray spacer-before observer callback recomputed a smaller window and undid the shift (the visible row jumped, e.g. index 90 -> 80).

WASM was unaffected because the restore there is synchronous.

## The fix

Extend the anchor-restore deferral (already used for `None`) to `Start` mode (but only when the prepend did not happen at the very top):

•  Virtualize.cs : keep `_pendingAnchorRestore` set across the `RestoreAnchorAsync` round-trip for a Start-mode prepend that started away from the top, so the premature callback can't revert it. A new flag (`_deferPrependAnchorClear`) carries the "was at top?" signal from prepend time to render time, where it's otherwise no longer available.
•  Virtualize.ts : skip the transient loading-gap anchor snapshot for `Start` too, guarded by `!convergingToTop`.

Why "not at top" matters: at the very top, `Start` mode must converge back to the new first item (show the freshly prepended rows), so that path is deliberately left untouched. Only once the viewport has left the top does Start need to anchor the current row (which is where the drift occurred).

<details><summary>New QuickGrid AnchorMode test coverage summary, updated after #67931</summary>

| Op · Position · Source | None | Start | End |
|---|---|---|---|
| ⬆️ · Exact top · Items          | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬆️ · Exact top · Prov           | V ✅ · QG ✅ 0/5 (fixed) | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ❌ 1/5 |
| ⬆️ · Exact top · Prov+delay     | V n/a · QG ✅ 0/5 (fixed) | V n/a · QG 🆕 ✅ 0/5 | V n/a · QG 🆕 ❌ 4/5 |
| ⬆️ · Near-top ~200px · Items     | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬆️ · Near-top ~200px · Prov      | V ✅ · QG ✅ 0/5 (fixed) | V ✅ · QG ✅ 0/5 (fixed†) | V ✅ · QG 🆕 ❌ 1/5 |
| ⬆️ · Near-top ~200px · Prov+delay | V n/a · QG ✅ 0/5 (fixed) | V n/a · QG ✅ 0/5 (fixed) | V n/a · QG 🆕 ❌ 4/5 |
| ⬆️ · Mid-list · Items           | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬆️ · Mid-list · Prov            | V ✅ · QG ✅ 0/5 (fixed) | V ✅ · QG ✅ 0/5 (fixed) | V ✅ · QG 🆕 ❌ 4/5 |
| ⬆️ · Mid-list · Prov+delay      | V ✅ · QG ✅ 0/5 (fixed, `None_AsyncProvider` `[Fact]`) | — | — |
| ⬆️ · Bottom · Items              | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬆️ · Bottom · Prov               | V ✅ · QG ✅ 0/5 (fixed) | V ✅ · QG ✅ 0/5 (fixed) | V ✅ · QG 🆕 ❌ 1/5 |
| ⬆️ · After leaving top · Items   | — | V ✅ · QG 🆕 ✅ 0/5 | — |
| ⬆️ · After leaving top · Prov    | — | V ✅ · QG 🆕 ✅ 0/5 | — |
| ⬇️ · Near-top · Items             | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · Near-top · Prov              | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · Top · Items                  | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · Top · Prov                   | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ❌ 1/6 |
| ⬇️ · Mid-list · Items             | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · Mid-list · Prov              | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · Bottom · Items               | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · Bottom · Prov                | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · After leaving bottom · Items | — | — | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · After leaving bottom · Prov  | — | — | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ LARGE (100) · Bottom · Items   | — | V ✅ · QG 🆕 ❌ WASM | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ LARGE (100) · Bottom · Prov    | — | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⌨️ Home key → top · Items/Prov    | — · QG 🆕 ✅ 0/5 | — · QG 🆕 ✅ 0/5 | — · QG 🆕 ✅ 0/5 |
| ⌨️ End key → bottom · Items/Prov  | — · QG 🆕 ✅ 0/5 | — · QG 🆕 ✅ 0/5 | — · QG 🆕 ❌ 1/6 (CI/Mono) |
