### PR TITLE
[Blazor] Propagate SignalR authentication refresh to server circuits

### DIFF
--- a/src/Components/Server/src/ComponentHub.cs
+++ b/src/Components/Server/src/ComponentHub.cs
@@ -85,6 +85,14 @@ internal sealed partial class ComponentHub : Hub
         return _circuitRegistry.DisconnectAsync(circuitHost, Context.ConnectionId);
     }
 
+    public override Task OnAuthenticationRefreshedAsync()
+    {
+        var circuitHost = _circuitHandleRegistry.GetCircuit(Context.Items, CircuitKey);
+        circuitHost?.SetCircuitUser(Context.User);
+
+        return Task.CompletedTask;
+    }
+
     public async ValueTask<string> StartCircuit(string baseUri, string uri, string serializedComponentRecords, string applicationState)
     {
         var circuitHost = _circuitHandleRegistry.GetCircuit(Context.Items, CircuitKey);

--- a/src/Components/Server/test/Circuits/ComponentHubTest.cs
+++ b/src/Components/Server/test/Circuits/ComponentHubTest.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
 using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
@@ -334,11 +335,44 @@ public class ComponentHubTest
         mockClientProxy.Verify(m => m.SendCoreAsync("JS.Error", new[] { errorMessage }, It.IsAny<CancellationToken>()), Times.Once());
     }
 
+    [Fact]
+    public async Task OnAuthenticationRefreshedAsyncUpdatesCircuitUser()
+    {
+        var authenticationStateProvider = new ServerAuthenticationStateProvider();
+        var services = new ServiceCollection()
+            .AddSingleton<AuthenticationStateProvider>(authenticationStateProvider)
+            .BuildServiceProvider();
+        var circuitHost = TestCircuitHost.Create(serviceScope: services.CreateAsyncScope());
+
+        var handleRegistryMock = new Mock<ICircuitHandleRegistry>();
+        handleRegistryMock.Setup(m => m.GetCircuit(It.IsAny<IDictionary<object, object>>(), It.IsAny<object>()))
+            .Returns(circuitHost);
+
+        var refreshedUser = new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim(ClaimTypes.Name, "refreshed-user")],
+            "TestAuthType"));
+        var (_, hub) = InitializeComponentHub(handleRegistry: handleRegistryMock.Object, user: refreshedUser);
+
+        await hub.OnAuthenticationRefreshedAsync();
+
+        var authenticationState = await authenticationStateProvider.GetAuthenticationStateAsync();
+        Assert.Same(refreshedUser, authenticationState.User);
+    }
+
+    [Fact]
+    public async Task OnAuthenticationRefreshedAsyncWithoutCircuitDoesNotThrow()
+    {
+        var (_, hub) = InitializeComponentHub();
+
+        await hub.OnAuthenticationRefreshedAsync();
+    }
+
     private static (Mock<ISingleClientProxy>, ComponentHub) InitializeComponentHub(
         TestServerComponentDeserializer deserializer = null,
         ICircuitHandleRegistry handleRegistry = null,
         ICircuitPersistenceProvider provider = null,
-        ICircuitFactory circuitFactory = null)
+        ICircuitFactory circuitFactory = null,
+        ClaimsPrincipal user = null)
     {
         deserializer ??= new TestServerComponentDeserializer();
         var ephemeralDataProtectionProvider = new EphemeralDataProtectionProvider();
@@ -384,6 +418,7 @@ public class ComponentHubTest
         feature.Set(httpContextFeature.Object);
         mockContext.Setup(x => x.Features).Returns(feature);
         mockContext.Setup(x => x.ConnectionId).Returns("123");
+        mockContext.Setup(x => x.User).Returns(user);
         hub.Context = mockContext.Object;
 
         return (mockClientProxy, hub);

--- a/src/Components/Server/test/Circuits/ComponentHubTest.cs
+++ b/src/Components/Server/test/Circuits/ComponentHubTest.cs
@@ -418,7 +418,7 @@ public class ComponentHubTest
         feature.Set(httpContextFeature.Object);
         mockContext.Setup(x => x.Features).Returns(feature);
         mockContext.Setup(x => x.ConnectionId).Returns("123");
-        mockContext.Setup(x => x.User).Returns(user);
+        mockContext.Setup(x => x.User).Returns(user ?? new ClaimsPrincipal());
         hub.Context = mockContext.Object;
 
         return (mockClientProxy, hub);

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerAuthTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerAuthTest.cs
@@ -58,18 +58,23 @@ public class ServerAuthTest : AuthTest
             appElement.FindElement(By.CssSelector("#authorize-role .not-authorized")).Text);
 
         var javascript = (IJavaScriptExecutor)Browser;
