### PR TITLE
Log a message when ResourceManagerStringLocalizer cannot find a resource

### DIFF
--- a/src/Localization/Localization/src/ResourceManagerStringLocalizer.cs
+++ b/src/Localization/Localization/src/ResourceManagerStringLocalizer.cs
@@ -166,18 +166,29 @@ public partial class ResourceManagerStringLocalizer : IStringLocalizer
 
         if (_missingManifestCache.ContainsKey(cacheKey))
         {
+            Log.ResourceNotFound(_logger, name, keyCulture);
             return null;
         }
 
+        string? value;
+
         try
         {
-            return _resourceManager.GetString(name, culture);
+            value = _resourceManager.GetString(name, culture);
         }
         catch (MissingManifestResourceException)
         {
             _missingManifestCache.TryAdd(cacheKey, null);
+            Log.ResourceNotFound(_logger, name, keyCulture);
             return null;
         }
+
+        if (value is null)
+        {
+            Log.ResourceNotFound(_logger, name, keyCulture);
+        }
+
+        return value;
     }
 
     private IEnumerable<string> GetResourceNamesFromCultureHierarchy(CultureInfo startingCulture)
@@ -221,5 +232,8 @@ public partial class ResourceManagerStringLocalizer : IStringLocalizer
     {
         [LoggerMessage(1, LogLevel.Debug, $"{nameof(ResourceManagerStringLocalizer)} searched for '{{Key}}' in '{{LocationSearched}}' with culture '{{Culture}}'.", EventName = "SearchedLocation")]
         public static partial void SearchedLocation(ILogger logger, string key, string locationSearched, CultureInfo culture);
+
+        [LoggerMessage(2, LogLevel.Debug, "A resource for '{Key}' with culture '{Culture}' was not found.", EventName = "ResourceNotFound")]
+        public static partial void ResourceNotFound(ILogger logger, string key, CultureInfo culture);
     }
 }

--- a/src/Localization/Localization/test/Microsoft.Extensions.Localization.Tests/ResourceManagerStringLocalizerTest.cs
+++ b/src/Localization/Localization/test/Microsoft.Extensions.Localization.Tests/ResourceManagerStringLocalizerTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -136,8 +137,122 @@ public class ResourceManagerStringLocalizerTest
         var value = localizer["a key!"];
 
         // Assert
-        var write = Assert.Single(Sink.Writes);
+        var write = Sink.Writes.First(w => w.EventId.Name == "SearchedLocation");
         Assert.Equal("ResourceManagerStringLocalizer searched for 'a key!' in 'Resources.TestResource' with culture 'en-US'.", write.State.ToString());
