### PR TITLE
[Infrastructure] Updated npm packages 2026-07-27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1997,9 +1997,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha1-TpCvZ7xR3e5s3vUoTt9XLsN2tZU=",
+      "version": "4.10.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha1-iRG9crLDZApUNgngQAuMTS5+fLY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3161,14 +3161,7 @@
         "node": ">=20"
       }
     },
-    "node_modules/@puppeteer/browsers/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha1-vz1uj3+P0ipl2XA0dbwBRzV6aw0=",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@puppeteer/browsers/node_modules/string-width": {
+    "node_modules/@puppeteer/browsers/node_modules/cliui/node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string-width/-/string-width-7.2.0.tgz",
       "integrity": "sha1-tbuOIWXOJ11NQ0dt0nAK2Qkdttw=",
@@ -3181,6 +3174,30 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha1-vz1uj3+P0ipl2XA0dbwBRzV6aw0=",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@puppeteer/browsers/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha1-cxBRZJPfV1dC/pivb66H2F1e0Kw=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3220,17 +3237,35 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@puppeteer/browsers/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha1-tbuOIWXOJ11NQ0dt0nAK2Qkdttw=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@puppeteer/browsers/node_modules/yargs": {
-      "version": "18.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs/-/yargs-18.0.0.tgz",
-      "integrity": "sha1-bIQlmAYnOnRrCfV5CHtoo8LSW9E=",
+      "version": "18.1.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha1-zX6YxwPvUWlbu/Bi7VjyjpQpG1Y=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^9.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
-        "string-width": "^7.2.0",
+        "string-width": "^8.2.1",
         "y18n": "^5.0.5",
         "yargs-parser": "^22.0.0"
       },
@@ -3395,9 +3430,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
-      "integrity": "sha1-XphJtmHCIpz5Z6CNvi276ejJkeU=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+      "integrity": "sha1-sKtCL7YPNYPIx4noVtZKMlB/KZ4=",
       "cpu": [
         "arm"
       ],
@@ -3409,9 +3444,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
-      "integrity": "sha1-WwaZ7l3UhLIiye10r/Q8keqLF/g=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+      "integrity": "sha1-BH6WfutECimfGrx3NXm1wlFvpI0=",
       "cpu": [
         "arm64"
       ],
@@ -3423,9 +3458,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
-      "integrity": "sha1-i8UsnXo86NBTPDUanJNd54HaoG8=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+      "integrity": "sha1-GDaeZ9DT/8sBqVVhIXRHt5Fydpc=",
       "cpu": [
         "arm64"
       ],
@@ -3437,9 +3472,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
-      "integrity": "sha1-ui7z6PsxDwrzVYjycM+lqpbkh2Q=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+      "integrity": "sha1-vyOuTFwPhBsSO8eeOyRhdsbQj9c=",
       "cpu": [
         "x64"
       ],
@@ -3451,9 +3486,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
-      "integrity": "sha1-k7EL2/6K2iJri8DALva39URHTZY=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+      "integrity": "sha1-ySobB9AkMYHybZ3rJ4w+8J4B8GU=",
       "cpu": [
         "arm64"
       ],
@@ -3465,9 +3500,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
-      "integrity": "sha1-PoqjjvPJwwCUaHHj/bsMMOCiD4Y=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+      "integrity": "sha1-tp2gQH6gZJfTlb4OeZzGAQBLNy4=",
       "cpu": [
         "x64"
       ],
@@ -3479,9 +3514,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
-      "integrity": "sha1-HXmUOEuwrRvEGSG1BuFkLU+df8M=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+      "integrity": "sha1-G0tjxX/CDm6kdIqOqGTYZRMyjsQ=",
       "cpu": [
         "arm"
       ],
@@ -3496,9 +3531,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
-      "integrity": "sha1-plQPR8+ESla4DKn/ldKs37LO+Xs=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+      "integrity": "sha1-ZDNPWlF4yrsV59KpH7WS2x+GIdM=",
       "cpu": [
         "arm"
       ],
@@ -3513,9 +3548,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
-      "integrity": "sha1-QE8gRWUYQMv0jakbptD0kPC8LL8=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+      "integrity": "sha1-H/KZ94JfD1Ko4Qfax/Fc5zAJhIs=",
       "cpu": [
         "arm64"
       ],
