### PR TITLE
Fix KeyRingProvider thread pool starvation on forced refresh

### DIFF
--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
@@ -399,19 +399,23 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
                 }
                 catch (Exception ex)
                 {
-                    if (existingCacheableKeyRing is null)
+                    // Mirror GetKeyRingFromCompletedTaskUnsynchronized: only extend the lifetime of a ring
+                    // that is present but already stale. A forced refresh can fail while the cached ring is
+                    // still valid; in that case we must leave it untouched, because WithTemporaryExtendedLifetime
+                    // would cut its expiration to 2 minutes and swap its expiration token for CancellationToken.None,
+                    // causing key changes to be ignored until the shortened lifetime elapses.
+                    if (existingCacheableKeyRing is not null && !CacheableKeyRing.IsValid(existingCacheableKeyRing, utcNow))
                     {
-                        // Cold start: there's no stale ring to extend via WithTemporaryExtendedLifetime.
-                        // Leave _cacheableKeyRing null so the next caller retries from scratch.
-                        _logger.ErrorOccurredWhileReadingKeyRing(ex);
+                        // Refresh failures are usually transient, so slightly extend the current entry's lifetime
+                        // to avoid hammering the backing store on every subsequent call, then surface the error.
+                        Volatile.Write(ref _cacheableKeyRing, existingCacheableKeyRing.WithTemporaryExtendedLifetime(utcNow));
+                        _logger.ErrorOccurredWhileRefreshingKeyRing(ex);
                     }
                     else
                     {
-                        // Forced refresh over a stale ring: refresh failures are usually transient, so
-                        // slightly extend the current entry's lifetime to avoid hammering the backing
-                        // store on every subsequent call, then surface the error to the caller.
-                        Volatile.Write(ref _cacheableKeyRing, existingCacheableKeyRing.WithTemporaryExtendedLifetime(utcNow));
-                        _logger.ErrorOccurredWhileRefreshingKeyRing(ex);
+                        // Cold start (no ring to extend) or a forced refresh over a still-valid ring
+                        // (which we deliberately leave in place): just surface the error.
+                        _logger.ErrorOccurredWhileReadingKeyRing(ex);
                     }
 
                     throw;
@@ -419,6 +423,17 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
 
                 Volatile.Write(ref _cacheableKeyRing, newCacheableKeyRing);
                 Debug.Assert(CacheableKeyRing.IsValid(newCacheableKeyRing, utcNow), "GetCacheableKeyRing produced a ring that is already invalid at utcNow.");
+
+                // This inline result is authoritative. If an async refresh scheduled by an earlier non-forced
+                // caller is still in flight, discard it so its older result can't later be consumed and clobber
+                // the ring we just published. Observe any fault so the discarded task doesn't surface as an
+                // unobserved TaskScheduler.UnobservedTaskException.
+                if (existingTask is not null)
+                {
+                    ObserveTaskException(existingTask);
+                    _cacheableKeyRingTask = null;
+                }
+
                 return newCacheableKeyRing.KeyRing;
             }
 
@@ -492,6 +507,17 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
 
             throw;
         }
+    }
+
+    // Ensures a discarded refresh task's exception is observed so it doesn't raise
+    // TaskScheduler.UnobservedTaskException. Non-blocking: the continuation only runs if the task faults.
+    private static void ObserveTaskException(Task task)
+    {
+        _ = task.ContinueWith(
+            static t => _ = t.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     private TimeSpan GetRefreshPeriodWithJitter(TimeSpan refreshPeriod)

--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
@@ -418,6 +418,7 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
                 }
 
                 Volatile.Write(ref _cacheableKeyRing, newCacheableKeyRing);
+                Debug.Assert(CacheableKeyRing.IsValid(newCacheableKeyRing, utcNow), "GetCacheableKeyRing produced a ring that is already invalid at utcNow.");
                 return newCacheableKeyRing.KeyRing;
             }
 
@@ -438,9 +439,8 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
             }
         }
 
-        // The only way to leave the lock without returning is as a non-forced caller that observed a
-        // present-but-stale ring (and kicked off the asynchronous refresh above). Prefer returning
-        // that stale ring to blocking.
+        // The only way to leave the lock without returning is as a non-forced caller that observed a present-but-stale ring
+        // (and kicked off the asynchronous refresh above). Prefer returning that stale ring to blocking.
         Debug.Assert(!forceRefresh, "A forced refresh should have produced a fresh key ring inline.");
         Debug.Assert(existingCacheableKeyRing is not null, "Should have refreshed inline when there was no cached key ring.");
         Debug.Assert(!CacheableKeyRing.IsValid(existingCacheableKeyRing, utcNow), "Should have returned a valid cached key ring above");

