### PR TITLE
Enable MSBuild node reuse for local builds

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -341,12 +341,6 @@ $performDotnetBuild = $msBuildEngine -ne 'vs' -and ($BuildJava -or $BuildManaged
 # Initialize global variables need to be set before the import of Arcade is imported
 $restore = $RunRestore
 
-# Though VS Code may indicate $nodeReuse is unused, tools.ps1 uses them.
-
-# Disable node reuse - Workaround perpetual issues in node reuse and custom task assemblies
-$nodeReuse = $false
-$env:MSBUILDDISABLENODEREUSE=1
-
 # Ensure passing neither -bl nor -nobl on CI avoids errors in tools.ps1. This is needed because both parameters are
 # $false by default i.e. they always exist. (We currently avoid binary logs but that is made visible in the YAML.)
 if ($CI -and -not $excludeCIBinarylog) {

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -362,10 +362,6 @@ fi
 # Initialize global variables need to be set before the import of Arcade is imported
 restore=$run_restore
 
-# Disable node reuse - Workaround perpetual issues in node reuse and custom task assemblies
-nodeReuse=false
-export MSBUILDDISABLENODEREUSE=1
-
 # Ensure passing neither --bl nor --nobl on CI avoids errors in tools.sh. This is needed because we set both variables
 # to false by default i.e. they always exist. (We currently avoid binary logs but that is made visible in the YAML.)
 if [[ "$ci" == true && "$exclude_ci_binary_log" == false ]]; then


### PR DESCRIPTION
Removes the unconditional node-reuse overrides from `eng/build.ps1` and `eng/build.sh`, allowing Arcade defaults to enable node reuse locally while continuing to disable it on CI.

Fixes #68251.