### PR TITLE
Fix Gateway publish race with concurrent top-level build

### DIFF
--- a/src/Components/Gateway/cli/Microsoft.AspNetCore.Components.Gateway.Cli.csproj
+++ b/src/Components/Gateway/cli/Microsoft.AspNetCore.Components.Gateway.Cli.csproj
@@ -37,11 +37,19 @@
                       PrivateAssets="All" />
   </ItemGroup>
 
-  <!-- Build and publish the gateway before packing so its binaries are available to the nuspec. -->
+  <!-- Build and publish the gateway before packing so its binaries are available to the nuspec.
+       Gateway.csproj also ships its own package, so it's already built directly as a top-level
+       project elsewhere in the overall (parallel) build. Forcing an explicit TargetFramework here
+       gave this MSBuild request a global property that the other invocation doesn't have (Gateway.csproj
+       is single-targeted, so it doesn't need one), making MSBuild treat the two as distinct, unrelated
+       build instances. Both ended up running concurrently and racing to write the same compressed
+       static web asset files (see https://github.com/dotnet/dotnet/issues/8005). Not overriding
+       Configuration/TargetFramework here lets this request's global properties match the other
+       invocation's, so MSBuild recognizes it as the same request and reuses/waits for its result
+       instead of duplicating it. -->
   <Target Name="_PublishGatewayForTool" BeforeTargets="GenerateNuspec">
     <MSBuild Projects="$(_GatewayProject)"
-             Targets="Publish"
-             Properties="Configuration=$(Configuration);TargetFramework=$(DefaultNetCoreTargetFramework)" />
+             Targets="Publish" />
 
     <Error Condition="!Exists('$(_GatewayPublishDir)blazor-gateway.dll')"
            Text="Expected the gateway to publish 'blazor-gateway.dll' to '$(_GatewayPublishDir)' but it was not found." />

--- a/src/Components/Gateway/cli/Microsoft.AspNetCore.Components.Gateway.Cli.csproj
+++ b/src/Components/Gateway/cli/Microsoft.AspNetCore.Components.Gateway.Cli.csproj
@@ -38,15 +38,9 @@
   </ItemGroup>
 
   <!-- Build and publish the gateway before packing so its binaries are available to the nuspec.
-       Gateway.csproj also ships its own package, so it's already built directly as a top-level
-       project elsewhere in the overall (parallel) build. Forcing an explicit TargetFramework here
-       gave this MSBuild request a global property that the other invocation doesn't have (Gateway.csproj
-       is single-targeted, so it doesn't need one), making MSBuild treat the two as distinct, unrelated
-       build instances. Both ended up running concurrently and racing to write the same compressed
-       static web asset files (see https://github.com/dotnet/dotnet/issues/8005). Not overriding
-       Configuration/TargetFramework here lets this request's global properties match the other
-       invocation's, so MSBuild recognizes it as the same request and reuses/waits for its result
-       instead of duplicating it. -->
+       No Properties override: Gateway.csproj is also built as a top-level project elsewhere in the
+       build, and forcing TargetFramework here made MSBuild treat the two as separate, racing builds
+       (see https://github.com/dotnet/dotnet/issues/8005). -->
   <Target Name="_PublishGatewayForTool" BeforeTargets="GenerateNuspec">
     <MSBuild Projects="$(_GatewayProject)"
              Targets="Publish" />


### PR DESCRIPTION
## Description

`Microsoft.AspNetCore.Components.Gateway.Cli.csproj`'s `_PublishGatewayForTool` target ran a nested `<MSBuild Targets="Publish">` call against `Gateway.csproj` with an explicit `Configuration`/`TargetFramework` override. `Gateway.csproj` also ships its own package and is built directly as a top-level project elsewhere in the overall build.

Forcing `TargetFramework` on the nested call gave that MSBuild request a global property that the other, independent build of `Gateway.csproj` doesn't have. Since MSBuild identifies a project build request by its project path + global properties, this made MSBuild treat the two as distinct, unrelated build instances rather than deduplicating/serializing them. Both ran concurrently and raced to write the same compressed static web asset output files under `artifacts/obj/.../compressed/publish/`, causing an intermittent file-lock error during unified build (VMR) publishing.

`Gateway.csproj` is single-targeted, so no override is needed here: dropping the explicit `Properties` lets this request's global properties match the other invocation's, so MSBuild recognizes it as the same build request and reuses/waits for its result instead of duplicating the build.

Fixes https://github.com/dotnet/dotnet/issues/8005