### PR TITLE
[Infrastructure] Update vulnerable npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2087,9 +2087,9 @@
       "license": "Python-2.0"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha1-o3XhTkHWcmF95pUmvgLQ13UaaQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2173,9 +2173,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha1-o3XhTkHWcmF95pUmvgLQ13UaaQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2603,9 +2603,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha1-o3XhTkHWcmF95pUmvgLQ13UaaQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4557,9 +4557,9 @@
       }
     },
     "node_modules/@wdio/config/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha1-o3XhTkHWcmF95pUmvgLQ13UaaQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5207,9 +5207,9 @@
       }
     },
     "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha1-o3XhTkHWcmF95pUmvgLQ13UaaQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6321,9 +6321,9 @@
       }
     },
     "node_modules/chrome-launcher/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha1-o3XhTkHWcmF95pUmvgLQ13UaaQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7166,9 +7166,9 @@
       }
     },
     "node_modules/del/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha1-o3XhTkHWcmF95pUmvgLQ13UaaQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7993,9 +7993,9 @@
       "license": "Python-2.0"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha1-o3XhTkHWcmF95pUmvgLQ13UaaQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8701,9 +8701,9 @@
       }
     },
     "node_modules/flat-cache/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha1-o3XhTkHWcmF95pUmvgLQ13UaaQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10219,9 +10219,9 @@
       "license": "MIT"
     },
     "node_modules/jasmine/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha1-o3XhTkHWcmF95pUmvgLQ13UaaQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10498,9 +10498,9 @@
       }
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha1-o3XhTkHWcmF95pUmvgLQ13UaaQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11213,9 +11213,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha1-o3XhTkHWcmF95pUmvgLQ13UaaQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12017,9 +12017,9 @@
       }
     },
     "node_modules/karma/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha1-o3XhTkHWcmF95pUmvgLQ13UaaQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13296,9 +13296,9 @@
       }
     },
     "node_modules/node-gyp/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha1-o3XhTkHWcmF95pUmvgLQ13UaaQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14351,9 +14351,9 @@
       }
     },
     "node_modules/puppeteer-core/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha1-o3XhTkHWcmF95pUmvgLQ13UaaQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16545,9 +16545,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha1-o3XhTkHWcmF95pUmvgLQ13UaaQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17453,9 +17453,9 @@
       }
     },
     "node_modules/webdriverio/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha1-o3XhTkHWcmF95pUmvgLQ13UaaQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18002,9 +18002,9 @@
       }
     },
     "node_modules/zip-stream/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.17",
+      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha1-o3XhTkHWcmF95pUmvgLQ13UaaQk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Updates `brace-expansion` from 1.1.16 to 1.1.17 throughout the root npm lockfile to resolve CVE-2026-14257.

The active low-severity `@babel/core` alert is already addressed by `@babel/core` 7.29.7 in the latest `main` lockfile. The medium-severity `keyv` alert remains because its remediation requires moving from 4.x to 5.5.3, and this update intentionally avoids major-version bumps for Medium and Low alerts.

The updated package was ingested through the `dotnet-public-npm` Azure Artifacts feed.