### PR TITLE
Onboard aspnetcore-ci-unofficial to CFSClean2 network isolation

### DIFF
--- a/.azure/pipelines/ci-unofficial.yml
+++ b/.azure/pipelines/ci-unofficial.yml
@@ -86,6 +86,8 @@ resources:
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean2
     sdl:
       sourceAnalysisPool:
         name: NetCore1ESPool-Svc-Internal


### PR DESCRIPTION
Fixes SFI-ES4.2.4 for `aspnetcore-ci-unofficial` (pipeline definition 1474). This pipeline had no `networkIsolationPolicy` configured, so it was still able to reach public package feeds forbidden by CFSClean policies.

`ci.yml` (the Official pipeline) is already onboarded to `Permissive,CFSClean2`; this applies the same setting to `ci-unofficial.yml`, which shares the same 1ES pipeline template family (Unofficial variant).