### PR TITLE
Fix Dependabot nuget scan timeout with exclude-paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,20 @@ updates:
   - "/"
   # Exposes packages Dependabot otherwise can't see; see eng/tools/DependabotDiscovery/README.md
   - "/eng/tools/DependabotDiscovery"
+  # Scanning every project under "/" times out (repo has 600+ csproj files, most of which have
+  # no explicit PackageReference versions and rely on Directory.Build.props/Dependencies.props
+  # indirection, so restoring them individually adds cost without adding visibility). Excluding
+  # test/sample/benchmark trees keeps the scan within Dependabot's job time limit.
+  exclude-paths:
+  - "**/test/**"
+  - "**/tests/**"
+  - "**/*.Tests/**"
+  - "**/*.FunctionalTests/**"
+  - "**/sample/**"
+  - "**/samples/**"
+  - "**/testassets/**"
+  - "**/perf/**"
+  - "**/benchmark*/**"
   registries:
   - dotnet-public
   open-pull-requests-limit: 10


### PR DESCRIPTION
## Description

The Dependabot nuget-updater job (GitHub's dynamic `dependabot/dependabot-updates` workflow) has been timing out on every run since #68012 merged, e.g. https://github.com/dotnet/aspnetcore/actions/runs/30814186376. It hits an internal ~55 minute job cap enforced by GitHub's Dependabot service (not configurable via workflow/dependabot.yml).

### Root cause

Dependabot performs an individual "single restore" per discovered `.csproj` file under the scanned directories (`/` and `/eng/tools/DependabotDiscovery`), at ~11.8s/project. The repo has 600+ `.csproj` files, but only 26 of them contain any explicit `PackageReference ... Version="..."` attribute -- the rest resolve versions indirectly via `Directory.Build.props`/`Dependencies.props` (`LatestPackageReference`) or reference in-repo shared-framework assemblies. Scanning those adds restore time without adding anything Dependabot can actually act on.

### Fix

Add `exclude-paths` (GA since Aug 2025) to skip manifest parsing/restoring for `test`/`tests`/`*.Tests`/`*.FunctionalTests`/`sample`/`samples`/`testassets`/`perf`/`benchmark*` trees, which account for the bulk of low-value scans. This brings the scanned project count from 618 down to ~219 (~43 min estimated restore time, comfortably under the ~55 min cap).

The handful of excluded `.csproj` files that do have explicit package versions (e.g. `src/Mvc/perf/benchmarkapps/BasicApi`, `IIS.NewHandler.FunctionalTests`, `InProcessNewShimWebSite`) are intentionally pinned to old versions for legacy/back-compat testing and shouldn't be bumped by Dependabot anyway.

## Testing

Validated the resulting YAML parses correctly. Modeled the exclude patterns against the full list of 618 `.csproj` paths in the repo to confirm the impact and estimate the new restore-time budget.
