### PR TITLE
Unquarantine AddValidationIntegrationTest.FormWithNestedValidation_Works

### DIFF
--- a/src/Components/test/E2ETest/ServerRenderingTests/AddValidationIntegrationTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/AddValidationIntegrationTest.cs
@@ -8,7 +8,6 @@ using Components.TestServer.RazorComponents;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
-using Microsoft.AspNetCore.InternalTesting;
 using OpenQA.Selenium;
 using TestServer;
 using Xunit.Abstractions;
@@ -28,7 +27,6 @@ public class AddValidationIntegrationTest : ServerTestBase<BasicTestAppServerSit
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/68223")]
     public void FormWithNestedValidation_Works()
     {
         Browser.Exists(By.Id("submit-form")).Click();


### PR DESCRIPTION
Reverts c10ee0eb580a5561b639b446b14dcc507a8f1050 (#68224), which quarantined `AddValidationIntegrationTest.FormWithNestedValidation_Works`.

The quarantine was based on stale CI data. The test is not flaky and MEV activation is not broken.

## The cited failures are all from before the fix

Issue #68223 lists four failing builds. All of them ran on 2026-07-08, and none of them contain the fix commit `0c3e825607` (#67680), which merged on 2026-07-08 at 19:48 UTC.

| Build | Queue time (UTC) | Commit | Contains #67680 |
| --- | --- | --- | --- |
| [1499278](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1499278) | 2026-07-08 12:08 | `3e156e1a74` (#67636, the regression itself) | No |
| [1499615](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1499615) | 2026-07-08 14:22 | `12fe5679d8` | No |
| [1499768](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1499768) | 2026-07-08 15:50 | `4b9040ecc8` | No |
| [1500081](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1500081) | 2026-07-08 19:20 | `cb1ac26bbd` | No |

These are the same builds already tracked by #67699, which was closed once #67680 merged. Issue #68223 effectively re-filed an already resolved problem a month later.

For contrast, the sibling issue #68226, generated by the same `Daily Test Quarantine Management` workflow run, cites genuinely recent builds ([1531284](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1531284), [1537634](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1537634)). So only this one issue picked up stale data.

## The original failure was deterministic, not a race

Both #67699 and #68223 describe the failure as a timing or rendering race. It was not.

PR #67636 removed generator discovery of `Microsoft.Extensions.Validation.Embedded.ValidatableTypeAttribute` from `ValidationsGenerator`. The test model `OrderModel` was annotated with an unqualified `[ValidatableType]` that bound to that SDK embedded attribute, so after #67636 the generator stopped emitting validatable type info for it.

Without a source generated resolver, `DataAnnotationsValidator` fell back to the plain `System.ComponentModel.DataAnnotations.Validator` path, which does not recurse into nested complex properties. That produces exactly the observed result: only the top level `Order Name is required.` message, and nothing from `CustomerModel`, `AddressModel`, or `OrderItemModel`.

PR #67680 fixed it by fully qualifying the attribute to `[Microsoft.Extensions.Validation.ValidatableType]`. That annotation is still in place today (`src/Components/test/testassets/Components.TestServer/RazorComponents/ValidationModels/OrderModel.cs`), and `ValidationsGenerator.cs` still discovers `Microsoft.Extensions.Validation.ValidatableTypeAttribute`.

Separately, #67702 added `src/Validation/*` to the `aspnetcore-components-e2e` path triggers, so MEV changes now run these E2E tests on the PR.

## The test has been green since

Across all 127 `aspnetcore-components-e2e` builds on `main` between 2026-07-09 and the quarantine on 2026-08-05, `FormWithNestedValidation` does not appear in any build log. The test name is only emitted on failure, so zero occurrences means zero failures.

The 17 builds that failed in that window failed for unrelated reasons: Mono leg failures, 120 minute agent timeouts, and other already quarantined tests.

Spot checks immediately before the quarantine:

| Build | Date | Result |
| --- | --- | --- |
| [1538405](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1538405) | 2026-08-03 | `Run E2E tests` passed, only quarantined legs failed |
| [1540079](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1540079) | 2026-08-04 | `Run E2E tests` passed, only quarantined legs failed |
| [1540791](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1540791) | 2026-08-05 12:55 | `Run E2E tests` passed, only quarantined legs failed |

And after the quarantine landed, [1541387](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1541387) (2026-08-05 18:07, includes `c10ee0eb58`) ran the test in the quarantined leg and it passed there too.

## Change

Removes the `[QuarantinedTest]` attribute and the now unused `Microsoft.AspNetCore.InternalTesting` using directive.

Closes #68223
