### PR TITLE
Improve Blazor WebAssembly E2E startup diagnostics

### DIFF
--- a/src/Components/test/E2ETest/Infrastructure/ServerFixtures/BlazorWasmTestAppFixture.cs
+++ b/src/Components/test/E2ETest/Infrastructure/ServerFixtures/BlazorWasmTestAppFixture.cs
@@ -41,21 +41,26 @@ public class BlazorWasmTestAppFixture<TProgram> : WebHostServerFixture
         var indexHtmlPath = Path.Combine(ContentRoot, "wwwroot", "index.html");
         var runtimeManifestPath = Path.ChangeExtension(clientAssemblyPath, ".staticwebassets.runtime.json");
         var endpointsManifestPath = Path.ChangeExtension(clientAssemblyPath, ".staticwebassets.endpoints.json");
+        var clientAssemblyExists = File.Exists(clientAssemblyPath);
+        var contentRootExists = Directory.Exists(ContentRoot);
+        var indexHtmlExists = File.Exists(indexHtmlPath);
+        var runtimeManifestExists = File.Exists(runtimeManifestPath);
+        var endpointsManifestExists = File.Exists(endpointsManifestPath);
 
-        if (!File.Exists(clientAssemblyPath) ||
-            !Directory.Exists(ContentRoot) ||
-            !File.Exists(indexHtmlPath) ||
-            !File.Exists(runtimeManifestPath) ||
-            !File.Exists(endpointsManifestPath))
+        if (!clientAssemblyExists ||
+            !contentRootExists ||
+            !indexHtmlExists ||
+            !runtimeManifestExists ||
+            !endpointsManifestExists)
         {
             throw new InvalidOperationException(
                 $"""
                 The Blazor WebAssembly E2E test app is not ready to start.
-                Client assembly: '{clientAssemblyPath}' ({(File.Exists(clientAssemblyPath) ? "found" : "missing")})
-                Content root: '{ContentRoot}' ({(Directory.Exists(ContentRoot) ? "found" : "missing")})
-                Entry point: '{indexHtmlPath}' ({(File.Exists(indexHtmlPath) ? "found" : "missing")})
-                Runtime manifest: '{runtimeManifestPath}' ({(File.Exists(runtimeManifestPath) ? "found" : "missing")})
-                Endpoints manifest: '{endpointsManifestPath}' ({(File.Exists(endpointsManifestPath) ? "found" : "missing")})
+                Client assembly: '{clientAssemblyPath}' ({(clientAssemblyExists ? "found" : "missing")})
+                Content root: '{ContentRoot}' ({(contentRootExists ? "found" : "missing")})
+                Entry point: '{indexHtmlPath}' ({(indexHtmlExists ? "found" : "missing")})
+                Runtime manifest: '{runtimeManifestPath}' ({(runtimeManifestExists ? "found" : "missing")})
+                Endpoints manifest: '{endpointsManifestPath}' ({(endpointsManifestExists ? "found" : "missing")})
 
                 Rebuild the E2E project and referenced test apps before rerunning the test with --no-build:
                   dotnet build src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj --no-restore

--- a/src/Components/test/E2ETest/Infrastructure/ServerFixtures/BlazorWasmTestAppFixture.cs
+++ b/src/Components/test/E2ETest/Infrastructure/ServerFixtures/BlazorWasmTestAppFixture.cs
@@ -36,8 +36,33 @@ public class BlazorWasmTestAppFixture<TProgram> : WebHostServerFixture
             return CreateStaticWebHost(staticFilePath);
         }
 
-        ContentRoot = FindSampleOrTestSitePath(
-            typeof(TProgram).Assembly.FullName);
+        var clientAssemblyPath = typeof(TProgram).Assembly.Location;
+        ContentRoot = FindSampleOrTestSitePath(typeof(TProgram).Assembly.FullName);
+        var indexHtmlPath = Path.Combine(ContentRoot, "wwwroot", "index.html");
+        var runtimeManifestPath = Path.ChangeExtension(clientAssemblyPath, ".staticwebassets.runtime.json");
+        var endpointsManifestPath = Path.ChangeExtension(clientAssemblyPath, ".staticwebassets.endpoints.json");
+
+        if (!File.Exists(clientAssemblyPath) ||
+            !Directory.Exists(ContentRoot) ||
+            !File.Exists(indexHtmlPath) ||
+            !File.Exists(runtimeManifestPath) ||
+            !File.Exists(endpointsManifestPath))
+        {
+            throw new InvalidOperationException(
+                $"""
+                The Blazor WebAssembly E2E test app is not ready to start.
+                Client assembly: '{clientAssemblyPath}' ({(File.Exists(clientAssemblyPath) ? "found" : "missing")})
+                Content root: '{ContentRoot}' ({(Directory.Exists(ContentRoot) ? "found" : "missing")})
+                Entry point: '{indexHtmlPath}' ({(File.Exists(indexHtmlPath) ? "found" : "missing")})
+                Runtime manifest: '{runtimeManifestPath}' ({(File.Exists(runtimeManifestPath) ? "found" : "missing")})
+                Endpoints manifest: '{endpointsManifestPath}' ({(File.Exists(endpointsManifestPath) ? "found" : "missing")})
+
+                Rebuild the E2E project and referenced test apps before rerunning the test with --no-build:
+                  dotnet build src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj --no-restore
+                A --no-dependencies build can copy existing dependency outputs, but it does not rebuild referenced client apps.
+                Do not use it when referenced app outputs may be stale or missing.
+                """);
+        }
 
         var host = "127.0.0.1";
         if (E2ETestOptions.Instance.SauceTest)
@@ -45,14 +70,13 @@ public class BlazorWasmTestAppFixture<TProgram> : WebHostServerFixture
             host = E2ETestOptions.Instance.Sauce.HostName;
         }
 
-        var assemblyLocation = typeof(TProgram).Assembly.Location;
         var args = new List<string>
             {
                 "--urls", $"http://{host}:0",
                 "--contentroot", ContentRoot,
                 "--Gateway:PathBase", PathBase,
-                "--staticWebAssets", Path.ChangeExtension(assemblyLocation, ".staticwebassets.runtime.json"),
-                "--ClientApps:app:EndpointsManifest", Path.ChangeExtension(assemblyLocation, ".staticwebassets.endpoints.json"),
+                "--staticWebAssets", runtimeManifestPath,
+                "--ClientApps:app:EndpointsManifest", endpointsManifestPath,
                 "--ClientApps:app:PathPrefix", "",
             };
 


### PR DESCRIPTION
# Improve Blazor WebAssembly E2E startup diagnostics

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Fail fast when non-trimmed WASM E2E prerequisites are missing

## Description

We started this while trying to make Components issue reproduction and build workflows easier for contributors and coding agents. While using Copilot to reproduce an unrelated Components issue in a fresh local worktree, incomplete E2E client outputs caused setup friction to dominate the investigation.

With the loaded runtime manifest missing, `/subdir` still returned 200, framework asset requests returned 500, and the unchanged test failed after about 4.3 minutes without clearly identifying the missing prerequisite.

This one-file change validates the exact inputs used by the non-trimmed client/WASM fixture before creating the host:

- The loaded client assembly
- The resolved content root
- `wwwroot/index.html` beneath that content root
- The runtime manifest beside the loaded assembly
- The endpoints manifest beside the loaded assembly

When an input is missing, startup now fails in about 12 seconds and reports every exact path with found/missing status plus the dependency-aware rebuild command. The guidance notes that a `--no-dependencies` build can copy existing dependency outputs, but it does not rebuild referenced client apps, so it should not be used when referenced app outputs may be stale or missing.

Valid unchanged baselines passed for `BasicTestApp`, `StandaloneApp` (a second direct generic `TProgram` fixture), and the independent server-execution path. Trimmed-app mode returns before the new guard and remains unchanged.

This intentionally detects missing prerequisites only. It does not attempt to validate stale-but-present manifest contents.

Fixes #N/A