### PR TITLE
[release/11.0-preview7] Fix Virtualize scroll jump from native/JS anchoring double-compensation

### DIFF
--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -146,8 +146,32 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   intersectionObserver.observe(spacerBefore);
   intersectionObserver.observe(spacerAfter);
 
-  let convergingElements = false;
-  let convergenceItems: Set<Element> = new Set();
+  const convergence = {
+    top: false,
+    bottom: false,
+    items: new Set<Element>(),
+    isConverging(): boolean {
+      return this.top || this.bottom;
+    },
+  };
+
+  const nativeAnchoring = {
+    suspendedFor: new Set<'convergence' | 'slide'>(),
+    suspend(reason: 'convergence' | 'slide'): void {
+      this.suspendedFor.add(reason);
+      if (useNativeAnchoring) {
+        scrollElement.style.overflowAnchor = 'none';
+      }
+    },
+    resume(reason: 'convergence' | 'slide'): void {
+      if (!this.suspendedFor.delete(reason)) {
+        return;
+      }
+      if (useNativeAnchoring && this.suspendedFor.size === 0) {
+        scrollElement.style.overflowAnchor = '';
+      }
+    },
+  };
 
   const anchoredItems: Map<Element, number> = new Map();
   let scrollTriggeredRender = false;
@@ -230,19 +254,18 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     // Convergence logic: keep scroll pinned to top/bottom while items load.
     // Do this before re-observing spacers so the IO callback sees the correct
     // scroll position, not the stale one from before the spacer resize.
