### PR TITLE
Fix UseAuthorization failing without routing registered (#53332)

### DIFF
--- a/src/Security/Authorization/Policy/src/AuthorizationPolicyCache.cs
+++ b/src/Security/Authorization/Policy/src/AuthorizationPolicyCache.cs
@@ -9,11 +9,21 @@ namespace Microsoft.AspNetCore.Authorization.Policy;
 
 internal sealed class AuthorizationPolicyCache : IDisposable
 {
-    // Caches AuthorizationPolicy instances
-    private readonly DataSourceDependentCache<ConcurrentDictionary<Endpoint, AuthorizationPolicy>> _policyCache;
+    // Caches AuthorizationPolicy instances. This is null when there is no EndpointDataSource
+    // registered (e.g. AddAuthorization() called without AddRouting()), in which case the
+    // cache no-ops since there are no endpoints to key policies on.
+    private readonly DataSourceDependentCache<ConcurrentDictionary<Endpoint, AuthorizationPolicy>>? _policyCache;
 
-    public AuthorizationPolicyCache(EndpointDataSource dataSource)
+    // EndpointDataSource is only registered when routing is added. We optionally resolve it so
+    // that authorization works in hosts that don't auto-register routing (raw WebHostBuilder,
+    // generic Host, Worker SDK). See https://github.com/dotnet/aspnetcore/issues/53332.
+    public AuthorizationPolicyCache(EndpointDataSource? dataSource = null)
     {
+        if (dataSource is null)
+        {
+            return;
+        }
+
         // We cache AuthorizationPolicy instances per-Endpoint for performance, but we want to wipe out
         // that cache if the endpoints change so that we don't allow unbounded memory growth.
         _policyCache = new DataSourceDependentCache<ConcurrentDictionary<Endpoint, AuthorizationPolicy>>(dataSource, (_) =>
@@ -26,17 +36,27 @@ internal sealed class AuthorizationPolicyCache : IDisposable
 
     public AuthorizationPolicy? Lookup(Endpoint endpoint)
     {
+        if (_policyCache is null)
+        {
+            return null;
+        }
+
         _policyCache.Value!.TryGetValue(endpoint, out var policy);
         return policy;
     }
 
     public void Store(Endpoint endpoint, AuthorizationPolicy policy)
     {
+        if (_policyCache is null)
+        {
+            return;
+        }
+
         _policyCache.Value![endpoint] = policy;
     }
 
     public void Dispose()
     {
-        _policyCache.Dispose();
+        _policyCache?.Dispose();
     }
 }

--- a/src/Security/Authorization/Policy/src/Microsoft.AspNetCore.Authorization.Policy.csproj
+++ b/src/Security/Authorization/Policy/src/Microsoft.AspNetCore.Authorization.Policy.csproj
@@ -24,4 +24,8 @@
     <Reference Include="Microsoft.AspNetCore.Routing.Abstractions" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.AspNetCore.Authorization.Test" />
+  </ItemGroup>
+
 </Project>

--- a/src/Security/Authorization/test/AuthorizationMiddlewareTests.cs
+++ b/src/Security/Authorization/test/AuthorizationMiddlewareTests.cs
@@ -323,6 +323,30 @@ public class AuthorizationMiddlewareTests
         Assert.Equal(3, next.CalledCount);
     }
 
+    [Fact]
+    public async Task UseAuthorization_WithoutRouting_DoesNotThrow()
+    {
+        // Regression test for https://github.com/dotnet/aspnetcore/issues/53332.
+        // A policy provider that allows caching forces the middleware to resolve AuthorizationPolicyCache,
+        // which must not fail when EndpointDataSource (registered by AddRouting) is absent.
+        var policy = new AuthorizationPolicyBuilder().RequireAssertion(_ => true).Build();
+        var policyProvider = new Mock<IAuthorizationPolicyProvider>();
+        policyProvider.Setup(p => p.GetDefaultPolicyAsync()).ReturnsAsync(policy);
+        policyProvider.Setup(p => p.AllowsCachingPolicies).Returns(true);
+        var next = new TestRequestDelegate();
+
+        var services = new ServiceCollection()
+            .AddAuthorization()
+            .BuildServiceProvider();
+
+        var middleware = CreateMiddleware(next.Invoke, policyProvider.Object, services);
+        var context = GetHttpContext(anonymous: true);
+
+        await middleware.Invoke(context);
+
+        Assert.True(next.Called);
+    }
+
     private class TestDefaultPolicyProvider : DefaultAuthorizationPolicyProvider
     {
         public int GetFallbackPolicyCount;

--- a/src/Security/Authorization/test/AuthorizationPolicyCacheTests.cs
+++ b/src/Security/Authorization/test/AuthorizationPolicyCacheTests.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Authorization.Policy;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Primitives;
+
+namespace Microsoft.AspNetCore.Authorization.Test;
+
+public class AuthorizationPolicyCacheTests
+{
+    [Fact]
+    public void WithoutEndpointDataSource_LookupReturnsNullAndStoreIsNoOp()
+    {
+        var cache = new AuthorizationPolicyCache();
+        var endpoint = CreateEndpoint();
+        var policy = new AuthorizationPolicyBuilder().RequireAssertion(_ => true).Build();
+
+        cache.Store(endpoint, policy);
+
+        Assert.Null(cache.Lookup(endpoint));
+        cache.Dispose();
+    }
+
+    [Fact]
+    public void Lookup_ReturnsStoredPolicyInstance()
+    {
+        var endpoint = CreateEndpoint();
+        using var cache = new AuthorizationPolicyCache(new TestEndpointDataSource(endpoint));
+        var policy = new AuthorizationPolicyBuilder().RequireAssertion(_ => true).Build();
+
+        cache.Store(endpoint, policy);
+
+        Assert.Same(policy, cache.Lookup(endpoint));
+    }
+
+    [Fact]
+    public void Cache_IsWipedWhenEndpointDataSourceChanges()
+    {
+        var endpoint = CreateEndpoint();
+        var dataSource = new TestEndpointDataSource(endpoint);
+        using var cache = new AuthorizationPolicyCache(dataSource);
+        var policy = new AuthorizationPolicyBuilder().RequireAssertion(_ => true).Build();
+        cache.Store(endpoint, policy);
+
+        dataSource.TriggerChange();
+
+        Assert.Null(cache.Lookup(endpoint));
+    }
+
+    private static Endpoint CreateEndpoint()
+        => new Endpoint(context => Task.CompletedTask, EndpointMetadataCollection.Empty, "Test endpoint");
+
+    private sealed class TestEndpointDataSource : EndpointDataSource
+    {
+        private CancellationTokenSource _cts = new();
+        private CancellationChangeToken _changeToken;
+
+        public TestEndpointDataSource(params Endpoint[] endpoints)
+        {
+            Endpoints = endpoints;
+            _changeToken = new CancellationChangeToken(_cts.Token);
+        }
+
+        public override IReadOnlyList<Endpoint> Endpoints { get; }
+
+        public override IChangeToken GetChangeToken() => _changeToken;
+
+        public void TriggerChange()
+        {
+            var previous = _cts;
+            _cts = new CancellationTokenSource();
+            _changeToken = new CancellationChangeToken(_cts.Token);
+            previous.Cancel();
+        }
+    }
+}


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Fix `AddAuthorization()` throwing when routing isn't registered

## Description

`AddAuthorization()` registers `AuthorizationPolicyCache` as a singleton, but the cache's constructor required a non-optional `EndpointDataSource` — a service that is only registered by `AddRouting()`. In hosts that do not auto-register routing (a raw `WebHostBuilder`, the generic `Host`, or the Worker SDK), calling `AddAuthorization()` without `AddRouting()` caused `AuthorizationMiddleware` activation to throw at startup:

```
System.InvalidOperationException: Unable to resolve service for type
'Microsoft.AspNetCore.Routing.EndpointDataSource' while attempting to activate
'Microsoft.AspNetCore.Authorization.Policy.AuthorizationPolicyCache'.
```

`AuthorizationMiddleware` resolves the cache via `services.GetService<AuthorizationPolicyCache>()`. Because the type *is* registered by `AddAuthorization()`, DI attempts to activate it and throws — the nullable `GetService` doesn't help. This is a regression since .NET 8 and does not reproduce with `WebApplication.CreateBuilder`, which calls `AddRouting()`.

Per the issue direction, this change makes `AuthorizationPolicyCache` **optionally resolve** `EndpointDataSource`:

- The constructor parameter is now `EndpointDataSource? dataSource = null`, so DI can activate the cache even when routing isn't registered.
- When no `EndpointDataSource` is present, the cache is a no-op (`Lookup` returns `null`, `Store` does nothing). Since per-endpoint caching only applies when an endpoint is present (which requires routing), authorization simply recomputes policies per request — identical to the existing non-caching path.
- When `EndpointDataSource` is present, behavior is unchanged: policies are cached per-endpoint and the cache is wiped when the endpoint data source changes.

The type remains `internal`; there are no public API changes.

### Tests

- `AuthorizationMiddlewareTests.UseAuthorization_WithoutRouting_DoesNotThrow` — `AddAuthorization()` without routing no longer throws.
- `AuthorizationPolicyCacheTests` (new) — the cache no-ops without an `EndpointDataSource`, returns the stored policy instance when one is present, and is wiped when the `EndpointDataSource` changes.

Fixes #53332
