### PR TITLE
Optimize TextOutputFormatter Accept-Charset sort

### DIFF
--- a/src/Mvc/Mvc.Core/src/Formatters/TextOutputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/TextOutputFormatter.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Core;
@@ -240,36 +239,54 @@ public abstract class TextOutputFormatter : OutputFormatter
             return values;
         }
 
-        var sorted = new List<StringWithQualityHeaderValue>(values.Count);
+        // Count the entries we're going to keep (everything except explicit q=0 rejections).
+        var count = 0;
         for (var i = 0; i < values.Count; i++)
         {
-            var value = values[i];
-            if (value.Quality != HeaderQuality.NoMatch)
+            if (values[i].Quality != HeaderQuality.NoMatch)
             {
-                sorted.Add(value);
+                count++;
             }
         }
 
-        // Sort in descending quality order in place over the list's backing array. QualityComparer
-        // produces an ascending order and treats equal-quality non-wildcard values as equal, and the
-        // framework sorts aren't stable, so we use an insertion sort (these header lists are tiny).
-        // This keeps the selection deterministic and, like the previous implementation, prefers the
-        // last header entry among equal-quality values.
-        var span = CollectionsMarshal.AsSpan(sorted);
-        for (var i = 1; i < span.Length; i++)
-        {
-            var current = span[i];
-            var j = i - 1;
-            while (j >= 0 &&
-                StringWithQualityHeaderValueComparer.QualityComparer.Compare(current, span[j]) >= 0)
-            {
-                span[j + 1] = span[j];
-                j--;
-            }
+        // Sort indices rather than the values themselves so we can use the framework's
+        // introspective sort (O(n log n) worst case) while still breaking equal-quality ties by the
+        // original header position. QualityComparer treats equal-quality non-wildcard values as
+        // equal and the framework sort isn't stable, so the explicit tie-break keeps the selection
+        // deterministic and, like the previous implementation, prefers the last header entry among
+        // equal-quality values. The index buffer is tiny and stack-allocated for the common case.
+        const int StackallocThreshold = 32;
+        Span<int> order = count <= StackallocThreshold ? stackalloc int[StackallocThreshold] : new int[count];
+        order = order[..count];
 
-            span[j + 1] = current;
+        var next = 0;
+        for (var i = 0; i < values.Count; i++)
+        {
+            if (values[i].Quality != HeaderQuality.NoMatch)
+            {
+                order[next++] = i;
+            }
+        }
+
+        order.Sort(new QualityDescendingComparer(values));
+
+        var sorted = new List<StringWithQualityHeaderValue>(count);
+        for (var i = 0; i < order.Length; i++)
+        {
+            sorted.Add(values[order[i]]);
         }
 
         return sorted;
+    }
+
+    // Orders indices into the source list by descending quality, using the original header position
+    // (larger index first) to break equal-quality ties so the result is deterministic.
+    private readonly struct QualityDescendingComparer(IList<StringWithQualityHeaderValue> values) : IComparer<int>
+    {
+        public int Compare(int x, int y)
+        {
+            var comparison = StringWithQualityHeaderValueComparer.QualityComparer.Compare(values[x], values[y]);
+            return comparison != 0 ? -comparison : y - x;
+        }
     }
 }

--- a/src/Mvc/Mvc.Core/src/Formatters/TextOutputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/TextOutputFormatter.cs
@@ -239,20 +239,37 @@ public abstract class TextOutputFormatter : OutputFormatter
             return values;
         }
 
-        var sorted = new List<StringWithQualityHeaderValue>(values.Count);
+        var sorted = new List<(StringWithQualityHeaderValue Value, int Index)>(values.Count);
         for (var i = 0; i < values.Count; i++)
         {
             var value = values[i];
             if (value.Quality != HeaderQuality.NoMatch)
             {
-                sorted.Add(value);
+                sorted.Add((value, i));
             }
         }
 
-        sorted.Sort(StringWithQualityHeaderValueComparer.QualityComparer);
+        // We want a descending sort. QualityComparer produces an ascending order and treats
+        // equal-quality non-wildcard values as equal, so because List.Sort isn't stable we break
+        // those ties by the original header position. This keeps the selection deterministic and,
+        // matching the previous insertion sort, prefers the last header entry among equal values.
+        sorted.Sort(static (a, b) =>
+        {
+            var comparison = StringWithQualityHeaderValueComparer.QualityComparer.Compare(a.Value, b.Value);
+            if (comparison != 0)
+            {
+                return -comparison;
+            }
 
-        // We want a descending sort, but List.Sort produces ascending order.
-        sorted.Reverse();
-        return sorted;
+            return b.Index - a.Index;
+        });
+
+        var result = new List<StringWithQualityHeaderValue>(sorted.Count);
+        for (var i = 0; i < sorted.Count; i++)
+        {
+            result.Add(sorted[i].Value);
+        }
+
+        return result;
     }
 }