@@ -3530,9 +3565,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
-      "integrity": "sha1-o0BP/d97R0tIyZuciTtiR7t2W6U=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+      "integrity": "sha1-mQUjgOepT6RAuRZsZ6kJqjVy8Ik=",
       "cpu": [
         "arm64"
       ],
@@ -3547,9 +3582,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
-      "integrity": "sha1-6KrG1Umzd5ReNJiC8Zm3yOt1yjg=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+      "integrity": "sha1-X1i1drNmjt9irPDFJlgmJnt9hY8=",
       "cpu": [
         "loong64"
       ],
@@ -3564,9 +3599,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
-      "integrity": "sha1-bi5E6lAxCzpYIHipFeX+uHnIINQ=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+      "integrity": "sha1-qM0DN+P/OgyV6tZ3FcUa93xa/zY=",
       "cpu": [
         "loong64"
       ],
@@ -3581,9 +3616,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
-      "integrity": "sha1-aJgwLabXegU3zeZLK0xrYGWb0RA=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+      "integrity": "sha1-YzXOwVtVprBj40y36WhRX6UA/9Q=",
       "cpu": [
         "ppc64"
       ],
@@ -3598,9 +3633,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
-      "integrity": "sha1-MzcXyV3Vpmvvj2Pn74qf2EX9GNA=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+      "integrity": "sha1-zytv0jjwkoxWV7uKXKd1HfwubOQ=",
       "cpu": [
         "ppc64"
       ],
@@ -3615,9 +3650,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
-      "integrity": "sha1-gbwGujgDUgBNAfSCbrfNzO+gW60=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+      "integrity": "sha1-35UIyHIUN/flGZDKqmHS8423PL8=",
       "cpu": [
         "riscv64"
       ],
@@ -3632,9 +3667,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
-      "integrity": "sha1-lafNOd4hOJrWeIpShOqqc44pykw=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+      "integrity": "sha1-DP6TBy9MOYu51mbllTNxoiq6f0o=",
       "cpu": [
         "riscv64"
       ],
@@ -3649,9 +3684,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
-      "integrity": "sha1-BubbLsG8SLU3THkj74PC6wJLJFI=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+      "integrity": "sha1-+Oe989QZhmtoiwnZNIJTklIy0cs=",
       "cpu": [
         "s390x"
       ],
@@ -3666,9 +3701,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
-      "integrity": "sha1-XcgYmIKF4J6IeQxkYt73JBPfLaM=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+      "integrity": "sha1-V+9/A5xPfeDpE/HyaAOFRnuGuxU=",
       "cpu": [
         "x64"
       ],
@@ -3683,9 +3718,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
-      "integrity": "sha1-IID0qTNJ6a/TS+b8GjfgH8i/yA8=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+      "integrity": "sha1-b1tWk9S+sVK/UYxIfSWTYtvs5Ek=",
       "cpu": [
         "x64"
       ],
@@ -3700,9 +3735,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
-      "integrity": "sha1-IdZKistmIhckuSPlGvUzPfGvBEs=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+      "integrity": "sha1-mQkBAJPtf7JIDHO8GTqPTUT/ueM=",
       "cpu": [
         "x64"
       ],
@@ -3714,9 +3749,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
-      "integrity": "sha1-jg/NnQIUHjN7TFtc/1dsuadrG6A=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+      "integrity": "sha1-q6kLV3Jfz0xAcslabb+891AKdw0=",
       "cpu": [
         "arm64"
       ],
@@ -3728,9 +3763,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
-      "integrity": "sha1-vbTMTv1Y7+gIIDNH8PVGPw6hblI=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+      "integrity": "sha1-Es7isubTfbuDYCaGgS5LuikMmqM=",
       "cpu": [
         "arm64"
       ],
@@ -3742,9 +3777,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
-      "integrity": "sha1-26695a/STq4O7+kV2QFjLny1mGA=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+      "integrity": "sha1-ORoNb4RYpnWtcgzMrpvLmkgQkBY=",
       "cpu": [
         "ia32"
       ],
@@ -3756,9 +3791,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
-      "integrity": "sha1-hBCehf6l+PE1NJn5ZXj9wqDosTg=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+      "integrity": "sha1-Pzi7GA/PHPqRl1xLNElB6YWm7RM=",
       "cpu": [
         "x64"
       ],
@@ -3770,9 +3805,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
-      "integrity": "sha1-NnHOP5uSjVwB+Hl5LVwLYK4U1K0=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+      "integrity": "sha1-DMr9RKjLyzP3/qqePoUDPnpSKVw=",
       "cpu": [
         "x64"
       ],
