### PR TITLE
Fix `InputDateInteractsWithEditContext_NonNullableDateTime` and `InputDateInteractsWithEditContext_NullableDateTimeOffset`

### DIFF
--- a/src/Components/test/E2ETest/Tests/FormsInputDateTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsInputDateTest.cs
@@ -45,22 +45,22 @@ public class FormsInputDateTest : ServerTestBase<ToggleExecutionModeServerFixtur
 
         // Validates on edit
         Browser.Equal("valid", () => renewalDateInput.GetDomAttribute("class"));
-        renewalDateInput.SendKeys($"{Keys.Backspace}\t{Keys.Backspace}\t{Keys.Backspace}\t");
-        renewalDateInput.SendKeys("01/01/2000\t");
+        ClearDate(renewalDateInput);
+        SetDate(renewalDateInput, "01/01/2000\t");
         Browser.Equal("modified valid", () => renewalDateInput.GetDomAttribute("class"));
 
         // Can become invalid
-        renewalDateInput.SendKeys("11-11-11111\t");
+        SetDate(renewalDateInput, "11-11-11111\t");
         Browser.Equal("modified invalid", () => renewalDateInput.GetDomAttribute("class"));
         Browser.Equal(new[] { "The RenewalDate field must be a date." }, messagesAccessor);
 
         // Empty is invalid, because it's not nullable
-        renewalDateInput.SendKeys($"{Keys.Backspace}\t{Keys.Backspace}\t{Keys.Backspace}\t");
+        ClearDate(renewalDateInput);
         Browser.Equal("modified invalid", () => renewalDateInput.GetDomAttribute("class"));
         Browser.Equal(new[] { "The RenewalDate field must be a date." }, messagesAccessor);
 
         // Can become valid
-        renewalDateInput.SendKeys("01/01/01\t");
+        SetDate(renewalDateInput, "01/01/01\t");
         Browser.Equal("modified valid", () => renewalDateInput.GetDomAttribute("class"));
         Browser.Empty(messagesAccessor);
     }
@@ -74,16 +74,16 @@ public class FormsInputDateTest : ServerTestBase<ToggleExecutionModeServerFixtur
 
         // Validates on edit
         Browser.Equal("valid", () => expiryDateInput.GetDomAttribute("class"));
-        expiryDateInput.SendKeys("01-01-2000\t");
+        SetDate(expiryDateInput, "01-01-2000\t");
         Browser.Equal("modified valid", () => expiryDateInput.GetDomAttribute("class"));
 
         // Can become invalid
-        expiryDateInput.SendKeys("11-11-11111\t");
+        SetDate(expiryDateInput, "11-11-11111\t");
         Browser.Equal("modified invalid", () => expiryDateInput.GetDomAttribute("class"));
         Browser.Equal(new[] { "The OptionalExpiryDate field must be a date." }, messagesAccessor);
 
         // Empty is valid, because it's nullable
-        expiryDateInput.SendKeys($"{Keys.Backspace}\t{Keys.Backspace}\t{Keys.Backspace}\t");
+        ClearDate(expiryDateInput);
         Browser.Equal("modified valid", () => expiryDateInput.GetDomAttribute("class"));
         Browser.Empty(messagesAccessor);
     }
@@ -232,6 +232,21 @@ public class FormsInputDateTest : ServerTestBase<ToggleExecutionModeServerFixtur
         appointmentInput.SendKeys(string.Concat(Enumerable.Repeat(Keys.ArrowLeft, 6)) + $"10101970{Keys.ArrowRight}105321");
         Browser.Equal("modified valid", () => appointmentInput.GetDomAttribute("class"));
         Browser.Equal("1970-10-10T10:53:21", () => appointmentInput.GetDomProperty("value"));
+    }
+
+    private static void SetDate(IWebElement input, string keys)
+    {
+        input.Click();
+        input.SendKeys(Keys.ArrowLeft + Keys.ArrowLeft + Keys.ArrowLeft);
+        input.SendKeys(keys);
+    }
+
+    private static void ClearDate(IWebElement input)
+    {
+        input.Click();
+        input.SendKeys(Keys.Control + "a");
+        input.SendKeys(Keys.Delete);
+        input.SendKeys(Keys.Tab);
     }
 
     private Func<string[]> CreateValidationMessagesAccessor(IWebElement appElement)


### PR DESCRIPTION
Contributes to https://github.com/dotnet/aspnetcore/issues/31734 and https://github.com/dotnet/aspnetcore/issues/67243.

See: https://github.com/dotnet/aspnetcore/issues/31734#issuecomment-5129349055

Locally both tests fail deterministically on both main and previous releases. This fix adds caret positioning so that at least local runs pass. I don't have hard evidence it will fix the CI version but it's worth a try.