### PR TITLE
Keep WebView modules fallback project-local

### DIFF
--- a/src/Components/WebView/WebView/src/StaticWebAssets.Groups.targets
+++ b/src/Components/WebView/WebView/src/StaticWebAssets.Groups.targets
@@ -7,7 +7,8 @@
        Purpose: WebView apps fetch _framework/blazor.modules.json at runtime. When the app
        contributes its own JS library modules, the SDK generates that manifest. When it does
        not, nothing would be served, so this package ships an empty ([]) fallback and
-       materializes it as the consumer's own static web asset ONLY in that case. The decision is
+       materializes it as the consumer's own current-project-only static web asset ONLY in that
+       case. The fallback does not flow from libraries to referencing projects. The decision is
        made here, during ResolveStaticWebAssetsInputs (before the build manifest is generated and
        its conflict check runs), so exactly one asset ever lands on the route and no group /
        conflict-resolution machinery is required. -->
@@ -53,7 +54,7 @@
       ContentRoot="$(_BlazorWebViewModulesFallbackRoot)"
       BasePath="/"
       AssetKind="All"
-      AssetMode="All"
+      AssetMode="CurrentProject"
       AssetRole="Primary"
       FingerprintCandidates="true">
       <Output TaskParameter="Assets" ItemName="_BlazorWebViewModulesFallbackAsset" />

--- a/src/Components/WebView/test/StaticWebAssets/ConsumerBuild.cs
+++ b/src/Components/WebView/test/StaticWebAssets/ConsumerBuild.cs
@@ -50,6 +50,9 @@ internal sealed class ConsumerBuild : IDisposable
         // fallback so the exact transitive package versions the repo restored (which may not be
         // published to public feeds yet) can still be resolved.
         var repoCache = StaticWebAssetsTestData.NuGetPackageRoot.TrimEnd('\\', '/');
