### PR TITLE
Reject malformed SNI server names in Kestrel's SniOptionsSelector

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
@@ -117,7 +117,7 @@ internal sealed class SniOptionsSelector
     {
         SniOptions? sniOptions = null;
 
-        if (IsValidSniServerName(serverName) && !_exactNameOptions.TryGetValue(serverName, out sniOptions))
+        if (!string.IsNullOrEmpty(serverName) && !_exactNameOptions.TryGetValue(serverName, out sniOptions) && IsValidSniServerName(serverName))
         {
             foreach (var (suffix, options) in _wildcardPrefixOptions)
             {
@@ -179,11 +179,9 @@ internal sealed class SniOptionsSelector
     // RFC 6066 §3 requires the SNI server_name to be a syntactically valid DNS hostname and
     // forbids a trailing dot. Uri.CheckHostName already rejects empty labels, leading dots,
     // non-LDH characters, embedded nulls, and IP literals, but it accepts a trailing dot as
-    // the DNS root, so that needs an explicit check. The empty-string check has to live here
-    // too (rather than at the call site) so the JIT can see it guards serverName[^1] and skip
-    // the bounds check.
-    private static bool IsValidSniServerName(string serverName) =>
-        !string.IsNullOrEmpty(serverName) && serverName[^1] != '.' && Uri.CheckHostName(serverName) == UriHostNameType.Dns;
+    // the DNS root, so that needs an explicit check. Callers check for null/empty first.
+    private static bool IsValidSniServerName(string serverName)
+        => !serverName.EndsWith('.') && Uri.CheckHostName(serverName) == UriHostNameType.Dns;
 
     public static ValueTask<SslServerAuthenticationOptions> OptionsCallback(TlsHandshakeCallbackContext callbackContext)
     {

--- a/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
@@ -117,7 +117,7 @@ internal sealed class SniOptionsSelector
     {
         SniOptions? sniOptions = null;
 
-        if (!string.IsNullOrEmpty(serverName) && IsValidSniServerName(serverName) && !_exactNameOptions.TryGetValue(serverName, out sniOptions))
+        if (IsValidSniServerName(serverName) && !_exactNameOptions.TryGetValue(serverName, out sniOptions))
         {
             foreach (var (suffix, options) in _wildcardPrefixOptions)
             {
@@ -179,9 +179,11 @@ internal sealed class SniOptionsSelector
     // RFC 6066 §3 requires the SNI server_name to be a syntactically valid DNS hostname and
     // forbids a trailing dot. Uri.CheckHostName already rejects empty labels, leading dots,
     // non-LDH characters, embedded nulls, and IP literals, but it accepts a trailing dot as
-    // the DNS root, so that needs an explicit check.
+    // the DNS root, so that needs an explicit check. The empty-string check has to live here
+    // too (rather than at the call site) so the JIT can see it guards serverName[^1] and skip
+    // the bounds check.
     private static bool IsValidSniServerName(string serverName) =>
-        serverName[^1] != '.' && Uri.CheckHostName(serverName) == UriHostNameType.Dns;
+        !string.IsNullOrEmpty(serverName) && serverName[^1] != '.' && Uri.CheckHostName(serverName) == UriHostNameType.Dns;
 
     public static ValueTask<SslServerAuthenticationOptions> OptionsCallback(TlsHandshakeCallbackContext callbackContext)
     {

--- a/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/SniOptionsSelector.cs
@@ -117,7 +117,7 @@ internal sealed class SniOptionsSelector
     {
         SniOptions? sniOptions = null;
 
-        if (!string.IsNullOrEmpty(serverName) && !_exactNameOptions.TryGetValue(serverName, out sniOptions))
+        if (!string.IsNullOrEmpty(serverName) && IsValidSniServerName(serverName) && !_exactNameOptions.TryGetValue(serverName, out sniOptions))
         {
             foreach (var (suffix, options) in _wildcardPrefixOptions)
             {
@@ -175,6 +175,13 @@ internal sealed class SniOptionsSelector
 
         return (sslOptions, sniOptions.ClientCertificateMode);
     }
+
+    // RFC 6066 §3 requires the SNI server_name to be a syntactically valid DNS hostname and
+    // forbids a trailing dot. Uri.CheckHostName already rejects empty labels, leading dots,
+    // non-LDH characters, embedded nulls, and IP literals, but it accepts a trailing dot as
+    // the DNS root, so that needs an explicit check.
+    private static bool IsValidSniServerName(string serverName) =>
+        serverName[^1] != '.' && Uri.CheckHostName(serverName) == UriHostNameType.Dns;
 
     public static ValueTask<SslServerAuthenticationOptions> OptionsCallback(TlsHandshakeCallbackContext callbackContext)
     {

--- a/src/Servers/Kestrel/Core/test/SniOptionsSelectorTests.cs
+++ b/src/Servers/Kestrel/Core/test/SniOptionsSelectorTests.cs
@@ -350,9 +350,9 @@ public class SniOptionsSelectorTests
     }
 
     // Malformed server names (RFC 6066 §3 / RFC 5890: embedded nulls, empty labels, trailing dot) must not be
-    // matched against exact-name or wildcard-suffix entries, since EndsWith-based suffix matching doesn't
-    // understand DNS label boundaries and can be fooled by a crafted prefix. They should fall through to the
-    // "*" catch-all, same as any other unrecognized name.
+    // matched against wildcard-suffix entries, since EndsWith-based suffix matching doesn't understand DNS
+    // label boundaries and can be fooled by a crafted prefix. They should fall through to the "*" catch-all,
+    // same as any other unrecognized name.
     [Theory]
     [InlineData("evil\0.example.org")]
     [InlineData(".example.org")]
@@ -437,6 +437,99 @@ public class SniOptionsSelectorTests
         // Without validation this would incorrectly match "*.example.org" via a naive EndsWith(".example.org") scan.
         var authEx = Assert.Throws<AuthenticationException>(() => sniOptionsSelector.GetOptions(new MockConnectionContext(), "evil\0.example.org"));
         Assert.Equal(CoreStrings.FormatSniNotConfiguredForServerName("evil\0.example.org", "TestEndpointName"), authEx.Message);
+    }
+
+    // RFC 6066 §3 forbids IP literals in the SNI server_name. Uri.CheckHostName classifies these as
+    // IPv4/IPv6 rather than Dns, so they don't reach the wildcard-suffix scan either.
+    [Theory]
+    [InlineData("192.168.1.1")]
+    [InlineData("[::1]")]
+    public void IPLiteralServerNameFallsThroughToWildcardOnly(string serverName)
+    {
+        var sniDictionary = new Dictionary<string, SniConfig>
+            {
+                {
+                    "*.1",
+                    new SniConfig
+                    {
+                        Certificate = new CertificateConfig
+                        {
+                            Path = "WildcardPrefix"
+                        }
+                    }
+                },
+                {
+                    "*",
+                    new SniConfig
+                    {
+                        Certificate = new CertificateConfig
+                        {
+                            Path = "WildcardOnly"
+                        }
+                    }
+                }
+            };
+
+        var mockCertificateConfigLoader = new MockCertificateConfigLoader();
+        var pathDictionary = mockCertificateConfigLoader.CertToPathDictionary;
+
+        var sniOptionsSelector = new SniOptionsSelector(
+            "TestEndpointName",
+            sniDictionary,
+            mockCertificateConfigLoader,
+            fallbackHttpsOptions: new HttpsConnectionAdapterOptions(),
+            fallbackHttpProtocols: HttpProtocols.Http1AndHttp2,
+            logger: Mock.Of<ILogger<HttpsConnectionMiddleware>>());
+
+        var (options, _) = sniOptionsSelector.GetOptions(new MockConnectionContext(), serverName);
+        Assert.Equal("WildcardOnly", pathDictionary[options.ServerCertificate]);
+    }
+
+    // The validation must not over-reject. Underscores and unicode IDN labels are unusual but still
+    // valid as far as Uri.CheckHostName is concerned, so these keep matching their wildcard prefix
+    // rather than being pushed onto the "*" catch-all.
+    [Theory]
+    [InlineData("my_host.example.org")]
+    [InlineData("münchen.example.org")]
+    public void UnusualButValidServerNameStillMatchesWildcardPrefix(string serverName)
+    {
+        var sniDictionary = new Dictionary<string, SniConfig>
+            {
+                {
+                    "*.example.org",
+                    new SniConfig
+                    {
+                        Certificate = new CertificateConfig
+                        {
+                            Path = "WildcardPrefix"
+                        }
+                    }
+                },
+                {
+                    "*",
+                    new SniConfig
+                    {
+                        Certificate = new CertificateConfig
+                        {
+                            Path = "WildcardOnly"
+                        }
+                    }
+                }
+            };
+
+        var mockCertificateConfigLoader = new MockCertificateConfigLoader();
+        var pathDictionary = mockCertificateConfigLoader.CertToPathDictionary;
+
+        var sniOptionsSelector = new SniOptionsSelector(
+            "TestEndpointName",
+            sniDictionary,
+            mockCertificateConfigLoader,
+            fallbackHttpsOptions: new HttpsConnectionAdapterOptions(),
+            fallbackHttpProtocols: HttpProtocols.Http1AndHttp2,
+            logger: Mock.Of<ILogger<HttpsConnectionMiddleware>>());
+
+        var (options, _) = sniOptionsSelector.GetOptions(new MockConnectionContext(), serverName);
+        Assert.Equal("WildcardPrefix", pathDictionary[options.ServerCertificate]);
     }
 
     [Fact]

--- a/src/Servers/Kestrel/Core/test/SniOptionsSelectorTests.cs
+++ b/src/Servers/Kestrel/Core/test/SniOptionsSelectorTests.cs
@@ -349,6 +349,96 @@ public class SniOptionsSelectorTests
         Assert.Equal(CoreStrings.FormatSniNotConfiguredToAllowNoServerName("TestEndpointName"), authExWithoutServerName.Message);
     }
 
+    // Malformed server names (RFC 6066 §3 / RFC 5890: embedded nulls, empty labels, trailing dot) must not be
+    // matched against exact-name or wildcard-suffix entries, since EndsWith-based suffix matching doesn't
+    // understand DNS label boundaries and can be fooled by a crafted prefix. They should fall through to the
+    // "*" catch-all, same as any other unrecognized name.
+    [Theory]
+    [InlineData("evil\0.example.org")]
+    [InlineData(".example.org")]
+    [InlineData("a..example.org")]
+    [InlineData("example.org.")]
+    public void MalformedServerNameFallsThroughToWildcardOnly(string serverName)
+    {
+        var sniDictionary = new Dictionary<string, SniConfig>
+            {
+                {
+                    "www.example.org",
+                    new SniConfig
+                    {
+                        Certificate = new CertificateConfig
+                        {
+                            Path = "Exact"
+                        }
+                    }
+                },
+                {
+                    "*.example.org",
+                    new SniConfig
+                    {
+                        Certificate = new CertificateConfig
+                        {
+                            Path = "WildcardPrefix"
+                        }
+                    }
+                },
+                {
+                    "*",
+                    new SniConfig
+                    {
+                        Certificate = new CertificateConfig
+                        {
+                            Path = "WildcardOnly"
+                        }
+                    }
+                }
+            };
+
+        var mockCertificateConfigLoader = new MockCertificateConfigLoader();
+        var pathDictionary = mockCertificateConfigLoader.CertToPathDictionary;
+
+        var sniOptionsSelector = new SniOptionsSelector(
+            "TestEndpointName",
+            sniDictionary,
+            mockCertificateConfigLoader,
+            fallbackHttpsOptions: new HttpsConnectionAdapterOptions(),
+            fallbackHttpProtocols: HttpProtocols.Http1AndHttp2,
+            logger: Mock.Of<ILogger<HttpsConnectionMiddleware>>());
+
+        var (options, _) = sniOptionsSelector.GetOptions(new MockConnectionContext(), serverName);
+        Assert.Equal("WildcardOnly", pathDictionary[options.ServerCertificate]);
+    }
+
+    [Fact]
+    public void MalformedServerNameThrowsWhenNoWildcardOnlyConfigured()
+    {
+        var sniDictionary = new Dictionary<string, SniConfig>
+            {
+                {
+                    "*.example.org",
+                    new SniConfig
+                    {
+                        Certificate = new CertificateConfig
+                        {
+                            Path = "WildcardPrefix"
+                        }
+                    }
+                }
+            };
+
+        var sniOptionsSelector = new SniOptionsSelector(
+            "TestEndpointName",
+            sniDictionary,
+            new MockCertificateConfigLoader(),
+            fallbackHttpsOptions: new HttpsConnectionAdapterOptions(),
+            fallbackHttpProtocols: HttpProtocols.Http1AndHttp2,
+            logger: Mock.Of<ILogger<HttpsConnectionMiddleware>>());
+
+        // Without validation this would incorrectly match "*.example.org" via a naive EndsWith(".example.org") scan.
+        var authEx = Assert.Throws<AuthenticationException>(() => sniOptionsSelector.GetOptions(new MockConnectionContext(), "evil\0.example.org"));
+        Assert.Equal(CoreStrings.FormatSniNotConfiguredForServerName("evil\0.example.org", "TestEndpointName"), authEx.Message);
+    }
+
     [Fact]
     public void WildcardOnlyMatchesNullServerNameDueToNoAlpn()
     {


### PR DESCRIPTION
Fixes #67721

SniOptionsSelector matches the TLS ClientHello server_name against configured exact-name and wildcard-suffix entries with no validation that the value is a syntactically valid DNS hostname per RFC 6066 §3 / RFC 5890. The wildcard path in particular is a plain `serverName.EndsWith(suffix, OrdinalIgnoreCase)` scan, which doesn't understand DNS label boundaries.

Added `IsValidSniServerName`, checked before both the exact-name lookup and the wildcard scan in `GetOptions`. I checked what `Uri.CheckHostName` actually accepts before writing this (results below), since the proposed fix in the issue mentions empty labels and leading/trailing dots as separate concerns:

    example.com    => Dns
    .example.com   => Unknown
    example.com.   => Dns          <- accepted, but RFC 6066 forbids a trailing dot
    a..b.com       => Unknown
    exa\0mple.com  => Unknown
    192.168.1.1    => IPv4         <- not Dns, correctly excluded (SNI must be a hostname, not an IP literal)

So `Uri.CheckHostName(name) == UriHostNameType.Dns` already rejects empty labels, leading dots, non-LDH characters, embedded nulls, and IP literals on its own. The only real gap is the trailing dot, which needs an explicit check.

A malformed name now falls through to the `"*"` catch-all like any other unrecognized name, or gets the existing `SniNotConfiguredForServerName` exception if no wildcard-only entry is configured, rather than being run through exact/wildcard matching.

Added two tests: `MalformedServerNameFallsThroughToWildcardOnly` (embedded null, leading dot, double dot, trailing dot, each against the same Exact/WildcardPrefix/WildcardOnly setup the existing precedence test uses) and `MalformedServerNameThrowsWhenNoWildcardOnlyConfigured`, which demonstrates the concrete case this closes: without validation, `evil\0.example.org` satisfies `EndsWith(".example.org")` and would incorrectly match the `*.example.org` entry.