### PR TITLE
[Blazor] Add ToggleEventArgs for toggle events

### DIFF
--- a/src/Components/Web.JS/src/Rendering/Events/EventTypes.ts
+++ b/src/Components/Web.JS/src/Rendering/Events/EventTypes.ts
@@ -169,8 +169,11 @@ registerBuiltInEventType(['wheel', 'mousewheel'], {
 registerBuiltInEventType([
   'cancel',
   'close',
-  'toggle',
 ], createBlankEventArgsOptions);
+
+registerBuiltInEventType(['toggle'], {
+  createEventArgs: e => parseToggleEvent(e as ToggleEvent),
+});
 
 function parseChangeEvent(event: Event): ChangeEventArgs {
   const element = event.target as Element;
@@ -246,6 +249,13 @@ function parseProgressEvent(event: ProgressEvent<EventTarget>): ProgressEventArg
     loaded: event.loaded,
     total: event.total,
     type: event.type,
+  };
+}
+
+function parseToggleEvent(event: ToggleEvent): ToggleEventArgs {
+  return {
+    newState: event.newState,
+    oldState: event.oldState,
   };
 }
 
@@ -462,6 +472,11 @@ interface ProgressEventArgs {
   loaded: number;
   total: number;
   type: string;
+}
+
+interface ToggleEventArgs {
+  newState: string;
+  oldState: string;
 }
 
 interface TouchEventArgs {

--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -59,6 +59,12 @@ Microsoft.AspNetCore.Components.Web.SupplyParameterFromTempDataAttribute.Name.ge
 Microsoft.AspNetCore.Components.Web.SupplyParameterFromTempDataAttribute.Name.set -> void
 Microsoft.AspNetCore.Components.Web.SupplyParameterFromTempDataAttribute.SupplyParameterFromTempDataAttribute() -> void
 virtual Microsoft.AspNetCore.Components.Forms.InputFile.Dispose(bool disposing) -> void
+Microsoft.AspNetCore.Components.Web.ToggleEventArgs
+Microsoft.AspNetCore.Components.Web.ToggleEventArgs.ToggleEventArgs() -> void
+Microsoft.AspNetCore.Components.Web.ToggleEventArgs.NewState.get -> string!
+Microsoft.AspNetCore.Components.Web.ToggleEventArgs.NewState.set -> void
+Microsoft.AspNetCore.Components.Web.ToggleEventArgs.OldState.get -> string!
+Microsoft.AspNetCore.Components.Web.ToggleEventArgs.OldState.set -> void
 Microsoft.AspNetCore.Components.Forms.DisplayName<TValue>
 Microsoft.AspNetCore.Components.Forms.DisplayName<TValue>.DisplayName() -> void
 Microsoft.AspNetCore.Components.Forms.DisplayName<TValue>.For.get -> System.Linq.Expressions.Expression<System.Func<TValue>!>?

--- a/src/Components/Web/src/Web/EventHandlers.cs
+++ b/src/Components/Web/src/Web/EventHandlers.cs
@@ -122,8 +122,8 @@ namespace Microsoft.AspNetCore.Components.Web;
 [EventHandler("onreadystatechange", typeof(EventArgs), true, true)]
 [EventHandler("onscroll", typeof(EventArgs), true, true)]
 
-// <details>
-[EventHandler("ontoggle", typeof(EventArgs), true, true)]
+// Toggle events
+[EventHandler("ontoggle", typeof(ToggleEventArgs), true, true)]
 
 // <dialog>
 [EventHandler("oncancel", typeof(EventArgs), false, true)]

--- a/src/Components/Web/src/Web/ToggleEventArgs.cs
+++ b/src/Components/Web/src/Web/ToggleEventArgs.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Web;
+
+/// <summary>
+/// Supplies information about a toggle event that is being raised.
+/// </summary>
+public class ToggleEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets or sets the state the element is transitioning from.
+    /// </summary>
+    public string OldState { get; set; } = default!;
+
+    /// <summary>
+    /// Gets or sets the state the element is transitioning to.
+    /// </summary>
+    public string NewState { get; set; } = default!;
+}

--- a/src/Components/Web/src/WebEventData/ToggleEventArgsReader.cs
+++ b/src/Components/Web/src/WebEventData/ToggleEventArgsReader.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Text.Json;
+
+namespace Microsoft.AspNetCore.Components.Web;
+
+internal static class ToggleEventArgsReader
+{
+    private static readonly JsonEncodedText NewState = JsonEncodedText.Encode("newState");
+    private static readonly JsonEncodedText OldState = JsonEncodedText.Encode("oldState");
+
+    internal static ToggleEventArgs Read(JsonElement jsonElement)
+    {
+        var eventArgs = new ToggleEventArgs();
+        foreach (var property in jsonElement.EnumerateObject())
+        {
+            if (property.NameEquals(NewState.EncodedUtf8Bytes))
+            {
+                eventArgs.NewState = property.Value.GetString()!;
+            }
+            else if (property.NameEquals(OldState.EncodedUtf8Bytes))
+            {
+                eventArgs.OldState = property.Value.GetString()!;
+            }
+            else
+            {
+                throw new JsonException($"Unknown property {property.Name}");
+            }
+        }
+
+        return eventArgs;
+    }
+}

--- a/src/Components/Web/src/WebEventData/WebEventData.cs
+++ b/src/Components/Web/src/WebEventData/WebEventData.cs
@@ -185,9 +185,12 @@ internal sealed class WebEventData
                 eventArgs = WheelEventArgsReader.Read(eventArgsJson);
                 return true;
 
+            case "toggle":
+                eventArgs = ToggleEventArgsReader.Read(eventArgsJson);
+                return true;
+
             case "cancel":
             case "close":
-            case "toggle":
                 eventArgs = EventArgs.Empty;
                 return true;
 

--- a/src/Components/Web/test/WebEventData/ToggleEventArgsReaderTest.cs
+++ b/src/Components/Web/test/WebEventData/ToggleEventArgsReaderTest.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+
+namespace Microsoft.AspNetCore.Components.Web;
+
+public class ToggleEventArgsReaderTest
+{
+    [Fact]
+    public void Read_Works()
+    {
+        var args = new ToggleEventArgs
+        {
+            NewState = "open",
+            OldState = "closed",
+        };
+
+        var jsonElement = GetJsonElement(args);
+        var result = ToggleEventArgsReader.Read(jsonElement);
+
+        Assert.Equal(args.NewState, result.NewState);
+        Assert.Equal(args.OldState, result.OldState);
+    }
+
+    private static JsonElement GetJsonElement<T>(T args)
+    {
+        var json = JsonSerializer.SerializeToUtf8Bytes(args, JsonSerializerOptionsProvider.Options);
+        var jsonReader = new Utf8JsonReader(json);
+
+        return JsonElement.ParseValue(ref jsonReader);
+    }
+}

--- a/src/Components/test/E2ETest/Tests/EventTest.cs
+++ b/src/Components/test/E2ETest/Tests/EventTest.cs
@@ -171,7 +171,7 @@ public class EventTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
     {
         Browser.MountTestComponent<ToggleEventComponent>();
 
-        var detailsToggle = Browser.Exists(By.Id("details-toggle"));
+        var detailsToggle = Browser.Exists(By.CssSelector("#details-toggle > summary"));
 
         var output = Browser.Exists(By.Id("output"));
         Assert.Equal(string.Empty, output.Text);
@@ -180,7 +180,11 @@ public class EventTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
         var actions = new Actions(Browser).Click(detailsToggle);
 
         actions.Perform();
-        Browser.Equal("ontoggle,", () => output.Text);
+        Browser.Equal("ToggleEventArgs:closed->open,", () => output.Text);
+
+        actions = new Actions(Browser).Click(detailsToggle);
+        actions.Perform();
+        Browser.Equal("ToggleEventArgs:closed->open,ToggleEventArgs:open->closed,", () => output.Text);
     }
 
     [Fact]

--- a/src/Components/test/testassets/BasicTestApp/ToggleEventComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/ToggleEventComponent.razor
@@ -1,6 +1,6 @@
 ﻿<div>
     <p>
-        Output: <span id="output">@message</span>
+        Output: <span id="output">@_message</span>
     </p>
 
 
@@ -15,10 +15,12 @@
 </div>
 
 @code {
-    string message { get; set; }
+    private string _message = string.Empty;
 
-    void OnToggle(EventArgs e)
+    private void OnToggle(EventArgs eventArgs)
     {
-        message += "ontoggle,";
+        _message += eventArgs is ToggleEventArgs toggleEventArgs
+            ? $"{nameof(ToggleEventArgs)}:{toggleEventArgs.OldState}->{toggleEventArgs.NewState},"
+            : $"{eventArgs.GetType().Name},";
     }
 }


### PR DESCRIPTION
## Description

Blazor currently handles `toggle` as a blank `EventArgs`, discarding the browser's `oldState` and `newState` values. This change serializes those values, adds a dedicated `ToggleEventArgs`, and dispatches that type for `@ontoggle` handlers.

The existing `Toggle_CanTrigger` scenario now verifies both the opening and closing transitions while retaining an `EventArgs` method-group handler to cover the issue's existing usage shape.

## Proposed API

```diff
namespace Microsoft.AspNetCore.Components.Web;

+public class ToggleEventArgs : EventArgs
+{
+    public string OldState { get; set; }
+    public string NewState { get; set; }
+}
```

Example usage:

```razor
<details @ontoggle="HandleToggle">
    <summary>Details</summary>
</details>

@code {
    private void HandleToggle(ToggleEventArgs eventArgs)
    {
        Console.WriteLine($"{eventArgs.OldState} -> {eventArgs.NewState}");
    }
}
```

## API review status

This is a draft implementation pending ASP.NET Core API review. `PublicAPI.Unshipped.txt` records the proposed surface but does not indicate approval. The linked issue still needs the API-review label progression, an owner/champion, and approval before this PR is ready to merge.

## Compatibility

Changing the `ontoggle` event metadata from `EventArgs` to `ToggleEventArgs` enables strongly typed handlers and preserves ordinary `OnToggle(EventArgs)` method groups. It can, however, break explicitly typed `(EventArgs eventArgs) => ...` lambdas and explicitly typed `EventCallback<EventArgs>` expressions. This tradeoff requires explicit compatibility/API-review signoff.

Keeping the metadata as `EventArgs` was considered, but that would require customers to cast a runtime subtype and would not provide the normal strongly typed Blazor event-handler experience.

## Testing

- Added focused `ToggleEventArgsReader` coverage.
- Extended the browser scenario to verify `closed -> open` and `open -> closed`.
- Built the E2E project successfully with no warnings or errors.
- The Components Web test assembly passes. A latest local E2E rerun passed one execution mode; the other was blocked by a test-host `/subdir` 404 before the component mounted. The same focused scenario passed during the earlier red/green validation.

Fixes #66479