### PR TITLE
Improve antiforgery error message for unauthenticated requests with authenticated tokens

### DIFF
--- a/src/Antiforgery/src/Internal/DefaultAntiforgeryTokenGenerator.cs
+++ b/src/Antiforgery/src/Internal/DefaultAntiforgeryTokenGenerator.cs
@@ -168,13 +168,17 @@ internal sealed class DefaultAntiforgeryTokenGenerator : IAntiforgeryTokenGenera
 
         if (!comparer.Equals(requestToken.Username, currentUsername))
         {
-            message = Resources.FormatAntiforgeryToken_UsernameMismatch(requestToken.Username, currentUsername);
+            message = IsTokenForAuthenticatedUserButCurrentUserIsNot(authenticatedIdentity, requestToken)
+                ? Resources.AntiforgeryToken_UnauthenticatedUser
+                : Resources.FormatAntiforgeryToken_UsernameMismatch(requestToken.Username, currentUsername);
             return false;
         }
 
         if (!AreIdenticalClaimUids(requestToken, extractedClaimUidBytes, currentClaimUidBytes))
         {
-            message = Resources.AntiforgeryToken_ClaimUidMismatch;
+            message = IsTokenForAuthenticatedUserButCurrentUserIsNot(authenticatedIdentity, requestToken)
+                ? Resources.AntiforgeryToken_UnauthenticatedUser
+                : Resources.AntiforgeryToken_ClaimUidMismatch;
             return false;
         }
 
@@ -188,6 +192,17 @@ internal sealed class DefaultAntiforgeryTokenGenerator : IAntiforgeryTokenGenera
 
         message = null;
         return true;
+
+        static bool IsTokenForAuthenticatedUserButCurrentUserIsNot(
+            ClaimsIdentity? currentAuthenticatedIdentity,
+            AntiforgeryToken token)
+        {
+            // The current request has no authenticated identity, yet the incoming token was generated for one
+            // (it carries a ClaimUid or a Username). This most commonly happens when UseAntiforgery() runs before
+            // UseAuthentication(), so the user has not been authenticated yet when the token is validated.
+            return currentAuthenticatedIdentity is null
+                && (token.ClaimUid is not null || !string.IsNullOrEmpty(token.Username));
+        }
 
         static bool AreIdenticalClaimUids(AntiforgeryToken token, bool claimUidBytesExtracted, Span<byte> claimUidBytes)
         {

--- a/src/Antiforgery/src/Resources.resx
+++ b/src/Antiforgery/src/Resources.resx
@@ -127,6 +127,9 @@
   <data name="AntiforgeryToken_ClaimUidMismatch" xml:space="preserve">
     <value>The provided antiforgery token was meant for a different claims-based user than the current user.</value>
   </data>
+  <data name="AntiforgeryToken_UnauthenticatedUser" xml:space="preserve">
+    <value>The provided antiforgery token was meant for an authenticated user, but the current request is not authenticated.</value>
+  </data>
   <data name="AntiforgeryToken_DeserializationFailed" xml:space="preserve">
     <value>The antiforgery token could not be decrypted.</value>
   </data>

--- a/src/Antiforgery/test/DefaultAntiforgeryTokenGeneratorTest.cs
+++ b/src/Antiforgery/test/DefaultAntiforgeryTokenGeneratorTest.cs
@@ -485,6 +485,100 @@ public class DefaultAntiforgeryTokenGeneratorProviderTest
     }
 
     [Fact]