--- a/src/Mvc/Mvc.Core/src/Formatters/TextOutputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/TextOutputFormatter.cs
@@ -215,8 +215,13 @@ public abstract class TextOutputFormatter : OutputFormatter
         return null;
     }
 
-    // There's no allocation-free way to sort an IList and we may have to filter anyway,
-    // so we're going to have to live with a single copy that we sort as we build it.
+    // We may have to filter q=0 values and reorder the rest by quality. StringWithQualityHeaderValue
+    // is a reference type, so it can't live in a stackalloc buffer, but its indices can: we sort a
+    // scratch buffer of indices into the original list and then materialize the result. Real
+    // Accept-Charset headers are tiny, so the scratch stays on the stack for the common case and only
+    // falls back to the heap for pathologically large headers.
+    private const int SortStackAllocThreshold = 32;
+
     private static IList<StringWithQualityHeaderValue> Sort(IList<StringWithQualityHeaderValue> values)
     {
         var sortNeeded = false;
@@ -239,34 +244,49 @@ public abstract class TextOutputFormatter : OutputFormatter
             return values;
         }
 
-        // Build the result directly in descending quality order with an insertion sort, filtering out
-        // the q=0 rejections as we go. We insert into descending order (rather than sorting ascending
-        // and reversing) because Accept-Charset headers usually list the most preferred charset first;
-        // for such already-descending input each value simply appends to the end with no shifting,
-        // making the common case O(n). QualityComparer produces an ascending order and treats
-        // equal-quality non-wildcard values as equal, so shifting past equals (Compare <= 0) places a
-        // later header entry ahead of earlier equals, preserving the previous last-entry-wins behavior.
-        var sorted = new List<StringWithQualityHeaderValue>(values.Count);
+        Span<int> indices = values.Count <= SortStackAllocThreshold
+            ? stackalloc int[SortStackAllocThreshold]
+            : new int[values.Count];
+
+        var count = 0;
         for (var i = 0; i < values.Count; i++)
         {
-            var value = values[i];
-            if (value.Quality == HeaderQuality.NoMatch)
+            if (values[i].Quality != HeaderQuality.NoMatch)
             {
-                continue;
+                indices[count++] = i;
             }
+        }
 
-            sorted.Add(value);
-            var j = sorted.Count - 1;
-            while (j > 0 &&
-                StringWithQualityHeaderValueComparer.QualityComparer.Compare(sorted[j - 1], value) <= 0)
-            {
-                sorted[j] = sorted[j - 1];
-                j--;
-            }
+        indices = indices[..count];
 
-            sorted[j] = value;
+        // The framework span sort is an introspective sort: O(n log n) in the worst case (no
+        // insertion-sort pathology) and, because the comparer breaks quality ties on the original
+        // index, its result is deterministic even though the sort itself isn't stable.
+        indices.Sort(new QualityDescendingComparer(values));
+
+        var sorted = new List<StringWithQualityHeaderValue>(count);
+        for (var i = 0; i < count; i++)
+        {
+            sorted.Add(values[indices[i]]);
         }
 
         return sorted;
+    }
+
+    // Orders indices into the source list by descending quality. QualityComparer already keeps concrete
+    // charsets ahead of an equal-quality wildcard; for a genuine tie (same quality, both non-wildcard)
+    // we keep the later header entry first, which preserves the previous last-entry-wins selection.
+    private readonly struct QualityDescendingComparer(IList<StringWithQualityHeaderValue> values) : IComparer<int>
+    {
+        public int Compare(int x, int y)
+        {
+            var comparison = StringWithQualityHeaderValueComparer.QualityComparer.Compare(values[y], values[x]);
+            if (comparison != 0)
+            {
+                return comparison;
+            }
+
+            return y.CompareTo(x);
+        }
     }
 }

--- a/src/Mvc/Mvc.Core/src/Formatters/TextOutputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/TextOutputFormatter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Core;
@@ -239,37 +240,36 @@ public abstract class TextOutputFormatter : OutputFormatter
             return values;
         }
 
-        var sorted = new List<(StringWithQualityHeaderValue Value, int Index)>(values.Count);
+        var sorted = new List<StringWithQualityHeaderValue>(values.Count);
         for (var i = 0; i < values.Count; i++)
         {
             var value = values[i];
             if (value.Quality != HeaderQuality.NoMatch)
             {
-                sorted.Add((value, i));
+                sorted.Add(value);
             }
         }
 