@@ -5055,19 +5090,6 @@
         "acorn-walk": "^8.0.2"
       }
     },
-    "node_modules/acorn-import-phases": {
-      "version": "1.0.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-      "integrity": "sha1-FuuFC6maBWy3y/6HL/uJcuGMi9c=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "peerDependencies": {
-        "acorn": "^8.14.0"
-      }
-    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -5692,9 +5714,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.44",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.10.44.tgz",
-      "integrity": "sha1-LgdGdeZAtnyzg1xUwRqi3ZEZwPg=",
+      "version": "2.11.4",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/baseline-browser-mapping/-/baseline-browser-mapping-2.11.4.tgz",
+      "integrity": "sha1-PaGod6i+LsBklRI86ZS0OvWMxV4=",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5861,9 +5883,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.6",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/browserslist/-/browserslist-4.28.6.tgz",
-      "integrity": "sha1-fPg6/NacVf3m+y3MUDn/D0ukJhA=",
+      "version": "4.28.7",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha1-QJBGUX/M0uUc3CDwd0VLcUEYQCg=",
       "dev": true,
       "funding": [
         {
@@ -5881,9 +5903,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.42",
-        "caniuse-lite": "^1.0.30001803",
-        "electron-to-chromium": "^1.5.389",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
         "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
@@ -7500,9 +7522,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.394",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.394.tgz",
-      "integrity": "sha1-G36vGrvqus7XzkAXBex8xIj9SSs=",
+      "version": "1.5.396",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
+      "integrity": "sha1-SqlkKEhsjRyciusgWy1uBJKMoEY=",
       "dev": true,
       "license": "ISC"
     },
@@ -8758,9 +8780,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha1-9cI8EH8PN96NvfJPE3IrO5jVJyY=",
+      "version": "3.4.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha1-vlwh6UOy16MouyN5WuKMmPAQOp4=",
       "dev": true,
       "license": "ISC"
     },
@@ -9837,9 +9859,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha1-gF/BeLIMUYvUyFSLJP4wiS1/MgY=",
+      "version": "10.3.1",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ip-address/-/ip-address-10.3.1.tgz",
+      "integrity": "sha1-kp+WKdFyT34bdIXOiXUvNnUzahA=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12136,20 +12158,6 @@
       "integrity": "sha1-7KKE910pZQeTCdwK2SVauy68FjI=",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/loader-runner": {
-      "version": "4.3.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/loader-runner/-/loader-runner-4.3.2.tgz",
-      "integrity": "sha1-mRPToVlx+PY1kV5gH7XJ1JXZGOk=",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.11.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
     },
     "node_modules/loader-utils": {
       "version": "2.0.4",
@@ -15301,9 +15309,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/rollup": {
-      "version": "4.62.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rollup/-/rollup-4.62.2.tgz",
-      "integrity": "sha1-2Q/Ey4EfBxMDyJC3eVlWNPNflUE=",
+      "version": "4.62.3",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/rollup/-/rollup-4.62.3.tgz",
+      "integrity": "sha1-A+6Z4rWwdE3Zm+bUI4svzUCHtPY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15317,31 +15325,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.62.2",
-        "@rollup/rollup-android-arm64": "4.62.2",
-        "@rollup/rollup-darwin-arm64": "4.62.2",
-        "@rollup/rollup-darwin-x64": "4.62.2",
-        "@rollup/rollup-freebsd-arm64": "4.62.2",
-        "@rollup/rollup-freebsd-x64": "4.62.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
-        "@rollup/rollup-linux-arm64-musl": "4.62.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
-        "@rollup/rollup-linux-loong64-musl": "4.62.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
-        "@rollup/rollup-linux-x64-gnu": "4.62.2",
-        "@rollup/rollup-linux-x64-musl": "4.62.2",
-        "@rollup/rollup-openbsd-x64": "4.62.2",
-        "@rollup/rollup-openharmony-arm64": "4.62.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
-        "@rollup/rollup-win32-x64-gnu": "4.62.2",
-        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "@rollup/rollup-android-arm-eabi": "4.62.3",
+        "@rollup/rollup-android-arm64": "4.62.3",
+        "@rollup/rollup-darwin-arm64": "4.62.3",
+        "@rollup/rollup-darwin-x64": "4.62.3",
+        "@rollup/rollup-freebsd-arm64": "4.62.3",
+        "@rollup/rollup-freebsd-x64": "4.62.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
+        "@rollup/rollup-linux-arm64-musl": "4.62.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
+        "@rollup/rollup-linux-loong64-musl": "4.62.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-musl": "4.62.3",
+        "@rollup/rollup-openbsd-x64": "4.62.3",
+        "@rollup/rollup-openharmony-arm64": "4.62.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
+        "@rollup/rollup-win32-x64-gnu": "4.62.3",
+        "@rollup/rollup-win32-x64-msvc": "4.62.3",
         "fsevents": "~2.3.2"
       }
     },
