### PR TITLE
Remove Publish-Build-Assets variable group from release/10.0

### DIFF
--- a/.azure/pipelines/ci-unofficial.yml
+++ b/.azure/pipelines/ci-unofficial.yml
@@ -35,8 +35,6 @@ variables:
            /p:OfficialBuildId=$(Build.BuildNumber)
            /p:SkipTestBuild=true
            /p:PostBuildSign=$(PostBuildSign)
-  # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-  - group: Publish-Build-Assets
   # The following extra properties are not set when testing. Use with final build.[cmd,sh] of asset-producing jobs.
   - name: _PublishArgs
     value: /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -58,8 +58,6 @@ variables:
            /p:OfficialBuildId=$(Build.BuildNumber)
            /p:SkipTestBuild=true
            /p:PostBuildSign=$(PostBuildSign)
-  # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-  - group: Publish-Build-Assets
   # The following extra properties are not set when testing. Use with final build.[cmd,sh] of asset-producing jobs.
   - name: _PublishArgs
     value: /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)


### PR DESCRIPTION
Removes the repository-owned `Publish-Build-Assets` variable group import from:

- `.azure/pipelines/ci-unofficial.yml`
- `.azure/pipelines/ci.yml`

This is part of the tracked VG20 cleanup: https://dev.azure.com/dnceng/internal/_workitems/edit/12131