-        // We want a descending sort. QualityComparer produces an ascending order and treats
-        // equal-quality non-wildcard values as equal, so because List.Sort isn't stable we break
-        // those ties by the original header position. This keeps the selection deterministic and,
-        // matching the previous insertion sort, prefers the last header entry among equal values.
-        sorted.Sort(static (a, b) =>
+        // Sort in descending quality order in place over the list's backing array. QualityComparer
+        // produces an ascending order and treats equal-quality non-wildcard values as equal, and the
+        // framework sorts aren't stable, so we use an insertion sort (these header lists are tiny).
+        // This keeps the selection deterministic and, like the previous implementation, prefers the
+        // last header entry among equal-quality values.
+        var span = CollectionsMarshal.AsSpan(sorted);
+        for (var i = 1; i < span.Length; i++)
         {
-            var comparison = StringWithQualityHeaderValueComparer.QualityComparer.Compare(a.Value, b.Value);
-            if (comparison != 0)
+            var current = span[i];
+            var j = i - 1;
+            while (j >= 0 &&
+                StringWithQualityHeaderValueComparer.QualityComparer.Compare(current, span[j]) >= 0)
             {
-                return -comparison;
+                span[j + 1] = span[j];
+                j--;
             }
 
-            return b.Index - a.Index;
-        });
-
-        var result = new List<StringWithQualityHeaderValue>(sorted.Count);
-        for (var i = 0; i < sorted.Count; i++)
-        {
-            result.Add(sorted[i].Value);
+            span[j + 1] = current;
         }
 
-        return result;
+        return sorted;
     }
 }

--- a/src/Mvc/Mvc.Core/src/Formatters/TextOutputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/TextOutputFormatter.cs
@@ -216,7 +216,7 @@ public abstract class TextOutputFormatter : OutputFormatter
     }
 
     // There's no allocation-free way to sort an IList and we may have to filter anyway,
-    // so we're going to have to live with the copy + insertion sort.
+    // so we're going to have to live with the copy + sort.
     private static IList<StringWithQualityHeaderValue> Sort(IList<StringWithQualityHeaderValue> values)
     {
         var sortNeeded = false;
@@ -239,30 +239,19 @@ public abstract class TextOutputFormatter : OutputFormatter
             return values;
         }
 
-        var sorted = new List<StringWithQualityHeaderValue>();
+        var sorted = new List<StringWithQualityHeaderValue>(values.Count);
         for (var i = 0; i < values.Count; i++)
         {
             var value = values[i];
-            if (value.Quality == HeaderQuality.NoMatch)
+            if (value.Quality != HeaderQuality.NoMatch)
             {
-                // Exclude this one
-            }
-            else
-            {
-                // Doing an insertion sort.
-                var position = sorted.BinarySearch(value, StringWithQualityHeaderValueComparer.QualityComparer);
-                if (position >= 0)
-                {
-                    sorted.Insert(position + 1, value);
-                }
-                else
-                {
-                    sorted.Insert(~position, value);
-                }
+                sorted.Add(value);
             }
         }
 
-        // We want a descending sort, but BinarySearch does ascending
+        sorted.Sort(StringWithQualityHeaderValueComparer.QualityComparer);
+
+        // We want a descending sort, but List.Sort produces ascending order.
         sorted.Reverse();
         return sorted;
     }

--- a/src/Mvc/Mvc.Core/src/Formatters/TextOutputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/TextOutputFormatter.cs
@@ -216,10 +216,12 @@ public abstract class TextOutputFormatter : OutputFormatter
     }
 
     // We may have to filter q=0 values and reorder the rest by quality. StringWithQualityHeaderValue
-    // is a reference type, so it can't live in a stackalloc buffer, but its indices can: we sort a
-    // scratch buffer of indices into the original list and then materialize the result. Real
-    // Accept-Charset headers are tiny, so the scratch stays on the stack for the common case and only
-    // falls back to the heap for pathologically large headers.
+    // is a reference type, so it can't live in a stackalloc buffer, but its indices can. Real
+    // Accept-Charset headers are tiny (a handful of charsets at most), so for anything within the
+    // threshold we sort a stack-allocated buffer of indices with an insertion sort and never touch the
+    // heap for scratch. No real client sends more than a handful of charsets, so the >32 branch only
+    // exists for correctness; there we fall back to a plain List.Sort and don't bother preserving the
+    // tie ordering, because nothing observable can depend on it.
     private const int SortStackAllocThreshold = 32;
 
     private static IList<StringWithQualityHeaderValue> Sort(IList<StringWithQualityHeaderValue> values)
@@ -244,25 +246,43 @@ public abstract class TextOutputFormatter : OutputFormatter
             return values;
         }
 
-        Span<int> indices = values.Count <= SortStackAllocThreshold
-            ? stackalloc int[SortStackAllocThreshold]
-            : new int[values.Count];
+        return values.Count <= SortStackAllocThreshold
+            ? SortSmall(values)
+            : SortLarge(values);
+    }
 
