### PR TITLE
Add build review guidance for architecture and design-time builds

### DIFF
--- a/.github/instructions/build.instructions.md
+++ b/.github/instructions/build.instructions.md
@@ -1,0 +1,14 @@
+---
+description: Instructions for MSBuild and repository build infrastructure
+applyTo: "eng/**,Directory.Build.*,**/*.props,**/*.targets"
+---
+
+# Build infrastructure changes
+
+- Read `docs/BuildFromSource.md` and `docs/BuildErrors.md`. Prefer the existing area or repository `build` and `restore` scripts. Before invoking `dotnet` directly, activate the repository SDK with `source activate.sh` or `. ./activate.ps1`.
+- Do not edit `eng/common/**` locally. Arcade automation overwrites that directory; make changes in `dotnet/arcade` instead.
+- Trace build properties through every applicable entry point. Check both wrapper scripts and bare `dotnet` or IDE evaluation; do not assume they assign the same defaults. In particular, `eng/build.sh` detects and passes the host architecture, while `eng/Common.props` currently defaults an unset `TargetArchitecture` to `x64`. Treat that fallback as behavior to investigate, not a convention to preserve.
+- Before proposing a fix, map the producer, persisted or shared intermediate state, consumer, and resulting diagnostic. Verify that state paths and cache keys distinguish every relevant configuration, OS, architecture, runtime identifier, and target framework.
+- Locate each custom task's `UsingTask` declaration or imported `.tasks` file and inspect its conditions. Ensure the task invocation is skipped in evaluations where registration is unavailable, especially `DesignTimeBuild`.
+- Select validation modes that exercise the changed surface: normal wrapper builds, direct CLI and IDE/design-time evaluation, restore and no-restore transitions, source-build or CI properties, and affected OS/architecture/RID combinations. Record distinct source or observed-output evidence for each applicable mode and include an unchanged control path; one focused target invocation is not broad build-system evidence.
+- Multiple reviewers or models are not independent evidence when they inspect the same entry point and evaluation mode. Treat evidence as independent only when it covers distinct property sources, state transitions, import modes, or platform dimensions.

--- a/.github/instructions/build.instructions.md
+++ b/.github/instructions/build.instructions.md
@@ -6,7 +6,6 @@ applyTo: "eng/**,Directory.Build.*,**/*.props,**/*.targets"
 # Build infrastructure changes
 
 - Read `docs/BuildFromSource.md` and `docs/BuildErrors.md`. Prefer the existing area or repository `build` and `restore` scripts. Before invoking `dotnet` directly, activate the repository SDK with `source activate.sh` or `. ./activate.ps1`.
-- Do not edit `eng/common/**` locally. Arcade automation overwrites that directory; make changes in `dotnet/arcade` instead.
 - Trace build properties through every applicable entry point. Check both wrapper scripts and bare `dotnet` or IDE evaluation; do not assume they assign the same defaults. In particular, `eng/build.sh` detects and passes the host architecture, while `eng/Common.props` currently defaults an unset `TargetArchitecture` to `x64`. Treat that fallback as behavior to investigate, not a convention to preserve.
 - Before proposing a fix, map the producer, persisted or shared intermediate state, consumer, and resulting diagnostic. Verify that state paths and cache keys distinguish every relevant configuration, OS, architecture, runtime identifier, and target framework.
 - Locate each custom task's `UsingTask` declaration or imported `.tasks` file and inspect its conditions. Ensure the task invocation is skipped in evaluations where registration is unavailable, especially `DesignTimeBuild`.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -223,6 +223,7 @@
     <NetCoreTargetingPackRoot Condition="'$(DotNetBuild)' != 'true'">$(LocalDotNetRoot)packs\</NetCoreTargetingPackRoot>
   </PropertyGroup>
 
+  <!-- RepoTasks are not registered when DesignTimeBuild is true. Targets using them must skip the task invocation in that evaluation. -->
   <Import Project="eng\tools\RepoTasks\RepoTasks.tasks" Condition="'$(MSBuildProjectName)' != 'RepoTasks' AND '$(DesignTimeBuild)' != 'true'" />
 
   <PropertyGroup>


### PR DESCRIPTION
## Why

A focused review of #68254 found two build-system paths that were easy to miss even after extensive validation:

- `eng/build.sh` detects and passes the host architecture, while bare `dotnet` and IDE evaluation can leave `TargetArchitecture` unset and reach the `x64` fallback in `eng/Common.props`.
- `Directory.Build.props` does not register RepoTasks during design-time builds. A target that invokes one of those tasks must skip the invocation whenever that registration is unavailable.

The first review missed both because every reviewer looked at roughly the same entry point and evaluation mode. These are repository-wide review hazards, not details specific to one SFX fix.

## What this changes

This adds path-scoped guidance for changes under `eng/**`, `Directory.Build.*`, and repository `.props` and `.targets` files. It asks reviewers and coding agents to:

- trace properties through wrapper scripts, direct CLI usage, and IDE evaluation;
- map the producer, persisted state, consumer, and resulting diagnostic before proposing a fix;
- inspect custom-task registration and import conditions, especially `DesignTimeBuild`;
- validate the modes that are actually affected, including restore/no-restore transitions, source-build or CI properties, and OS/architecture/RID combinations;
- treat different reviewers as independent evidence only when they inspect different property sources, state transitions, import modes, or platform dimensions.

A comment beside the conditional RepoTasks import also keeps the design-time registration invariant next to the code that enforces it.

## Why merge this

The build behavior is unchanged. This PR makes existing repository behavior discoverable at the point where build-infrastructure changes are reviewed, so a focused validation pass is less likely to miss a different entry point or evaluation mode.

This is defense in depth, not a claim that instructions guarantee perfect reviews. Behavioral evaluation improved defective-patch blocking and evidence diversity, but exact mechanism recovery was not reliable enough to claim full coverage. The current Vally infrastructure also does not model production `.github/instructions` `applyTo` loading, so a checked-in behavior eval is intentionally left for follow-up infrastructure work.

This PR also does not change the current `TargetArchitecture` fallback. That needs separate compatibility research rather than being mixed into a guidance-only change.

## Validation

- Parsed the instruction frontmatter and verified the expected `applyTo` patterns.
- Parsed `Directory.Build.props` with `xmllint`.
- Ran `git diff --check`.
- Verified the branch applies cleanly to current `main`.
- Verified the specific architecture and RepoTasks claims against the current repository sources.

## Checklist

- [x] Read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] Tests are not applicable because this changes guidance and a source comment only.
- [x] Related review context is captured in #68254.