### PR TITLE
Add diagnostic for missing MessagePack submodule sources

### DIFF
--- a/src/Components/Server/src/Microsoft.AspNetCore.Components.Server.csproj
+++ b/src/Components/Server/src/Microsoft.AspNetCore.Components.Server.csproj
@@ -86,21 +86,22 @@
     <Compile Include="$(RepoRoot)src\SignalR\common\Shared\TryGetReturnType.cs" LinkBase="BlazorPack" />
 
     <!-- MessagePack -->
-    <Compile Include="$(MessagePackRoot)BufferWriter.cs" LinkBase="BlazorPack\MessagePack" />
-    <Compile Include="$(MessagePackRoot)ExtensionHeader.cs" LinkBase="BlazorPack\MessagePack" />
-    <Compile Include="$(MessagePackRoot)ExtensionResult.cs" LinkBase="BlazorPack\MessagePack" />
-    <Compile Include="$(MessagePackRoot)MessagePackCode.cs" LinkBase="BlazorPack\MessagePack" />
-    <Compile Include="$(MessagePackRoot)MessagePackReader.cs" LinkBase="BlazorPack\MessagePack" />
-    <Compile Include="$(MessagePackRoot)T4\MessagePackReader.Integers.cs" LinkBase="BlazorPack\MessagePack" />
-    <Compile Include="$(MessagePackRoot)MessagePackSerializationException.cs" LinkBase="BlazorPack\MessagePack" />
-    <Compile Include="$(MessagePackRoot)MessagePackWriter.cs" LinkBase="BlazorPack\MessagePack" />
-    <Compile Include="$(MessagePackRoot)Nil.cs" LinkBase="BlazorPack\MessagePack" />
-    <Compile Include="$(MessagePackRoot)Internal\DateTimeConstants.cs" LinkBase="BlazorPack\MessagePack" />
-    <Compile Include="$(MessagePackRoot)StringEncoding.cs" LinkBase="BlazorPack\MessagePack" />
-    <Compile Include="$(MessagePackRoot)SequencePool.cs" LinkBase="BlazorPack\MessagePack" />
-    <Compile Include="$(MessagePackRoot)SequenceReader.cs" LinkBase="BlazorPack\MessagePack" />
-    <Compile Include="$(MessagePackRoot)SequenceReaderExtensions.cs" LinkBase="BlazorPack\MessagePack" />
-    <Compile Include="$(MessagePackRoot)Utilities.cs" LinkBase="BlazorPack\MessagePack" />
+    <_MessagePackSource Include="$(MessagePackRoot)BufferWriter.cs" />
+    <_MessagePackSource Include="$(MessagePackRoot)ExtensionHeader.cs" />
+    <_MessagePackSource Include="$(MessagePackRoot)ExtensionResult.cs" />
+    <_MessagePackSource Include="$(MessagePackRoot)MessagePackCode.cs" />
+    <_MessagePackSource Include="$(MessagePackRoot)MessagePackReader.cs" />
+    <_MessagePackSource Include="$(MessagePackRoot)T4\MessagePackReader.Integers.cs" />
+    <_MessagePackSource Include="$(MessagePackRoot)MessagePackSerializationException.cs" />
+    <_MessagePackSource Include="$(MessagePackRoot)MessagePackWriter.cs" />
+    <_MessagePackSource Include="$(MessagePackRoot)Nil.cs" />
+    <_MessagePackSource Include="$(MessagePackRoot)Internal\DateTimeConstants.cs" />
+    <_MessagePackSource Include="$(MessagePackRoot)StringEncoding.cs" />
+    <_MessagePackSource Include="$(MessagePackRoot)SequencePool.cs" />
+    <_MessagePackSource Include="$(MessagePackRoot)SequenceReader.cs" />
+    <_MessagePackSource Include="$(MessagePackRoot)SequenceReaderExtensions.cs" />
+    <_MessagePackSource Include="$(MessagePackRoot)Utilities.cs" />
+    <Compile Include="@(_MessagePackSource)" LinkBase="BlazorPack\MessagePack" />
 
     <!-- Shared descriptor infrastructure with MVC -->
     <Compile Include="$(RepoRoot)src\Shared\Components\ComponentMarker.cs" />
@@ -120,4 +121,12 @@
   <ItemGroup>
     <EmbeddedResource Include="Properties\ILLink.Substitutions.xml" LogicalName="ILLink.Substitutions.xml" />
   </ItemGroup>
+
+  <Target Name="ValidateMessagePackSources" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <_MissingMessagePackSource Include="@(_MessagePackSource)" Condition="!Exists('%(Identity)')" />
+    </ItemGroup>
+    <Error Condition="'@(_MissingMessagePackSource->Count())' != '0'"
+           Text="MessagePack-CSharp source files are missing. If the submodule is not initialized, run from the repository root: git submodule update --init src/submodules/MessagePack-CSharp" />
+  </Target>
 </Project>


### PR DESCRIPTION
# Add diagnostic for missing MessagePack submodule sources

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Add a focused diagnostic for missing MessagePack submodule sources

## Description

While using Copilot to reproduce an unrelated Components issue in a fresh linked worktree, incomplete local setup ended up dominating the investigation. The MessagePack-CSharp submodule was not initialized, but Components.Server reported that prerequisite as a cascade of missing-source `CS2001` compiler errors with no indication of how to fix the checkout.

This keeps the diagnostic close to the project that consumes the sources. The 15 MessagePack files are defined once, used as the `Compile` input, and validated from the same list before `CoreCompile`. If any consumed source is missing, the build stops with one focused message explaining that an uninitialized submodule may be the cause and provides:

```console
git submodule update --init src/submodules/MessagePack-CSharp
```

This helps contributors and coding agents diagnose incomplete local setup quickly. It does not mutate the checkout or hide genuinely missing files.

Validation:

- A fresh worktree with the submodule uninitialized produced repeated MessagePack `CS2001` errors before this change; afterward it produces one actionable build error and zero `CS2001` errors.
- Temporarily removing a consumed non-`BufferWriter` file verifies that validation covers the authoritative source list rather than a single sentinel.
- Initializing or restoring the sources allows the targeted Components.Server build to succeed.