### PR TITLE
Remove Publish-Build-Assets variable group from release/8.0

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -61,8 +61,6 @@ variables:
            /p:SkipTestBuild=true
            /p:PostBuildSign=$(PostBuildSign)
   # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
-  # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-  - group: Publish-Build-Assets
   # The following extra properties are not set when testing. Use with final build.[cmd,sh] of asset-producing jobs.
   - name: _PublishArgs
     value: /p:Publish=true


### PR DESCRIPTION
Removes the repository-owned `Publish-Build-Assets` variable group import from:

- `.azure/pipelines/ci.yml`

This is part of the tracked VG20 cleanup: https://dev.azure.com/dnceng/internal/_workitems/edit/12131