+        var nonShippingSource = Directory.Exists(StaticWebAssetsTestData.NonShippingPackagesDir)
+            ? $"""<add key="local-nonshipping" value="{StaticWebAssetsTestData.NonShippingPackagesDir.TrimEnd('\\', '/')}" />"""
+            : "";
         File.WriteAllText(Path.Combine(_root, "NuGet.config"), $"""
             <configuration>
               <config>
@@ -62,7 +65,7 @@ internal sealed class ConsumerBuild : IDisposable
               <packageSources>
                 <clear />
                 <add key="local-shipping" value="{StaticWebAssetsTestData.ShippingPackagesDir.TrimEnd('\\', '/')}" />
-                <add key="local-nonshipping" value="{StaticWebAssetsTestData.NonShippingPackagesDir.TrimEnd('\\', '/')}" />
+                {nonShippingSource}
                 <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
                 <add key="nuget" value="https://api.nuget.org/v3/index.json" />
               </packageSources>
@@ -201,9 +204,9 @@ internal sealed record ProcessResult(int ExitCode, string Output, string BinlogP
     /// </summary>
     public bool LooksLikeNetworkFailure
         => !Succeeded &&
+           !Output.Contains("The local source", StringComparison.OrdinalIgnoreCase) &&
            (Output.Contains("Unable to load the service index", StringComparison.OrdinalIgnoreCase) ||
             Output.Contains("NU1301", StringComparison.OrdinalIgnoreCase) ||
-            Output.Contains("Unable to resolve", StringComparison.OrdinalIgnoreCase) && Output.Contains("nuget", StringComparison.OrdinalIgnoreCase) ||
             Output.Contains("The remote name could not be resolved", StringComparison.OrdinalIgnoreCase) ||
             Output.Contains("No such host is known", StringComparison.OrdinalIgnoreCase));
 }

--- a/src/Components/WebView/test/StaticWebAssets/WebViewBuildBehaviorTests.cs
+++ b/src/Components/WebView/test/StaticWebAssets/WebViewBuildBehaviorTests.cs
@@ -119,6 +119,103 @@ public class WebViewBuildBehaviorTests
     }
 
     [ConditionalFact]
+    public void Publish_AppAndRclWithoutJsModulesBothReferencingWebView_ProducesSingleFallbackManifest()
+    {
+        using var build = new ConsumerBuild(_output);
+
+        build.CreateProject("rcl", "rcl.csproj", $"""
+            <Project Sdk="Microsoft.NET.Sdk.Razor">
+              <PropertyGroup>
+                <TargetFramework>{StaticWebAssetsTestData.DefaultTargetFramework}</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.AspNetCore.Components.WebView" Version="{StaticWebAssetsTestData.PackageVersion}" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        build.CreateProject("app", "app.csproj", $"""
+            <Project Sdk="Microsoft.NET.Sdk.Razor">
+              <PropertyGroup>
+                <TargetFramework>{StaticWebAssetsTestData.DefaultTargetFramework}</TargetFramework>
+                <OutputType>Exe</OutputType>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.AspNetCore.Components.WebView" Version="{StaticWebAssetsTestData.PackageVersion}" />
+                <ProjectReference Include="..\rcl\rcl.csproj" />
+              </ItemGroup>
+            </Project>
+            """);
+        build.CreateFile("app/Program.cs", "class Program { static void Main() { } }");
+
+        var result = build.Run("publish -c Release -v:m", "app/app.csproj");
+        if (result.LooksLikeNetworkFailure)
+        {
+            return;
+        }
+
+        Assert.True(result.Succeeded, $"Publish should succeed.\n{result.Output}");
+        Assert.DoesNotContain("Conflicting assets with the same target path", result.Output);
+
+        var routes = GetModulesManifestRoutes(build.Root);
+        Assert.Equal("_framework/blazor.modules.json", Assert.Single(routes));
+
+        var publishedManifest = FindPublishedFile(build.Root, "blazor.modules.json");
+        Assert.NotNull(publishedManifest);
+        Assert.Equal("[]", File.ReadAllText(publishedManifest!).Trim());
+    }
+
+    [ConditionalFact]
+    public void Publish_AppAndRclWithJsModulesBothReferencingWebView_ProducesSingleModulesManifest()
+    {
+        using var build = new ConsumerBuild(_output);
+
+        build.CreateProject("rcl", "rcl.csproj", $"""
+            <Project Sdk="Microsoft.NET.Sdk.Razor">
+              <PropertyGroup>
+                <TargetFramework>{StaticWebAssetsTestData.DefaultTargetFramework}</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.AspNetCore.Components.WebView" Version="{StaticWebAssetsTestData.PackageVersion}" />
+              </ItemGroup>
+            </Project>
+            """);
+        build.CreateFile("rcl/wwwroot/rcl.lib.module.js", "export function afterStarted() {}");
+
+        build.CreateProject("app", "app.csproj", $"""
+            <Project Sdk="Microsoft.NET.Sdk.Razor">
+              <PropertyGroup>
+                <TargetFramework>{StaticWebAssetsTestData.DefaultTargetFramework}</TargetFramework>
+                <OutputType>Exe</OutputType>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.AspNetCore.Components.WebView" Version="{StaticWebAssetsTestData.PackageVersion}" />
+                <ProjectReference Include="..\rcl\rcl.csproj" />
+              </ItemGroup>
+            </Project>
+            """);
+        build.CreateFile("app/Program.cs", "class Program { static void Main() { } }");
+
+        var result = build.Run("publish -c Release -v:m", "app/app.csproj");
+        if (result.LooksLikeNetworkFailure)
+        {
+            return;
+        }
+
+        Assert.True(result.Succeeded, $"Publish should succeed.\n{result.Output}");
+        Assert.DoesNotContain("Conflicting assets with the same target path", result.Output);
+
+        var routes = GetModulesManifestRoutes(build.Root);
+        Assert.Equal("_framework/blazor.modules.json", Assert.Single(routes));
+
+        var publishedManifest = FindPublishedFile(build.Root, "blazor.modules.json");
+        Assert.NotNull(publishedManifest);
+        var publishedContent = File.ReadAllText(publishedManifest!);
+        Assert.Contains("_content/rcl/", publishedContent);
+        Assert.Contains(".lib.module.js", publishedContent);
+    }
+
+    [ConditionalFact]
     public void Publish_ProjectReferenceToWebViewWithJsModuleRcl_SucceedsWithSingleModulesManifest()
     {
         // ProjectReference (P2P) variant of the publish repro. An app references the WebView *source


### PR DESCRIPTION
# Keep WebView modules fallback project-local

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Keep the WebView modules fallback from flowing across project references.

## Description

The conditional fallback introduced by #67375 and backported in #67401 correctly avoids colliding with an app-generated `blazor.modules.json` when a single consumer contributes JS modules. A remaining multi-project graph can still produce two fallbacks:

1. An executable Razor app directly references `Microsoft.AspNetCore.Components.WebView`.
2. A Razor class library also directly references the WebView package.
3. The app references the RCL.
4. Neither project contributes a JS module.

Both projects independently materialize the package's raw `build/blazor.modules.json`. Because the fallback was authored with `AssetMode="All"`, the RCL asset flows across the project-reference boundary as `SourceType=Project, SourceId=rcl`. It then conflicts with the app's independently materialized `SourceType=Discovered, SourceId=app` asset at `_framework/blazor.modules.json`.

This changes the fallback to `AssetMode="CurrentProject"`. That keeps the fallback available to each direct consumer while preventing a library-owned fallback from flowing into referencing projects. It matches the SDK's own build and publish JS-module manifests, which are also current-project-only. SDK conflict detection remains strict; the malformed duplicate is prevented at the package-authoring boundary rather than suppressed during aggregation.

The build-behavior coverage now includes the exact direct/direct no-module graph and a sibling graph where the directly-referencing RCL contributes a JS module. The consumer-build helper also omits an optional local package source when its directory does not exist and narrows network-failure detection so a missing local source cannot silently skip product assertions.

### Validation

The exact new no-module assertion failed before the product change with:

```
Conflicting assets with the same target path '_framework/blazor.modules.json'
```

After changing the fallback to `CurrentProject`, the same assertion passes and publishes one empty `[]` manifest.

All five `WebViewBuildBehaviorTests` pass against current `main`, covering:

- app plus RCL modules with a package reference;
- app-only empty fallback;
- app and RCL both directly referencing WebView with no modules;
- app and RCL both directly referencing WebView with RCL modules;
- WebView source-project/P2P consumption with RCL modules.

Related context: #67375, #67401, and dotnet/sdk#54779.