### PR TITLE
[8.0] Fix Debian package descriptions

### DIFF
--- a/src/Installers/Debian/Runtime/Debian.Runtime.debproj
+++ b/src/Installers/Debian/Runtime/Debian.Runtime.debproj
@@ -15,7 +15,7 @@
     <DotnetRuntimeDependencyVersion Condition="$(DotnetRuntimeDependencyVersion.Contains('-'))">$(DotnetRuntimeDependencyVersion.Substring(0, $(DotnetRuntimeDependencyVersion.IndexOf('-'))))~$(DotnetRuntimeDependencyVersion.Substring($([MSBuild]::Add($(DotnetRuntimeDependencyVersion.IndexOf('-')), 1))))</DotnetRuntimeDependencyVersion>
     <DotnetRuntimeDependencyMajorMinorVersion>$(MicrosoftNETCoreAppRuntimeVersion.Split('.')[0]).$(MicrosoftNETCoreAppRuntimeVersion.Split('.')[1])</DotnetRuntimeDependencyMajorMinorVersion>
 
-    <PackageSummary>$(SharedFxProductName)</PackageSummary>
+    <PackageSummary>$(SharedFxName).Runtime $(VersionPrefix)</PackageSummary>
     <PackageDescription>$(SharedFxDescription)</PackageDescription>
     <DebianConfigProperties>
       DotnetRuntimeDependencyMajorMinorVersion=$(DotnetRuntimeDependencyMajorMinorVersion);

--- a/src/Installers/Debian/TargetingPack/Debian.TargetingPack.debproj
+++ b/src/Installers/Debian/TargetingPack/Debian.TargetingPack.debproj
@@ -18,8 +18,6 @@
     <DotnetTargetingPackDependencyVersion Condition="$(DotnetTargetingPackDependencyVersion.Contains('-'))">$(DotnetTargetingPackDependencyVersion.Substring(0, $(DotnetTargetingPackDependencyVersion.IndexOf('-'))))~$(DotnetTargetingPackDependencyVersion.Substring($([MSBuild]::Add($(DotnetTargetingPackDependencyVersion.IndexOf('-')), 1))))</DotnetTargetingPackDependencyVersion>
     <DotnetTargetingPackDependencyMajorMinorVersion>$(MicrosoftNETCoreAppRefVersion.Split('.')[0]).$(MicrosoftNETCoreAppRefVersion.Split('.')[1])</DotnetTargetingPackDependencyMajorMinorVersion>
 
-    <PackageSummary>$(SharedFxProductName)</PackageSummary>
-    <PackageDescription>$(SharedFxDescription)</PackageDescription>
     <DebianConfigProperties>
       DotnetTargetingPackDependencyMajorMinorVersion=$(DotnetTargetingPackDependencyMajorMinorVersion);
       DotnetTargetingPackDependencyVersion=$(DotnetTargetingPackDependencyVersion);


### PR DESCRIPTION
Sets a short, non-empty synopsis for the ASP.NET Core runtime Debian package and preserves the targeting pack summary and package-specific description.

SharedFxProductName is assigned after project evaluation, so using it in these projects produced an empty first line and caused Debian tools to display the long description as the synopsis.

Contributes to #64105.
