### PR TITLE
[release/8.0] Quarantine System_UsesProvidedCertificateNotFromStore

### DIFF
--- a/src/DataProtection/Extensions/test/DataProtectionProviderTests.cs
+++ b/src/DataProtection/Extensions/test/DataProtectionProviderTests.cs
@@ -167,6 +167,7 @@ public class DataProtectionProviderTests
     }
 
     [ConditionalFact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/66637")]
     [X509StoreIsAvailable(StoreName.My, StoreLocation.CurrentUser)]
     public void System_UsesProvidedCertificateNotFromStore()
     {


### PR DESCRIPTION
Quarantines `DataProtectionProviderTests.System_UsesProvidedCertificateNotFromStore`, which is repeatedly failing on `OSX.15.Amd64.Open` because the test keychain cannot be found.

Recent failures:
- https://dev.azure.com/dnceng-public/public/_build/results?buildId=1537319
- https://dev.azure.com/dnceng-public/public/_build/results?buildId=1537870
- https://dev.azure.com/dnceng-public/public/_build/results?buildId=1541195
- https://dev.azure.com/dnceng-public/public/_build/results?buildId=1541490

The same test was previously quarantined on `main`. Its subsequent clean run streak occurred after `main` moved to `OSX.26.Arm64.Open`; `release/8.0` continues to use the affected macOS 15 x64 queue.

Tracking issue: https://github.com/dotnet/aspnetcore/issues/66637