### PR TITLE
Fix NavigationManager.Refresh ignoring forceReload parameter

### DIFF
--- a/src/Components/Components/src/NavigationManager.cs
+++ b/src/Components/Components/src/NavigationManager.cs
@@ -253,7 +253,7 @@ public abstract class NavigationManager
     /// falling back on a full page reload if necessary.
     /// </remarks>
     public virtual void Refresh(bool forceReload = false)
-        => NavigateTo(Uri, forceLoad: true, replace: true);
+        => NavigateTo(Uri, forceLoad: forceReload, replace: true);
 
     /// <summary>
     /// Handles setting the NotFound state.

--- a/src/Components/Components/test/NavigationManagerTest.cs
+++ b/src/Components/Components/test/NavigationManagerTest.cs
@@ -1102,6 +1102,49 @@ public class NavigationManagerTest
             testNavManager.ResolveRelativeToCurrentPath(null!));
     }
 
+    [Fact]
+    public void Refresh_WithForceReloadFalse_PassesForceLoadFalseToNavigateTo()
+    {
+        var baseUri = "scheme://host/";
+        var currentUri = "scheme://host/page.html";
+        var testNavManager = new TestNavigationManagerWithNavigationTracking(baseUri, currentUri);
+
+        testNavManager.Refresh(forceReload: false);
+
+        Assert.Single(testNavManager.Navigations);
+        Assert.Equal(currentUri, testNavManager.Navigations[0].uri);
+        Assert.False(testNavManager.Navigations[0].options.ForceLoad);
+        Assert.True(testNavManager.Navigations[0].options.ReplaceHistoryEntry);
+    }
+
+    [Fact]
+    public void Refresh_WithForceReloadTrue_PassesForceLoadTrueToNavigateTo()
+    {
+        var baseUri = "scheme://host/";
+        var currentUri = "scheme://host/page.html";
+        var testNavManager = new TestNavigationManagerWithNavigationTracking(baseUri, currentUri);
+
+        testNavManager.Refresh(forceReload: true);
+
+        Assert.Single(testNavManager.Navigations);
+        Assert.Equal(currentUri, testNavManager.Navigations[0].uri);
+        Assert.True(testNavManager.Navigations[0].options.ForceLoad);
+        Assert.True(testNavManager.Navigations[0].options.ReplaceHistoryEntry);
+    }
+
+    [Fact]
+    public void Refresh_WithDefaultParameter_DoesNotForceReload()
+    {
+        var baseUri = "scheme://host/";
+        var currentUri = "scheme://host/page.html";
+        var testNavManager = new TestNavigationManagerWithNavigationTracking(baseUri, currentUri);
+
+        testNavManager.Refresh();
+
+        Assert.Single(testNavManager.Navigations);
+        Assert.False(testNavManager.Navigations[0].options.ForceLoad);
+    }
+
     private class TestNavigationManager : NavigationManager
     {
         public TestNavigationManager()


### PR DESCRIPTION
## Problem

`NavigationManager.Refresh(bool forceReload = false)` always performed a full
forced page reload, regardless of the `forceReload` argument passed in:

```csharp
public virtual void Refresh(bool forceReload = false)
    => NavigateTo(Uri, forceLoad: true, replace: true);
```

The `forceReload` parameter was accepted but never used — `forceLoad: true`
was hardcoded. This contradicts the method's own doc comment, which states
that when `forceReload` is `false` the response may be merged with the
existing document to preserve client-side state (enhanced navigation),
falling back to a full reload only if necessary.

This affects any `NavigationManager` that relies on the base class's default
`Refresh` implementation (e.g. `HttpNavigationManager`, used for
non-interactive/static server-side rendering) rather than overriding it.
`RemoteNavigationManager` (Blazor Server) and `WebAssemblyNavigationManager`
already forward `forceReload` correctly through their own overrides, so this
does not affect interactive Blazor Server/WebAssembly circuits.

## Fix

Pass `forceReload` through to `NavigateTo`'s `forceLoad` option instead of
hardcoding `true`:

```csharp
public virtual void Refresh(bool forceReload = false)
    => NavigateTo(Uri, forceLoad: forceReload, replace: true);
```

## Testing

Added three regression tests in `NavigationManagerTest.cs` covering
`Refresh(false)`, `Refresh(true)`, and the default parameter value, asserting
the `ForceLoad` option passed to `NavigateTo` matches the argument.

Ran the full `Microsoft.AspNetCore.Components.Tests` suite
(`eng\build.cmd -test -projects .\src\Components\Components\test\Microsoft.AspNetCore.Components.Tests.csproj`):
1278 tests, 1265 passed, 5 failed, 8 skipped. The 5 failures are pre-existing
on a clean checkout of `main` (unrelated `EventCallbackFactoryBinderExtensionsTest`
date-formatting tests and one `PersistentServicesRegistryTest` test, likely
culture-dependent) and are unaffected by this change — confirmed by running
the same suite before applying the fix.

Fixes #59854
