### PR TITLE
Emit framework versions from Blazor WASM benchmark Driver

### DIFF
--- a/src/Components/benchmarkapps/Wasm.Performance/Driver/Program.cs
+++ b/src/Components/benchmarkapps/Wasm.Performance/Driver/Program.cs
@@ -226,6 +226,45 @@ public class Program
                 ?.Value,
         });
 
+        // Framework versions of the build under test. crank normally captures these
+        // via the Microsoft.Crank.EventSources EventSource, but that channel isn't
+        // available for container-based jobs (this benchmark builds from a Dockerfile),
+        // so the values must be emitted over stdout. The RegressionBot uses the
+        // "aspNetCoreVersion"/"netCoreAppVersion" result keys (each formatted as
+        // "<version>+<commitHash>") to attribute regressions to dependency updates,
+        // populating the "Dependencies" column of the filed regression issues.
+        output.Metadata.Add(new BenchmarkMetadata
+        {
+            Source = "BlazorWasm",
+            Name = "netCoreAppVersion",
+            ShortDescription = ".NET Runtime Version",
+        });
+
+        output.Measurements.Add(new BenchmarkMeasurement
+        {
+            Timestamp = DateTime.UtcNow,
+            Name = "netCoreAppVersion",
+            Value = typeof(object).Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                ?.InformationalVersion,
+        });
+
+        output.Metadata.Add(new BenchmarkMetadata
+        {
+            Source = "BlazorWasm",
+            Name = "aspNetCoreVersion",
+            ShortDescription = "ASP.NET Core Version",
+        });
+
+        output.Measurements.Add(new BenchmarkMeasurement
+        {
+            Timestamp = DateTime.UtcNow,
+            Name = "aspNetCoreVersion",
+            Value = typeof(WebApplication).Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                ?.InformationalVersion,
+        });
+
         foreach (var result in benchmarkResult.ScenarioResults)
         {
             var scenarioName = result.Descriptor.Name;


### PR DESCRIPTION
## Summary
Perf-regression issues filed for the docker-built `blazorwasmbenchmark` scenario show an **empty Dependencies column** (e.g. dotnet/aspnetcore#68100), unlike server scenarios which list `Microsoft.AspNetCore.App` / `Microsoft.NETCore.App` diffs.

crank's RegressionBot (`Microsoft.Crank.RegressionBot` -> `CreateDotNetDependencies`) synthesizes those dependency rows from the `aspNetCoreVersion` / `netCoreAppVersion` result keys (each formatted `<version>+<commitHash>`). crank normally captures these via the `Microsoft.Crank.EventSources` EventSource (EventPipe), but that channel is **not available for container/Dockerfile-based jobs**. The blazorwasm scenario builds via a Dockerfile, so the only result channel is the Driver's stdout `#StartJobStatistics` JSON.

## Change
`Wasm.Performance/Driver/Program.cs` `FormatAsBenchmarksOutput` now emits `netCoreAppVersion` (from `System.Private.CoreLib`'s `AssemblyInformationalVersionAttribute`) and `aspNetCoreVersion` (from `Microsoft.AspNetCore`'s) over the same stdout channel it already uses for `blazorwasm/commit`. This lets `RegressionBot.CreateDotNetDependencies` populate the Dependencies column of filed regression issues.

## Notes
- Benchmark-infra-only change; **no product impact**.
- Follows the existing `blazorwasm/commit` emission pattern in the same method.

Refs dotnet/aspnetcore#68100