### PR TITLE
Clarify Components E2E build workflow

### DIFF
--- a/src/Components/AGENTS.md
+++ b/src/Components/AGENTS.md
@@ -215,14 +215,15 @@ E2E tests are located in `src/Components/test/E2ETest`.
 The E2E tests use Selenium. To build and run tests:
 
 ```bash
-# Build the E2E test project (this includes all test assets as dependencies)
+# Build the E2E test project and its dependencies
 dotnet build src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj --no-restore -v:q
 
-# Run a specific test
+# After the build succeeds, run a specific test
 dotnet test src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj --no-build --filter "FullyQualifiedName~TestName"
 ```
+
+For the first E2E run in a fresh worktree, or after relevant build, configuration, or output changes, run the dependency-aware build above. Do not use `--no-dependencies` to prepare E2E tests when referenced test-app outputs may be stale or missing. It may copy existing dependency outputs, but it does not rebuild referenced projects or apps. After the build succeeds, `--no-build` is the supported fast loop for repeated targeted tests while those inputs remain unchanged.
 
 **Important**: Never run all E2E tests locally as that is extremely costly. Full test runs should only happen on CI machines.
 
 If a test is failing, it's best to run the server manually and navigate to the test to investigate. The test output won't be very useful for debugging.
-


### PR DESCRIPTION
# Clarify Components E2E build workflow

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable. (Documentation-only change.)
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Clarify dependency-aware preparation for Components E2E tests

## Description

Clarifies that a fresh worktree, or relevant build/configuration/output changes, requires a dependency-aware build of the Components E2E project before using the supported `--no-build` fast loop for targeted tests.

This follows fresh-worktree Components/Copilot reproduction friction. It also explains why `--no-dependencies` is unsafe preparation when referenced test-app outputs may be stale or missing: the option can copy existing outputs but does not rebuild referenced projects or apps.

This documentation complements the missing-input diagnostics in #68200 but is independent of that PR and does not depend on it.
