### PR TITLE
Fix persisted state being dropped on enhanced navigation

### DIFF
--- a/src/Components/Web.JS/src/Services/WebRootComponentManager.ts
+++ b/src/Components/Web.JS/src/Services/WebRootComponentManager.ts
@@ -272,13 +272,17 @@ export class WebRootComponentManager implements DescriptorHandler, RootComponent
     const operationsByRendererId = new Map<WebRendererId, RootComponentOperation[]>();
     const rendererIds: Set<WebRendererId> = new Set<WebRendererId>();
     for (const component of components) {
+      const operation = this.determinePendingOperation(component);
+
+      // Capture the renderer IDs for the available components to determine the
+      // effective render modes in the document for discovering new persisted state.
+      // This must happen after determining the pending operation, because a component
+      // that is being activated for the first time only gets assigned a renderer ID
+      // as part of computing its 'add' operation.
       if (discoverNewState && component.assignedRendererId !== undefined) {
-        // Capture the renderer IDs for the available components to determine the
-        // effective render modes in the document for discovering new persisted state.
         rendererIds.add(component.assignedRendererId);
       }
 
-      const operation = this.determinePendingOperation(component);
       if (!operation) {
         continue;
       }

--- a/src/Components/test/E2ETest/Tests/StatePersistenceTest.cs
+++ b/src/Components/test/E2ETest/Tests/StatePersistenceTest.cs
@@ -311,6 +311,52 @@ public class StatePersistenceTest : ServerTestBase<BasicTestAppServerSiteFixture
             stateValue: "other");
     }
 
+    // Same regression as above, but with streaming rendering, where the persisted state only reaches
+    // the document on a streaming update at the end of the response, after the interactive components
+    // have already been discovered.
+    [Theory]
+    [InlineData("server", typeof(InteractiveServerRenderMode), "ServerStreaming")]
+    [InlineData("wasm", typeof(InteractiveWebAssemblyRenderMode), "WebAssemblyStreaming")]
+    public void StateIsRestoredOnSubsequentEnhancedNavigationsWithStreamingRendering(string mode, Type renderMode, string streaming)
+    {
+        Navigate($"subdir/persistent-state/page-no-components?render-mode={mode}");
+        ((IJavaScriptExecutor)Browser).ExecuteScript("sessionStorage.setItem('keep-circuit-alive', 'true')");
+        Navigate($"subdir/persistent-state/page-no-components?render-mode={mode}&streaming-id={streaming}");
+
+        // First enhanced navigation to a page with components. This activates the runtime.
+        Browser.Click(By.Id("page-with-components-link-and-declarative-state"));
+        EndStreamingAndAssertStateIsRestored();
+
+        // Navigate away and back. The runtime is already running, so the components get activated
+        // through a root component update rather than through the initial update.
+        Browser.Click(By.Id("page-no-components-link"));
+        Browser.Click(By.Id("page-with-components-link-and-declarative-state"));
+        EndStreamingAndAssertStateIsRestored();
+
+        void EndStreamingAndAssertStateIsRestored()
+        {
+            // Wait for the component to be streaming before releasing it, so that we know the
+            // persisted state is emitted after the components have been discovered.
+            AssertDeclarativePageState(
+                mode: mode,
+                renderMode: renderMode.Name,
+                interactive: false,
+                stateValue: null,
+                streamingId: streaming,
+                streamingCompleted: false);
+
+            Browser.Click(By.Id("end-streaming"));
+
+            AssertDeclarativePageState(
+                mode: mode,
+                renderMode: renderMode.Name,
+                interactive: true,
+                stateValue: "other",
+                streamingId: streaming,
+                streamingCompleted: true);
+        }
+    }
+
     [Theory]
     [InlineData("ServerNonPrerendered")]
     [InlineData("WebAssemblyNonPrerendered")]

--- a/src/Components/test/E2ETest/Tests/StatePersistenceTest.cs
+++ b/src/Components/test/E2ETest/Tests/StatePersistenceTest.cs
@@ -276,6 +276,41 @@ public class StatePersistenceTest : ServerTestBase<BasicTestAppServerSiteFixture
         RenderComponentsWithPersistentStateAndValidate(suppressEnhancedNavigation: false, mode, typeof(InteractiveServerRenderMode), streaming, stateValue: "other");
     }
 