-        Assert.Equal(1L, javascript.ExecuteScript("return authenticationRefreshTest.negotiateCount;"));
+        var connectionId = Assert.IsType<string>(
+            javascript.ExecuteScript("return authenticationRefreshConnection.connectionId;"));
 
         SignInAs("Someone", "TestRole", useSeparateTab: true);
-        var refreshStatus = javascript.ExecuteAsyncScript("""
+        var refreshError = javascript.ExecuteAsyncScript("""
             const callback = arguments[arguments.length - 1];
-            authenticationRefreshTest.refresh().then(callback, error => callback(String(error)));
+            authenticationRefreshConnection.refreshAuthentication().then(
+                () => callback(),
+                error => callback(String(error)));
             """);
 
-        Assert.Equal(200L, refreshStatus);
+        Assert.Null(refreshError);
         Browser.Equal("Welcome, Someone!", () =>
             appElement.FindElement(By.CssSelector("#authorize-role .authorized")).Text);
-        Assert.Equal(1L, javascript.ExecuteScript("return authenticationRefreshTest.negotiateCount;"));
+        Assert.Equal(
+            connectionId,
+            Assert.IsType<string>(javascript.ExecuteScript("return authenticationRefreshConnection.connectionId;")));
     }
 
     private void SignInAs(string usernName, string roles, bool useSeparateTab = false) =>

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerAuthTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerAuthTest.cs
@@ -49,6 +49,29 @@ public class ServerAuthTest : AuthTest
         }
     }
 
+    [Fact]
+    public void UpdatesAuthenticationStateWhenAuthenticationRefreshed()
+    {
+        SignInAs("Someone", "IrrelevantRole");
+        var appElement = MountAndNavigateToAuthTest(AuthorizeViewCases, "?captureAuthenticationRefresh");
+        Browser.Equal("You're not authorized, Someone", () =>
+            appElement.FindElement(By.CssSelector("#authorize-role .not-authorized")).Text);
+
+        var javascript = (IJavaScriptExecutor)Browser;
+        Assert.Equal(1L, javascript.ExecuteScript("return authenticationRefreshTest.negotiateCount;"));
+
+        SignInAs("Someone", "TestRole", useSeparateTab: true);
+        var refreshStatus = javascript.ExecuteAsyncScript("""
+            const callback = arguments[arguments.length - 1];
+            authenticationRefreshTest.refresh().then(callback);
+            """);
+
+        Assert.Equal(200L, refreshStatus);
+        Browser.Equal("Welcome, Someone!", () =>
+            appElement.FindElement(By.CssSelector("#authorize-role .authorized")).Text);
+        Assert.Equal(1L, javascript.ExecuteScript("return authenticationRefreshTest.negotiateCount;"));
+    }
+
     private void SignInAs(string usernName, string roles, bool useSeparateTab = false) =>
         Browser.SignInAs(new Uri(_serverFixture.RootUri, "/subdir"), usernName, roles, useSeparateTab);
 

--- a/src/Components/test/E2ETest/ServerExecutionTests/ServerAuthTest.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/ServerAuthTest.cs
@@ -63,7 +63,7 @@ public class ServerAuthTest : AuthTest
         SignInAs("Someone", "TestRole", useSeparateTab: true);
         var refreshStatus = javascript.ExecuteAsyncScript("""
             const callback = arguments[arguments.length - 1];
-            authenticationRefreshTest.refresh().then(callback);
+            authenticationRefreshTest.refresh().then(callback, error => callback(String(error)));
             """);
 
         Assert.Equal(200L, refreshStatus);

--- a/src/Components/test/E2ETest/Tests/AuthTest.cs
+++ b/src/Components/test/E2ETest/Tests/AuthTest.cs
@@ -225,9 +225,9 @@ public class AuthTest : ServerTestBase<ToggleExecutionModeServerFixture<Program>
         Browser.Exists(By.Id("auth-links"));
     }
 
-    protected IWebElement MountAndNavigateToAuthTest(string authLinkText)
+    protected IWebElement MountAndNavigateToAuthTest(string authLinkText, string queryString = "")
     {
-        Navigate(ServerPathBase);
+        Navigate($"{ServerPathBase}{queryString}");
         var appElement = Browser.MountTestComponent<BasicTestApp.AuthTest.AuthRouter>();
         Browser.Exists(By.Id("auth-links"));
         appElement.FindElement(By.LinkText(authLinkText)).Click();

--- a/src/Components/test/testassets/Components.TestServer/AuthenticationStartup.cs
+++ b/src/Components/test/testassets/Components.TestServer/AuthenticationStartup.cs
@@ -61,7 +61,7 @@ public class AuthenticationStartupBase
             {
                 endpoints.MapControllers();
                 endpoints.MapRazorPages();
-                endpoints.MapBlazorHub()
+                endpoints.MapBlazorHub(options => options.EnableAuthenticationRefresh = true)
                     .AddEndpointFilter(async (context, next) =>
                     {
                         if (context.HttpContext.WebSockets.IsWebSocketRequest)

--- a/src/Components/test/testassets/Components.TestServer/Pages/_ServerHost.cshtml
+++ b/src/Components/test/testassets/Components.TestServer/Pages/_ServerHost.cshtml
@@ -53,27 +53,17 @@
 
     <script src="_framework/blazor.server.js" autostart="false"></script>
     <script>
-        if (new URLSearchParams(location.search).has('captureAuthenticationRefresh')) {
-            const originalFetch = window.fetch;
-            window.authenticationRefreshTest = {
-                negotiateCount: 0,
-                async refresh() {
-                    const url = new URL('_blazor/refresh', document.baseURI);
-                    url.searchParams.set('id', this.connectionToken);
-                    return (await originalFetch(url, { method: 'POST' })).status;
-                },
-            };
-            window.fetch = async (input, init) => {
-                const response = await originalFetch(input, init);
-                if (`${input}`.includes('/negotiate')) {
-                    authenticationRefreshTest.negotiateCount++;
-                    authenticationRefreshTest.connectionToken = (await response.clone().json()).connectionToken;
-                }
-                return response;
-            };
-        }
-
         Blazor.start({
+            configureSignalR: builder => {
+                if (new URLSearchParams(location.search).has('captureAuthenticationRefresh')) {
+                    const build = builder.build.bind(builder);
+                    builder.build = () => {
+                        const connection = build();
+                        window.authenticationRefreshConnection = connection;
+                        return connection;
+                    };
+                }
+            },
             reconnectionOptions: {
                 // It's easier to test the reconnection logic if we wait a bit
                 // before attempting to reconnect

--- a/src/Components/test/testassets/Components.TestServer/Pages/_ServerHost.cshtml
+++ b/src/Components/test/testassets/Components.TestServer/Pages/_ServerHost.cshtml
@@ -53,6 +53,26 @@
 
     <script src="_framework/blazor.server.js" autostart="false"></script>
     <script>
+        if (new URLSearchParams(location.search).has('captureAuthenticationRefresh')) {
+            const originalFetch = window.fetch;
+            window.authenticationRefreshTest = {
+                negotiateCount: 0,
+                async refresh() {
+                    const url = new URL('_blazor/refresh', document.baseURI);
+                    url.searchParams.set('id', this.connectionToken);
+                    return (await originalFetch(url, { method: 'POST' })).status;
+                },
+            };
+            window.fetch = async (input, init) => {
+                const response = await originalFetch(input, init);
+                if (`${input}`.includes('/negotiate')) {
+                    authenticationRefreshTest.negotiateCount++;
+                    authenticationRefreshTest.connectionToken = (await response.clone().json()).connectionToken;
+                }
+                return response;
+            };
+        }
+
         Blazor.start({
             reconnectionOptions: {
                 // It's easier to test the reconnection logic if we wait a bit


### PR DESCRIPTION
## Description

`ComponentHub` now overrides `Hub.OnAuthenticationRefreshedAsync` so a Blazor server circuit picks up a refreshed principal without reconnecting. SignalR can refresh the authentication of an active connection through the `/refresh` endpoint added in #67111 and #67964, and it notifies a hub by calling that method. `ComponentHub` did not override it, so the circuit kept the principal it captured when the connection was established. `AuthorizeView` and other `AuthenticationStateProvider` consumers showed a stale user until the circuit reconnected.

The override passes `Context.User` to `CircuitHost.SetCircuitUser`, which is the same call `ConnectCircuit` already makes when a circuit reattaches to a new connection. `SetCircuitUser` sets the state on `IHostEnvironmentAuthenticationStateProvider`, which raises `AuthenticationStateChanged` and re-renders the affected components. 

No public API is added. Applications opt in through the existing `EnableAuthenticationRefresh` option on the server and `configureSignalR` in `Blazor.start` on the client.

Fixes #68170