+    }
+
+    [Fact]
+    [ReplaceCulture("en-US", "en-US")]
+    public void GetString_LogsResourceNotFound_WhenResourceIsMissing()
+    {
+        // Arrange
+        var baseName = "Resources.TestResource";
+        var resourceNamesCache = new ResourceNamesCache();
+        var resourceAssembly = new TestAssemblyWrapper();
+        var resourceManager = new TestResourceManager(baseName, resourceAssembly);
+        var resourceStreamManager = new TestResourceStringProvider(resourceNamesCache, resourceManager, resourceAssembly.Assembly, baseName);
+        var logger = Logger;
+
+        var localizer = new ResourceManagerStringLocalizer(
+            resourceManager,
+            resourceStreamManager,
+            baseName,
+            resourceNamesCache,
+            logger);
+
+        // Act
+        var value = localizer["a key!"];
+
+        // Assert
+        Assert.True(value.ResourceNotFound);
+        var write = Assert.Single(Sink.Writes, w => w.EventId.Name == "ResourceNotFound");
+        Assert.Equal(LogLevel.Debug, write.LogLevel);
+        Assert.Equal("A resource for 'a key!' with culture 'en-US' was not found.", write.State.ToString());
+    }
+
+    [Fact]
+    [ReplaceCulture("fr-FR", "fr-FR")]
+    public void GetString_LogsResourceNotFound_IncludesCurrentUICulture()
+    {
+        // Arrange
+        var baseName = "Resources.TestResource";
+        var resourceNamesCache = new ResourceNamesCache();
+        var resourceAssembly = new TestAssemblyWrapper();
+        var resourceManager = new TestResourceManager(baseName, resourceAssembly);
+        var resourceStreamManager = new TestResourceStringProvider(resourceNamesCache, resourceManager, resourceAssembly.Assembly, baseName);
+        var logger = Logger;
+
+        var localizer = new ResourceManagerStringLocalizer(
+            resourceManager,
+            resourceStreamManager,
+            baseName,
+            resourceNamesCache,
+            logger);
+
+        // Act
+        var value = localizer["a key!"];
+
+        // Assert
+        var write = Assert.Single(Sink.Writes, w => w.EventId.Name == "ResourceNotFound");
+        Assert.Equal("A resource for 'a key!' with culture 'fr-FR' was not found.", write.State.ToString());
+    }
+
+    [Fact]
+    [ReplaceCulture("en-US", "en-US")]
+    public void GetString_DoesNotLogResourceNotFound_WhenResourceIsFound()
+    {
+        // Arrange
+        var baseName = "Resources.TestResource";
+        var resourceNamesCache = new ResourceNamesCache();
+        var resourceAssembly = new TestAssemblyWrapper();
+        var resourceManager = new TestResourceManager(baseName, resourceAssembly, new Dictionary<string, string> { ["a key!"] = "a value!" });
+        var resourceStreamManager = new TestResourceStringProvider(resourceNamesCache, resourceManager, resourceAssembly.Assembly, baseName);
+        var logger = Logger;
+
+        var localizer = new ResourceManagerStringLocalizer(
+            resourceManager,
+            resourceStreamManager,
+            baseName,
+            resourceNamesCache,
+            logger);
+
+        // Act
+        var value = localizer["a key!"];
+
+        // Assert
+        Assert.Equal("a value!", value.Value);
+        Assert.False(value.ResourceNotFound);
+        Assert.DoesNotContain(Sink.Writes, w => w.EventId.Name == "ResourceNotFound");
+    }
+
+    [Fact]
+    [ReplaceCulture("en-US", "en-US")]
+    public void GetString_LogsResourceNotFoundOnce_WhenManifestIsMissing()
+    {
+        // Arrange
+        var baseName = "Resources.TestResource";
+        var resourceNamesCache = new ResourceNamesCache();
+        var resourceAssembly = new TestAssemblyWrapper();
+        var resourceManager = new TestResourceManager(baseName, resourceAssembly) { ThrowMissingManifest = true };
+        var resourceStreamManager = new TestResourceStringProvider(resourceNamesCache, resourceManager, resourceAssembly.Assembly, baseName);
+        var logger = Logger;
+
+        var localizer = new ResourceManagerStringLocalizer(
+            resourceManager,
+            resourceStreamManager,
+            baseName,
+            resourceNamesCache,
+            logger);
+
+        // Act
+        _ = localizer["a key!"];
+        _ = localizer["a key!"];
+
+        // Assert
+        // The second lookup is served from the missing manifest cache but is still reported as a miss.
+        var writes = Sink.Writes.Where(w => w.EventId.Name == "ResourceNotFound").ToList();
+        Assert.Equal(2, writes.Count);
+        Assert.All(writes, w => Assert.Equal("A resource for 'a key!' with culture 'en-US' was not found.", w.State.ToString()));
     }
 
     [Theory]
