### PR TITLE
[release/2.3] Add direct PackageReference to System.Security.Cryptography.Xml

### DIFF
--- a/src/Antiforgery/src/Microsoft.AspNetCore.Antiforgery.csproj
+++ b/src/Antiforgery/src/Microsoft.AspNetCore.Antiforgery.csproj
@@ -14,6 +14,7 @@
     <Reference Include="Microsoft.AspNetCore.Http.Extensions" />
     <Reference Include="Microsoft.AspNetCore.WebUtilities" />
     <Reference Include="Microsoft.Extensions.ObjectPool" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/DataProtection/Extensions/src/Microsoft.AspNetCore.DataProtection.Extensions.csproj
+++ b/src/DataProtection/Extensions/src/Microsoft.AspNetCore.DataProtection.Extensions.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.DataProtection" />
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/DataProtection/SystemWeb/src/Microsoft.AspNetCore.DataProtection.SystemWeb.csproj
+++ b/src/DataProtection/SystemWeb/src/Microsoft.AspNetCore.DataProtection.SystemWeb.csproj
@@ -17,6 +17,7 @@
     <Reference Include="Microsoft.Extensions.DependencyInjection" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Middleware/Session/src/Microsoft.AspNetCore.Session.csproj
+++ b/src/Middleware/Session/src/Microsoft.AspNetCore.Session.csproj
@@ -15,6 +15,7 @@
     <Reference Include="Microsoft.Extensions.Caching.Abstractions" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Mvc/Mvc.ViewFeatures/src/Microsoft.AspNetCore.Mvc.ViewFeatures.csproj
+++ b/src/Mvc/Mvc.ViewFeatures/src/Microsoft.AspNetCore.Mvc.ViewFeatures.csproj
@@ -35,6 +35,7 @@ Microsoft.AspNetCore.Mvc.ViewComponent</Description>
     <Reference Include="Microsoft.Extensions.WebEncoders" />
     <Reference Include="Newtonsoft.Json.Bson" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authentication/Cookies/src/Microsoft.AspNetCore.Authentication.Cookies.csproj
+++ b/src/Security/Authentication/Cookies/src/Microsoft.AspNetCore.Authentication.Cookies.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Authentication" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authentication/Core/src/Microsoft.AspNetCore.Authentication.csproj
+++ b/src/Security/Authentication/Core/src/Microsoft.AspNetCore.Authentication.csproj
@@ -20,6 +20,7 @@
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />
     <Reference Include="Microsoft.Extensions.Options" />
     <Reference Include="Microsoft.Extensions.WebEncoders" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authentication/JwtBearer/src/Microsoft.AspNetCore.Authentication.JwtBearer.csproj
+++ b/src/Security/Authentication/JwtBearer/src/Microsoft.AspNetCore.Authentication.JwtBearer.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Authentication" />
     <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authentication/OAuth/src/Microsoft.AspNetCore.Authentication.OAuth.csproj
+++ b/src/Security/Authentication/OAuth/src/Microsoft.AspNetCore.Authentication.OAuth.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Authentication" />
     <Reference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authentication/WsFederation/src/Microsoft.AspNetCore.Authentication.WsFederation.csproj
+++ b/src/Security/Authentication/WsFederation/src/Microsoft.AspNetCore.Authentication.WsFederation.csproj
@@ -12,6 +12,7 @@
     <Reference Include="Microsoft.AspNetCore.Authentication" />
     <Reference Include="Microsoft.IdentityModel.Protocols.WsFederation" />
     <Reference Include="System.IdentityModel.Tokens.Jwt" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Interop/src/Microsoft.Owin.Security.Interop.csproj
+++ b/src/Security/Interop/src/Microsoft.Owin.Security.Interop.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.DataProtection.Extensions" />
     <Reference Include="Microsoft.Owin.Security" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Description

Addresses a Component Governance alert requiring these projects to consume `System.Security.Cryptography.Xml` 8.0.4 directly. Each of these projects already depends transitively on the package but did not pin a direct version, so CG flags the transitive reference.

Adds `<PackageReference Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />` (currently 8.0.4, per `build/dependencies.props`) to:

- src/Antiforgery/src/Microsoft.AspNetCore.Antiforgery.csproj
- src/DataProtection/Extensions/src/Microsoft.AspNetCore.DataProtection.Extensions.csproj
- src/DataProtection/SystemWeb/src/Microsoft.AspNetCore.DataProtection.SystemWeb.csproj
- src/Middleware/Session/src/Microsoft.AspNetCore.Session.csproj
- src/Mvc/Mvc.ViewFeatures/src/Microsoft.AspNetCore.Mvc.ViewFeatures.csproj
- src/Security/Authentication/Cookies/src/Microsoft.AspNetCore.Authentication.Cookies.csproj
- src/Security/Authentication/Core/src/Microsoft.AspNetCore.Authentication.csproj
- src/Security/Authentication/JwtBearer/src/Microsoft.AspNetCore.Authentication.JwtBearer.csproj
- src/Security/Authentication/OAuth/src/Microsoft.AspNetCore.Authentication.OAuth.csproj
- src/Security/Authentication/WsFederation/src/Microsoft.AspNetCore.Authentication.WsFederation.csproj
- src/Security/Interop/src/Microsoft.Owin.Security.Interop.csproj

This follows the same pattern already used elsewhere in the repo (e.g. `Microsoft.AspNetCore.Mvc.csproj`, `Microsoft.AspNetCore.Identity.csproj`) and mirrors a similar prior fix (PR 60291) for the 2.3.10 patch.

No version bump was needed since `SystemSecurityCryptographyXmlPackageVersion` is already 8.0.4 on release/2.3. All affected packages are already included in the 2.3.12 patch via the blanket `IsPackageInThisPatch` rule in `Directory.Build.targets` (everything except Razor packages), so no `PatchConfig.props` changes are required.
