### PR TITLE
Handle DefaultConnectionContext abort/dispose cancellation race

### DIFF
--- a/src/Servers/Connections.Abstractions/src/DefaultConnectionContext.cs
+++ b/src/Servers/Connections.Abstractions/src/DefaultConnectionContext.cs
@@ -98,7 +98,17 @@ public class DefaultConnectionContext : ConnectionContext,
     /// <inheritdoc />
     public override void Abort(ConnectionAbortedException abortReason)
     {
-        ThreadPool.UnsafeQueueUserWorkItem(cts => ((CancellationTokenSource)cts!).Cancel(), _connectionClosedTokenSource);
+        ThreadPool.UnsafeQueueUserWorkItem(static cts =>
+        {
+            try
+            {
+                ((CancellationTokenSource)cts!).Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // The connection can be disposed between scheduling and running the cancellation.
+            }
+        }, _connectionClosedTokenSource);
     }
 
     /// <inheritdoc />

--- a/src/Servers/Kestrel/Core/test/ConnectionContextTests.cs
+++ b/src/Servers/Kestrel/Core/test/ConnectionContextTests.cs
@@ -1,7 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.DotNet.RemoteExecutor;
 using Moq;
 using Xunit;
 
@@ -22,5 +27,47 @@ public class ConnectionContextTests
 
         Assert.NotNull(ex);
         Assert.Equal("The connection was aborted by the application via ConnectionContext.Abort().", ex.Message);
+    }
+
+    [ConditionalFact]
+    [RemoteExecutionSupported]
+    public void DefaultConnectionContextDisposeAsyncAfterAbortDoesNotCrashProcess()
+    {
+        using var remoteHandle = RemoteExecutor.Invoke(static async () =>
+        {
+            ThreadPool.GetMinThreads(out var originalMinWorkerThreads, out var originalMinCompletionPortThreads);
+            ThreadPool.GetMaxThreads(out var originalMaxWorkerThreads, out var originalMaxCompletionPortThreads);
+
+            Assert.True(ThreadPool.SetMinThreads(1, originalMinCompletionPortThreads));
+            Assert.True(ThreadPool.SetMaxThreads(1, originalMaxCompletionPortThreads));
+
+            using var blockerStarted = new ManualResetEventSlim();
+            using var releaseBlocker = new ManualResetEventSlim();
+
+            try
+            {
+                ThreadPool.QueueUserWorkItem(_ =>
+                {
+                    blockerStarted.Set();
+                    releaseBlocker.Wait();
+                });
+
+                Assert.True(blockerStarted.Wait(TimeSpan.FromSeconds(10)));
+
+                var connection = new DefaultConnectionContext();
+                connection.Abort();
+                await connection.DisposeAsync();
+
+                releaseBlocker.Set();
+
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+            finally
+            {
+                releaseBlocker.Set();
+                ThreadPool.SetMaxThreads(originalMaxWorkerThreads, originalMaxCompletionPortThreads);
+                ThreadPool.SetMinThreads(originalMinWorkerThreads, originalMinCompletionPortThreads);
+            }
+        });
     }
 }


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Summary of the changes (Less than 80 chars)

Handle DefaultConnectionContext abort/dispose cancellation race

## Description

`DefaultConnectionContext.Abort()` queues cancellation of the connection-closed token on the ThreadPool. If the connection is disposed before that queued work runs, the queued `Cancel()` can observe a disposed `CancellationTokenSource` and raise `ObjectDisposedException` on the background worker.

This change makes the queued cancellation tolerate that already-disposed state. It also adds a `RemoteExecutor` regression test that forces the queued cancellation to run after `DisposeAsync()`.

Validation:

- `./restore.sh --no-build-nodejs --no-build-java --no-build-native`
- `source ./activate.sh >/dev/null && dotnet test src/Servers/Kestrel/Core/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj --no-restore --filter DefaultConnectionContextDisposeAsyncAfterAbortDoesNotCrashProcess`
- `source ./activate.sh >/dev/null && dotnet test src/Servers/Kestrel/Core/test/Microsoft.AspNetCore.Server.Kestrel.Core.Tests.csproj --no-restore`

Fixes #57098