### PR TITLE
[.NET 11] Update MCP template dependency

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -169,7 +169,7 @@
     <MicrosoftIdentityWebDownstreamApiVersion>3.15.1</MicrosoftIdentityWebDownstreamApiVersion>
     <MicrosoftWindowsCsWin32Version>0.3.296</MicrosoftWindowsCsWin32Version>
     <MessagePackAnalyzerVersion>$(MessagePackVersion)</MessagePackAnalyzerVersion>
-    <ModelContextProtocolVersion>1.2.0</ModelContextProtocolVersion>
+    <ModelContextProtocolVersion>2.1.0</ModelContextProtocolVersion>
     <ModelContextProtocolAspNetCoreVersion>$(ModelContextProtocolVersion)</ModelContextProtocolAspNetCoreVersion>
     <MoqVersion>4.20.72</MoqVersion>
     <MonoCecilVersion>0.11.2</MonoCecilVersion>


### PR DESCRIPTION
Updates the MCP server template's generated `ModelContextProtocol` and `ModelContextProtocol.AspNetCore` package references to 2.1.0.

## Customer Impact
Aligns new project creations to create MCP 2.x-based applications, enabling support for the 2026-07-28 Model Context Protocol specification.

We also updated .NET 11 (for RC1) with [[.NET 11] Update MCP template dependency (dotnet/aspnetcore#68212)](https://nam06.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2Fdotnet%2Faspnetcore%2Fpull%2F68212&data=05%7C02%7CJeff.Handley%40microsoft.com%7Cd616e7cd02a54f7f021308def4225efb%7C72f988bf86f141af91ab2d7cd011db47%7C1%7C0%7C639216625640511856%7CUnknown%7CTWFpbGZsb3d8eyJFbXB0eU1hcGkiOnRydWUsIlYiOiIwLjAuMDAwMCIsIlAiOiJXaW4zMiIsIkFOIjoiTWFpbCIsIldUIjoyfQ%3D%3D%7C0%7C%7C%7C&sdata=Gsu5qEX%2B00C2hSEVwSEelsrj%2F4Axu3d6tjJ7K3Q7Q4Q%3D&reserved=0).

## Risk
Low. This has the same effect as creating a project with the prior version and updating the package references. I also verified that the ModelContextProtocol 2.1.0 packages were successfully restored from internal feeds using the aspnetcore-ci-official pipeline.

## Validation

- Packed `Microsoft.McpServer.ProjectTemplates`.
- Generated local and remote non-self-contained MCP server templates.
- Verified generated package references use 2.1.0 and built both generated projects.