### PR TITLE
Fix parallel publish race in Gateway CLI packaging

### DIFF
--- a/src/Components/Gateway/cli/Microsoft.AspNetCore.Components.Gateway.Cli.csproj
+++ b/src/Components/Gateway/cli/Microsoft.AspNetCore.Components.Gateway.Cli.csproj
@@ -39,9 +39,13 @@
 
   <!-- Build and publish the gateway before packing so its binaries are available to the nuspec. -->
   <Target Name="_PublishGatewayForTool" BeforeTargets="GenerateNuspec">
+    <!-- Intentionally omit TargetFramework from Properties: passing it as a global property would
+         create a distinct MSBuild project instance for Gateway.csproj, causing a parallel publish
+         race with the instance already scheduled by the main build graph. Configuration is
+         forwarded explicitly so cross-configuration builds (e.g. Debug vs Release) are correct. -->
     <MSBuild Projects="$(_GatewayProject)"
              Targets="Publish"
-             Properties="Configuration=$(Configuration);TargetFramework=$(DefaultNetCoreTargetFramework)" />
+             Properties="Configuration=$(Configuration)" />
 
     <Error Condition="!Exists('$(_GatewayPublishDir)blazor-gateway.dll')"
            Text="Expected the gateway to publish 'blazor-gateway.dll' to '$(_GatewayPublishDir)' but it was not found." />


### PR DESCRIPTION
Contributes to https://github.com/dotnet/dotnet/issues/8005

## Why

When `Gateway.Cli.csproj` packages the dotnet tool, its `_PublishGatewayForTool` target called:

```xml
<MSBuild Projects="$(_GatewayProject)"
         Targets="Publish"
         Properties="Configuration=$(Configuration);TargetFramework=$(DefaultNetCoreTargetFramework)" />
```

MSBuild identifies project instances by `(path + global properties)`. Passing `TargetFramework` as a global property here creates a **second, distinct instance** of `Gateway.csproj` - separate from the instance already scheduled by the main build graph (which has no `TargetFramework` in global props). In a parallel build, both instances invoke `Publish` concurrently and race to write the same compressed static web asset files in `ResolvePublishCompressedStaticWebAssets`.

## What changed

Removed `TargetFramework=$(DefaultNetCoreTargetFramework)` from the `Properties` attribute, keeping only `Configuration=$(Configuration)`:

```xml
<MSBuild Projects="$(_GatewayProject)"
         Targets="Publish"
         Properties="Configuration=$(Configuration)" />
```

`Gateway.csproj` is a single-target project - it declares `<TargetFramework>` inside the project file, so MSBuild resolves it without any global property override. Dropping the override means the nested invocation reuses the existing project instance instead of spawning a new one, making `Publish` a no-op duplicate that MSBuild deduplicates away.

A comment is included to explain the intentional omission.

## Validation

Ran `dotnet pack` on `Gateway.Cli.csproj` with binlog capture:

- `_PublishGatewayForTool` executed exactly once
- Only **one** `Gateway.csproj` project instance appeared in the build graph (previously there were two)
- Both `<Error>` output checks passed (`blazor-gateway.dll` and `blazor-gateway.runtimeconfig.json` present)
- `Microsoft.AspNetCore.Components.Gateway.Cli.11.0.0-dev.nupkg` produced successfully