### PR TITLE
Exclude restored packages from CodeQL analysis

### DIFF
--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -7,3 +7,6 @@ path_classifiers:
     # The test/ directories don't contain shipping implementations of code, so they should
     # be excluded from analysis. 
     - src/**/test/*
+  library:
+    # The .packages/ directory contains restored third-party dependencies.
+    - .packages


### PR DESCRIPTION
## Description

Classifies `.packages` as library code in `.CodeQL.yml` so CodeQL and TSA do not report findings from restored third-party dependencies such as node-gyp and Emscripten.