### PR TITLE
Fix `AnchorMode_End_PrependAtTop_ViewportStaysStable`

### DIFF
--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -709,7 +709,13 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
         const modePinsTopItem = !anchorModeIs.beginning || !convergence.top;
         const itemAlreadyShifted = rect.top - containerTop > rect.height;
         if (nativeAnchoringUnavailable && modePinsTopItem && existing && itemAlreadyShifted) {
-          if (existing.scrollTop < 1 && !anchorModeIs.beginning) {
+          // Only End mode needs the racing before-spacer load suppressed at the
+          // very top: it pins the top row while prepended items land, and on
+          // Blazor Server the spacer callback can otherwise load them before the
+          // async anchor restore completes. None mode must NOT be suppressed here
+          // — with no user scroll to clear it, the before spacer that reveals the
+          // topmost item would stay stuck (e.g. a 50px spacer that never reaches 0).
+          if (existing.scrollTop < 1 && anchorModeIs.end) {
             suppressSpacerCallbacks = true;
           }
           return;

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -708,6 +708,9 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
         const modePinsTopItem = !anchorModeIs.beginning || !convergence.top;
         const itemAlreadyShifted = rect.top - containerTop > rect.height;
         if (nativeAnchoringUnavailable && modePinsTopItem && existing && itemAlreadyShifted) {
+          if (existing.scrollTop < 1) {
+            suppressSpacerCallbacks = true;
+          }
           return;
         }
         observersByDotNetObjectId[id].anchorSnapshot = {

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -709,12 +709,6 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
         const modePinsTopItem = !anchorModeIs.beginning || !convergence.top;
         const itemAlreadyShifted = rect.top - containerTop > rect.height;
         if (nativeAnchoringUnavailable && modePinsTopItem && existing && itemAlreadyShifted) {
-          // Only End mode needs the racing before-spacer load suppressed at the
-          // very top: it pins the top row while prepended items land, and on
-          // Blazor Server the spacer callback can otherwise load them before the
-          // async anchor restore completes. None mode must NOT be suppressed here
-          // — with no user scroll to clear it, the before spacer that reveals the
-          // topmost item would stay stuck (e.g. a 50px spacer that never reaches 0).
           if (existing.scrollTop < 1 && anchorModeIs.end) {
             suppressSpacerCallbacks = true;
           }

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -416,6 +416,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     if (anchorModeIs.beginning && snapshot.scrollTop < 1) {
       scrollElement.scrollTop = 0;
       startConvergenceObserving('top');
+      reobserveSpacers();
       return;
     }
 
@@ -708,7 +709,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
         const modePinsTopItem = !anchorModeIs.beginning || !convergence.top;
         const itemAlreadyShifted = rect.top - containerTop > rect.height;
         if (nativeAnchoringUnavailable && modePinsTopItem && existing && itemAlreadyShifted) {
-          if (existing.scrollTop < 1) {
+          if (existing.scrollTop < 1 && !anchorModeIs.beginning) {
             suppressSpacerCallbacks = true;
           }
           return;

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -4174,6 +4174,77 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     [InlineData(true, false)]
     [InlineData(false, true)]
     [InlineData(true, true)]
+    public void AnchorMode_None_LargePrependAtTop_ViewportStaysStable(bool variableHeight, bool useItemsProvider)
+    {
+        MountAnchorModeComponent("0", variableHeight, useItemsProvider, delay: useItemsProvider);
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+
+        Assert.Equal(0, (long)js.ExecuteScript("return arguments[0].scrollTop", container));
+
+        var (indexBefore, relTopBefore, _) = GetItemPositionInContainer(js, container, ".item");
+
+        Browser.Exists(By.Id("prepend-many-items")).Click();
+        Browser.Contains("Prepended 100 items", () => Browser.Exists(By.Id("status")).Text);
+        WaitForRenderToSettle(container, js);
+
+        // None mode at the top: viewport should stay stable — the same item
+        // stays at the same position regardless of how many items were prepended.
+        AssertViewportStaysStable(
+            js,
+            By.Id("scroll-container"),
+            ".item",
+            indexBefore,
+            relTopBefore,
+            "None mode at top: viewport should stay stable after large prepend",
+            driftTolerance: variableHeight ? 5 : 2);
+
+        // Scroll up and verify the prepended items are actually reachable.
+        ScrollContainer(js, container, 0);
+        Browser.True(() =>
+        {
+            return container.FindElements(By.CssSelector("[data-index='-100']")).Count > 0;
+        }, TimeSpan.FromSeconds(5), "None mode: prepended items should be reachable after scrolling up");
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public void AnchorMode_End_LargePrependAtTop_ViewportStaysStable(bool variableHeight, bool useItemsProvider)
+    {
+        MountAnchorModeComponent("2", variableHeight, useItemsProvider, delay: useItemsProvider);
+
+        var container = Browser.Exists(By.Id("scroll-container"));
+        var js = (IJavaScriptExecutor)Browser;
+
+        Assert.Equal(0, (long)js.ExecuteScript("return arguments[0].scrollTop", container));
+
+        var (indexBefore, relTopBefore, _) = GetItemPositionInContainer(js, container, ".item");
+
+        Browser.Exists(By.Id("prepend-many-items")).Click();
+        Browser.Contains("Prepended 100 items", () => Browser.Exists(By.Id("status")).Text);
+        WaitForRenderToSettle(container, js);
+
+        // End mode at the top: viewport should stay stable — the same items
+        // stay visible. scrollTop may increase to compensate for prepended items.
+        AssertViewportStaysStable(
+            js,
+            By.Id("scroll-container"),
+            ".item",
+            indexBefore,
+            relTopBefore,
+            "End mode at top: viewport should stay stable after large prepend",
+            driftTolerance: variableHeight ? 5 : 2);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
     public virtual void AnchorMode_End_AppendAfterLeavingBottom_DoesNotReengage(bool variableHeight, bool useItemsProvider)
     {
         MountAnchorModeComponent("2", variableHeight, useItemsProvider, delay: useItemsProvider);


### PR DESCRIPTION
## Summary

Fixes a flaky failure in `ServerVirtualizationTest.AnchorMode_End_PrependAtTop_ViewportStaysStable(useItemsProvider: true)`. The test intermittently failed with the viewport jumping to the prepended items instead of staying stable:

```
End mode at top: viewport should stay stable after prepend (index before: 0, after: -10, relTop before: 1, after: 1, scrollTop: 0, tolerance: 5)
```

## Root cause

This is a Blazor Server timing race, not a logic error (the anchor mechanism is correct).

When items are prepended while the viewport is at the very top (`scrollTop == 0`), `Virtualize` preserves the pre-shift anchor snapshot and relies on `RestoreAnchorAsync` to reposition the scroll so the previously-visible row stays at its place. On Server, `RestoreAnchorAsync` is a SignalR round-trip. Because the grown `spacerBefore` is already visible at `scrollTop == 0`, its `IntersectionObserver` fires and dispatches `OnSpacerBeforeVisible` to the server, loading the prepended rows (`-10..-1`) into the viewport before the restore round-trip completes. An async `ItemsProvider` with delay widens the window, making the race more probable to happen. WebAssembly/synchronous paths don't race because restore is effectively synchronous.

## Fix

In the snapshot-preserve branch of `updateAnchorSnapshot`, set `suppressSpacerCallbacks = true` only when the pin originated at the very top (`existing.scrollTop < 1`) and the anchor mode is `End`. This blocks the racing `spacerBefore` callback from dispatching a load to the server for the one render cycle until the anchor restore runs. The suppression is cleared on the next user scroll (`handleScroll` -> `reobserveSpacers`), so the prepended rows remain fully reachable when the user scrolls up.

The `existing.scrollTop < 1` gate is required: an unconditional suppress would re-suppress the spacer every time the user scrolled back to the top, permanently preventing the above-viewport rows from loading and breaking the "prepended items become reachable" assertion.