### PR TITLE
Fix extra `\n` in resourceManagement for breaking change announcement

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -672,11 +672,11 @@ configuration:
 
             ${assignees}, after you commit this PR please take the following actions, as part of the breaking changes announcement process:
 
-            \n- [ ] Create an announcement issue by using the [ASP.NET Core breaking change](https://github.com/aspnet/Announcements/issues/new?assignees=&labels=Breaking+change&template=breaking-change.yaml&title=%5BBreaking+change%5D%3A+) issue template.
+            - [ ] Create an announcement issue by using the [ASP.NET Core breaking change](https://github.com/aspnet/Announcements/issues/new?assignees=&labels=Breaking+change&template=breaking-change.yaml&title=%5BBreaking+change%5D%3A+) issue template.
 
-            \n- [ ] Link the breaking change announcement issue from this PR.
+            - [ ] Link the breaking change announcement issue from this PR.
 
-            \n- [ ] Remove the `needs-breaking-change-announcement` label.
+            - [ ] Remove the `needs-breaking-change-announcement` label.
       description: Breaking change actions reminder
     - if:
       - payloadType: Issues


### PR DESCRIPTION
See malformed comment in https://github.com/dotnet/aspnetcore/pull/67077#issuecomment-5187714182