### PR TITLE
Avoid resolving HybridCache during Redis connection

### DIFF
--- a/src/Caching/StackExchangeRedis/src/RedisCacheImpl.cs
+++ b/src/Caching/StackExchangeRedis/src/RedisCacheImpl.cs
@@ -11,20 +11,20 @@ namespace Microsoft.Extensions.Caching.StackExchangeRedis;
 
 internal sealed class RedisCacheImpl : RedisCache
 {
-    private readonly IServiceProvider _services;
+    private readonly IServiceProviderIsService? _serviceProviderIsService;
 
     internal override bool IsHybridCacheActive()
-        => _services.GetService<HybridCache>() is not null;
+        => _serviceProviderIsService?.IsService(typeof(HybridCache)) == true;
 
-    public RedisCacheImpl(IOptions<RedisCacheOptions> optionsAccessor, ILogger<RedisCache> logger, IServiceProvider services)
+    public RedisCacheImpl(IOptions<RedisCacheOptions> optionsAccessor, ILogger<RedisCache> logger, IServiceProviderIsService? serviceProviderIsService = null)
         : base(optionsAccessor, logger)
     {
-        _services = services; // important: do not check for HybridCache here due to dependency - creates a cycle
+        _serviceProviderIsService = serviceProviderIsService;
     }
 
-    public RedisCacheImpl(IOptions<RedisCacheOptions> optionsAccessor, IServiceProvider services)
+    public RedisCacheImpl(IOptions<RedisCacheOptions> optionsAccessor, IServiceProviderIsService? serviceProviderIsService = null)
         : base(optionsAccessor)
     {
-        _services = services; // important: do not check for HybridCache here due to dependency - creates a cycle
+        _serviceProviderIsService = serviceProviderIsService;
     }
 }

--- a/src/Caching/StackExchangeRedis/test/CacheServiceExtensionsTests.cs
+++ b/src/Caching/StackExchangeRedis/test/CacheServiceExtensionsTests.cs
@@ -2,18 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Hybrid;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
@@ -137,6 +132,7 @@ public class CacheServiceExtensionsTests
     {
         // Arrange
         var services = new ServiceCollection();
+        var hybridCacheResolved = false;
 
         services.AddLogging();
 
@@ -144,56 +140,16 @@ public class CacheServiceExtensionsTests
         services.AddStackExchangeRedisCache(options => { });
         if (hybridCacheActive)
         {
-            services.AddMemoryCache();
-            services.TryAddSingleton<HybridCache, DummyHybridCache>();
+            services.TryAddSingleton<HybridCache>(_ =>
+            {
+                hybridCacheResolved = true;
+                throw new InvalidOperationException("HybridCache should not be resolved.");
+            });
         }
 
         using var provider = services.BuildServiceProvider();
         var cache = Assert.IsAssignableFrom<RedisCache>(provider.GetRequiredService<IDistributedCache>());
         Assert.Equal(hybridCacheActive, cache.IsHybridCacheActive());
-    }
-
-    sealed class DummyHybridCache : HybridCache
-    {
-        // emulate the layout from HybridCache in dotnet/extensions
-        public DummyHybridCache(IOptions<HybridCacheOptions> options, IServiceProvider services)
-        {
-            if (services is null)
-            {
-                throw new ArgumentNullException(nameof(services));
-            }
-
-            var l1 = services.GetRequiredService<IMemoryCache>();
-            _ = options.Value;
-            var logger = services.GetService<ILoggerFactory>()?.CreateLogger(typeof(HybridCache)) ?? NullLogger.Instance;
-            // var clock = services.GetService<TimeProvider>() ?? TimeProvider.System;
-            var l2 = services.GetService<IDistributedCache>(); // note optional
-
-            // ignore L2 if it is really just the same L1, wrapped
-            // (note not just an "is" test; if someone has a custom subclass, who knows what it does?)
-            if (l2 is not null
-                && l2.GetType() == typeof(MemoryDistributedCache)
-                && l1.GetType() == typeof(MemoryCache))
-            {
-                l2 = null;
-            }
-
-            IHybridCacheSerializerFactory[] factories = services.GetServices<IHybridCacheSerializerFactory>().ToArray();
-            Array.Reverse(factories);
-        }
-
-        public class HybridCacheOptions { }
-
-        public override ValueTask<T> GetOrCreateAsync<TState, T>(string key, TState state, Func<TState, CancellationToken, ValueTask<T>> factory, HybridCacheEntryOptions options = null, IEnumerable<string> tags = null, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
-
-        public override ValueTask RemoveAsync(string key, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
-
-        public override ValueTask RemoveByTagAsync(string tag, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
-
-        public override ValueTask SetAsync<T>(string key, T value, HybridCacheEntryOptions options = null, IEnumerable<string> tags = null, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException();
+        Assert.False(hybridCacheResolved);
     }
 }


### PR DESCRIPTION
## Summary

`RedisCacheImpl` determines whether HybridCache is active by resolving the `HybridCache` singleton while preparing a Redis connection. Only the presence of the registration is needed to add the `HC` library-name suffix.

This change:

- uses `IServiceProviderIsService` to inspect the `HybridCache` registration without constructing it
- keeps the capability optional for compatibility with containers that do not provide `IServiceProviderIsService`
- updates the existing test to prove that detection does not invoke the registered `HybridCache` factory

### Relationship to dotnet/runtime#124331

The functional problem reported in #67904 occurs with the .NET 10 DI implementation. With a synchronously completed `ConnectionMultiplexerFactory`, such as the factory used by Aspire Redis distributed caching, connection preparation can re-enter singleton resolution and publish a second `HybridCache` instance.

The .NET 11 DI change in dotnet/runtime#124331 detects this re-entry and throws instead. In this specific connection path, `RedisCache.TryAddSuffix` catches that exception, so the duplicate instance is not created, but the `HC` suffix is omitted.

This PR removes the unnecessary re-entrant resolution from the component.

Addresses #67904.

## Testing

- negative control: the HybridCache detection test fails on both targets with the previous `GetService<HybridCache>()` implementation

> [!NOTE]
> This pull request was created with the assistance of GitHub Copilot.