@@ -248,15 +363,32 @@ public class ResourceManagerStringLocalizerTest
 
     internal class TestResourceManager : ResourceManager
     {
-        private AssemblyWrapper _assemblyWrapper;
+        private readonly AssemblyWrapper _assemblyWrapper;
+        private readonly IDictionary<string, string>? _strings;
 
         public TestResourceManager(string baseName, AssemblyWrapper assemblyWrapper)
+            : this(baseName, assemblyWrapper, strings: null)
+        {
+        }
+
+        public TestResourceManager(string baseName, AssemblyWrapper assemblyWrapper, IDictionary<string, string>? strings)
             : base(baseName, assemblyWrapper.Assembly)
         {
             _assemblyWrapper = assemblyWrapper;
+            _strings = strings;
         }
 
-        public override string? GetString(string name, CultureInfo? culture) => null;
+        public bool ThrowMissingManifest { get; set; }
+
+        public override string? GetString(string name, CultureInfo? culture)
+        {
+            if (ThrowMissingManifest)
+            {
+                throw new MissingManifestResourceException();
+            }
+
+            return _strings is not null && _strings.TryGetValue(name, out var value) ? value : null;
+        }
 
         public override ResourceSet? GetResourceSet(CultureInfo culture, bool createIfNotExists, bool tryParents)
         {


### PR DESCRIPTION
Fixes #43109

## Description

`IStringLocalizer` silently falls back to returning the key when a resource is missing, so there's no way to discover which strings are still untranslated. The only log on this path (`SearchedLocation`) fires on *every* lookup and doesn't distinguish a hit from a miss.

This adds a second `Debug`-level log to `ResourceManagerStringLocalizer`, emitted only when a lookup misses:

```
A resource for '{Key}' with culture '{Culture}' was not found.
```

`EventId` 2, `EventName = "ResourceNotFound"`. `SearchedLocation` (EventId 1) is unchanged.

The log is emitted from `GetStringSafely`, which is the single lookup choke point, so all three miss paths are covered exactly once per lookup:

1. an early return from `_missingManifestCache`,
2. a caught `MissingManifestResourceException`,
3. `ResourceManager.GetString` returning `null`.

No "resource found" log is added, per @halter73's review feedback on the prior attempt.

This is a continuation of #55897 by @hishamco, which was closed for inactivity in Dec 2024 with a reopen explicitly invited. Credit for the original change goes to him; this PR applies the review feedback from that thread (drop the found-log, pass `Culture` into the not-found log, use the agreed message text) and fixes the build/test failures it hit — the original `LoggerMessage` declared a `{Culture}` placeholder but the method took only `key`, and it keyed the miss off `name != value` rather than `value is null`.

## Tradeoff to discuss: log volume :speech_balloon:

Worth an explicit call before merging, since a miss is not necessarily an error condition here.

The common `_localizer["Some English text"]` pattern uses the display text as the key and ships no neutral `.resx`, so for the default culture **a miss is the normal path** — every single localized string on a page will emit one of these. `Debug` level is the main mitigation: nobody runs Debug for `Microsoft.Extensions.Localization` in production, and when you *do* turn it on, seeing every miss is exactly the point of the feature.

The other knob is repeat misses served from `_missingManifestCache`. This PR **logs those too**, so the message reflects what the caller actually observed on each lookup rather than only the first time. The alternative — suppress on cache hit — would cut volume substantially for the missing-manifest case, but makes the log lossy and order-dependent (the same key logs or doesn't depending on whether something else warmed the cache first), which seems worse for a diagnostic whose whole job is "tell me which strings are missing". Happy to flip this if the team prefers the quieter behavior.

## Notes

- No public API change: `Log` is a `private static partial class`, so no `PublicAPI.Unshipped.txt` edits are needed.
- There is no `ResourceManagerWithCultureStringLocalizer` in this repo, so nothing to mirror. `Microsoft.Extensions.Localization.RootNamespace.Tests` asserts only localized values and needs no update (verified passing).

## Testing

`ResourceManagerStringLocalizerTest`, following the existing `GetString_LogsLocationSearched` pattern:

- `GetString_LogsResourceNotFound_WhenResourceIsMissing` — a miss logs the message at `Debug`, exactly once.
- `GetString_DoesNotLogResourceNotFound_WhenResourceIsFound` — a hit logs nothing.
- `GetString_LogsResourceNotFound_IncludesCurrentUICulture` — the culture appears in the message (`fr-FR`).
- `GetString_LogsResourceNotFoundOnce_WhenManifestIsMissing` — pins the `_missingManifestCache` behavior described above.

`GetString_LogsLocationSearched` now selects its write by `EventId.Name` instead of `Assert.Single`, since that lookup is also a miss and now produces two writes. `TestResourceManager` gained an optional string dictionary (so a lookup can succeed) and a `ThrowMissingManifest` switch; both are opt-in and existing call sites are unchanged.

```
dotnet test src\Localization\Localization\test\Microsoft.Extensions.Localization.Tests\Microsoft.Extensions.Localization.Tests.csproj
```

35/35 pass on `net11.0` and `net472`.
