### PR TITLE
[test-quarantine] Stabilize the NavigationLock overlapping navigation E2E test

### DIFF
--- a/src/Components/test/E2ETest/ServerExecutionTests/TestSubclasses.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/TestSubclasses.cs
@@ -44,6 +44,7 @@ public class ServerRoutingTest : RoutingTest
     {
     }
 
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/61080")]
     public override void NavigationLock_OverlappingNavigationsCancelExistingNavigations_HistoryNavigation()
         => base.NavigationLock_OverlappingNavigationsCancelExistingNavigations_HistoryNavigation();
 

--- a/src/Components/test/E2ETest/ServerExecutionTests/TestSubclasses.cs
+++ b/src/Components/test/E2ETest/ServerExecutionTests/TestSubclasses.cs
@@ -44,7 +44,6 @@ public class ServerRoutingTest : RoutingTest
     {
     }
 
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/61080")]
     public override void NavigationLock_OverlappingNavigationsCancelExistingNavigations_HistoryNavigation()
         => base.NavigationLock_OverlappingNavigationsCancelExistingNavigations_HistoryNavigation();
 

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -989,11 +989,12 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
         // Add a navigation lock that blocks internal navigations
         Browser.FindElement(By.Id("add-navigation-lock")).Click();
         Browser.FindElement(By.CssSelector("#navigation-lock-0 > input.block-internal-navigation")).Click();
+        Browser.Equal("true", () => Browser.FindElement(By.CssSelector("#navigation-lock-0 > input.navigation-lock-ready")).GetDomProperty("value"));
 
         Browser.Navigate().Back();
 
         // The navigation lock has initiated its "location changing" handler and is displaying navigation controls
-        // Wait for blocking-controls to appear before checking state (ensures PreventNavigation() has taken effect on server)
+        Browser.Equal(expectedStartingAbsoluteUri, () => app.FindElement(By.Id("test-info")).Text);
         Browser.Exists(By.CssSelector("#navigation-lock-0 > div.blocking-controls"));
 
         // The location was reverted to what it was before the navigation started
@@ -1006,10 +1007,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
 
         // The first navigation was canceled and logged
         var expectedCanceledAbsoluteUri = $"{_serverFixture.RootUri}subdir/mytestpath0";
-        // Wait for blocking-controls to appear, then ensure the log entry exists before accessing its text (accounts for SignalR latency on server-side variant)
-        Browser.Exists(By.CssSelector("#navigation-lock-0 > div.blocking-controls"));
-        var logEntryElement = Browser.Exists(By.CssSelector("#navigation-lock-0 > p.navigation-log > span.navigation-log-entry-0"));
-        Browser.Equal($"Canceling '{expectedCanceledAbsoluteUri}'", () => logEntryElement.Text);
+        Browser.Equal($"Canceling '{expectedCanceledAbsoluteUri}'", () => app.FindElement(By.CssSelector("#navigation-lock-0 > p.navigation-log > span.navigation-log-entry-0"))?.Text);
 
         // Unblock the new navigation
         Browser.FindElement(By.CssSelector("#navigation-lock-0 > div.blocking-controls > button.navigation-continue")).Click();

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -993,7 +993,7 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
         Browser.Navigate().Back();
 
         // The navigation lock has initiated its "location changing" handler and is displaying navigation controls
-        Browser.Equal(expectedStartingAbsoluteUri, () => app.FindElement(By.Id("test-info")).Text);
+        // Wait for blocking-controls to appear before checking state (ensures PreventNavigation() has taken effect on server)
         Browser.Exists(By.CssSelector("#navigation-lock-0 > div.blocking-controls"));
 
         // The location was reverted to what it was before the navigation started
@@ -1006,7 +1006,8 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
 
         // The first navigation was canceled and logged
         var expectedCanceledAbsoluteUri = $"{_serverFixture.RootUri}subdir/mytestpath0";
-        // Ensure the log entry exists before accessing its text (accounts for SignalR latency on server-side variant)
+        // Wait for blocking-controls to appear, then ensure the log entry exists before accessing its text (accounts for SignalR latency on server-side variant)
+        Browser.Exists(By.CssSelector("#navigation-lock-0 > div.blocking-controls"));
         var logEntryElement = Browser.Exists(By.CssSelector("#navigation-lock-0 > p.navigation-log > span.navigation-log-entry-0"));
         Browser.Equal($"Canceling '{expectedCanceledAbsoluteUri}'", () => logEntryElement.Text);
 

