### PR TITLE
Cleanup OpenAPI handling of primitive formats

### DIFF
--- a/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
@@ -25,28 +25,30 @@ namespace Microsoft.AspNetCore.OpenApi;
 /// </summary>
 internal static class JsonNodeSchemaExtensions
 {
-    private static readonly Dictionary<Type, OpenApiSchema> _simpleTypeToOpenApiSchema = new()
+    private static readonly Dictionary<Type, string> _simpleTypeToFormat = new()
     {
-        [typeof(bool)] = new() { Type = JsonSchemaType.Boolean },
-        [typeof(byte)] = new() { Type = JsonSchemaType.Integer, Format = "uint8" },
-        [typeof(byte[])] = new() { Type = JsonSchemaType.String, Format = "byte" },
-        [typeof(int)] = new() { Type = JsonSchemaType.Integer, Format = "int32" },
-        [typeof(uint)] = new() { Type = JsonSchemaType.Integer, Format = "uint32" },
-        [typeof(long)] = new() { Type = JsonSchemaType.Integer, Format = "int64" },
-        [typeof(ulong)] = new() { Type = JsonSchemaType.Integer, Format = "uint64" },
-        [typeof(short)] = new() { Type = JsonSchemaType.Integer, Format = "int16" },
-        [typeof(ushort)] = new() { Type = JsonSchemaType.Integer, Format = "uint16" },
-        [typeof(float)] = new() { Type = JsonSchemaType.Number, Format = "float" },
-        [typeof(double)] = new() { Type = JsonSchemaType.Number, Format = "double" },
-        [typeof(decimal)] = new() { Type = JsonSchemaType.Number, Format = "double" },
-        [typeof(DateTime)] = new() { Type = JsonSchemaType.String, Format = "date-time" },
-        [typeof(DateTimeOffset)] = new() { Type = JsonSchemaType.String, Format = "date-time" },
-        [typeof(Guid)] = new() { Type = JsonSchemaType.String, Format = "uuid" },
-        [typeof(char)] = new() { Type = JsonSchemaType.String, Format = "char" },
-        [typeof(Uri)] = new() { Type = JsonSchemaType.String, Format = "uri" },
-        [typeof(string)] = new() { Type = JsonSchemaType.String },
-        [typeof(TimeOnly)] = new() { Type = JsonSchemaType.String, Format = "time" },
-        [typeof(DateOnly)] = new() { Type = JsonSchemaType.String, Format = "date" },
+        [typeof(byte)] = "uint8",
+        // Note: byte format is deprecated per https://spec.openapis.org/registry/format/
+        // We should follow the >= 3.1 approach stated in https://spec.openapis.org/oas/v3.2.0.html#migrating-binary-descriptions-from-oas-3-0
+        // In addition, we should ensure that Microsoft.OpenApi will be able to serialize the >= 3.1 representation correctly when
+        // it's asked to serialize as < 3.1 document.
+        [typeof(byte[])] = "byte",
+        [typeof(int)] = "int32",
+        [typeof(uint)] = "uint32",
+        [typeof(long)] = "int64",
+        [typeof(ulong)] = "uint64",
+        [typeof(short)] = "int16",
+        [typeof(ushort)] = "uint16",
+        [typeof(float)] = "float",
+        [typeof(double)] = "double",
+        [typeof(decimal)] = "double",
+        [typeof(DateTime)] = "date-time",
+        [typeof(DateTimeOffset)] = "date-time",
+        [typeof(Guid)] = "uuid",
+        [typeof(char)] = "char",
+        [typeof(Uri)] = "uri",
+        [typeof(TimeOnly)] = "time",
+        [typeof(DateOnly)] = "date",
     };
 
     /// <summary>
@@ -191,12 +193,11 @@ internal static class JsonNodeSchemaExtensions
     }
 
     /// <summary>
-    /// Applies the primitive types and formats to the schema based on the type.
+    /// Applies the format of known types to the schema.
     /// </summary>
     /// <remarks>
-    /// OpenAPI v3 requires support for the format keyword in generated types. Because the
-    /// underlying schema generator does not support this, we need to manually apply the
-    /// supported formats to the schemas associated with the generated type.
+    /// OpenAPI hosts a format registry in https://spec.openapis.org/registry/format/.
+    /// See also https://json-schema.org/draft/2020-12/json-schema-validation#name-vocabularies-for-semantic-c
     ///
     /// Note that this method targets <see cref="JsonNode"/> and not <see cref="OpenApiSchema"/> because
     /// it is is designed to be invoked via the `OnGenerated` callback in the underlying schema generator as
@@ -204,20 +205,13 @@ internal static class JsonNodeSchemaExtensions
     /// </remarks>
     /// <param name="schema">The <see cref="JsonNode"/> produced by the underlying schema generator.</param>
     /// <param name="context">The <see cref="JsonSchemaExporterContext"/> associated with the <see paramref="schema"/>.</param>
-    /// <param name="createSchemaReferenceId">A delegate that generates the reference ID to create for a type.</param>
-    internal static void ApplyPrimitiveTypesAndFormats(this JsonNode schema, JsonSchemaExporterContext context, Func<JsonTypeInfo, string?> createSchemaReferenceId)
+    internal static void ApplyPrimitiveFormats(this JsonNode schema, JsonSchemaExporterContext context)
     {
         var type = context.TypeInfo.Type;
         var underlyingType = Nullable.GetUnderlyingType(type);
-        if (_simpleTypeToOpenApiSchema.TryGetValue(underlyingType ?? type, out var openApiSchema))
+        if (_simpleTypeToFormat.TryGetValue(underlyingType ?? type, out var format))
         {
-            if (underlyingType != null && MapJsonNodeToSchemaType(schema[OpenApiSchemaKeywords.TypeKeyword]) is { } schemaTypes &&
-                !schemaTypes.HasFlag(JsonSchemaType.Null))
-            {
-                schema[OpenApiSchemaKeywords.TypeKeyword] = (schemaTypes | JsonSchemaType.Null).ToString();
-            }
-            schema[OpenApiSchemaKeywords.FormatKeyword] = openApiSchema.Format;
-            schema[OpenApiConstants.SchemaId] = createSchemaReferenceId(context.TypeInfo);
+            schema[OpenApiSchemaKeywords.FormatKeyword] = format;
         }
     }
 

--- a/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
+++ b/src/OpenApi/src/Services/Schemas/OpenApiSchemaService.cs
@@ -99,7 +99,7 @@ internal sealed class OpenApiSchemaService(
                 schema = new JsonObject();
             }
             var createSchemaReferenceId = optionsMonitor.Get(documentName).CreateSchemaReferenceId;
-            schema.ApplyPrimitiveTypesAndFormats(context, createSchemaReferenceId);
+            schema.ApplyPrimitiveFormats(context);
             schema.ApplySchemaReferenceId(context, createSchemaReferenceId);
             schema.MapPolymorphismOptionsToDiscriminator(context, createSchemaReferenceId);
             if (context.PropertyInfo is { } jsonPropertyInfo)


### PR DESCRIPTION
This code only needs to decide the `OpenApiSchema.Format` to use.

- The schema id part is already applied in `ApplySchemaReferenceId` call that happens right after `ApplyPrimitiveFormats`. So there is no need for `ApplyPrimitiveFormats` to do anything there.
- The `JsonSchemaType` should be correctly set by STJ. We don't need anything special there as well.
- The nullability handling became a dead code. It in the past used to set `nullable: true` (before OpenAPI 3.1+ support). But now that we are setting only `Type`, it's irrelevant and STJ should get us the right thing already (if needed)

This PR should have no behavior changes, and is only a cleanup.