### PR TITLE
Unquarantine BlazorWebTemplateTest.BlazorWebTemplate_CanUsePasskeys

### DIFF
--- a/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs
@@ -55,7 +55,6 @@ public class BlazorWebTemplateTest(ProjectFactoryFixture projectFactory) : Blazo
 
     [Theory]
     [InlineData(BrowserKind.Chromium)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/66708")]
     public async Task BlazorWebTemplate_CanUsePasskeys(BrowserKind browserKind)
     {
         var project = await CreateBuildPublishAsync(args: ["-int", "None", "-au", "Individual"]);


### PR DESCRIPTION
Unquarantine `BlazorWebTemplateTest.BlazorWebTemplate_CanUsePasskeys`.

## Why

The failures tracked by #66708 were a real regression, not flakiness. They were fixed by #67589 (Fix Blazor passkey registration under CsrfProtection), and the test has been green on `main` ever since.

The failing window maps exactly onto that fix:

| Build | Commit | Result |
| --- | --- | --- |
| 1503010 | `d1866a2` (parent) | Failed |
| 1503140 | `68dacc0f34` (#67589) | Passed |

All 28 failures reproduced the issue signature `Timeout 30000ms exceeded ... waiting for Locator("text=Error: No passkey was provided by the authenticator.")` and failed on retry too, which is consistent with a product regression rather than a timing-sensitive test.

## Stats

Source: `aspnetcore-quarantined-pr` (def 86, dnceng-public), `refs/heads/main`, full AzDO retention window.

| Period | Passed | Failed | Job did not run |
| --- | --- | --- | --- |
| Jul 8 to Jul 10 (pre-fix) | 0 | 28 | 0 |
| Jul 10 (post-fix) to Aug 7 | 469 | 0 | 21 |

That is a **469 run consecutive green streak over ~28 days**. The 21 "did not run" entries are job-level infrastructure failures where the whole build produced no test results, not test outcomes.

A sample of the 120 most recent PR-triggered builds of the same pipeline (all branches) shows 92 passed and 2 failed. Both failures (builds 1543843 and 1543841) are on `release/11.0-preview5` and `release/11.0-preview6`, neither of which contains #67589.

## Notes

`Templates.Blazor.Tests.csproj` sets `BuildHelixPayload=false` (see #38818), so this test never runs on Helix and produced no results in the daily `aspnetcore-quarantined-tests` pipeline. All the data above comes from the Windows agent job of `aspnetcore-quarantined-pr`. After unquarantining, the test runs in `aspnetcore-ci`, also on a Windows agent, so the signal is representative.

The sibling test `BlazorWebTemplate_Works` (#66403) is intentionally left quarantined. Its `WebAssembly` and `Auto` theory cases fail deterministically (0% pass rate) with `MSB4216` from `Microsoft.NET.Sdk.WebAssembly.Browser.targets`, an agent/SDK task-host issue that also blocks #66292 and #66293.

Closes #66708