--- a/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
+++ b/src/DataProtection/DataProtection/src/KeyManagement/KeyRingProvider.cs
@@ -341,8 +341,7 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
             }
         }
 
-        CacheableKeyRing? existingCacheableKeyRing = null;
-        Task<CacheableKeyRing>? existingTask = null;
+        CacheableKeyRing? existingCacheableKeyRing;
 
         lock (_cacheableKeyRingLockObj)
         {
@@ -357,116 +356,95 @@ internal sealed class KeyRingProvider : ICacheableKeyRingProvider, IKeyRingProvi
                 }
             }
 
-            existingTask = _cacheableKeyRingTask;
-            if (existingTask is null)
+            var existingTask = _cacheableKeyRingTask;
+
+            // If work kicked off by a previous caller has already completed, we should use those results.
+            // Logically, it would probably make more sense to check this before checking whether
+            // the cache is valid - there could be a newer value available - but keeping that path
+            // fast is more important.  The next forced refresh or cache expiration will cause the
+            // new value to be picked up.
+            //
+            // An unconsumed task result is considered to satisfy forceRefresh.  One could quibble that this isn't really
+            // a forced refresh, but we'll still return a key ring newer than the one the caller was dissatisfied with.
+            if (existingTask is { IsCompleted: true })
             {
-                // The forceRefresh path skipped reading _cacheableKeyRing above; read it now.
-                existingCacheableKeyRing ??= Volatile.Read(ref _cacheableKeyRing);
+                var taskKeyRing = GetKeyRingFromCompletedTaskUnsynchronized(existingTask, utcNow); // Throws if the task failed
+                Debug.Assert(taskKeyRing is not null, "How did _cacheableKeyRingTask change while we were holding the lock?");
+                return taskKeyRing;
+            }
 
