### PR TITLE
Never stabilize Components.Media and Components.Testing packages

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,6 +17,15 @@
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <!-- Allowed values: '', 'prerelease', 'release'. Set to 'release' when stabilizing. -->
     <DotNetFinalVersionKind></DotNetFinalVersionKind>
+    <!--
+      Label and iteration used by packages that intentionally never stabilize. Such projects set
+      SuppressFinalPackageVersion=true and override PreReleaseVersionLabel/PreReleaseVersionIteration with these
+      values, so they keep producing dated prerelease versions (e.g. 11.0.0-preview.7.25580.1) even when the rest of
+      the repo builds RC or RTM versions. Overriding the label is required because Arcade builds the version suffix
+      from PreReleaseVersionLabel, and because the suffix logic is skipped entirely when that label is empty.
+    -->
+    <PreviewOnlyPackagePreReleaseVersionLabel>preview</PreviewOnlyPackagePreReleaseVersionLabel>
+    <PreviewOnlyPackagePreReleaseVersionIteration>7</PreviewOnlyPackagePreReleaseVersionIteration>
 
     <!-- PreReleaseBrandingLabel is automatically calculated based on PreReleaseVersionLabel -->
     <PreReleaseBrandingLabel Condition="'$(PreReleaseVersionLabel)' == 'alpha'">Alpha $(PreReleaseVersionIteration)</PreReleaseBrandingLabel>