+    // Fast path for realistic headers. We insert the surviving indices into a stack-allocated buffer in
+    // descending quality order, filtering out the q=0 rejections as we go. Building descending directly
+    // (rather than sorting ascending and reversing) means an already-preferred-first header appends with
+    // no shifting, so the common case is O(n); the worst case is an O(n^2) insertion sort, which is
+    // irrelevant for at most SortStackAllocThreshold entries. QualityComparer keeps a concrete charset
+    // ahead of an equal-quality wildcard and treats two equal-quality concrete values as equal, so
+    // shifting past equals (Compare <= 0) lands a later header entry ahead of earlier equals, preserving
+    // the previous last-entry-wins selection.
+    private static IList<StringWithQualityHeaderValue> SortSmall(IList<StringWithQualityHeaderValue> values)
+    {
+        Span<int> indices = stackalloc int[SortStackAllocThreshold];
         var count = 0;
+
         for (var i = 0; i < values.Count; i++)
         {
-            if (values[i].Quality != HeaderQuality.NoMatch)
+            var value = values[i];
+            if (value.Quality == HeaderQuality.NoMatch)
             {
-                indices[count++] = i;
+                continue;
             }
+
+            var j = count;
+            while (j > 0 &&
+                StringWithQualityHeaderValueComparer.QualityComparer.Compare(values[indices[j - 1]], value) <= 0)
+            {
+                indices[j] = indices[j - 1];
+                j--;
+            }
+
+            indices[j] = i;
+            count++;
         }
-
-        indices = indices[..count];
-
-        // The framework span sort is an introspective sort: O(n log n) in the worst case (no
-        // insertion-sort pathology) and, because the comparer breaks quality ties on the original
-        // index, its result is deterministic even though the sort itself isn't stable.
-        indices.Sort(new QualityDescendingComparer(values));
 
         var sorted = new List<StringWithQualityHeaderValue>(count);
         for (var i = 0; i < count; i++)
@@ -273,20 +293,26 @@ public abstract class TextOutputFormatter : OutputFormatter
         return sorted;
     }
 
-    // Orders indices into the source list by descending quality. QualityComparer already keeps concrete
-    // charsets ahead of an equal-quality wildcard; for a genuine tie (same quality, both non-wildcard)
-    // we keep the later header entry first, which preserves the previous last-entry-wins selection.
-    private readonly struct QualityDescendingComparer(IList<StringWithQualityHeaderValue> values) : IComparer<int>
+    // Pathological path that no real client will ever exercise: more than SortStackAllocThreshold
+    // charsets in a single Accept-Charset header. We don't allocate an index buffer or preserve the
+    // tie ordering here; a plain List.Sort is unstable, but with this many client-declared charsets
+    // there is nothing observable that could depend on how equal-quality values are ordered.
+    private static IList<StringWithQualityHeaderValue> SortLarge(IList<StringWithQualityHeaderValue> values)
     {
-        public int Compare(int x, int y)
+        var sorted = new List<StringWithQualityHeaderValue>(values.Count);
+        for (var i = 0; i < values.Count; i++)
         {
-            var comparison = StringWithQualityHeaderValueComparer.QualityComparer.Compare(values[y], values[x]);
-            if (comparison != 0)
+            var value = values[i];
+            if (value.Quality != HeaderQuality.NoMatch)
             {
-                return comparison;
+                sorted.Add(value);
             }
-
-            return y.CompareTo(x);
         }
+
+        // QualityComparer sorts ascending; reverse for the descending order we return.
+        sorted.Sort(StringWithQualityHeaderValueComparer.QualityComparer);
+        sorted.Reverse();
+
+        return sorted;
     }
 }

--- a/src/Mvc/Mvc.Core/src/Formatters/TextOutputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/TextOutputFormatter.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Core;
@@ -216,13 +217,27 @@ public abstract class TextOutputFormatter : OutputFormatter
     }
 
     // We may have to filter q=0 values and reorder the rest by quality. StringWithQualityHeaderValue
-    // is a reference type, so it can't live in a stackalloc buffer, but its indices can. Real
-    // Accept-Charset headers are tiny (a handful of charsets at most), so for anything within the
-    // threshold we sort a stack-allocated buffer of indices with an insertion sort and never touch the
-    // heap for scratch. No real client sends more than a handful of charsets, so the >32 branch only
-    // exists for correctness; there we fall back to a plain List.Sort and don't bother preserving the
-    // tie ordering, because nothing observable can depend on it.
+    // is a reference type, so it can't live in a stack buffer, but its indices can. Real Accept-Charset
+    // headers are tiny (a handful of charsets at most), so for anything within the threshold we sort a
+    // stack-allocated inline-array buffer of indices with an insertion sort and never touch the heap for
+    // scratch. No real client sends more than a handful of charsets, so the >32 branch only exists for
+    // correctness; there we fall back to a plain List.Sort and don't bother preserving the tie ordering,
+    // because nothing observable can depend on it.
     private const int SortStackAllocThreshold = 32;
