### PR TITLE
Fix double-publish compression error in TestContentPackage

### DIFF
--- a/src/Components/test/testassets/TestContentPackage/TestContentPackage.csproj
+++ b/src/Components/test/testassets/TestContentPackage/TestContentPackage.csproj
@@ -6,6 +6,13 @@
     <StaticWebAssetBasePath>_content/TestContentPackage</StaticWebAssetBasePath>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(_SkipReferencedProjectPublishAssets)' == 'true'">
+    <StaticWebAssetsGetPublishAssetsTargets>_SkipGetPublishAssetsForTrimmedBuild</StaticWebAssetsGetPublishAssetsTargets>
+  </PropertyGroup>
+
+  <!-- No-op target used to prevent the Static Web Assets SDK from redundantly re-publishing this project. -->
+  <Target Name="_SkipGetPublishAssetsForTrimmedBuild" />
+
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Components" />
     <Reference Include="Microsoft.AspNetCore.Components.Authorization" />


### PR DESCRIPTION
Trying to fix the reported race issue: https://github.com/dotnet/aspnetcore/issues/61178#issuecomment-5116105445. The methodology used is same as in https://github.com/dotnet/aspnetcore/pull/65675, we just extend it to `TestContentPackage` asset.