### PR TITLE
[test-quarantine] Fix flaky AnchorMode_End_AppendAfterLeavingBottom_DoesNotReengage E2E test

### DIFF
--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -4156,8 +4156,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
 
             return (sh - st - ch) > 300;
-        },
-        "Should be at least 300px away from bottom before second append");
+        }, "Should be at least 300px away from bottom before second append");
 
         var scrollTopBeforeSecondAppend = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
         var scrollHeightBeforeSecondAppend = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -4145,9 +4145,19 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var currentScrollTop = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
         var targetScrollTop = (int)(currentScrollTop - 500);
         ScrollUntil(js, container, () => ScrollContainer(js, container, targetScrollTop),
-            st => st < currentScrollTop - 100,
-            $"scrollTop < {currentScrollTop - 100} after scrolling away from bottom");
+            st => st < currentScrollTop - 300,
+            $"scrollTop < {currentScrollTop - 300} after scrolling away from bottom");
         WaitForRenderToSettle(container, js);
+
+        Browser.True(() =>
+        {
+            var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+            var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
+            var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);
+
+            return (sh - st - ch) > 300;
+        },
+        "Should be at least 300px away from bottom before second append");
 
         var scrollTopBeforeSecondAppend = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
         var scrollHeightBeforeSecondAppend = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);


### PR DESCRIPTION
## Description

This PR hardens `AnchorMode_End_AppendAfterLeavingBottom_DoesNotReengage` by strengthening the test's "leave bottom" precondition before validating that `AnchorMode.End` does not re-engage after a subsequent append. The change ensures the test explicitly verifies that the viewport has moved sufficiently away from the bottom-anchor region prior to the second append, reducing sensitivity to timing differences that may occur on slower CI agents.

## Background

The test has been intermittently failing in CI, while proving difficult to reproduce locally.

As part of the investigation:

- Ran the failing test repeatedly in a local environment (100 consecutive executions).
- No local reproductions were observed.
- Failure logs from CI indicated that after the second append operation the viewport continued following the bottom of the list.

Example failure:

```
scrollTop before: 31320
scrollTop after : 31940

scrollHeight before: 31620
scrollHeight after : 32240
```

Both values increased by the same amount:

```
scrollTop delta    = 620
scrollHeight delta = 620
```

which suggests the viewport may have remained effectively bottom anchored when the second append occurred.

## Investigation

The original test attempted to leave the bottom state using:

```
st => st < currentScrollTop - 100
```
 
even though the intended target scroll position was:

```
currentScrollTop - 500
```

This could allow the test to proceed after moving only 100px away from the previous bottom position.

On slower CI agents, this may create a window where:

- The test believes the user has left the bottom.
- Rendering has stabilized.
- The viewport may still be sufficiently close to the bottom that anchor-follow behavior can occur during the next append.

As a result, the subsequent append may continue to follow the bottom and cause the assertion to fail.

The CI failure data is consistent with this behavior. In the observed failure, both `scrollTop` and `scrollHeight` increased by the same amount after the second append:

```
scrollTop delta    = 620
scrollHeight delta = 620
```

which suggests that the viewport continued following the end of the list rather than remaining at its previous position.

## Changes

### Strengthen scroll-away validation

Changed:

```
st => st < currentScrollTop - 100
```

to:

```
st => st < currentScrollTop - 300
```

This requires the viewport to move substantially farther away from the bottom before continuing.

### Explicitly verify distance from bottom

Added an additional guard before the second append:

```
Browser.True(() =>
{
    var st = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
    var sh = (long)js.ExecuteScript("return arguments[0].scrollHeight", container);
    var ch = (long)js.ExecuteScript("return arguments[0].clientHeight", container);

    return (sh - st - ch) > 300;
}, "Should be at least 300px away from bottom before second append");
```

This makes the test validate the condition it actually depends on:

```
User has left the bottom-anchor region.
```

rather than inferring it from a smaller scroll offset.

## Result

The behavioral intent of the test remains unchanged:

- First append while at bottom should follow the bottom.
- After the user leaves the bottom, subsequent appends should not re-engage bottom anchoring.

The change only strengthens the test setup and reduces sensitivity to CI timing differences and render/scroll synchronization behavior.

## Validation

### Targeted repro validation

Investigated the failure by repeatedly executing the affected test locally:

```
1..100 | % {
    dotnet test src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj `
      --no-build `
      --filter "FullyQualifiedName~ServerVirtualizationTest.AnchorMode_End_AppendAfterLeavingBottom_DoesNotReengage"
}
```

Result:

```
100/100 passing before the change.
100/100 passing after the change.

No local reproductions were observed.
```

### Regression validation

Executed the full virtualization test suite before and after the change:

```
dotnet test src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj \
  --no-build \
  --filter "FullyQualifiedName~ServerVirtualizationTest"
```

Result:

```
All ServerVirtualizationTest tests passed before the change.
All ServerVirtualizationTest tests passed after the change.

No regressions were observed in related virtualization scenarios.
```

This helps verify that the change only strengthens the test preconditions and does not alter the behavior being validated or introduce regressions in related virtualization scenarios.

Fixes #66970