+    public void TryValidateTokenSet_UnauthenticatedUser_WithClaimUidToken_ReturnsUnauthenticatedMessage()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        var identity = new ClaimsIdentity(); // Not authenticated.
+        httpContext.User = new ClaimsPrincipal(identity);
+
+        var cookieToken = new AntiforgeryToken() { IsCookieToken = true };
+        var fieldtoken = new AntiforgeryToken()
+        {
+            SecurityToken = cookieToken.SecurityToken,
+            IsCookieToken = false,
+            ClaimUid = new BinaryBlob(256) // Token was generated for an authenticated user.
+        };
+
+        var claimUidExtractor = new DummyClaimUidExtractor(identity, null, failsExtraction: true);
+        var tokenProvider = new DefaultAntiforgeryTokenGenerator(claimUidExtractor, additionalDataProvider: null);
+
+        var expectedMessage =
+            "The provided antiforgery token was meant for an authenticated user, " +
+            "but the current request is not authenticated.";
+
+        // Act
+        var result = tokenProvider.TryValidateTokenSet(httpContext, cookieToken, fieldtoken, out var message);
+
+        // Assert
+        Assert.False(result);
+        Assert.Equal(expectedMessage, message);
+    }
+
+    [Fact]
+    public void TryValidateTokenSet_UnauthenticatedUser_WithUsernameToken_ReturnsUnauthenticatedMessage()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        var identity = new ClaimsIdentity(); // Not authenticated.
+        httpContext.User = new ClaimsPrincipal(identity);
+
+        var cookieToken = new AntiforgeryToken() { IsCookieToken = true };
+        var fieldtoken = new AntiforgeryToken()
+        {
+            SecurityToken = cookieToken.SecurityToken,
+            IsCookieToken = false,
+            Username = "the-user" // Token was generated for an authenticated user.
+        };
+
+        var claimUidExtractor = new DummyClaimUidExtractor(identity, null, failsExtraction: true);
+        var tokenProvider = new DefaultAntiforgeryTokenGenerator(claimUidExtractor, additionalDataProvider: null);
+
+        var expectedMessage =
+            "The provided antiforgery token was meant for an authenticated user, " +
+            "but the current request is not authenticated.";
+
+        // Act
+        var result = tokenProvider.TryValidateTokenSet(httpContext, cookieToken, fieldtoken, out var message);
+
+        // Assert
+        Assert.False(result);
+        Assert.Equal(expectedMessage, message);
+    }
+
+    [Fact]
+    public void TryValidateTokenSet_AuthenticatedUser_ClaimUidMismatch_StillUsesClaimUidMismatchMessage()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        var identity = GetAuthenticatedIdentity("the-user"); // Authenticated.
+        httpContext.User = new ClaimsPrincipal(identity);
+
+        var cookieToken = new AntiforgeryToken() { IsCookieToken = true };
+        var fieldtoken = new AntiforgeryToken()
+        {
+            SecurityToken = cookieToken.SecurityToken,
+            IsCookieToken = false,
+            ClaimUid = new BinaryBlob(256)
+        };
+
+        var differentToken = new BinaryBlob(256);
+        var dummyClaimUidExtractor = new DummyClaimUidExtractor(identity, differentToken);
+        var tokenProvider = new DefaultAntiforgeryTokenGenerator(claimUidExtractor: dummyClaimUidExtractor, additionalDataProvider: null);
+
+        var expectedMessage =
+            "The provided antiforgery token was meant for a different " +
+            "claims-based user than the current user.";
+
+        // Act
+        var result = tokenProvider.TryValidateTokenSet(httpContext, cookieToken, fieldtoken, out var message);
+
+        // Assert
+        Assert.False(result);
+        Assert.Equal(expectedMessage, message);
+    }
+
+    [Fact]
     public void TryValidateTokenSet_AdditionalDataRejected()
     {
         // Arrange


### PR DESCRIPTION
Fixes #63218

## Summary

When antiforgery validation fails because the request token was generated for an authenticated user but the current request is **not** authenticated, the error message was misleading:

- `AntiforgeryToken_ClaimUidMismatch` -> *"The provided antiforgery token was meant for a different claims-based user than the current user."*
- `AntiforgeryToken_UsernameMismatch` -> *"...but the current user is \"\"."*

Both imply there is a *different current user*, when in fact there is **no** authenticated user at all. This is confusing to diagnose.

This change detects that specific state (current request has no authenticated identity, yet the incoming token carries a `ClaimUid` or `Username`) and returns a clearer, cause-neutral message:

> The provided antiforgery token was meant for an authenticated user, but the current request is not authenticated.

The wording deliberately states the fact only and does not assert a single root cause (e.g. middleware ordering), since the same runtime state also occurs legitimately when the user has signed out or the authentication cookie has expired.

## Scope / safety

The message is only surfaced to developers via logs and the developer exception page. Every consumer of `AntiforgeryValidationException` (`AntiforgeryMiddleware`, minimal APIs, MVC filters, Razor Components) records the exception on `IAntiforgeryValidationFeature` and logs it; responses are empty `BadRequestResult`/400s. The message text is never written into the HTTP response body sent to end users.

## Tests

Added unit tests in `DefaultAntiforgeryTokenGeneratorTest` covering the unauthenticated request with a `ClaimUid`-based token and a `Username`-based token, plus a regression test confirming an authenticated user with a genuine claim mismatch still receives the original `ClaimUidMismatch` message. Full `Microsoft.AspNetCore.Antiforgery.Test` suite passes (185 tests).