+
+    // Inline-array buffer of SortStackAllocThreshold indices. Preferred over stackalloc because the
+    // compiler puts stronger guarantees on inline arrays (no stack cookie, better bounds analysis).
+    [InlineArray(SortStackAllocThreshold)]
+    private struct IndexBuffer
+    {
+#pragma warning disable CA1823 // Avoid unused private fields
+#pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0051 // Remove unused private members
+        private int _element0;
+#pragma warning restore IDE0051 // Remove unused private members
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning restore CA1823 // Avoid unused private fields
+    }
 
     private static IList<StringWithQualityHeaderValue> Sort(IList<StringWithQualityHeaderValue> values)
     {
@@ -261,7 +276,8 @@ public abstract class TextOutputFormatter : OutputFormatter
     // the previous last-entry-wins selection.
     private static IList<StringWithQualityHeaderValue> SortSmall(IList<StringWithQualityHeaderValue> values)
     {
-        Span<int> indices = stackalloc int[SortStackAllocThreshold];
+        var buffer = new IndexBuffer();
+        Span<int> indices = buffer;
         var count = 0;
 
         for (var i = 0; i < values.Count; i++)

--- a/src/Mvc/Mvc.Core/src/Formatters/TextOutputFormatter.cs
+++ b/src/Mvc/Mvc.Core/src/Formatters/TextOutputFormatter.cs
@@ -216,7 +216,7 @@ public abstract class TextOutputFormatter : OutputFormatter
     }
 
     // There's no allocation-free way to sort an IList and we may have to filter anyway,
-    // so we're going to have to live with the copy + sort.
+    // so we're going to have to live with a single copy that we sort as we build it.
     private static IList<StringWithQualityHeaderValue> Sort(IList<StringWithQualityHeaderValue> values)
     {
         var sortNeeded = false;
@@ -239,54 +239,34 @@ public abstract class TextOutputFormatter : OutputFormatter
             return values;
         }
 
-        // Count the entries we're going to keep (everything except explicit q=0 rejections).
-        var count = 0;
+        // Build the result directly in descending quality order with an insertion sort, filtering out
+        // the q=0 rejections as we go. We insert into descending order (rather than sorting ascending
+        // and reversing) because Accept-Charset headers usually list the most preferred charset first;
+        // for such already-descending input each value simply appends to the end with no shifting,
+        // making the common case O(n). QualityComparer produces an ascending order and treats
+        // equal-quality non-wildcard values as equal, so shifting past equals (Compare <= 0) places a
+        // later header entry ahead of earlier equals, preserving the previous last-entry-wins behavior.
+        var sorted = new List<StringWithQualityHeaderValue>(values.Count);
         for (var i = 0; i < values.Count; i++)
         {
-            if (values[i].Quality != HeaderQuality.NoMatch)
+            var value = values[i];
+            if (value.Quality == HeaderQuality.NoMatch)
             {
-                count++;
+                continue;
             }
-        }
 
-        // Sort indices rather than the values themselves so we can use the framework's
-        // introspective sort (O(n log n) worst case) while still breaking equal-quality ties by the
-        // original header position. QualityComparer treats equal-quality non-wildcard values as
-        // equal and the framework sort isn't stable, so the explicit tie-break keeps the selection
-        // deterministic and, like the previous implementation, prefers the last header entry among
-        // equal-quality values. The index buffer is tiny and stack-allocated for the common case.
-        const int StackallocThreshold = 32;
-        Span<int> order = count <= StackallocThreshold ? stackalloc int[StackallocThreshold] : new int[count];
-        order = order[..count];
-
-        var next = 0;
-        for (var i = 0; i < values.Count; i++)
-        {
-            if (values[i].Quality != HeaderQuality.NoMatch)
+            sorted.Add(value);
+            var j = sorted.Count - 1;
+            while (j > 0 &&
+                StringWithQualityHeaderValueComparer.QualityComparer.Compare(sorted[j - 1], value) <= 0)
             {
-                order[next++] = i;
+                sorted[j] = sorted[j - 1];
+                j--;
             }
-        }
 
-        order.Sort(new QualityDescendingComparer(values));
-
-        var sorted = new List<StringWithQualityHeaderValue>(count);
-        for (var i = 0; i < order.Length; i++)
-        {
-            sorted.Add(values[order[i]]);
+            sorted[j] = value;
         }
 
         return sorted;
-    }
-
-    // Orders indices into the source list by descending quality, using the original header position
-    // (larger index first) to break equal-quality ties so the result is deterministic.
-    private readonly struct QualityDescendingComparer(IList<StringWithQualityHeaderValue> values) : IComparer<int>
-    {
-        public int Compare(int x, int y)
-        {
-            var comparison = StringWithQualityHeaderValueComparer.QualityComparer.Compare(values[x], values[y]);
-            return comparison != 0 ? -comparison : y - x;
-        }
     }
 }