-    if (convergingToBottom || convergingToTop) {
-      scrollElement.scrollTop = convergingToBottom ? scrollElement.scrollHeight : 0;
-      const spacer = convergingToBottom ? spacerAfter : spacerBefore;
+    if (convergence.isConverging()) {
+      scrollElement.scrollTop = convergence.bottom ? scrollElement.scrollHeight : 0;
+      const spacer = convergence.bottom ? spacerAfter : spacerBefore;
       if (spacer.offsetHeight === 0) {
-        convergingToBottom = convergingToTop = false;
         stopConvergenceObserving();
       }
-    } else if (convergingElements) {
-      stopConvergenceObserving();
     }
 
+    let spacerResized = false;
     for (const entry of entries) {
       if (entry.target === spacerBefore || entry.target === spacerAfter) {
+        spacerResized = true;
         const spacer = entry.target as HTMLElement;
         if (spacer.isConnected) {
           intersectionObserver.unobserve(spacer);
@@ -254,6 +277,11 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     // Manual scroll compensation: adjust scrollTop for above-viewport resizes.
     if (!useNativeAnchoring) {
       compensateScrollForItemResizes(entries);
+      return;
+    }
+
+    if (spacerResized) {
+      nativeAnchoring.resume('slide');
     }
   });
 
@@ -261,17 +289,17 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
   resizeObserver.observe(spacerBefore);
   resizeObserver.observe(spacerAfter);
 
-  function refreshObservedElements(): void {
+  function refreshObservedElements(isLoading: boolean): void {
     // Ensure spacers are always observed (idempotent).
     resizeObserver.observe(spacerBefore);
     resizeObserver.observe(spacerAfter);
 
     // During convergence, keep the observed element set in sync with the DOM
     // and force scroll position to prevent bounce-back between renders.
-    if (convergingElements) {
-      if (convergingToBottom) {
+    if (convergence.isConverging()) {
+      if (convergence.bottom) {
         scrollElement.scrollTop = scrollElement.scrollHeight;
-      } else if (convergingToTop) {
+      } else if (convergence.top) {
         scrollElement.scrollTop = 0;
       }
 
@@ -281,12 +309,12 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
         currentItems.add(el);
       }
       // Unobserve items removed during re-render.
-      for (const el of convergenceItems) {
+      for (const el of convergence.items) {
         if (!currentItems.has(el)) {
           resizeObserver.unobserve(el);
         }
       }
-      convergenceItems = currentItems;
+      convergence.items = currentItems;
       return;
     }
 
@@ -307,7 +335,12 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
         }
       }
     }
+    const wasScrollTriggered = scrollTriggeredRender;
     scrollTriggeredRender = false;
+
+    if (!wasScrollTriggered || isLoading) {
+      nativeAnchoring.resume('slide');
+    }
 
     // End mode: pin new items into view if we're at the bottom now, or were and are still following.
     if ((anchorMode & 2) && (bottomTracking.wasAtBottomLastRender || bottomTracking.reached)) {
@@ -315,11 +348,10 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       ignoreAnchorScroll = true;
       // Start convergence only when there are more items to load (spacerAfter > 0).
       // When all items fit in DOM, the single scrollTop assignment above is sufficient.
-      if (!convergingToBottom && !convergingToTop && spacerAfter.offsetHeight > 0) {
-        convergingToBottom = true;
+      if (!convergence.bottom && !convergence.top && spacerAfter.offsetHeight > 0) {
         suppressSpacerCallbacks = false;
         reobserveSpacers();
-        startConvergenceObserving();
+        startConvergenceObserving('bottom');
       }
     }
 
@@ -357,7 +389,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     }
     observersByDotNetObjectId[id].anchorSnapshot = null;
 
-    if (convergingToTop || convergingToBottom) {
+    if (convergence.isConverging()) {
       return;
     }
 
@@ -371,9 +403,8 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
 
     // Beginning mode at the very top: show new items by converging to top.
     if ((anchorMode & 1) && snapshot.scrollTop < 1) {
-      convergingToTop = true;
       scrollElement.scrollTop = 0;
-      startConvergenceObserving();
+      startConvergenceObserving('top');
       return;
     }
 
@@ -412,35 +443,30 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     }
   }
 
-  function startConvergenceObserving(): void {
-    if (convergingElements) return;
-    convergingElements = true;
-    if (useNativeAnchoring) {
-      scrollElement.style.overflowAnchor = 'none';
-    }
+  function startConvergenceObserving(direction: 'top' | 'bottom'): void {
+    const alreadyConverging = convergence.isConverging();
+    convergence[direction] = true;
+    if (alreadyConverging) return;
+    nativeAnchoring.suspend('convergence');
     for (let el = spacerBefore.nextElementSibling; el && el !== spacerAfter; el = el.nextElementSibling) {
       resizeObserver.observe(el);
-      convergenceItems.add(el);
+      convergence.items.add(el);
     }
   }
 
   function stopConvergenceObserving(): void {
-    if (!convergingElements) return;
-    convergingElements = false;
-    for (const el of convergenceItems) {
+    if (!convergence.isConverging()) return;
+    convergence.top = false;
+    convergence.bottom = false;
+    for (const el of convergence.items) {
       resizeObserver.unobserve(el);
     }
-    convergenceItems.clear();
-    if (useNativeAnchoring) {
-      scrollElement.style.overflowAnchor = '';
-    }
+    convergence.items.clear();
+    nativeAnchoring.resume('convergence');
     anchoredItems.clear();
     // Take a fresh snapshot so the next anchor restore has valid data.
     updateAnchorSnapshot();
   }
-
-  let convergingToBottom = false;
-  let convergingToTop = false;
 
   let pendingJumpToEnd = false;
   let pendingJumpToStart = false;
@@ -453,18 +479,16 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       reobserveSpacers();
       pendingJumpToEnd = true;
       pendingJumpToStart = false;
-      if (!convergingToBottom && spacerAfter.offsetHeight > 0) {
-        convergingToBottom = true;
-        startConvergenceObserving();
+      if (!convergence.bottom && spacerAfter.offsetHeight > 0) {
+        startConvergenceObserving('bottom');
       }
     } else if (ke.key === 'Home') {
       suppressSpacerCallbacks = false;
       reobserveSpacers();
       pendingJumpToStart = true;
       pendingJumpToEnd = false;
-      if (!convergingToTop && spacerBefore.offsetHeight > 0) {
-        convergingToTop = true;
-        startConvergenceObserving();
+      if (!convergence.top && spacerBefore.offsetHeight > 0) {
+        startConvergenceObserving('top');
       }
     }
   }
@@ -472,7 +496,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
 
   const scrollEventTarget: EventTarget = scrollContainer ?? window;
   function handleScroll(): void {
-    if (convergingToBottom || convergingToTop) {
+    if (convergence.isConverging()) {
       return;
     }
 
@@ -532,11 +556,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       ignoreAnchorScroll = true;
       suppressSpacerCallbacks = true;
       observersByDotNetObjectId[id].anchorSnapshot = null;
-      if (convergingToTop || convergingToBottom) {
-        convergingToTop = false;
-        convergingToBottom = false;
-        stopConvergenceObserving();
-      }
+      stopConvergenceObserving();
       return;
     }
     pendingAlignLocalIndex = null;
@@ -545,11 +565,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       suppressSpacerCallbacks = true;
       // Programmatic scroll establishes a new explicit position — invalidate any pending anchor snapshot and cancel in-progress convergence.
       observersByDotNetObjectId[id].anchorSnapshot = null;
-      if (convergingToTop || convergingToBottom) {
-        convergingToTop = false;
-        convergingToBottom = false;
-        stopConvergenceObserving();
-      }
+      stopConvergenceObserving();
       pendingJumpToStart = false;
       pendingJumpToEnd = false;
       scrollElement.scrollTo({ top: scrollElement.scrollTop + delta, behavior: 'instant' });
@@ -562,7 +578,6 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     refreshObservedElements,
     scrollElement,
     startConvergenceObserving,
-    setConvergingToBottom: () => { convergingToBottom = true; },
     isFollowingBottom: () => bottomTracking.following,
     setAnchorMode: (mode: number) => { anchorMode = mode; bottomTracking.following = (mode & 2) !== 0; bottomTracking.reached = isViewportAtBottom(); },
     restoreAnchor: restoreAnchorForShift,
@@ -606,19 +621,17 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
 
   function onSpacerAfterVisible(): void {
     if (spacerAfter.offsetHeight === 0) {
-      if (convergingToBottom) {
-        convergingToBottom = false;
+      if (convergence.bottom) {
         stopConvergenceObserving();
       }
       return;
     }
-    if (convergingToBottom) return;
+    if (convergence.bottom) return;
 
     // pendingJumpToEnd is user-initiated (End key) — always honor it.
     // Data-driven convergence only fires when End anchoring is enabled.
     if (pendingJumpToEnd) {
-      convergingToBottom = true;
-      startConvergenceObserving();
+      startConvergenceObserving('bottom');
       scrollElement.scrollTop = scrollElement.scrollHeight;
       pendingJumpToEnd = false;
       return;
@@ -629,25 +642,22 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     const atBottom = scrollElement.scrollTop + scrollElement.clientHeight >= scrollElement.scrollHeight - 1;
     if (!atBottom) return;
 
-    convergingToBottom = true;
-    startConvergenceObserving();
+    startConvergenceObserving('bottom');
   }
 
   function onSpacerBeforeVisible(): void {
     if (spacerBefore.offsetHeight === 0) {
-      if (convergingToTop) {
-        convergingToTop = false;
+      if (convergence.top) {
         stopConvergenceObserving();
       }
       return;
     }
-    if (convergingToTop) return;
+    if (convergence.top) return;
 
     // pendingJumpToStart is user-initiated (Home key) — always honor it.
     // Data-driven convergence only fires when Beginning anchoring is enabled.
     if (pendingJumpToStart) {
-      convergingToTop = true;
-      startConvergenceObserving();
+      startConvergenceObserving('top');
       scrollElement.scrollTop = 0;
       pendingJumpToStart = false;
       return;
@@ -658,8 +668,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     const atTop = scrollElement.scrollTop < 1;
     if (!atTop) return;
 
-    convergingToTop = true;
-    startConvergenceObserving();
+    startConvergenceObserving('top');
   }
 
   // Saves the first visible item's child index and viewport-relative position.
@@ -677,8 +686,8 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       const rect = el.getBoundingClientRect();
       if (rect.bottom > containerTop) {
         const existing = observersByDotNetObjectId[id].anchorSnapshot;
-        const startAnchoring = (anchorMode & 1) !== 0 && !convergingToTop;
-        if (!useNativeAnchoring && (anchorMode === 0 || startAnchoring) && existing && rect.top - containerTop > rect.height) {
+        const startAnchoring = (anchorMode & 1) !== 0 && !convergence.top;
+        if (!useNativeAnchoring && (anchorMode === 0 || anchorMode === 2 || startAnchoring) && existing && rect.top - containerTop > rect.height) {
           return;
         }
         observersByDotNetObjectId[id].anchorSnapshot = {
@@ -721,9 +730,9 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
         }
         return true;
       }
-      if (entry.target === spacerAfter && convergingToBottom && spacerAfter.offsetHeight > 0) {
+      if (entry.target === spacerAfter && convergence.bottom && spacerAfter.offsetHeight > 0) {
         scrollElement.scrollTop = scrollElement.scrollHeight;
-      } else if (entry.target === spacerBefore && convergingToTop && spacerBefore.offsetHeight > 0) {
+      } else if (entry.target === spacerBefore && convergence.top && spacerBefore.offsetHeight > 0) {
         scrollElement.scrollTop = 0;
       }
       return false;
@@ -742,16 +751,20 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     intersectingEntries.forEach((entry): void => {
       const containerSize = (entry.rootBounds?.height ?? 0) / scaleFactor;
 
-      // So that RefreshObservedElements can skip item observation (avoids layout interference drift).
-      scrollTriggeredRender = true;
-
       if (entry.target === spacerBefore) {
+        // So that RefreshObservedElements can skip item observation (avoids layout interference drift).
+        scrollTriggeredRender = true;
+        if (spacerBefore.offsetHeight > 0) {
+          nativeAnchoring.suspend('slide');
+        }
         const spacerSize = (entry.intersectionRect.top - entry.boundingClientRect.top) / scaleFactor;
         dotNetHelper.invokeMethodAsync('OnSpacerBeforeVisible', spacerSize, spacerSeparation, containerSize);
       } else if (entry.target === spacerAfter && spacerAfter.offsetHeight > 0) {
         // When we first start up, both the "before" and "after" spacers will be visible, but it's only relevant to raise a
         // single event to load the initial data. To avoid raising two events, skip the one for the "after" spacer if we know
         // it's meaningless to talk about any overlap into it.
+        scrollTriggeredRender = true;
+        nativeAnchoring.suspend('slide');
         const spacerSize = (entry.boundingClientRect.bottom - entry.intersectionRect.bottom) / scaleFactor;
         dotNetHelper.invokeMethodAsync('OnSpacerAfterVisible', spacerSize, spacerSeparation, containerSize);
       }
@@ -772,16 +785,15 @@ function scrollToBottom(dotNetHelper: DotNet.DotNetObject): void {
   const { observersByDotNetObjectId, id } = getObserversMapEntry(dotNetHelper);
   const entry = observersByDotNetObjectId[id];
   if (entry && entry.isFollowingBottom?.()) {
-    entry.setConvergingToBottom?.();
     entry.scrollElement.scrollTop = entry.scrollElement.scrollHeight;
-    entry.startConvergenceObserving?.();
+    entry.startConvergenceObserving?.('bottom');
   }
 }
 
-function refreshObservers(dotNetHelper: DotNet.DotNetObject): void {
+function refreshObservers(dotNetHelper: DotNet.DotNetObject, isLoading: boolean): void {
   const { observersByDotNetObjectId, id } = getObserversMapEntry(dotNetHelper);
   const entry = observersByDotNetObjectId[id];
-  entry?.refreshObservedElements?.();
+  entry?.refreshObservedElements?.(isLoading);
 }
 
 function setAnchorMode(dotNetHelper: DotNet.DotNetObject, mode: number): void {

--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -498,7 +498,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
             _pendingAnchorRestore = false;
             _deferPrependAnchorClear = false;
 
-            await _jsInterop.RefreshObserversAsync();
+            await _jsInterop.RefreshObserversAsync(_loading);
         }
 
         // Apply InitialItemIndex once: drive the first fetch via ScrollToItemAsync rather than

--- a/src/Components/Web/src/Virtualization/VirtualizeJsInterop.cs
+++ b/src/Components/Web/src/Virtualization/VirtualizeJsInterop.cs
@@ -47,9 +47,9 @@ internal sealed class VirtualizeJsInterop : IAsyncDisposable
         return _jsRuntime.InvokeVoidAsync($"{JsFunctionsPrefix}.scrollToBottom", _selfReference);
     }
 
-    public ValueTask RefreshObserversAsync()
+    public ValueTask RefreshObserversAsync(bool isLoading)
     {
-        return _jsRuntime.InvokeVoidAsync($"{JsFunctionsPrefix}.refreshObservers", _selfReference);
+        return _jsRuntime.InvokeVoidAsync($"{JsFunctionsPrefix}.refreshObservers", _selfReference, isLoading);
     }
 
     public ValueTask SetAnchorModeAsync(int anchorMode)

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -2837,6 +2837,78 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     }
 
     [Fact]
+    public void ViewportAnchoring_RenderlessAboveViewportResize_AfterScroll_VisibleItemStaysInPlace()
+    {
+        Browser.MountTestComponent<VirtualizationComponent>();
+
+        var container = Browser.Exists(By.Id("incorrect-size-container"));
+        var js = (IJavaScriptExecutor)Browser;
+        Browser.True(() => GetElementCount(container, ".incorrect-size-item") > 0);
+
+        // Scroll down in increments so spacer redistribution runs, then let it settle.
+        // No further interaction happens after this, so there is no trailing Blazor render
+        // and the scroll-triggered suppression of overflow-anchor is the last state written.
+        for (var pos = 0; pos <= 1000; pos += 100)
+        {
+            ScrollContainer(js, container, pos);
+        }
+        AssertScrollTop(js, container, st => st >= 1000, "scrollTop >= 1000");
+
+        Browser.True(
+            () => (string)js.ExecuteScript(
+                "return getComputedStyle(arguments[0]).overflowAnchor", container) != "none",
+            TimeSpan.FromSeconds(5),
+            "overflow-anchor was not restored after scrolling settled");
+
+        WaitForRenderToSettle(container, js, ".incorrect-size-item");
+
+        var (indexBefore, relTopBefore, _) = GetItemPositionInContainer(js, container, ".incorrect-size-item");
+
+        // Grow the item immediately ABOVE the viewport by mutating its style directly.
+        // This is a browser-only reflow: it does NOT trigger a Blazor render, so the only
+        // thing that can keep the visible content stable is native scroll anchoring.
+        var growResult = js.ExecuteScript(@"
+            var container = arguments[0];
+            var grow = arguments[1];
+            var cRect = container.getBoundingClientRect();
+            var items = container.querySelectorAll('.incorrect-size-item');
+            for (var i = items.length - 1; i >= 0; i--) {
+                var r = items[i].getBoundingClientRect();
+                if (r.bottom <= cRect.top + 1) {
+                    items[i].style.height = (r.height + grow) + 'px';
+                    return { grew: true, text: items[i].textContent, anchor: getComputedStyle(container).overflowAnchor };
+                }
+            }
+            return { grew: false, anchor: getComputedStyle(container).overflowAnchor };
+        ", container, 200L) as Dictionary<string, object>;
+
+        Assert.NotNull(growResult);
+        Assert.True((bool)growResult["grew"], "Expected at least one rendered item above the viewport to grow.");
+
+        // Poll until the tracked item's position stops changing, so we measure the
+        // browser's settled response to the reflow (with or without scroll anchoring)
+        // deterministically instead of waiting a fixed amount of time.
+        var relTopAfter = relTopBefore;
+        var lastRelTop = double.NaN;
+        var stableReads = 0;
+        Browser.True(() =>
+        {
+            var (_, relTop, _) = GetItemPositionInContainer(js, container, ".incorrect-size-item", indexBefore);
+            stableReads = Math.Abs(relTop - lastRelTop) < 0.5 ? stableReads + 1 : 0;
+            lastRelTop = relTop;
+            relTopAfter = relTop;
+
+            // Require a few consecutive stable reads to be sure the reflow has settled.
+            return stableReads >= 3;
+        }, TimeSpan.FromSeconds(10), "Tracked item position did not settle after the render-less resize");
+
+        Assert.True(Math.Abs(relTopAfter - relTopBefore) < 5,
+            $"Item '{indexBefore}' should not have moved when an off-screen item grew via a " +
+            $"render-less browser reflow (overflow-anchor='{growResult["anchor"]}', grew item '{growResult["text"]}'). " +
+            $"RelTop Before: {relTopBefore:F1}, After: {relTopAfter:F1}, Delta: {relTopAfter - relTopBefore:F1}px");
+    }
+
+    [Fact]
     public void Table_VariableHeight_IncrementalScrollDoesNotCauseWildJumps()
     {
         // Guards against a browser-level CSS Scroll Anchoring bug with <table> layout.
@@ -2867,6 +2939,27 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             $"Total: {result["startY"]}->{result["endY"]} = {totalDelta}px (expected ~{expectedDelta}px). " +
             $"Jumps: [{result["jumps"]}]. " +
             $"Large jumps indicate CSS scroll anchoring is miscalculating on <tr> elements.");
+    }
+
+    [Fact]
+    public void ItemsIncrementalScroll_DoesNotJumpToStartOrEnd()
+    {
+        // Before the fix, each ~100px scroll produced large jumps in both directions.
+        Browser.MountTestComponent<VirtualizationComponent>();
+
+        Browser.True(() => GetElementCount(By.ClassName("incorrect-size-item")) > 0);
+
+        var result = ExecuteContainerScrollJumpDetectionScript("incorrect-size-container");
+
+        var maxJump = Convert.ToInt64(result["maxJump"], CultureInfo.InvariantCulture);
+        var scrollDelta = Convert.ToInt64(result["scrollDelta"], CultureInfo.InvariantCulture);
+
+        // Healthy behaviour: every step moves ~scrollDelta (100px)
+        Assert.True(maxJump < scrollDelta * 4,
+            $"Incremental scrolling should not cause the viewport to jump to the start/end of the list. " +
+            $"Largest single-step jump was {maxJump}px (each step requested {scrollDelta}px). " +
+            $"Down jumps: [{result["downJumps"]}]. Up jumps: [{result["upJumps"]}]. " +
+            $"Large jumps indicate the Virtualize reserved-height compensation is over-shifting (issue #67729).");
     }
 
     private void MountAnchorModeComponent(string anchorMode, bool variableHeight = false, bool useItemsProvider = false, bool useDefaultComparer = false)
@@ -4634,11 +4727,12 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
 
     /// <summary>
     /// Waits for the Virtualize render cycle to settle by checking that the rendered
-    /// item count, scrollTop, and first visible item index stabilize.
+    /// item count, scrollTop, and first visible item identity stabilize.
     /// Use after actions that trigger async rendering (prepend/append with ItemsProvider on Server)
     /// to ensure anchor restore has completed before making single-shot assertions.
+    /// Pass <paramref name="itemSelector"/> for containers whose rows are not <c>.item[data-index]</c>.
     /// </summary>
-    private void WaitForRenderToSettle(IWebElement container, IJavaScriptExecutor js)
+    private void WaitForRenderToSettle(IWebElement container, IJavaScriptExecutor js, string itemSelector = ".item[data-index]")
     {
         long lastScrollTop = -1;
         int lastItemCount = -1;
@@ -4649,18 +4743,19 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         {
             var result = js.ExecuteScript(@"
                 var c = arguments[0];
-                var items = c.querySelectorAll('.item[data-index]');
+                var selector = arguments[1];
+                var items = c.querySelectorAll(selector);
                 var cr = c.getBoundingClientRect();
                 var firstIdx = '';
                 for (var i = 0; i < items.length; i++) {
                     var r = items[i].getBoundingClientRect();
                     if (r.bottom > cr.top + 2 && r.top < cr.bottom - 2) {
-                        firstIdx = items[i].getAttribute('data-index');
+                        firstIdx = items[i].getAttribute('data-index') || items[i].textContent;
                         break;
                     }
                 }
                 return { scrollTop: Math.round(c.scrollTop), itemCount: items.length, firstIndex: firstIdx };
-            ", container) as Dictionary<string, object>;
+            ", container, itemSelector) as Dictionary<string, object>;
 
             var scrollTop = Convert.ToInt64(result["scrollTop"], CultureInfo.InvariantCulture);
             var itemCount = Convert.ToInt32(result["itemCount"], CultureInfo.InvariantCulture);
@@ -4950,6 +5045,50 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     /// miscalculations on &lt;tr&gt; elements.
     /// Returns startY, endY, totalDelta, expected, maxJump, and comma-separated jumps.
     /// </summary>
+    private const string ScrollJumpDetectionHelpersJs = @"
+                // Event-driven wait: watches for DOM mutations from C# re-renders,
+                // then waits 3 animation frames with no new mutations (layout settled).
+                // Falls back after 30 frames if no mutations occur.
+                const waitForRenderSettle = (observed) => new Promise(resolve => {
+                    let mutationSeen = false;
+                    let framesSinceLastMutation = 0;
+                    let totalFrames = 0;
+
+                    const mo = new MutationObserver(() => {
+                        mutationSeen = true;
+                        framesSinceLastMutation = 0;
+                    });
+                    mo.observe(observed, { childList: true, subtree: true, attributes: true });
+
+                    const checkSettle = () => {
+                        totalFrames++;
+                        framesSinceLastMutation++;
+                        if ((mutationSeen && framesSinceLastMutation >= 3) || totalFrames >= 30) {
+                            mo.disconnect();
+                            resolve();
+                        } else {
+                            requestAnimationFrame(checkSettle);
+                        }
+                    };
+                    requestAnimationFrame(checkSettle);
+                });
+
+                const runScrollPass = async (observed, readPos, doScroll, count) => {
+                    const jumps = [];
+                    let maxJump = 0;
+                    for (let i = 0; i < count; i++) {
+                        const before = readPos();
+                        doScroll();
+                        await waitForRenderSettle(observed);
+                        const after = readPos();
+                        const jump = after - before;
+                        jumps.push(jump);
+                        if (Math.abs(jump) > Math.abs(maxJump)) maxJump = jump;
+                    }
+                    return { jumps, maxJump };
+                };
+";
+
     private Dictionary<string, object> ExecuteViewportScrollJumpDetectionScript(
         string tableId, int scrollCount = 15, int scrollDelta = 300)
     {
@@ -4957,59 +5096,48 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             var done = arguments[0];
             (async () => {{
                 const tbody = document.querySelector('#{tableId} > tbody');
-
-                // Event-driven wait: watches for DOM mutations from C# re-renders,
-                // then waits 3 animation frames with no new mutations (layout settled).
-                // Falls back after 30 frames if no mutations occur.
-                const waitForRenderSettle = () => new Promise(resolve => {{
-                    let mutationSeen = false;
-                    let framesSinceLastMutation = 0;
-                    let totalFrames = 0;
-
-                    const mo = new MutationObserver(() => {{
-                        mutationSeen = true;
-                        framesSinceLastMutation = 0;
-                    }});
-                    mo.observe(tbody, {{ childList: true, subtree: true }});
-
-                    const checkSettle = () => {{
-                        totalFrames++;
-                        framesSinceLastMutation++;
-                        if ((mutationSeen && framesSinceLastMutation >= 3) || totalFrames >= 30) {{
-                            mo.disconnect();
-                            resolve();
-                        }} else {{
-                            requestAnimationFrame(checkSettle);
-                        }}
-                    }};
-                    requestAnimationFrame(checkSettle);
-                }});
-
+                {ScrollJumpDetectionHelpersJs}
                 const scrollCount = {scrollCount};
                 const scrollDelta = {scrollDelta};
                 const startY = Math.round(window.scrollY);
-                let maxJump = 0;
-                let prevY = startY;
-                const jumps = [];
-
-                for (let i = 0; i < scrollCount; i++) {{
-                    window.scrollBy(0, scrollDelta);
-                    await waitForRenderSettle();
-
-                    const currentY = Math.round(window.scrollY);
-                    const jump = currentY - prevY;
-                    jumps.push(jump);
-                    if (Math.abs(jump) > Math.abs(maxJump)) maxJump = jump;
-                    prevY = currentY;
-                }}
+                const pass = await runScrollPass(
+                    tbody,
+                    () => Math.round(window.scrollY),
+                    () => window.scrollBy(0, scrollDelta),
+                    scrollCount);
 
                 done({{
                     startY: startY,
                     endY: Math.round(window.scrollY),
                     totalDelta: Math.round(window.scrollY) - startY,
                     expected: scrollCount * scrollDelta,
-                    maxJump: maxJump,
-                    jumps: jumps.join(',')
+                    maxJump: pass.maxJump,
+                    jumps: pass.jumps.join(',')
+                }});
+            }})();";
+
+        return (Dictionary<string, object>)((IJavaScriptExecutor)Browser).ExecuteAsyncScript(script);
+    }
+
+    private Dictionary<string, object> ExecuteContainerScrollJumpDetectionScript(
+        string containerId, int scrollCount = 40, int scrollDelta = 100)
+    {
+        var script = $@"
+            var done = arguments[0];
+            (async () => {{
+                const container = document.getElementById('{containerId}');
+                {ScrollJumpDetectionHelpersJs}
+                const scrollCount = {scrollCount};
+                const scrollDelta = {scrollDelta};
+                const readPos = () => Math.round(container.scrollTop);
+                const down = await runScrollPass(container, readPos, () => {{ container.scrollTop = readPos() + scrollDelta; }}, scrollCount);
+                const up = await runScrollPass(container, readPos, () => {{ container.scrollTop = readPos() - scrollDelta; }}, scrollCount);
+
+                done({{
+                    scrollDelta: scrollDelta,
+                    maxJump: Math.max(Math.abs(down.maxJump), Math.abs(up.maxJump)),
+                    downJumps: down.jumps.join(','),
+                    upJumps: up.jumps.join(',')
                 }});
             }})();";
 

--- a/src/Components/test/testassets/BasicTestApp/VirtualizationComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/VirtualizationComponent.razor
@@ -49,10 +49,10 @@
 </p>
 
 <p>
-    Slightly incorrect item size:<br />
+    Incorrect item size (declared 50, actual 30):<br />
     <div id="incorrect-size-container" style="background-color: #eee; height: 500px; overflow-y: auto">
         <Virtualize Items="@fixedItems" ItemSize="50" OverscanCount="3">
-            <div @key="context" class="incorrect-size-item" style="height: 49px; background-color: rgb(@((context % 2) * 255), @((1-(context % 2)) * 255), 255);">Item @context</div>
+            <div @key="context" class="incorrect-size-item" data-index="@context" style="height: 30px; background-color: rgb(@((context % 2) * 255), @((1-(context % 2)) * 255), 255);">Item @context</div>
         </Virtualize>
     </div>
 </p>


### PR DESCRIPTION
# [release/11.0-preview7] Fix Virtualize scroll jump from native/JS anchoring double-compensation

Backport of #67934 to release/11.0-preview7

## Description

`Virtualize` in native scroll-anchoring mode (browsers that support CSS `overflow-anchor` — i.e. not Safari, and not `<table>` layouts) could jump to the start or end of the list while the user scrolled. When a scroll brought a spacer into view, `Virtualize` slid its render window (an intentional content shift) but the browser's `overflow-anchor` also tried to hold the content
still. Both authorities compensated the same shift, the viewport overshot, and edge convergence latched it to the top or bottom.

This change makes native `overflow-anchor` and `Virtualize`'s own scroll handling cooperate so that exactly one authority acts per render, via a reason-counted `nativeAnchoring.suspend/resume` helper. All changes are confined to the `useNativeAnchoring` code paths; the manual JS compensation path used by Safari/WebKit and table layouts is unchanged.

Fixes #67729

## Customer Impact

Customers using the Blazor `Virtualize` component (including `QuickGrid`) in Chromium/Firefox-based browsers see the list unexpectedly jump to the top or bottom during normal scrolling, making long lists effectively unusable. This is a visible functional regression introduced in preview.

## Regression?

- [ ] Yes
- [x] No

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Changes are scoped to the `useNativeAnchoring` code paths only; the non-native (Safari/table) compensation path is untouched. Covered by two new E2E tests plus the existing anchoring suite.

## Verification

- [x] Manual (required)
- [x] Automated

Two E2E tests added to `VirtualizationTest.cs` (`ItemsIncrementalScroll_DoesNotJumpToStartOrEnd` and `ViewportAnchoring_RenderlessAboveViewportResize_AfterScroll_VisibleItemStaysInPlace`).

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A