--- a/src/Components/Media/src/Microsoft.AspNetCore.Components.Media.csproj
+++ b/src/Components/Media/src/Microsoft.AspNetCore.Components.Media.csproj
@@ -1,10 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk" TreatAsLocalProperty="PreReleaseVersionLabel;PreReleaseVersionIteration">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <Description>Media components for Blazor applications, including Image, Video, and FileDownload.</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
+    <!--
+      This package does not ship a stable version as part of .NET 11.0. Keep producing dated prerelease versions even
+      when the repo builds RC or RTM versions. The label/iteration overrides are required so the version reads
+      sensibly (and so Arcade's version suffix logic keeps running) once the branch moves to 'rc' or 'rtm'; they are
+      listed in TreatAsLocalProperty above so they win even if the label is passed in as a global property.
+    -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    <PreReleaseVersionLabel>$(PreviewOnlyPackagePreReleaseVersionLabel)</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>$(PreviewOnlyPackagePreReleaseVersionIteration)</PreReleaseVersionIteration>
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 

--- a/src/Components/Testing/src/Microsoft.AspNetCore.Components.Testing.csproj
+++ b/src/Components/Testing/src/Microsoft.AspNetCore.Components.Testing.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk" TreatAsLocalProperty="PreReleaseVersionLabel;PreReleaseVersionIteration">
 
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
@@ -11,6 +11,15 @@
     <NoWarn>$(NoWarn);NU5100;RS0026</NoWarn>
     <Description>Cross-render-mode E2E testing library for Blazor using Playwright, xUnit V3, and YARP.</Description>
     <PackageTags>blazor;e2e;testing;playwright</PackageTags>
+    <!--
+      This package does not ship a stable version as part of .NET 11.0. Keep producing dated prerelease versions even
+      when the repo builds RC or RTM versions. The label/iteration overrides are required so the version reads
+      sensibly (and so Arcade's version suffix logic keeps running) once the branch moves to 'rc' or 'rtm'; they are
+      listed in TreatAsLocalProperty above so they win even if the label is passed in as a global property.
+    -->
+    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
+    <PreReleaseVersionLabel>$(PreviewOnlyPackagePreReleaseVersionLabel)</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>$(PreviewOnlyPackagePreReleaseVersionIteration)</PreReleaseVersionIteration>
   </PropertyGroup>
 
 


### PR DESCRIPTION
## Overview

`Microsoft.AspNetCore.Components.Media` and `Microsoft.AspNetCore.Components.Testing` are not shipping a stable version as part of .NET 11.0, so they must never produce an `11.0.0` (RTM) or `11.0.0-rc.N` (branded RC) package, even when the release branch does a stabilized build. This change opts both packages out of version stabilization in Arcade so they keep producing dated prerelease versions like `11.0.0-preview.7.26378.1` in every build kind. Three files change: `eng/Versions.props` plus the two `src` project files. No product code changes, and `VersionPrefix` is untouched, so assembly and file versions stay `11.0.0.0`.

## Design

The contract is a pair of new repo-level properties in `eng/Versions.props` that own the label used by packages that intentionally never stabilize, so the label does not drift when the release branch flips `PreReleaseVersionLabel` to `rc` or `rtm`:

```xml
<!-- eng/Versions.props -->
<PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
<!-- Allowed values: '', 'prerelease', 'release'. Set to 'release' when stabilizing. -->
<DotNetFinalVersionKind></DotNetFinalVersionKind>
<!--
  Label and iteration used by packages that intentionally never stabilize. Such projects set
  SuppressFinalPackageVersion=true and override PreReleaseVersionLabel/PreReleaseVersionIteration with these
  values, so they keep producing dated prerelease versions (e.g. 11.0.0-preview.7.25580.1) even when the rest of
  the repo builds RC or RTM versions. Overriding the label is required because Arcade builds the version suffix
  from PreReleaseVersionLabel, and because the suffix logic is skipped entirely when that label is empty.
-->
<PreviewOnlyPackagePreReleaseVersionLabel>preview</PreviewOnlyPackagePreReleaseVersionLabel>
<PreviewOnlyPackagePreReleaseVersionIteration>7</PreviewOnlyPackagePreReleaseVersionIteration>
```

Two design decisions are worth calling out, because the obvious simpler versions of this change do not work.

**`SuppressFinalPackageVersion` alone is not enough.** Arcade's escape hatch restores the dated suffix, but that suffix is built from `PreReleaseVersionLabel`, which the release branch sets to `rtm` at GA. Without the label override the package version becomes `11.0.0-rtm.7.26378.1`, which is prerelease but reads like an RTM build. Worse, if the branch ever sets `PreReleaseVersionLabel` to empty (Arcade's release-only path), the entire suffix block is skipped, `SuppressFinalPackageVersion` is never consulted, and the version collapses to `11.0.737801`. Pinning a non-empty label defends against both.

**The properties must live in the project body, not in `Directory.Build.targets`.** Arcade computes the version in `Version.BeforeCommonTargets.targets`, which is imported after the project body but before `Directory.Build.targets`, so anything set in the repo's targets file is too late to be observed.

## Implementation

Both projects get the same three properties. `Media` is the representative case:

```xml
<!-- src/Components/Media/src/Microsoft.AspNetCore.Components.Media.csproj -->
<!-- TreatAsLocalProperty lets the values below override the same properties when they arrive as MSBuild
     global properties, which is exactly how the official build passes the label (/p:PreReleaseVersionLabel=rtm).
     Without it, a global property wins over the project-level assignment and the RTM build produced
     11.0.0-rtm.7.26378.1 instead of 11.0.0-preview.7.26378.1. -->
<Project Sdk="Microsoft.NET.Sdk" TreatAsLocalProperty="PreReleaseVersionLabel;PreReleaseVersionIteration">

  <PropertyGroup>
    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
    <Description>Media components for Blazor applications, including Image, Video, and FileDownload.</Description>
    <GenerateDocumentationFile>true</GenerateDocumentationFile>
    <Nullable>enable</Nullable>
    <!--
      This package does not ship a stable version as part of .NET 11.0. Keep producing dated prerelease versions even
      when the repo builds RC or RTM versions. The label/iteration overrides are required so the version reads
      sensibly (and so Arcade's version suffix logic keeps running) once the branch moves to 'rc' or 'rtm'; they are
      listed in TreatAsLocalProperty above so they win even if the label is passed in as a global property.
    -->
    <SuppressFinalPackageVersion>true</SuppressFinalPackageVersion>
    <PreReleaseVersionLabel>$(PreviewOnlyPackagePreReleaseVersionLabel)</PreReleaseVersionLabel>
    <PreReleaseVersionIteration>$(PreviewOnlyPackagePreReleaseVersionIteration)</PreReleaseVersionIteration>
    <IsTrimmable>true</IsTrimmable>
  </PropertyGroup>
```

`src/Components/Testing/src/Microsoft.AspNetCore.Components.Testing.csproj` takes the identical `TreatAsLocalProperty` attribute and the identical three-property block; nothing else differs between the two, so it is not repeated here. The `Testing` package also packs `Testing/gen` and `Testing/tasks` as content, but both of those already set `IsPackable=false`, so only the two packages above are affected.

This is safe to do per-project because neither package is part of the shared framework. Neither appears in `eng/SharedFramework.Local.props`, they are listed only in `eng/ShippingAssemblies.props`, `eng/ProjectReferences.props` and `eng/TrimmableProjects.props`, and nothing in the repo takes a versioned dependency on them, so decoupling their package version from the product version has no ripple effect. `eng/Publishing.props` does not filter packages by version either, so a prerelease-versioned shipping package still gets signed and published normally.

## Outcome

Verified by MSBuild property evaluation against `Microsoft.AspNetCore.Components.QuickGrid` as an unmodified control, using `-p:OfficialBuildId=20260728.1`:

| Scenario | Media / Testing | QuickGrid (control) |
|---|---|---|
| RTM (`DotNetFinalVersionKind=release`, label `rtm`) | `11.0.0-preview.7.26378.1` | `11.0.0` |
| RC1 (`DotNetFinalVersionKind=prerelease`, label `rc`, iteration 1) | `11.0.0-preview.7.26378.1` | `11.0.0-rc.1.final` |
| Daily official build | `11.0.0-preview.7.26378.1` | `11.0.0-preview.7.26378.1` |
| Empty `PreReleaseVersionLabel` (Arcade's release-only path) | `11.0.0-preview.7.26378.1` | `11.0.737801` |
| Local dev build (no `OfficialBuildId`) | `11.0.0-dev` | `11.0.0-dev` |

A real `-t:Pack` of the Media project under the RTM simulation produced `Microsoft.AspNetCore.Components.Media.11.0.0-preview.7.26378.1.nupkg` while `Microsoft.AspNetCore.App.Internal.Assets.11.0.0.nupkg` packed stable in the same run, confirming the opt-out is scoped to the intended project. Packing the Testing project end to end was not possible locally because it transitively builds ANCM, which requires full `MSBuild.exe`; its version was confirmed through evaluation instead.

Two related decisions are deliberately left out of this change and still need a call: whether these packages keep `IsShippingPackage=true` and get published to nuget.org at GA, and whether their APIs stay in `PublicAPI.Unshipped.txt` through the RTM shipped-API sweep so we do not take stable-API compat obligations on packages that never shipped stable.