### PR TITLE
Fix flaky RefreshChangingUserIdentifierClosesConnection test

### DIFF
--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.AuthenticationRefresh.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.AuthenticationRefresh.cs
@@ -324,7 +324,20 @@ public partial class HubConnectionTests
     [MemberData(nameof(TransportTypes))]
     public async Task RefreshChangingUserIdentifierClosesConnection(HttpTransportType transportType)
     {
-        await using (var server = await StartServer<Startup>())
+        // Changing the user identifier on refresh aborts the connection on the server. With Long Polling the
+        // client sends a best-effort DELETE to clean up the connection when it's disposed. That DELETE carries
+        // the refreshed token (which now maps to a different user) and races the server's teardown: if the
+        // connection hasn't been removed from the manager yet, the server rejects the DELETE with 403 and the
+        // transport logs ErrorSendingDeleteRequest. Once the connection has been removed the DELETE gets a 404
+        // and is treated as benign, so whether the error is logged depends purely on timing. The connection is
+        // already closed either way (the test asserts that below), so this teardown error is expected.
+        bool ExpectedErrors(WriteContext writeContext)
+        {
+            return writeContext.LoggerName == LongPollingTransportLoggerName &&
+                   writeContext.EventId.Name == "ErrorSendingDeleteRequest";
+        }
+
+        await using (var server = await StartServer<Startup>(ExpectedErrors))
         {
             // The SignalR UserIdentifier is derived from the JWT NameIdentifier claim, so changing
             // the user name on refresh changes the connection's UserIdentifier and should close it.

--- a/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
+++ b/src/SignalR/clients/csharp/Client/test/FunctionalTests/HubConnectionTests.cs
@@ -30,6 +30,7 @@ public class HubConnectionTestsCollection : ICollectionFixture<InProcessTestServ
 public partial class HubConnectionTests : FunctionalTestBase
 {
     private const string DefaultHubDispatcherLoggerName = "Microsoft.AspNetCore.SignalR.Internal.DefaultHubDispatcher";
+    private const string LongPollingTransportLoggerName = "Microsoft.AspNetCore.Http.Connections.Client.Internal.LongPollingTransport";
 
     private HubConnection CreateHubConnection(
         string url,


### PR DESCRIPTION
## Summary

Fixes flakiness in the Long Polling variant of `HubConnectionTests.RefreshChangingUserIdentifierClosesConnection`.

## Root cause

When the refresh changes the user identifier, the server aborts the connection. On dispose, the Long Polling client sends a best-effort `DELETE` carrying the refreshed (userB) token. That `DELETE` races the server's teardown:

- If the connection hasn't been removed from the manager yet, the server's `RejectIfUserChangedAsync` returns **403 Forbidden** (the connection is still bound to userA), and `LongPollingTransport` logs `ErrorSendingDeleteRequest` at Error level — which fails the test's `VerifyNoErrorsScope`.
- Once the connection has been removed, the same `DELETE` gets a benign **404** and is logged at Debug.

So whether the error is logged depends purely on timing. The connection is torn down by the abort either way (the test still asserts `Disconnected`), so this teardown error is expected and harmless.

Only this test hits the race, because it's the only refresh test that changes the SignalR `UserIdentifier` while running over real Long Polling. WebSockets/SSE don't send an authenticated `DELETE` on dispose, and the other refresh tests keep the same user so their cleanup `DELETE` stays authorized.

## Fix

Allow-list that one specific teardown error (`LongPollingTransport` / `ErrorSendingDeleteRequest`) via the existing `expectedErrors` filter on `StartServer`, matching the established pattern used by sibling refresh tests. The filter is deliberately narrow so genuine failures still surface.

Test-only change. Verified by running all three transports (3/3 pass) and stressing the Long Polling variant (6/6 pass).