--- a/src/Mvc/Mvc.Core/test/Formatters/TextOutputFormatterTests.cs
+++ b/src/Mvc/Mvc.Core/test/Formatters/TextOutputFormatterTests.cs
@@ -27,6 +27,31 @@ public class TextOutputFormatterTests
             yield return new object[] { "utf-8; q=0.0, utf-16; q=0.0", new string[] { "utf-8", "utf-16" }, "utf-8" };
 
             yield return new object[] { "*; q=0.0", new string[] { "utf-8", "utf-16" }, "utf-8" };
+
+            // Weighted values are considered in descending quality order.
+            yield return new object[] { "utf-8; q=0.5, utf-16; q=0.8", new string[] { "utf-8", "utf-16" }, "utf-16" };
+            yield return new object[] { "utf-16; q=0.8, utf-8; q=0.5", new string[] { "utf-8", "utf-16" }, "utf-16" };
+
+            // An entry with q=0 is excluded when sorting occurs.
+            yield return new object[] { "utf-8; q=0.0, utf-16; q=0.5", new string[] { "utf-8", "utf-16" }, "utf-16" };
+
+            // A concrete charset is preferred over a wildcard with the same quality.
+            yield return new object[] { "*; q=0.8, utf-16; q=0.8", new string[] { "utf-8", "utf-16" }, "utf-16" };
+
+            // Wildcards still match a supported encoding.
+            yield return new object[] { "*; q=0.5", new string[] { "utf-8", "utf-16" }, "utf-8" };
+            yield return new object[] { "utf-32; q=0.3, *; q=0.5", new string[] { "utf-8", "utf-16" }, "utf-8" };
+
+            // Equal-quality concrete charsets preserve the existing observable selection behavior.
+            yield return new object[] { "utf-8; q=0.5, utf-16; q=0.5", new string[] { "utf-8", "utf-16" }, "utf-16" };
+
+            // Large collections of weighted values produce the same selected encoding as before.
+            yield return new object[]
+            {
+                "utf-32; q=0.1, us-ascii; q=0.2, iso-8859-1; q=0.3, utf-16; q=0.4, utf-8; q=0.9",
+                new string[] { "utf-8", "utf-16" },
+                "utf-8"
+            };
         }
     }
 

--- a/src/Mvc/perf/Microbenchmarks/Microsoft.AspNetCore.Mvc/Microsoft.AspNetCore.Mvc.Microbenchmarks.csproj
+++ b/src/Mvc/perf/Microbenchmarks/Microsoft.AspNetCore.Mvc/Microsoft.AspNetCore.Mvc.Microbenchmarks.csproj
@@ -14,6 +14,7 @@
     <Reference Include="Microsoft.AspNetCore.Mvc.Core" />
     <Reference Include="Microsoft.Extensions.Configuration" />
     <Reference Include="Microsoft.Extensions.Logging" />
+    <Reference Include="Microsoft.Net.Http.Headers" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Mvc.Views\Microsoft.AspNetCore.Mvc.Views.Microbenchmarks.csproj" />
     <Reference Include="BenchmarkDotNet" />
 

--- a/src/Mvc/perf/Microbenchmarks/Microsoft.AspNetCore.Mvc/TextOutputFormatterSortBenchmark.cs
+++ b/src/Mvc/perf/Microbenchmarks/Microsoft.AspNetCore.Mvc/TextOutputFormatterSortBenchmark.cs
@@ -3,6 +3,7 @@
 
 using BenchmarkDotNet.Attributes;
 using Microsoft.Net.Http.Headers;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.AspNetCore.Mvc.Microbenchmarks;
 