+    // Regression test for https://github.com/dotnet/aspnetcore/issues/63895
+    // The first enhanced navigation to a page with interactive components goes through the initial
+    // root component update, which reads the persisted state independently. Subsequent enhanced
+    // navigations activate components through 'updateRootComponents' instead, and used to drop the
+    // persisted state because the renderer had not been assigned to the component yet at the time
+    // we decided which persisted state to look for.
+    [Theory]
+    [InlineData("server", typeof(InteractiveServerRenderMode))]
+    [InlineData("wasm", typeof(InteractiveWebAssemblyRenderMode))]
+    public void StateIsRestoredOnSubsequentEnhancedNavigationsToPagesWithComponents(string mode, Type renderMode)
+    {
+        // The test app tears down idle circuits aggressively. Keep the circuit alive so that the
+        // second activation happens on the existing runtime through a root component update,
+        // instead of through circuit creation, which reads the persisted state independently.
+        Navigate($"subdir/persistent-state/page-no-components?render-mode={mode}");
+        ((IJavaScriptExecutor)Browser).ExecuteScript("sessionStorage.setItem('keep-circuit-alive', 'true')");
+        Navigate($"subdir/persistent-state/page-no-components?render-mode={mode}");
+
+        // First enhanced navigation to a page with components. This activates the runtime.
+        Browser.Click(By.Id("page-with-components-link"));
+        RenderComponentsWithPersistentStateAndValidate(suppressEnhancedNavigation: false, mode, renderMode, streaming: null);
+
+        // Navigate away and back. The runtime is already running, so the components get activated
+        // through a root component update rather than through the initial update.
+        Browser.Click(By.Id("page-no-components-link"));
+        Browser.Click(By.Id("page-with-components-link-and-state"));
+
+        RenderComponentsWithPersistentStateAndValidate(
+            suppressEnhancedNavigation: false,
+            mode,
+            renderMode,
+            streaming: null,
+            stateValue: "other");
+    }
+
     [Theory]
     [InlineData("ServerNonPrerendered")]
     [InlineData("WebAssemblyNonPrerendered")]

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/App.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/App.razor
@@ -164,6 +164,7 @@
             const suppressEnhancedNavigation = sessionStorage.getItem('suppress-enhanced-navigation') === 'true';
             const blockLoadBootResource = sessionStorage.getItem('block-load-boot-resource') === 'true';
             const blockWebassemblySettings = sessionStorage.getItem('block-webassembly-settings') === 'true';
+            const keepCircuitAlive = sessionStorage.getItem('keep-circuit-alive') === 'true';
             sessionStorage.removeItem('block-load-boot-resource');
             sessionStorage.removeItem('enable-classic-initializers');
             sessionStorage.removeItem('block-webassembly-settings');
@@ -221,8 +222,10 @@
                 ssr: {
                     disableDomPreservation: suppressEnhancedNavigation,
 
-                    // We use a short timeout so tests don't take too long
-                    circuitInactivityTimeoutMs: 100,
+                    // We use a short timeout so tests don't take too long, except for tests that
+                    // need the circuit to survive navigating through pages with no interactive
+                    // components so that components get reactivated on the existing circuit.
+                    circuitInactivityTimeoutMs: keepCircuitAlive ? 20000 : 100,
                 },
                 enableClassicInitializers: enableClassicInitializers,
                 webAssembly: webAssemblySettings,


### PR DESCRIPTION
# Fix persisted state being dropped on enhanced navigation

Fixes #63895

## Root Cause Analysis

Persisted component state is not restored when interactive components are activated as a result of an enhanced navigation, unless they happen to be the first interactive components activated on the page.

In `WebRootComponentManager.refreshRootComponents`, the set of renderer IDs used to decide which persisted state to look for in the document was collected **before** calling `determinePendingOperation`:

```ts
for (const component of components) {
  if (discoverNewState && component.assignedRendererId !== undefined) {
    rendererIds.add(component.assignedRendererId);   // read before it is set
  }

  const operation = this.determinePendingOperation(component);  // assigns assignedRendererId
  ...
}
```

`determinePendingOperation` is what assigns `assignedRendererId`, as part of producing the `add` operation for a component that is being activated for the first time.

During enhanced navigation we deliberately defer activating new components (`isPageLoading()` short-circuits the activation), so a component is first activated on the very `refreshRootComponents(discoverNewState: true)` call triggered by `onEnhancedNavigationCompleted()`. On that call its renderer ID was not in `rendererIds` yet, so `discoverServerPersistedState` / `discoverWebAssemblyPersistedState` were never called and we passed an empty state string to the runtime. The component then re-ran its initialization logic, re-fetching data that was already persisted.

The reason this was not caught earlier is that the **first** enhanced navigation to a page with interactive components goes through `resolveInitialUpdate`, which reads the state independently via `Blazor._internal.getPersistedState`. The bug only reproduces from the **second** activation onwards, when components are activated through `updateRootComponents`. The existing E2E tests only covered the first hop.

## Fix

Move the `rendererIds.add(...)` bookkeeping after `determinePendingOperation`, so that a component being activated on this pass contributes its renderer ID. This applies equally to Server and WebAssembly.

## Verification

Using the repro from the issue, instrumenting `Blazor._internal.updateRootComponents` and `fetch`, and navigating Home ↔ Counter:

| | client service calls | `api/counterstate` requests |
| --- | --- | --- |
| before | 3 / 3 enhanced navs | 3 |
| after | **0** | **0** |

The state was present in the document the whole time and simply not picked up:

```
stateLen: 0
stateCommentsInDom: ["Blazor-WebAssembly-Component-State:eyIvMXovUk5BNVJVYzdDeDVSS...len=1315"]
```

After the fix `updateRootComponents` receives `stateLen: 1280` on every navigation.

## Test Coverage

Added `StateIsRestoredOnSubsequentEnhancedNavigationsToPagesWithComponents` to `StatePersistenceTest`, covering both `server` and `wasm`. It navigates to a page with components, away, and back, so the second activation goes through a root component update rather than the initial update.

The test app disposes idle circuits after 100 ms, which would make the server case go through circuit creation (which reads the state independently) and silently not exercise the regression. Added an opt-in `keep-circuit-alive` session storage flag to the test app that raises the inactivity timeout, following the existing flag pattern, so the server case is deterministic.

Validated as a genuine regression test:

- without the fix: **2 failed** (`Expected: State found:True / Actual: State found:False`) for both `server` and `wasm`
- with the fix: **2 passed**

Regression runs, all green:

- `StatePersistenceTest` — 30/30
- `InteractivityTest` + `EnhancedNavigation` — 258/258