### PR TITLE
Fix QuickGrid End-mode async-provider prepend viewport drift

### DIFF
--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -678,7 +678,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       if (rect.bottom > containerTop) {
         const existing = observersByDotNetObjectId[id].anchorSnapshot;
         const startAnchoring = (anchorMode & 1) !== 0 && !convergingToTop;
-        if (!useNativeAnchoring && (anchorMode === 0 || startAnchoring) && existing && rect.top - containerTop > rect.height) {
+        if (!useNativeAnchoring && (anchorMode === 0 || (anchorMode & 2) !== 0 || startAnchoring) && existing && rect.top - containerTop > rect.height) {
           return;
         }
         observersByDotNetObjectId[id].anchorSnapshot = {

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -678,7 +678,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       if (rect.bottom > containerTop) {
         const existing = observersByDotNetObjectId[id].anchorSnapshot;
         const startAnchoring = (anchorMode & 1) !== 0 && !convergingToTop;
-        if (!useNativeAnchoring && (anchorMode === 0 || (anchorMode & 2) !== 0 || startAnchoring) && existing && rect.top - containerTop > rect.height) {
+        if (!useNativeAnchoring && (anchorMode === 0 || anchorMode === 2 || startAnchoring) && existing && rect.top - containerTop > rect.height) {
           return;
         }
         observersByDotNetObjectId[id].anchorSnapshot = {

--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -484,7 +484,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
 
             var deferAnchorRestoreClear = shouldRestore
                 && (AnchorMode == VirtualizeAnchorMode.None
-                    || (AnchorMode & VirtualizeAnchorMode.End) != 0
+                    || AnchorMode == VirtualizeAnchorMode.End
                     || ((AnchorMode & VirtualizeAnchorMode.Start) != 0 && _deferPrependAnchorClear));
             if (!deferAnchorRestoreClear)
             {

--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -484,6 +484,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
 
             var deferAnchorRestoreClear = shouldRestore
                 && (AnchorMode == VirtualizeAnchorMode.None
+                    || (AnchorMode & VirtualizeAnchorMode.End) != 0
                     || ((AnchorMode & VirtualizeAnchorMode.Start) != 0 && _deferPrependAnchorClear));
             if (!deferAnchorRestoreClear)
             {

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -1998,8 +1998,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     [InlineData("2", false)]
     [InlineData("0", true)]
     [InlineData("1", true)]
-    // End async variant still disabled pending fix https://github.com/dotnet/aspnetcore/issues/67865:
-    // [InlineData("2", true)]
+    [InlineData("2", true)]
     public void QuickGrid_AnchorMode_NearTop_PrependKeepsViewportStable(string anchorMode, bool useItemsProvider)
     {
         MountQuickGridAnchorModeComponent(anchorMode, useItemsProvider);
@@ -2127,8 +2126,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     [InlineData("2", false)]
     [InlineData("0", true)]
     [InlineData("1", true)]
-    // End async variant still disabled pending fix https://github.com/dotnet/aspnetcore/issues/67865:
-    // [InlineData("2", true)]
+    [InlineData("2", true)]
     public void QuickGrid_AnchorMode_Bottom_PrependKeepsViewportStable(string anchorMode, bool useItemsProvider)
     {
         MountQuickGridAnchorModeComponent(anchorMode, useItemsProvider);
@@ -2218,8 +2216,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
 
     [Theory]
     [InlineData(false)]
-    // Disabled pending fix https://github.com/dotnet/aspnetcore/issues/67865 (provider async-anchor race; Items false is 0/5 across runs):
-    // [InlineData(true)]
+    [InlineData(true)]
     public void QuickGrid_AnchorMode_End_PrependAtTop_ViewportStaysStable(bool useItemsProvider)
     {
         MountQuickGridAnchorModeComponent("2", useItemsProvider);
@@ -2518,8 +2515,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
 
     [Theory]
     [InlineData(false)]
-    // Disabled pending fix https://github.com/dotnet/aspnetcore/issues/67865 (provider async-anchor race: index jumps 90->80):
-    // [InlineData(true)]
+    [InlineData(true)]
     public void QuickGrid_AnchorMode_End_MidList_ViewportStable(bool useItemsProvider)
     {
         MountQuickGridAnchorModeComponent("2", useItemsProvider);


### PR DESCRIPTION
Follow-up to #67931 (`AnchorMode.None`) and #67935 (`AnchorMode.Start`), extending the same fix to `AnchorMode.End`. Contributes to #67865.

## The problem

`QuickGrid` renders as a `<table>`, so `Virtualize` uses manual JS scroll compensation. On Blazor Server the anchor restore is an async round-trip, and during that latency two things went wrong in `End` mode (same failures already fixed for `None/Start`):

1. Anchor captured mid-load: the top row sat in a placeholder gap, so the restore used the wrong offset.
2. Premature scroll callback undid the shift: a stray spacer-before observer recomputed a smaller window and reverted the prepend (index jumped 90 -> 80).

## The fix

Extend the two existing guards to `End`: hold `_pendingAnchorRestore` across the round-trip (`Virtualize.cs`) and skip the transient loading-gap snapshot (`Virtualize.ts`).

The key difference from `Start`: `End` needs no "not at top" gate. Start must converge to the new first item on a top prepend (so #67935 gates it with `_deferPrependAnchorClear`/`!convergingToTop`). `End` anchors the current row at every position and never anchors an append (`ShouldAnchorForAppend` excludes `End`), so its deferral is unconditional. Uses the bitmask form to match convention and cover `Start | End`.

<details><summary>New QuickGrid AnchorMode test coverage summary, updated</summary>

| Op · Position · Source | None | Start | End |
|---|---|---|---|
| ⬆️ · Exact top · Items          | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬆️ · Exact top · Prov           | V ✅ · QG ✅ 0/5 (fixed) | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG ✅ 0/5 (fixed End) |
| ⬆️ · Exact top · Prov+delay     | V n/a · QG ✅ 0/5 (fixed) | V n/a · QG 🆕 ✅ 0/5 | V n/a · QG ✅ 0/5 (fixed End) |
| ⬆️ · Near-top ~200px · Items     | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬆️ · Near-top ~200px · Prov      | V ✅ · QG ✅ 0/5 (fixed) | V ✅ · QG ✅ 0/5 (fixed Start) | V ✅ · QG ✅ 0/5 (fixed End) |
| ⬆️ · Near-top ~200px · Prov+delay | V n/a · QG ✅ 0/5 (fixed) | V n/a · QG ✅ 0/5 (fixed Start) | V n/a · QG ✅ 0/5 (fixed End) |
| ⬆️ · Mid-list · Items           | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬆️ · Mid-list · Prov            | V ✅ · QG ✅ 0/5 (fixed) | V ✅ · QG ✅ 0/5 (fixed Start) | V ✅ · QG ✅ 0/5 (fixed End) |
| ⬆️ · Mid-list · Prov+delay      | V ✅ · QG ✅ 0/5 (fixed, `None_AsyncProvider` `[Fact]`) | — | — |
| ⬆️ · Bottom · Items              | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬆️ · Bottom · Prov               | V ✅ · QG ✅ 0/5 (fixed) | V ✅ · QG ✅ 0/5 (fixed Start) | V ✅ · QG ✅ 0/5 (fixed End) |
| ⬆️ · After leaving top · Items   | — | V ✅ · QG 🆕 ✅ 0/5 | — |
| ⬆️ · After leaving top · Prov    | — | V ✅ · QG 🆕 ✅ 0/5 | — |
| ⬇️ · Near-top · Items             | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · Near-top · Prov              | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · Top · Items                  | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · Top · Prov                   | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ❌ 1/6 |
| ⬇️ · Mid-list · Items             | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · Mid-list · Prov              | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · Bottom · Items               | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · Bottom · Prov                | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · After leaving bottom · Items | — | — | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ · After leaving bottom · Prov  | — | — | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ LARGE (100) · Bottom · Items   | — | V ✅ · QG 🆕 ❌ WASM | V ✅ · QG 🆕 ✅ 0/5 |
| ⬇️ LARGE (100) · Bottom · Prov    | — | V ✅ · QG 🆕 ✅ 0/5 | V ✅ · QG 🆕 ✅ 0/5 |
| ⌨️ Home key → top · Items/Prov    | — · QG 🆕 ✅ 0/5 | — · QG 🆕 ✅ 0/5 | — · QG 🆕 ✅ 0/5 |
| ⌨️ End key → bottom · Items/Prov  | — · QG 🆕 ✅ 0/5 | — · QG 🆕 ✅ 0/5 | — · QG 🆕 ❌ 1/6 (CI/Mono) |