--- a/src/Components/test/E2ETest/Tests/RoutingTest.cs
+++ b/src/Components/test/E2ETest/Tests/RoutingTest.cs
@@ -1006,7 +1006,9 @@ public class RoutingTest : ServerTestBase<ToggleExecutionModeServerFixture<Progr
 
         // The first navigation was canceled and logged
         var expectedCanceledAbsoluteUri = $"{_serverFixture.RootUri}subdir/mytestpath0";
-        Browser.Equal($"Canceling '{expectedCanceledAbsoluteUri}'", () => app.FindElement(By.CssSelector("#navigation-lock-0 > p.navigation-log > span.navigation-log-entry-0"))?.Text);
+        // Ensure the log entry exists before accessing its text (accounts for SignalR latency on server-side variant)
+        var logEntryElement = Browser.Exists(By.CssSelector("#navigation-lock-0 > p.navigation-log > span.navigation-log-entry-0"));
+        Browser.Equal($"Canceling '{expectedCanceledAbsoluteUri}'", () => logEntryElement.Text);
 
         // Unblock the new navigation
         Browser.FindElement(By.CssSelector("#navigation-lock-0 > div.blocking-controls > button.navigation-continue")).Click();

--- a/src/Components/test/testassets/BasicTestApp/RouterTest/ConfigurableNavigationLock.razor
+++ b/src/Components/test/testassets/BasicTestApp/RouterTest/ConfigurableNavigationLock.razor
@@ -1,7 +1,11 @@
 ﻿@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.JSInterop
+
+@inject IJSRuntime JSRuntime
 
 <input class="block-internal-navigation" type="checkbox" @bind-value="_blockInternalNavigation" />Block internal navigation<br />
 <input class="confirm-external-navigation" type="checkbox" @bind-value="_confirmExternalNavigation" />Confirm external navigation<br />
+<input class="navigation-lock-ready" type="hidden" @ref="_navigationLockReadyElement" />
 
 <p class="navigation-log">
     @for (var i = 0; i < _log.Count; i++)
@@ -40,7 +44,19 @@
     private LocationChangingContext _context;
 
     private bool _blockInternalNavigation;
+    private bool _reportedBlockInternalNavigation;
     private bool _confirmExternalNavigation;
+    private ElementReference _navigationLockReadyElement;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_reportedBlockInternalNavigation != _blockInternalNavigation)
+        {
+            await Task.Yield();
+            await JSRuntime.InvokeVoidAsync("setElementValue", _navigationLockReadyElement, _blockInternalNavigation ? "true" : "false");
+            _reportedBlockInternalNavigation = _blockInternalNavigation;
+        }
+    }
 
     public async Task BlockNavigationAsync(LocationChangingContext context)
     {


### PR DESCRIPTION
# Quarantine Microsoft.AspNetCore.Components.E2ETest.ServerExecutionTests.ServerRoutingTest.NavigationLock_OverlappingNavigationsCancelExistingNavigations_HistoryNavigation

 
## Description

This fixes the intermittent failure in `NavigationLock_OverlappingNavigationsCancelExistingNavigations_HistoryNavigation`.

The test failed primarily in the Blazor Server execution variant when browser history navigation started before the browser had finished registering the location-changing listener.

### Root cause
 
Enabling internal navigation blocking causes NavigationLock to register its location-changing handler during OnAfterRenderAsync.

For Blazor Server, the browser-side listener is enabled through an asynchronous JS interop call. The test could call Browser.Navigate().Back() before the browser processed that call. The resulting popstate event bypassed the navigation lock, causing the test to observe an unexpected URI or fail to find the blocking controls.

Waiting after Browser.Navigate().Back() did not close the race because the history navigation could already have bypassed the lock.
 
### Fix
 
Add a browser-side readiness acknowledgement to the test component and wait for it before starting history navigation:

- Yield until the NavigationLock after-render callback registers the handler
- Complete a JS interop round trip after browser listener registration is queued
- Expose the acknowledgement through a hidden test element
- Wait for that element before calling Browser.Navigate().Back()

The original navigation behavior and assertions are preserved. The test still verifies that overlapping history navigations cancel the existing navigation, log the cancellation, and continue to the expected URI.

 
 
### Validation
Ran the test 100 consecutive times, and the test case passed successfully every time.

 
 
Fixes #61080 #65961