@@ -137,7 +138,8 @@ public class TextOutputFormatterSortBenchmark
 
     private static IList<StringWithQualityHeaderValue> SortAfterSmall(IList<StringWithQualityHeaderValue> values)
     {
-        Span<int> indices = stackalloc int[SortStackAllocThreshold];
+        var buffer = new IndexBuffer();
+        Span<int> indices = buffer;
         var count = 0;
 
         for (var i = 0; i < values.Count; i++)
@@ -184,5 +186,17 @@ public class TextOutputFormatterSortBenchmark
         sorted.Sort(StringWithQualityHeaderValueComparer.QualityComparer);
         sorted.Reverse();
         return sorted;
+    }
+
+    [InlineArray(SortStackAllocThreshold)]
+    private struct IndexBuffer
+    {
+#pragma warning disable CA1823 // Avoid unused private fields
+#pragma warning disable IDE0044 // Add readonly modifier
+#pragma warning disable IDE0051 // Remove unused private members
+        private int _element0;
+#pragma warning restore IDE0051 // Remove unused private members
+#pragma warning restore IDE0044 // Add readonly modifier
+#pragma warning restore CA1823 // Avoid unused private fields
     }
 }

--- a/src/Mvc/perf/Microbenchmarks/Microsoft.AspNetCore.Mvc/TextOutputFormatterSortBenchmark.cs
+++ b/src/Mvc/perf/Microbenchmarks/Microsoft.AspNetCore.Mvc/TextOutputFormatterSortBenchmark.cs
@@ -1,0 +1,188 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.Net.Http.Headers;
+
+namespace Microsoft.AspNetCore.Mvc.Microbenchmarks;
+
+/// <summary>
+/// Compares the previous and current implementations of the internal
+/// <c>TextOutputFormatter.Sort</c> used to order weighted Accept-Charset values.
+///
+/// The two implementations are inlined here (the production method is private) so the benchmark can
+/// measure the sort in isolation, before/after, for different numbers of header values and input
+/// orderings:
+/// <list type="bullet">
+/// <item><c>PreferredFirst</c> - values already listed highest-quality first, which is what real
+/// clients send. This is the common case and the one the change is optimized for.</item>
+/// <item><c>Reversed</c> - values listed lowest-quality first, included to show each algorithm's
+/// pathological ordering.</item>
+/// </list>
+/// </summary>
+[MemoryDiagnoser]
+public class TextOutputFormatterSortBenchmark
+{
+    private const int SortStackAllocThreshold = 32;
+
+    [Params(2, 8, 16, 32, 64)]
+    public int HeaderCount { get; set; }
+
+    [Params(true, false)]
+    public bool PreferredFirst { get; set; }
+
+    private IList<StringWithQualityHeaderValue> _values = default!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var values = new StringWithQualityHeaderValue[HeaderCount];
+        for (var i = 0; i < HeaderCount; i++)
+        {
+            // Distinct qualities in (0, 1) so ordering is well defined. When PreferredFirst is true the
+            // highest quality comes first (descending), otherwise the lowest quality comes first.
+            var rank = PreferredFirst ? HeaderCount - i : i + 1;
+            var quality = rank / (double)(HeaderCount + 1);
+            values[i] = new StringWithQualityHeaderValue($"charset{i}", quality);
+        }
+
+        _values = values;
+    }
+
+    [Benchmark(Baseline = true)]
+    public IList<StringWithQualityHeaderValue> Before() => SortBefore(_values);
+
+    [Benchmark]
+    public IList<StringWithQualityHeaderValue> After() => SortAfter(_values);
+
+    // Original implementation: build an ascending list with BinarySearch + Insert, then Reverse.
+    private static IList<StringWithQualityHeaderValue> SortBefore(IList<StringWithQualityHeaderValue> values)
+    {
+        var sortNeeded = false;
+
+        for (var i = 0; i < values.Count; i++)
+        {
+            var value = values[i];
+            if (value.Quality == HeaderQuality.NoMatch)
+            {
+                // Exclude this one
+            }
+            else if (value.Quality != null)
+            {
+                sortNeeded = true;
+            }
+        }
+
+        if (!sortNeeded)
+        {
+            return values;
+        }
+
+        var sorted = new List<StringWithQualityHeaderValue>();
+        for (var i = 0; i < values.Count; i++)
+        {
+            var value = values[i];
+            if (value.Quality == HeaderQuality.NoMatch)
+            {
+                // Exclude this one
+            }
+            else
+            {
+                // Doing an insertion sort.
+                var position = sorted.BinarySearch(value, StringWithQualityHeaderValueComparer.QualityComparer);
+                if (position >= 0)
+                {
+                    sorted.Insert(position + 1, value);
+                }
+                else
+                {
+                    sorted.Insert(~position, value);
+                }
+            }
+        }
+
+        // We want a descending sort, but BinarySearch does ascending
+        sorted.Reverse();
+        return sorted;
+    }
+
+    // Current implementation: stack-allocated index buffer + insertion build for realistic headers,
+    // List.Sort + Reverse fallback for the pathological >32 case.
+    private static IList<StringWithQualityHeaderValue> SortAfter(IList<StringWithQualityHeaderValue> values)
+    {
+        var sortNeeded = false;
+
+        for (var i = 0; i < values.Count; i++)
+        {
+            var value = values[i];
+            if (value.Quality == HeaderQuality.NoMatch)
+            {
+                // Exclude this one
+            }
+            else if (value.Quality != null)
+            {
+                sortNeeded = true;
+            }
+        }
+
+        if (!sortNeeded)
+        {
+            return values;
+        }
+
+        return values.Count <= SortStackAllocThreshold
+            ? SortAfterSmall(values)
+            : SortAfterLarge(values);
+    }
+
+    private static IList<StringWithQualityHeaderValue> SortAfterSmall(IList<StringWithQualityHeaderValue> values)
+    {
+        Span<int> indices = stackalloc int[SortStackAllocThreshold];
+        var count = 0;
+
+        for (var i = 0; i < values.Count; i++)
+        {
+            var value = values[i];
+            if (value.Quality == HeaderQuality.NoMatch)
+            {
+                continue;
+            }
+
+            var j = count;
+            while (j > 0 &&
+                StringWithQualityHeaderValueComparer.QualityComparer.Compare(values[indices[j - 1]], value) <= 0)
+            {
+                indices[j] = indices[j - 1];
+                j--;
+            }
+
+            indices[j] = i;
+            count++;
+        }
+
+        var sorted = new List<StringWithQualityHeaderValue>(count);
+        for (var i = 0; i < count; i++)
+        {
+            sorted.Add(values[indices[i]]);
+        }
+
+        return sorted;
+    }
+
+    private static IList<StringWithQualityHeaderValue> SortAfterLarge(IList<StringWithQualityHeaderValue> values)
+    {
+        var sorted = new List<StringWithQualityHeaderValue>(values.Count);
+        for (var i = 0; i < values.Count; i++)
+        {
+            var value = values[i];
+            if (value.Quality != HeaderQuality.NoMatch)
+            {
+                sorted.Add(value);
+            }
+        }
+
+        sorted.Sort(StringWithQualityHeaderValueComparer.QualityComparer);
+        sorted.Reverse();
+        return sorted;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #67965.

`TextOutputFormatter.Sort` orders weighted `Accept-Charset` values before matching them against the supported encodings. The original implementation built an ascending list with a `BinarySearch` + `List.Insert` loop and then reversed it. That is pessimal for the realistic case where a header lists its most-preferred charset first (already descending by quality): every insert hits the front of the list and shifts every existing element, making the common case O(n²).

This replaces it with two paths, keyed on how many charsets the header declares:

### Fast path — `SortSmall` (≤ 32 charsets, the only case real clients hit)
- Sorts a **stack-allocated `int` index buffer** (`stackalloc int[32]`). `StringWithQualityHeaderValue` is a reference type so it can't live in a `stackalloc` buffer, but its indices can — so there is **no heap scratch**; the only allocation is the result `List` we have to return.
- Builds the result **directly in descending quality order** with an insertion sort, filtering out `q=0` (`HeaderQuality.NoMatch`) entries as it goes. For a preferred-first header each value just appends with no shifting → **O(n)** common case, and no trailing `Reverse`.
- Worst case is an O(n²) insertion sort, which is irrelevant at ≤ 32 entries.
- Shifting past equal-quality entries (`QualityComparer.Compare(prev, value) <= 0`) lands a later header entry ahead of earlier equals, **preserving the previous last-entry-wins selection deterministically** — no unstable framework sort, no original-index tie-break comparer needed.

### Fallback — `SortLarge` (> 32 charsets, never happens in practice)
- No real client sends more than a handful of charsets in a single `Accept-Charset` header, so this branch exists only for correctness. It uses a plain `List.Sort(QualityComparer)` + `Reverse` and does **not** preserve tie ordering — with that many client-declared charsets nothing observable can depend on how equal-quality values are ordered.

The `sortNeeded` scan and its allocation-free early return (returns the original `values` untouched when no explicit non-zero quality requires sorting) are unchanged.

## Behavior preserved

- Descending quality order.
- `q=0` entries excluded once sorting occurs.
- A concrete charset is preferred over an equal-quality wildcard (`QualityComparer` orders wildcards below concrete values).
- Wildcards still match a supported encoding.
- Equal-quality concrete charsets keep the previous observable selection (last header entry wins) on the fast path.

## Tests

Added characterization rows to `SelectResponseCharacterEncodingData` in `TextOutputFormatterTests` covering: no-quality fast path, descending-quality weighting, `q=0` exclusion, concrete-over-wildcard, wildcard match, equal-quality last-wins, and a large weighted collection.

`dotnet test src/Mvc/Mvc.Core/test/Microsoft.AspNetCore.Mvc.Core.Test.csproj --filter "FullyQualifiedName~TextOutputFormatterTests"` → **23 passed, 0 failed**, no new warnings.