-                if (existingCacheableKeyRing is null)
+            // The forceRefresh path skipped reading _cacheableKeyRing above; read it now.
+            existingCacheableKeyRing = Volatile.Read(ref _cacheableKeyRing);
+
+            // Any caller that has to block for a value must produce it itself, on this thread,
+            // rather than scheduling the work to TaskScheduler.Default and then waiting on it.
+            // If all available thread-pool threads are blocked waiting on the result, the queued
+            // work item can't be picked up and the app hangs until the runtime injects more
+            // threads. See https://github.com/dotnet/aspnetcore/issues/66380. Two situations block:
+            //
+            //   * Cold start: there's no cached key ring at all, so every caller must wait.
+            //   * Forced refresh: the caller has explicitly rejected the cached ring (e.g. during
+            //     the two-minute startup auto-refresh window an incoming cookie names a key that
+            //     isn't in the current ring), so it must wait for a freshly read one.
+            //
+            // Running inline means racing blocking callers simply serialize on
+            // _cacheableKeyRingLockObj, which matches the pre-#54675 behavior that the
+            // DisableAsyncKeyRingUpdate switch preserves (https://github.com/dotnet/aspnetcore/pull/54675).
+            if (existingCacheableKeyRing is null || forceRefresh)
+            {
+                CacheableKeyRing newCacheableKeyRing;
+                try
                 {
-                    // Cold start: run the refresh inline on this thread. Scheduling the work
-                    // onto TaskScheduler.Default would risk thread-pool starvation - if all
-                    // available pool threads are blocked waiting on the result, the queued
-                    // work item can't be picked up and the app hangs until the runtime
-                    // injects more threads. See https://github.com/dotnet/aspnetcore/issues/66380.
-                    //
-                    // Other concurrent callers are parked on _cacheableKeyRingLockObj while we
-                    // run; once we publish _cacheableKeyRing and release the lock, they wake up.
-                    // Non-force-refresh callers can then re-check the cache and return the
-                    // freshly populated ring, while forceRefresh callers observe that a cached
-                    // ring now exists and continue through the stale-cache refresh path below.
-                    // This matches the pre-#54675 behavior (https://github.com/dotnet/aspnetcore/pull/54675).
-                    CacheableKeyRing newCacheableKeyRing;
-                    try
+                    newCacheableKeyRing = CacheableKeyRingProvider.GetCacheableKeyRing(utcNow);
+                }
+                catch (Exception ex)
+                {
+                    if (existingCacheableKeyRing is null)
                     {
-                        newCacheableKeyRing = CacheableKeyRingProvider.GetCacheableKeyRing(utcNow);
-                    }
-                    catch (Exception ex)
-                    {
-                        // Cold-start branch: always a "reading" rather than "refreshing" failure, and
-                        // there's no stale ring to extend via WithTemporaryExtendedLifetime.
-                        // The async refresh path handles both concerns. We leave _cacheableKeyRing
-                        // and _cacheableKeyRingTask null, so the next caller retries from scratch.
+                        // Cold start: there's no stale ring to extend via WithTemporaryExtendedLifetime.
+                        // Leave _cacheableKeyRing null so the next caller retries from scratch.
                         _logger.ErrorOccurredWhileReadingKeyRing(ex);
-                        throw;
+                    }
+                    else
+                    {
+                        // Forced refresh over a stale ring: refresh failures are usually transient, so
+                        // slightly extend the current entry's lifetime to avoid hammering the backing
+                        // store on every subsequent call, then surface the error to the caller.
+                        Volatile.Write(ref _cacheableKeyRing, existingCacheableKeyRing.WithTemporaryExtendedLifetime(utcNow));
+                        _logger.ErrorOccurredWhileRefreshingKeyRing(ex);
                     }
 
-                    Volatile.Write(ref _cacheableKeyRing, newCacheableKeyRing);
-                    return newCacheableKeyRing.KeyRing;
+                    throw;
                 }
 
-                // Stale ring exists: dispatch the refresh asynchronously and let every other
-                // caller return the stale ring without waiting. This is the perf win from #54675.
+                Volatile.Write(ref _cacheableKeyRing, newCacheableKeyRing);
+                return newCacheableKeyRing.KeyRing;
+            }
+
+            // Non-forced caller with a stale (but present) ring: dispatch the refresh asynchronously
+            // and fall through to return the stale ring below without waiting. No caller ever blocks
+            // on this task, so scheduling it to the thread pool cannot cause the starvation above.
+            // This is the perf win from #54675.
+            if (existingTask is null)
+            {
                 // PERF: Closing over utcNow substantially slows down the fast case (valid cache) in micro-benchmarks
                 // (closing over `this` for CacheableKeyRingProvider doesn't seem impactful)
-                existingTask = Task.Factory.StartNew(
+                _cacheableKeyRingTask = Task.Factory.StartNew(
                     utcNowState => CacheableKeyRingProvider.GetCacheableKeyRing((DateTime)utcNowState!),
                     utcNow,
                     CancellationToken.None, // GetKeyRingFromCompletedTaskUnsynchronized will need to react if this becomes cancellable
                     TaskCreationOptions.DenyChildAttach,
                     TaskScheduler.Default);
-                _cacheableKeyRingTask = existingTask;
-            }
-
-            // This is mostly for the case where existingTask already set, but no harm in checking a fresh one
-            if (existingTask.IsCompleted)
-            {
-                // If work kicked off by a previous caller has completed, we should use those results.
-                // Logically, it would probably make more sense to check this before checking whether
-                // the cache is valid - there could be a newer value available - but keeping that path
-                // fast is more important.  The next forced refresh or cache expiration will cause the
-                // new value to be picked up.
-
-                // An unconsumed task result is considered to satisfy forceRefresh.  One could quibble that this isn't really
-                // a forced refresh, but we'll still return a key ring newer than the one the caller was dissatisfied with.
-                var taskKeyRing = GetKeyRingFromCompletedTaskUnsynchronized(existingTask, utcNow); // Throws if the task failed
-                Debug.Assert(taskKeyRing is not null, "How did _cacheableKeyRingTask change while we were holding the lock?");
-                return taskKeyRing;
             }
         }
 