@@ -15448,20 +15456,20 @@
       "license": "MIT"
     },
     "node_modules/saucelabs": {
-      "version": "9.0.2",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/saucelabs/-/saucelabs-9.0.2.tgz",
-      "integrity": "sha1-mfYXDz14n8sL4vJw99N6nXzfUYc=",
+      "version": "9.1.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/saucelabs/-/saucelabs-9.1.0.tgz",
+      "integrity": "sha1-24euAORBhyHAxNpCGpARE3uQuB8=",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "change-case": "^4.1.2",
-        "compressing": "^1.10.0",
-        "form-data": "^4.0.0",
+        "compressing": "^1.10.5",
+        "form-data": "^4.0.6",
         "got": "^11.8.6",
         "hash.js": "^1.1.7",
         "query-string": "^7.1.3",
         "tunnel": "^0.0.6",
-        "yargs": "^17.2.1"
+        "yargs": "^17.7.3"
       },
       "bin": {
         "sl": "bin/sl"
@@ -16540,9 +16548,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha1-N6ZaqRHL1phkAC4Uv4qSalVR4kA=",
+      "version": "7.5.22",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha1-ppb5mBNucUh9w/hpqFu6LGeXG6k=",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -16933,9 +16941,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.11",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ts-jest/-/ts-jest-29.4.11.tgz",
-      "integrity": "sha1-QvXeIcN8zAGlgCU6+uaVWrv00LM=",
+      "version": "29.4.12",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/ts-jest/-/ts-jest-29.4.12.tgz",
+      "integrity": "sha1-w0zZHwLTZOkobSwBaEMxX9Dv/3Y=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16945,7 +16953,7 @@
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.8.0",
+        "semver": "^7.8.5",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -17776,9 +17784,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.108.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack/-/webpack-5.108.4.tgz",
-      "integrity": "sha1-FBgYpBFmJ3OguzLcVTasxUCZQ7c=",
+      "version": "5.109.0",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/webpack/-/webpack-5.109.0.tgz",
+      "integrity": "sha1-hx2O7l4tXm6vXsjRptt06mVJEDA=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17788,22 +17796,20 @@
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
         "acorn": "^8.16.0",
-        "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.22.2",
+        "enhanced-resolve": "^5.24.2",
         "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "graceful-fs": "^4.2.11",
-        "loader-runner": "^4.3.2",
         "mime-db": "^1.54.0",
         "minimizer-webpack-plugin": "^5.6.1",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
         "watchpack": "^2.5.2",
-        "webpack-sources": "^3.5.0"
+        "webpack-sources": "^3.5.1"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -18842,16 +18848,16 @@
       }
     },
     "src/JSInterop/Microsoft.JSInterop.JS/src/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha1-Gw5GlltHna1lr3N7SgJ5CgVJgzc=",
+      "version": "5.0.8",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "src/JSInterop/Microsoft.JSInterop.JS/src/node_modules/comment-parser": {


### PR DESCRIPTION
Refreshes `package-lock.json` against the internal Azure DevOps npm feed to pick up dependency updates and ingest them into the feed.

Notably fixes [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) / CVE-2026-14257 (brace-expansion DoS via unbounded expansion length): `src/JSInterop/Microsoft.JSInterop.JS/src`'s nested `brace-expansion` copy moves from the vulnerable `5.0.7` to the patched `5.0.8`.

`npm audit` still flags older `brace-expansion` 1.x/2.x copies (`1.1.16`, `2.1.2` — the latest available on those lines) pulled in transitively by npm-internal tooling packages (`glob`, `rimraf`, `cacache`, etc.). Per the advisory, the only real fix is the `5.x` line, which requires Node >=20 (a breaking `engines` bump) and isn't adopted yet by those dependents' latest majors. Not addressed here, consistent with not introducing breaking dependency bumps as part of this routine update.

🤖 Generated with [Copilot CLI](https://github.com/github/copilot-cli)