### PR TITLE
Mark RenderFragment serialization API as experimental

### DIFF
--- a/docs/list-of-diagnostics.md
+++ b/docs/list-of-diagnostics.md
@@ -2,7 +2,7 @@
 
 ## Analyzer Warnings
 
-### ASP (`ASP0000-ASP0031`)
+### ASP (`ASP0000-ASP0032`)
 
 | Diagnostic ID     | Description |
 | :---------------- | :---------- |
@@ -37,6 +37,7 @@
 |  __`ASP0029`__ | Experimental warning for validations resolver APIs |
 |  __`ASP0030`__ | Experimental warning for QuickGrid virtualization anchoring APIs |
 |  __`ASP0031`__ | Experimental warning for Device Bound Sessions (DBSC) APIs |
+|  __`ASP0032`__ | Experimental warning for RenderFragment serialization APIs |
 
 ### API (`API1000-API1003`)
 

--- a/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
+++ b/src/Components/Components/src/Rendering/RenderTreeBuilder.cs
@@ -786,6 +786,7 @@ public sealed class RenderTreeBuilder : IDisposable
     /// <param name="value">The new attribute value.</param>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="frameIndex"/> is outside the range of appended frames.</exception>
     /// <exception cref="InvalidOperationException">Thrown when the frame at <paramref name="frameIndex"/> is not of type <see cref="RenderTreeFrameType.Attribute"/>.</exception>
+    [Experimental("ASP0032", UrlFormat = "https://aka.ms/aspnet/analyzer/{0}")]
     public void SetAttributeValue(int frameIndex, object? value)
     {
         var frames = _entries.Buffer;

--- a/src/Components/Shared/src/RenderFragmentCapture.cs
+++ b/src/Components/Shared/src/RenderFragmentCapture.cs
@@ -82,7 +82,9 @@ internal sealed class RenderFragmentCapture
                     // populates innerCapture._capturedFrames. Looking up the capture by frame
                     // index in _childCaptures would otherwise find an entry whose frames were
                     // never recorded.
+#pragma warning disable ASP0032
                     builder.SetAttributeValue(j, (RenderFragment)innerCapture.Invoke);
+#pragma warning restore ASP0032
                     _childCaptures[j - start] = innerCapture;
                 }
             }


### PR DESCRIPTION
# Mark RenderFragment serialization API as experimental

Marks the public `RenderTreeBuilder.SetAttributeValue` API as experimental.

## Description

Per the API review for #66828, the `RenderTreeBuilder.SetAttributeValue(int frameIndex, object? value)` method should ship as experimental. It is a low-level infrastructure API, and marking it experimental allows its shape to change in the future without a breaking change.

The API remains public and functionally unchanged; callers outside the framework now receive the `ASP0032` experimental diagnostic and must explicitly opt in.

## Breaking Changes

None. `SetAttributeValue` is an unshipped (preview) API. Consumers who reference it will now see the `ASP0032` experimental warning and need to acknowledge it, but there is no source or behavioral break for shipped APIs.

Fixes #66828