-        // Prefer a stale cached key ring to blocking
-        if (!forceRefresh && existingCacheableKeyRing is not null)
-        {
-            Debug.Assert(!CacheableKeyRing.IsValid(existingCacheableKeyRing, utcNow), "Should have returned a valid cached key ring above");
-            return existingCacheableKeyRing.KeyRing;
-        }
-
-        // If there's not even a stale cached key ring we can use, we have to wait.
-        // It's not ideal to wait for a task that was just scheduled, but it makes the code a lot simpler
-        // (compared to having a separate, synchronous code path).
-
-        // The reason we yield the lock and wait for the task instead is to allow racing forceRefresh threads
-        // to wait for the same task, rather than being sequentialized (and each doing its own refresh).
-
-        // Cleverness: swallow any exceptions - they'll be surfaced by GetKeyRingFromCompletedTaskUnsynchronized, if appropriate.
-        existingTask
-            .ContinueWith(
-                static t => _ = t.Exception, // Still observe the exception - just don't throw it
-                CancellationToken.None,
-                TaskContinuationOptions.ExecuteSynchronously,
-                TaskScheduler.Default)
-            .Wait();
-
-        lock (_cacheableKeyRingLockObj)
-        {
-            var newKeyRing = GetKeyRingFromCompletedTaskUnsynchronized(existingTask, utcNow); // Throws if the task failed (winning thread only)
-            if (newKeyRing is null)
-            {
-                // Another thread won - check whether it cached a new key ring
-                var newCacheableKeyRing = Volatile.Read(ref _cacheableKeyRing);
-                if (newCacheableKeyRing is null)
-                {
-                    // There will have been a better exception from the winning thread
-                    throw Error.KeyRingProvider_RefreshFailedOnOtherThread(existingTask.Exception);
-                }
-
-                newKeyRing = newCacheableKeyRing.KeyRing;
-            }
-
-            return newKeyRing;
-        }
+        // The only way to leave the lock without returning is as a non-forced caller that observed a
+        // present-but-stale ring (and kicked off the asynchronous refresh above). Prefer returning
+        // that stale ring to blocking.
+        Debug.Assert(!forceRefresh, "A forced refresh should have produced a fresh key ring inline.");
+        Debug.Assert(existingCacheableKeyRing is not null, "Should have refreshed inline when there was no cached key ring.");
+        Debug.Assert(!CacheableKeyRing.IsValid(existingCacheableKeyRing, utcNow), "Should have returned a valid cached key ring above");
+        return existingCacheableKeyRing!.KeyRing;
     }
 
     /// <summary>

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/KeyRingProviderTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/KeyRingProviderTests.cs
@@ -854,6 +854,58 @@ public class KeyRingProviderTests
         Assert.Equal(callingThreadId, refreshThreadId);
     }
 
+    // Regression test for https://github.com/dotnet/aspnetcore/issues/66380.
+    // The cold-start starvation was fixed, but a second variant remained: when a valid key
+    // ring is already cached and a caller forces a refresh (e.g. during the two-minute startup
+    // auto-refresh window, an incoming cookie names a key that isn't in the current ring), the
+    // new async-refresh path scheduled the refresh to TaskScheduler.Default and then blocked
+    // on Task.Wait(). With every thread-pool thread parked on that wait, the queued refresh
+    // could not be picked up, reproducing the same starvation and multi-second freeze.
+    //
+    // As with the cold-start test above, we verify the invariant that makes starvation
+    // impossible by construction rather than the (non-deterministic) timing: a forced refresh
+    // must perform the refresh on the calling thread, not on a pool worker.
+    [Fact]
+    public void GetCurrentKeyRing_ForceRefreshWithCachedRing_RefreshRunsOnCallingThread()
+    {
+        var now = StringToDateTime("2015-03-01 00:00:00Z");
+        var refreshTime = now.AddMinutes(1);
+        var initialKeyRing = new Mock<IKeyRing>().Object;
+        var refreshedKeyRing = new Mock<IKeyRing>().Object;
+
+        int? refreshThreadId = null;
+
+        var mockCacheableKeyRingProvider = new Mock<ICacheableKeyRingProvider>();
+        mockCacheableKeyRingProvider
+            .Setup(o => o.GetCacheableKeyRing(now))
+            .Returns(new CacheableKeyRing(
+                expirationToken: CancellationToken.None,
+                expirationTime: now.AddDays(1),
+                keyRing: initialKeyRing));
+        mockCacheableKeyRingProvider
+            .Setup(o => o.GetCacheableKeyRing(refreshTime))
+            .Returns(() =>
+            {
+                refreshThreadId = Environment.CurrentManagedThreadId;
+                return new CacheableKeyRing(
+                    expirationToken: CancellationToken.None,
+                    expirationTime: refreshTime.AddDays(1),
+                    keyRing: refreshedKeyRing);
+            });
+
+        var keyRingProvider = CreateKeyRingProvider(mockCacheableKeyRingProvider.Object);
+
+        // Populate the cache with a valid ring.
+        Assert.Same(initialKeyRing, keyRingProvider.GetCurrentKeyRingCore(now));
+
+        // Force a refresh even though the cached ring is still valid.
+        var callingThreadId = Environment.CurrentManagedThreadId;
+        var keyRing = keyRingProvider.GetCurrentKeyRingCore(refreshTime, forceRefresh: true);
+
+        Assert.Same(refreshedKeyRing, keyRing);
+        Assert.Equal(callingThreadId, refreshThreadId);
+    }
+
     [Fact]
     public async Task MultipleThreadsSeeExpiredCachedValue()
     {

--- a/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/KeyRingProviderTests.cs
+++ b/src/DataProtection/DataProtection/test/Microsoft.AspNetCore.DataProtection.Tests/KeyManagement/KeyRingProviderTests.cs
@@ -906,6 +906,137 @@ public class KeyRingProviderTests
         Assert.Equal(callingThreadId, refreshThreadId);
     }
 
