### PR TITLE
Fix dev-certs EventSource Boolean payload

### DIFF
--- a/src/Shared/CertificateGeneration/CertificateManager.cs
+++ b/src/Shared/CertificateGeneration/CertificateManager.cs
@@ -1148,8 +1148,8 @@ internal abstract class CertificateManager
         [Event(22, Level = EventLevel.Error, Message = "An error has occurred saving the certificate: {0}.")]
         public void SaveCertificateInStoreError(string e) => WriteEvent(22, e);
 
-        [Event(23, Level = EventLevel.Verbose, Message = "Saving certificate '{0}' to {1} {2} private key.")]
-        public void ExportCertificateStart(string certificate, string path, bool includePrivateKey) => WriteEvent(23, certificate, path, includePrivateKey ? "with" : "without");
+        [Event(23, Level = EventLevel.Verbose, Message = "Saving certificate '{0}' to {1}. Include private key: {2}.")]
+        public void ExportCertificateStart(string certificate, string path, bool includePrivateKey) => WriteEvent(23, certificate, path, includePrivateKey);
 
         [Event(24, Level = EventLevel.Verbose, Message = "Exporting certificate with private key but no password.")]
         public void NoPasswordForCertificate() => WriteEvent(24);

--- a/src/Shared/test/Shared.Tests/CertificateManagerEventSourceTests.cs
+++ b/src/Shared/test/Shared.Tests/CertificateManagerEventSourceTests.cs
@@ -1,11 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.Tracing;
 using Microsoft.AspNetCore.Certificates.Generation;
 using Microsoft.AspNetCore.InternalTesting.Tracing;
 
 namespace Microsoft.AspNetCore.Internal.Tests;
 
+[Collection(nameof(CertificateManagerEventSourceTestCollection))]
 public class CertificateManagerEventSourceTests
 {
     [Fact]
@@ -13,4 +15,41 @@ public class CertificateManagerEventSourceTests
     {
         EventSourceValidator.ValidateEventSourceIds<CertificateManager.CertificateManagerEventSource>();
     }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ExportCertificateStartWritesIncludePrivateKeyAsBoolean(bool includePrivateKey)
+    {
+        var eventSource = CertificateManager.Log;
+        using var listener = new TestEventListener(eventId: 23);
+        listener.EnableEvents(eventSource, EventLevel.Verbose);
+
+        eventSource.ExportCertificateStart("certificate", "path", includePrivateKey);
+
+        var eventData = Assert.IsType<EventWrittenEventArgs>(listener.EventData);
+        Assert.Equal(23, eventData.EventId);
+        Assert.Collection(
+            eventData.Payload!,
+            payload => Assert.Equal("certificate", payload),
+            payload => Assert.Equal("path", payload),
+            payload => Assert.Equal(includePrivateKey, Assert.IsType<bool>(payload)));
+    }
+
+    private sealed class TestEventListener(int eventId) : EventListener
+    {
+        public EventWrittenEventArgs? EventData { get; private set; }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (eventData.EventId == eventId)
+            {
+                EventData = eventData;
+            }
+        }
+    }
 }
+
+// EventSource instances are process-global, so isolate these tests from other certificate tests.
+[CollectionDefinition(nameof(CertificateManagerEventSourceTestCollection), DisableParallelization = true)]
+public class CertificateManagerEventSourceTestCollection { }


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Fix the dev-certs EventSource Boolean payload

## Description

`CertificateManagerEventSource.ExportCertificateStart` declares `includePrivateKey` as a Boolean, but passed `"with"` or `"without"` to `WriteEvent`. EventSource consumers therefore received a string payload that did not match the event contract.

This change writes the Boolean value directly, updates the event message to format that value, and adds regression coverage for both `true` and `false` payloads.

## Testing

```text
.\.dotnet\dotnet.exe test .\src\Shared\test\Shared.Tests\Microsoft.AspNetCore.Shared.Tests.csproj --no-build --no-restore --verbosity minimal
```

Passed: 1,329; Failed: 0; Skipped: 0.

Fixes #29541
