### PR TITLE
[.NET 10] Update Model Context Protocol to 2.1.0

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -150,7 +150,7 @@
     <MicrosoftIdentityWebDownstreamApiVersion>3.15.1</MicrosoftIdentityWebDownstreamApiVersion>
     <MicrosoftWindowsCsWin32Version>0.3.46-beta</MicrosoftWindowsCsWin32Version>
     <MessagePackAnalyzerVersion>$(MessagePackVersion)</MessagePackAnalyzerVersion>
-    <ModelContextProtocolVersion>1.2.0</ModelContextProtocolVersion>
+    <ModelContextProtocolVersion>2.1.0</ModelContextProtocolVersion>
     <ModelContextProtocolAspNetCoreVersion>$(ModelContextProtocolVersion)</ModelContextProtocolAspNetCoreVersion>
     <MoqVersion>4.10.0</MoqVersion>
     <MonoCecilVersion>0.11.2</MonoCecilVersion>


### PR DESCRIPTION
Updates the MCP server template's generated `ModelContextProtocol` and `ModelContextProtocol.AspNetCore` package references to 2.1.0.

## Validation

- Packed `Microsoft.McpServer.ProjectTemplates`.
- Generated local and remote non-self-contained MCP server templates.
- Verified generated package references use 2.1.0 and built both generated projects.