+    // When a forced refresh fails while the cached key ring is still valid, the cached ring must be left completely intact.
+    [Fact]
+    public async Task GetCurrentKeyRing_ForcedRefreshFailsOverValidRing_DoesNotDowngradeCachedRing()
+    {
+        var now = StringToDateTime("2015-03-01 00:00:00Z");
+        var throwTime = StringToDateTime("2015-03-01 00:01:00Z");
+        var readTime = StringToDateTime("2015-03-01 00:01:05Z"); // within the buggy two-minute extension window
+
+        var validCts = new CancellationTokenSource();
+        var initialKeyRing = new Mock<IKeyRing>().Object;
+        var refreshedKeyRing = new Mock<IKeyRing>().Object;
+
+        var mockCacheableKeyRingProvider = new Mock<ICacheableKeyRingProvider>();
+        mockCacheableKeyRingProvider
+            .Setup(o => o.GetCacheableKeyRing(now))
+            .Returns(new CacheableKeyRing(
+                expirationToken: validCts.Token,
+                expirationTime: now.AddDays(1),
+                keyRing: initialKeyRing));
+        mockCacheableKeyRingProvider
+            .Setup(o => o.GetCacheableKeyRing(throwTime))
+            .Throws(new Exception("Refresh failed."));
+        mockCacheableKeyRingProvider
+            .Setup(o => o.GetCacheableKeyRing(readTime))
+            .Returns(new CacheableKeyRing(
+                expirationToken: CancellationToken.None,
+                expirationTime: now.AddDays(1),
+                keyRing: refreshedKeyRing));
+
+        var keyRingProvider = CreateKeyRingProvider(mockCacheableKeyRingProvider.Object);
+
+        Assert.Same(initialKeyRing, keyRingProvider.GetCurrentKeyRingCore(now));
+
+        // A forced refresh over the still-valid ring fails; the ring must be left untouched.
+        ExceptionAssert.Throws<Exception>(
+            () => keyRingProvider.GetCurrentKeyRingCore(throwTime, forceRefresh: true), "Refresh failed.");
+
+        // Simulate a key change by cancelling the ring's original expiration token. If the failed forced
+        // refresh had downgraded the ring, this token would have been disconnected and the cancellation
+        // ignored, so the stale ring would keep being served for the duration of the extended lifetime.
+        validCts.Cancel();
+
+        var refreshed = false;
+        for (var i = 0; i < 20 && !refreshed; i++)
+        {
+            var observed = keyRingProvider.GetCurrentKeyRingCore(readTime);
+            if (ReferenceEquals(refreshedKeyRing, observed))
+            {
+                refreshed = true;
+                break;
+            }
+
+            Assert.Same(initialKeyRing, observed); // stale ring is served only while the async refresh is in flight
+            await Task.Delay(100);
+        }
+
+        Assert.True(refreshed, "The cancelled expiration token was ignored; a downgraded ring was served instead of refreshing.");
+    }
+
+    // A non-forced caller that finds a stale ring schedules an asynchronous refresh.
+    // If a forced caller then produces a fresh ring inline while that async refresh is still running,
+    // the async result (an older read) must not later overwrite the fresher inline ring.
+    [Fact]
+    public void GetCurrentKeyRing_InlineForcedRefresh_DiscardsInFlightAsyncRefresh()
+    {
+        var now = StringToDateTime("2015-03-01 00:00:00Z");
+        var staleReadTime = StringToDateTime("2015-03-01 00:01:00Z");
+        var forceTime = StringToDateTime("2015-03-01 00:02:00Z");
+        var probeTime = StringToDateTime("2015-03-01 00:03:00Z");
+
+        var initialCts = new CancellationTokenSource();
+        var initialKeyRing = new Mock<IKeyRing>().Object;   // seeds the cache
+        var asyncKeyRing = new Mock<IKeyRing>().Object;      // the older async read that must not win
+        var inlineKeyRing = new Mock<IKeyRing>().Object;     // the authoritative inline forced result
+        var probeKeyRing = new Mock<IKeyRing>().Object;      // produced by later forced probes
+
+        using var asyncEntered = new ManualResetEventSlim(false);
+        using var releaseAsync = new ManualResetEventSlim(false);
+        using var asyncCompleted = new ManualResetEventSlim(false);
+
+        var mockCacheableKeyRingProvider = new Mock<ICacheableKeyRingProvider>();
+        mockCacheableKeyRingProvider
+            .Setup(o => o.GetCacheableKeyRing(now))
+            .Returns(new CacheableKeyRing(initialCts.Token, now.AddDays(1), initialKeyRing));
+        mockCacheableKeyRingProvider
+            .Setup(o => o.GetCacheableKeyRing(staleReadTime))
+            .Returns(() =>
+            {
+                asyncEntered.Set();
+                Assert.True(releaseAsync.Wait(TimeSpan.FromSeconds(10)));
+                try
+                {
+                    return new CacheableKeyRing(CancellationToken.None, now.AddDays(1), asyncKeyRing);
+                }
+                finally
+                {
+                    asyncCompleted.Set();
+                }
+            });
+        mockCacheableKeyRingProvider
+            .Setup(o => o.GetCacheableKeyRing(forceTime))
+            .Returns(new CacheableKeyRing(CancellationToken.None, now.AddDays(1), inlineKeyRing));
+        mockCacheableKeyRingProvider
+            .Setup(o => o.GetCacheableKeyRing(probeTime))
+            .Returns(new CacheableKeyRing(CancellationToken.None, now.AddDays(1), probeKeyRing));
+
+        var keyRingProvider = CreateKeyRingProvider(mockCacheableKeyRingProvider.Object);
+
+        Assert.Same(initialKeyRing, keyRingProvider.GetCurrentKeyRingCore(now));
+        initialCts.Cancel(); // make the cached ring stale-but-present
+
+        // Non-forced caller schedules the (slow) async refresh and returns the stale ring without waiting.
+        Assert.Same(initialKeyRing, keyRingProvider.GetCurrentKeyRingCore(staleReadTime));
+        Assert.True(asyncEntered.Wait(TimeSpan.FromSeconds(10))); // the async refresh is now in flight
+
+        // Forced caller produces a fresh ring inline while the async refresh is still blocked.
+        Assert.Same(inlineKeyRing, keyRingProvider.GetCurrentKeyRingCore(forceTime, forceRefresh: true));
+
+        // Let the async refresh finish; its result must be discarded, not cached.
+        releaseAsync.Set();
+        Assert.True(asyncCompleted.Wait(TimeSpan.FromSeconds(10)));
+
+        // A later caller entering the critical section must never observe the discarded async ring.
+        for (var i = 0; i < 20; i++)
+        {
+            var observed = keyRingProvider.GetCurrentKeyRingCore(probeTime, forceRefresh: true);
+            Assert.NotSame(asyncKeyRing, observed);
+            Thread.Sleep(10);
+        }
+    }
+
     [Fact]
     public async Task MultipleThreadsSeeExpiredCachedValue()
     {


### PR DESCRIPTION
The cold-start starvation fix (#66683/#66737) left a second variant: when a valid key ring is cached and a caller forces a refresh (e.g. during the two-minute startup auto-refresh window an incoming cookie names a key not in the current ring), `GetCurrentKeyRingCoreNew` scheduled the refresh onto TaskScheduler.Default and blocked on Task.Wait(). With every thread-pool thread parked on that wait, the queued refresh could not run, causing thread pool starvation and a multi-second freeze. See https://github.com/dotnet/aspnetcore/issues/66380#issuecomment-5056250856.

Unify the invariant that already protects cold start: any caller that must block for a value produces it inline on its own thread, so no caller ever blocks on TaskScheduler.Default work. Non-forced callers with a stale ring still dispatch the async refresh and return the stale ring without waiting, preserving the perf win from #54675.

Fixes #66380