### PR TITLE
Use PreReleaseVersionLabel to detect servicing branches in CodeCheck.ps1

### DIFF
--- a/eng/scripts/CodeCheck.ps1
+++ b/eng/scripts/CodeCheck.ps1
@@ -182,6 +182,26 @@ try {
         $changedFilesFromTarget = git --no-pager diff origin/$targetBranch --ignore-space-change --name-only --diff-filter=ar
         $changedAPIBaselines = [System.Collections.Generic.List[string]]::new()
 
+        # Use the target branch's actual PreReleaseVersionLabel instead of its name to detect an
+        # API-frozen (rtm or servicing) branch. A branch can be named like "release/11.0" long
+        # before it reaches 'rtm' or 'servicing', and API surface is still expected to change
+        # until then.
+        $targetVersionsPropsContent = git show "origin/${targetBranch}:eng/Versions.props" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "Unable to read eng/Versions.props from origin/${targetBranch}: $targetVersionsPropsContent"
+        }
+        $targetVersionsProps = [xml]($targetVersionsPropsContent | Out-String)
+        $preReleaseVersionLabelNode = $targetVersionsProps.SelectSingleNode('/Project/PropertyGroup/PreReleaseVersionLabel')
+        if (!$preReleaseVersionLabelNode) {
+            throw "eng/Versions.props on origin/${targetBranch} does not define PreReleaseVersionLabel"
+        }
+        $preReleaseVersionLabel = $preReleaseVersionLabelNode.InnerText.Trim()
+        $validPreReleaseVersionLabels = @('alpha', 'preview', 'rc', 'rtm', 'servicing')
+        if ($preReleaseVersionLabel -notin $validPreReleaseVersionLabels) {
+            throw "eng/Versions.props on origin/${targetBranch} has an unrecognized PreReleaseVersionLabel: '$preReleaseVersionLabel'"
+        }
+        $isRtmOrServicing = $preReleaseVersionLabel -in @('rtm', 'servicing')
+
         if ($changedFilesFromTarget) {
             foreach ($file in $changedFilesFromTarget) {
                 # Check for changes in Shipped in all branches
@@ -190,8 +210,8 @@ try {
                         $changedAPIBaselines.Add($file)
                     }
                 }
-                # Check for changes in Unshipped in servicing branches
-                if ($targetBranch -like 'release*' -and $targetBranch -notlike '*preview*' -and $targetBranch -notlike '*rc1*' -and $targetBranch -notlike '*rc2*' -and $file -like '*PublicAPI.Unshipped.txt') {
+                # Check for changes in Unshipped once the branch has reached rtm or servicing
+                if ($isRtmOrServicing -and $file -like '*PublicAPI.Unshipped.txt') {
                     $changedAPIBaselines.Add($file)
                 }
             }


### PR DESCRIPTION
Fixes #50635

`CodeCheck.ps1` tried to exclude `rc1`/`rc2` branches from the `PublicAPI.Unshipped.txt` check by testing whether `$targetBranch` (e.g. `release/11.0`) contained `rc1`/`rc2` as a substring. But that information lives in `PreReleaseVersionLabel`, not the branch name, so the check never matched — `release/11.0` was incorrectly flagged as a servicing branch throughout its entire `rc1`/`rc2` lifetime, well before it actually reached `rtm`/`servicing`.

Fix: read the target branch's actual `PreReleaseVersionLabel` from its `eng/Versions.props` (via `git show origin/$targetBranch:eng/Versions.props`) and only flag `Unshipped.txt` changes once the label is `rtm` or `servicing` — the same source of truth used elsewhere (e.g. `IsServicingBuild`). Fails closed if the ref/file can't be read or the label is missing/unrecognized.

Validated with PowerShell 7 against real refs (`origin/main` → `alpha`, `origin/release/8.0` → `servicing`) and simulated failure cases.

🤖 Generated with [Copilot CLI](https://github.com/github/copilot-cli)