### PR TITLE
[Blazor] Generate AOT-safe binding metadata

### DIFF
--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Components.HotReload;
@@ -1651,6 +1652,63 @@ public static class BindConverter
         return true;
     }
 
+    /// <remarks>
+    /// Used instead of <see cref="ConvertToEnum{T}"/> when runtime code generation is unavailable.
+    /// <c>T</c> here is unconstrained, so the generic <see cref="Enum.TryParse{TEnum}(string, out TEnum)"/>
+    /// cannot be called directly and the framework would otherwise have to close it over the runtime
+    /// type. The non-generic overload needs no instantiation to exist, which is what makes this safe
+    /// under Native AOT. This mirrors what <c>ParameterBindingMethodCache</c> does for the same problem
+    /// in minimal API parameter binding.
+    /// </remarks>
+    internal static bool ConvertToEnumDynamicCodeSafe<T>(object? obj, CultureInfo? _, [MaybeNullWhen(false)] out T value)
+    {
+        var text = (string?)obj;
+        if (string.IsNullOrEmpty(text))
+        {
+            value = default!;
+            return true;
+        }
+
+        if (!Enum.TryParse(typeof(T), text, out var converted)
+            || converted is null
+            || !Enum.IsDefined(typeof(T), converted))
+        {
+            value = default;
+            return false;
+        }
+
+        value = (T)converted;
+        return true;
+    }
+
+    /// <remarks>
+    /// The nullable counterpart of <see cref="ConvertToEnumDynamicCodeSafe{T}"/>. <c>T</c> is a
+    /// <see cref="Nullable{T}"/> of an enum, so the enum type is recovered from it and the boxed result
+    /// unboxes directly to <c>T</c>.
+    /// </remarks>
+    internal static bool ConvertToNullableEnumDynamicCodeSafe<T>(object? obj, CultureInfo? _, [MaybeNullWhen(false)] out T value)
+    {
+        var text = (string?)obj;
+        if (string.IsNullOrEmpty(text))
+        {
+            value = default!;
+            return true;
+        }
+
+        var underlyingType = Nullable.GetUnderlyingType(typeof(T))!;
+
+        if (!Enum.TryParse(underlyingType, text, out var converted)
+            || converted is null
+            || !Enum.IsDefined(underlyingType, converted))
+        {
+            value = default;
+            return false;
+        }
+
+        value = (T)converted;
+        return true;
+    }
+
     /// <summary>
     /// Attempts to convert a value to a value of type <typeparamref name="T"/>.
     /// </summary>
@@ -1794,9 +1852,17 @@ public static class BindConverter
                 }
                 else if (typeof(T).IsArray)
                 {
-                    var method = _makeArrayFormatter ??= typeof(FormatterDelegateCache).GetMethod(nameof(MakeArrayFormatter), BindingFlags.NonPublic | BindingFlags.Static)!;
-                    var elementType = typeof(T).GetElementType()!;
-                    formatter = (Delegate)method.MakeGenericMethod(elementType).Invoke(null, null)!;
+                    if (RuntimeFeature.IsDynamicCodeSupported)
+                    {
+                        var method = _makeArrayFormatter ??= typeof(FormatterDelegateCache).GetMethod(nameof(MakeArrayFormatter), BindingFlags.NonPublic | BindingFlags.Static)!;
+                        var elementType = typeof(T).GetElementType()!;
+                        formatter = (Delegate)method.MakeGenericMethod(elementType).Invoke(null, null)!;
+                    }
+                    else
+                    {
+                        ParserDelegateCache.EnsureCanFormatElementType(typeof(T).GetElementType()!);
+                        formatter = (BindFormatter<T>)FormatArrayValueDynamicCodeSafe;
+                    }
                 }
                 else
                 {
@@ -1836,6 +1902,37 @@ public static class BindConverter
                 builder.Append(']');
 
                 return builder.ToString();
+            }
+        }
+
+        private static object? FormatArrayValueDynamicCodeSafe<T>(T value, CultureInfo? culture)
+        {
+            var array = (Array)(object)value!;
+            if (array.Length == 0)
+            {
+                return "[]";
+            }
+
+            var elementType = typeof(T).GetElementType()!;
+            var builder = new StringBuilder("[\"");
+            AppendElement(array.GetValue(0));
+
+            for (var i = 1; i < array.Length; i++)
+            {
+                builder.Append(", \"");
+                AppendElement(array.GetValue(i));
+            }
+
+            builder.Append(']');
+            return builder.ToString();
+
+            void AppendElement(object? element)
+            {
+                var formatted = elementType.IsArray
+                    ? ParserDelegateCache.FormatArray(element, elementType.GetElementType()!, culture)
+                    : ParserDelegateCache.FormatElement(element, elementType, culture);
+                builder.Append(JsonEncodedText.Encode(formatted ?? string.Empty).Value);
+                builder.Append('\"');
             }
         }
 
@@ -1997,21 +2094,43 @@ public static class BindConverter
                 }
                 else if (typeof(T).IsEnum)
                 {
-                    // We have to deal invoke this dynamically to work around the type constraint on Enum.TryParse.
-                    var method = _convertToEnum ??= typeof(BindConverter).GetMethod(nameof(ConvertToEnum), BindingFlags.NonPublic | BindingFlags.Static)!;
-                    parser = method.MakeGenericMethod(typeof(T)).CreateDelegate(typeof(BindParser<T>), target: null);
+                    if (RuntimeFeature.IsDynamicCodeSupported)
+                    {
+                        // We have to deal invoke this dynamically to work around the type constraint on Enum.TryParse.
+                        var method = _convertToEnum ??= typeof(BindConverter).GetMethod(nameof(ConvertToEnum), BindingFlags.NonPublic | BindingFlags.Static)!;
+                        parser = method.MakeGenericMethod(typeof(T)).CreateDelegate(typeof(BindParser<T>), target: null);
+                    }
+                    else
+                    {
+                        parser = (BindParser<T>)ConvertToEnumDynamicCodeSafe<T>;
+                    }
                 }
                 else if (Nullable.GetUnderlyingType(typeof(T)) is Type innerType && innerType.IsEnum)
                 {
-                    // We have to deal invoke this dynamically to work around the type constraint on Enum.TryParse.
-                    var method = _convertToNullableEnum ??= typeof(BindConverter).GetMethod(nameof(ConvertToNullableEnum), BindingFlags.NonPublic | BindingFlags.Static)!;
-                    parser = method.MakeGenericMethod(innerType).CreateDelegate(typeof(BindParser<T>), target: null);
+                    if (RuntimeFeature.IsDynamicCodeSupported)
+                    {
+                        // We have to deal invoke this dynamically to work around the type constraint on Enum.TryParse.
+                        var method = _convertToNullableEnum ??= typeof(BindConverter).GetMethod(nameof(ConvertToNullableEnum), BindingFlags.NonPublic | BindingFlags.Static)!;
+                        parser = method.MakeGenericMethod(innerType).CreateDelegate(typeof(BindParser<T>), target: null);
+                    }
+                    else
+                    {
+                        parser = (BindParser<T>)ConvertToNullableEnumDynamicCodeSafe<T>;
+                    }
                 }
                 else if (typeof(T).IsArray)
                 {
-                    var method = _makeArrayTypeConverter ??= typeof(ParserDelegateCache).GetMethod(nameof(MakeArrayTypeConverter), BindingFlags.NonPublic | BindingFlags.Static)!;
-                    var elementType = typeof(T).GetElementType()!;
-                    parser = (Delegate)method.MakeGenericMethod(elementType).Invoke(null, null)!;
+                    if (RuntimeFeature.IsDynamicCodeSupported)
+                    {
+                        var method = _makeArrayTypeConverter ??= typeof(ParserDelegateCache).GetMethod(nameof(MakeArrayTypeConverter), BindingFlags.NonPublic | BindingFlags.Static)!;
+                        var elementType = typeof(T).GetElementType()!;
+                        parser = (Delegate)method.MakeGenericMethod(elementType).Invoke(null, null)!;
+                    }
+                    else
+                    {
+                        EnsureCanParseElementType(typeof(T).GetElementType()!);
+                        parser = (BindParser<T>)ConvertToArrayDynamicCodeSafe;
+                    }
                 }
                 else
                 {
@@ -2054,6 +2173,35 @@ public static class BindConverter
             }
         }
 
+        private static bool ConvertToArrayDynamicCodeSafe<T>(
+            object? obj,
+            CultureInfo? culture,
+            [MaybeNullWhen(false)] out T value)
+        {
+            if (obj is not Array initialArray)
+            {
+                value = default;
+                return false;
+            }
+
+            var arrayType = typeof(T);
+            var elementType = arrayType.GetElementType()!;
+            var convertedArray = Array.CreateInstanceFromArrayType(arrayType, initialArray.Length);
+            for (var i = 0; i < initialArray.Length; i++)
+            {
+                if (!TryConvertElement(initialArray.GetValue(i), elementType, culture, out var converted))
+                {
+                    value = default;
+                    return false;
+                }
+
+                convertedArray.SetValue(converted, i);
+            }
+
+            value = (T)(object)convertedArray;
+            return true;
+        }
+
         [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "We expect unknown underlying types are configured by application code to be retained.")]
         private static BindParser<T> MakeTypeConverterConverter<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
         {
@@ -2086,6 +2234,345 @@ public static class BindConverter
                 value = (T)converted;
                 return true;
             }
+        }
+
+        internal static string? FormatArray(object? value, Type elementType, CultureInfo? culture)
+        {
+            var array = (Array)value!;
+            if (array.Length == 0)
+            {
+                return "[]";
+            }
+
+            var builder = new StringBuilder("[\"");
+            AppendElement(array.GetValue(0));
+
+            for (var i = 1; i < array.Length; i++)
+            {
+                builder.Append(", \"");
+                AppendElement(array.GetValue(i));
+            }
+
+            builder.Append(']');
+            return builder.ToString();
+
+            void AppendElement(object? element)
+            {
+                var formatted = elementType.IsArray
+                    ? FormatArray(element, elementType.GetElementType()!, culture)
+                    : FormatElement(element, elementType, culture);
+                builder.Append(JsonEncodedText.Encode(formatted ?? string.Empty).Value);
+                builder.Append('\"');
+            }
+        }
+
+        internal static string? FormatElement(object? value, Type type, CultureInfo? culture)
+        {
+            if (value is null)
+            {
+                return null;
+            }
+
+            if (type == typeof(string))
+            {
+                return (string)value;
+            }
+
+            if (type.IsEnum || Nullable.GetUnderlyingType(type) is Type { IsEnum: true })
+            {
+                return value.ToString();
+            }
+
+            if (type == typeof(bool) || type == typeof(bool?))
+            {
+                return ((bool)value).ToString();
+            }
+
+            var underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+            if (underlyingType == typeof(int) ||
+                underlyingType == typeof(long) ||
+                underlyingType == typeof(short) ||
+                underlyingType == typeof(float) ||
+                underlyingType == typeof(double) ||
+                underlyingType == typeof(decimal) ||
+                underlyingType == typeof(DateTime) ||
+                underlyingType == typeof(DateTimeOffset) ||
+                underlyingType == typeof(DateOnly) ||
+                underlyingType == typeof(TimeOnly))
+            {
+                return ((IFormattable)value).ToString(format: null, culture ?? CultureInfo.CurrentCulture);
+            }
+
+            if (underlyingType == typeof(Guid))
+            {
+                return value.ToString();
+            }
+
+            // Native AOT applications using a custom TypeConverter register its type with TypeDescriptor.RegisterType<T>().
+            var converter = TypeDescriptor.GetConverterFromRegisteredType(type);
+            if (!converter.CanConvertTo(typeof(string)))
+            {
+                throw new InvalidOperationException(
+                    $"The type '{type.FullName}' does not have an associated {typeof(TypeConverter).Name} that supports " +
+                    $"conversion to a string. Apply '{typeof(TypeConverterAttribute).Name}' to the type to register a converter.");
+            }
+
+            return converter.ConvertToString(context: null, culture ?? CultureInfo.CurrentCulture, value);
+        }
+
+        internal static void EnsureCanFormatElementType(Type type)
+        {
+            if (type.IsArray)
+            {
+                EnsureCanFormatElementType(type.GetElementType()!);
+                return;
+            }
+
+            var underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+            if (underlyingType == typeof(string) ||
+                underlyingType == typeof(bool) ||
+                underlyingType == typeof(int) ||
+                underlyingType == typeof(long) ||
+                underlyingType == typeof(short) ||
+                underlyingType == typeof(float) ||
+                underlyingType == typeof(double) ||
+                underlyingType == typeof(decimal) ||
+                underlyingType == typeof(DateTime) ||
+                underlyingType == typeof(DateTimeOffset) ||
+                underlyingType == typeof(DateOnly) ||
+                underlyingType == typeof(TimeOnly) ||
+                underlyingType == typeof(Guid) ||
+                underlyingType.IsEnum)
+            {
+                return;
+            }
+
+            var converter = TypeDescriptor.GetConverterFromRegisteredType(type);
+            if (!converter.CanConvertTo(typeof(string)))
+            {
+                throw new InvalidOperationException(
+                    $"The type '{type.FullName}' does not have an associated {typeof(TypeConverter).Name} that supports " +
+                    $"conversion to a string. Apply '{typeof(TypeConverterAttribute).Name}' to the type to register a converter.");
+            }
+        }
+
+        private static bool TryConvertElement(object? obj, Type type, CultureInfo? culture, out object? value)
+        {
+            if (type.IsArray)
+            {
+                return TryConvertArray(obj, type, culture, out value);
+            }
+
+            var nullableType = Nullable.GetUnderlyingType(type);
+            var targetType = nullableType ?? type;
+            if (targetType == typeof(string))
+            {
+                return TryConvertElement(ConvertToString, obj, culture, out value);
+            }
+
+            if (targetType == typeof(bool))
+            {
+                return nullableType is null
+                    ? TryConvertElement(ConvertToBool, obj, culture, out value)
+                    : TryConvertElement(ConvertToNullableBool, obj, culture, out value);
+            }
+
+            if (targetType == typeof(int))
+            {
+                return nullableType is null
+                    ? TryConvertElement(ConvertToInt, obj, culture, out value)
+                    : TryConvertElement(ConvertToNullableInt, obj, culture, out value);
+            }
+
+            if (targetType == typeof(long))
+            {
+                return nullableType is null
+                    ? TryConvertElement(ConvertToLong, obj, culture, out value)
+                    : TryConvertElement(ConvertToNullableLong, obj, culture, out value);
+            }
+
+            if (targetType == typeof(short))
+            {
+                return nullableType is null
+                    ? TryConvertElement(ConvertToShort, obj, culture, out value)
+                    : TryConvertElement(ConvertToNullableShort, obj, culture, out value);
+            }
+
+            if (targetType == typeof(float))
+            {
+                return nullableType is null
+                    ? TryConvertElement(ConvertToFloat, obj, culture, out value)
+                    : TryConvertElement(ConvertToNullableFloat, obj, culture, out value);
+            }
+
+            if (targetType == typeof(double))
+            {
+                return nullableType is null
+                    ? TryConvertElement(ConvertToDoubleDelegate, obj, culture, out value)
+                    : TryConvertElement(ConvertToNullableDoubleDelegate, obj, culture, out value);
+            }
+
+            if (targetType == typeof(decimal))
+            {
+                return nullableType is null
+                    ? TryConvertElement(ConvertToDecimal, obj, culture, out value)
+                    : TryConvertElement(ConvertToNullableDecimal, obj, culture, out value);
+            }
+
+            if (targetType == typeof(DateTime))
+            {
+                return nullableType is null
+                    ? TryConvertElement(ConvertToDateTime, obj, culture, out value)
+                    : TryConvertElement(ConvertToNullableDateTime, obj, culture, out value);
+            }
+
+            if (targetType == typeof(DateTimeOffset))
+            {
+                return nullableType is null
+                    ? TryConvertElement(ConvertToDateTimeOffset, obj, culture, out value)
+                    : TryConvertElement(ConvertToNullableDateTimeOffset, obj, culture, out value);
+            }
+
+            if (targetType == typeof(DateOnly))
+            {
+                return nullableType is null
+                    ? TryConvertElement(ConvertToDateOnly, obj, culture, out value)
+                    : TryConvertElement(ConvertToNullableDateOnly, obj, culture, out value);
+            }
+
+            if (targetType == typeof(TimeOnly))
+            {
+                return nullableType is null
+                    ? TryConvertElement(ConvertToTimeOnly, obj, culture, out value)
+                    : TryConvertElement(ConvertToNullableTimeOnly, obj, culture, out value);
+            }
+
+            if (targetType == typeof(Guid))
+            {
+                return nullableType is null
+                    ? TryConvertElement(ConvertToGuid, obj, culture, out value)
+                    : TryConvertElement(ConvertToNullableGuid, obj, culture, out value);
+            }
+
+            if (targetType.IsEnum)
+            {
+                var text = (string?)obj;
+                if (string.IsNullOrEmpty(text))
+                {
+                    value = nullableType is null ? Enum.ToObject(targetType, 0) : null;
+                    return true;
+                }
+
+                if (!Enum.TryParse(targetType, text, out var converted) ||
+                    converted is null ||
+                    !Enum.IsDefined(targetType, converted))
+                {
+                    value = null;
+                    return false;
+                }
+
+                value = converted;
+                return true;
+            }
+
+            return TryConvertElementWithTypeConverter(obj, type, culture, out value);
+        }
+
+        private static void EnsureCanParseElementType(Type type)
+        {
+            if (type.IsArray)
+            {
+                EnsureCanParseElementType(type.GetElementType()!);
+                return;
+            }
+
+            var underlyingType = Nullable.GetUnderlyingType(type) ?? type;
+            if (underlyingType == typeof(string) ||
+                underlyingType == typeof(bool) ||
+                underlyingType == typeof(int) ||
+                underlyingType == typeof(long) ||
+                underlyingType == typeof(short) ||
+                underlyingType == typeof(float) ||
+                underlyingType == typeof(double) ||
+                underlyingType == typeof(decimal) ||
+                underlyingType == typeof(DateTime) ||
+                underlyingType == typeof(DateTimeOffset) ||
+                underlyingType == typeof(DateOnly) ||
+                underlyingType == typeof(TimeOnly) ||
+                underlyingType == typeof(Guid) ||
+                underlyingType.IsEnum)
+            {
+                return;
+            }
+
+            var converter = TypeDescriptor.GetConverterFromRegisteredType(type);
+            if (!converter.CanConvertFrom(typeof(string)))
+            {
+                throw new InvalidOperationException(
+                    $"The type '{type.FullName}' does not have an associated {typeof(TypeConverter).Name} that supports " +
+                    $"conversion from a string. Apply '{typeof(TypeConverterAttribute).Name}' to the type to register a converter.");
+            }
+        }
+
+        private static bool TryConvertElement<T>(
+            BindParser<T> parser,
+            object? obj,
+            CultureInfo? culture,
+            out object? value)
+        {
+            var result = parser(obj, culture, out var converted);
+            value = converted;
+            return result;
+        }
+
+        private static bool TryConvertArray(object? obj, Type arrayType, CultureInfo? culture, out object? value)
+        {
+            if (obj is not Array initialArray)
+            {
+                value = null;
+                return false;
+            }
+
+            var elementType = arrayType.GetElementType()!;
+            var convertedArray = Array.CreateInstanceFromArrayType(arrayType, initialArray.Length);
+            for (var i = 0; i < initialArray.Length; i++)
+            {
+                if (!TryConvertElement(initialArray.GetValue(i), elementType, culture, out var converted))
+                {
+                    value = null;
+                    return false;
+                }
+
+                convertedArray.SetValue(converted, i);
+            }
+
+            value = convertedArray;
+            return true;
+        }
+
+        private static bool TryConvertElementWithTypeConverter(
+            object? obj,
+            Type type,
+            CultureInfo? culture,
+            out object? value)
+        {
+            // Native AOT applications using a custom TypeConverter register its type with TypeDescriptor.RegisterType<T>().
+            var converter = TypeDescriptor.GetConverterFromRegisteredType(type);
+            if (!converter.CanConvertFrom(typeof(string)))
+            {
+                throw new InvalidOperationException(
+                    $"The type '{type.FullName}' does not have an associated {typeof(TypeConverter).Name} that supports " +
+                    $"conversion from a string. Apply '{typeof(TypeConverterAttribute).Name}' to the type to register a converter.");
+            }
+
+            if (obj is null)
+            {
+                value = null;
+                return true;
+            }
+
+            value = converter.ConvertFrom(context: null, culture ?? CultureInfo.CurrentCulture, obj);
+            return true;
         }
     }
 }

--- a/src/Components/Components/src/ComponentBase.cs
+++ b/src/Components/Components/src/ComponentBase.cs
@@ -29,6 +29,10 @@ public abstract class ComponentBase : IComponent, IHandleEvent, IHandleAfterRend
     private bool _hasPendingQueuedRender;
     private bool _hasCalledOnAfterRender;
 
+    // Gives framework components in assemblies with InternalsVisibleTo access to renderer-scoped
+    // services carried by the handle without exposing the handle itself.
+    internal RenderHandle Handle => _renderHandle;
+
     /// <summary>
     /// Constructs an instance of <see cref="ComponentBase"/>.
     /// </summary>

--- a/src/Components/Components/src/Infrastructure/BindableIndexerDescriptor.cs
+++ b/src/Components/Components/src/Infrastructure/BindableIndexerDescriptor.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.Components.Infrastructure;
+
+/// <summary>
+/// Describes one single-argument indexer of a form model type, so that a binding expression can
+/// traverse it without compiling a delegate.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reached through <see cref="BindableTypeDescriptor.Indexers"/>. The declaring type is the containing
+/// <see cref="BindableTypeDescriptor.Type"/>, and the framework selects an indexer by matching
+/// <see cref="IndexType"/> against the static type of the index expression.
+/// </para>
+/// <para>
+/// This API is experimental, unsupported, and subject to change or removal in any release.
+/// </para>
+/// </remarks>
+/// <example>
+/// The descriptor for <c>List&lt;Order&gt;.this[int]</c>:
+/// <code>
+/// new BindableIndexerDescriptor
+/// {
+///     IndexType = typeof(int),
+///     ValueType = typeof(Order),
+///     GetValue = static (target, index) =&gt; ((List&lt;Order&gt;)target)[(int)index!],
+/// }
+/// </code>
+/// </example>
+[Experimental("ASPNETCORE9004", UrlFormat = "https://aka.ms/aspnet/analyzer/{0}")]
+public sealed class BindableIndexerDescriptor
+{
+    /// <summary>
+    /// Gets the type of the indexer's single argument.
+    /// </summary>
+    public required Type IndexType { get; init; }
+
+    /// <summary>
+    /// Gets the type the indexer returns, which is the type of the next hop in the chain.
+    /// </summary>
+    public required Type ValueType { get; init; }
+
+    /// <summary>
+    /// Gets the delegate that reads an indexed value from an instance of the declaring type.
+    /// </summary>
+    public required Func<object, object?, object?> GetValue { get; init; }
+}

--- a/src/Components/Components/src/Infrastructure/BindableMemberDescriptor.cs
+++ b/src/Components/Components/src/Infrastructure/BindableMemberDescriptor.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.Components.Infrastructure;
+
+/// <summary>
+/// Describes one instance field or property of a form model type, so that a binding expression can
+/// traverse it without compiling a delegate.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reached through <see cref="BindableTypeDescriptor.Members"/>.
+/// </para>
+/// <para>
+/// This API is experimental, unsupported, and subject to change or removal in any release.
+/// </para>
+/// </remarks>
+[Experimental("ASPNETCORE9004", UrlFormat = "https://aka.ms/aspnet/analyzer/{0}")]
+public sealed class BindableMemberDescriptor
+{
+    /// <summary>
+    /// Gets the name of the field or property, used to match the member the expression names.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets the declared type of the member, which is the type of the next hop in the chain.
+    /// </summary>
+    public required Type MemberType { get; init; }
+
+    /// <summary>
+    /// Gets the delegate that reads the member's value from an instance of the declaring type.
+    /// </summary>
+    public required Func<object, object?> GetValue { get; init; }
+}

--- a/src/Components/Components/src/Infrastructure/BindableTypeDescriptor.cs
+++ b/src/Components/Components/src/Infrastructure/BindableTypeDescriptor.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.Components.Infrastructure;
+
+/// <summary>
+/// Describes the members and indexers of a form model type that a binding expression may traverse,
+/// so that the framework can evaluate the expression without compiling a delegate.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <c>@bind</c> or <c>For</c> expression is a chain of member accesses rooted in a constant. The
+/// framework anchors that chain at the node whose static type matches the type of the edit context's
+/// model, takes that node's value from the edit context, and then evaluates one hop at a time through
+/// the descriptors here. Only the model graph needs describing: the component half of the chain is
+/// anchored rather than walked.
+/// </para>
+/// <para>
+/// Instances are produced by the Blazor Native AOT metadata source generator for every type named by a
+/// <c>BindableModelAttribute</c> and every type reachable from it.
+/// </para>
+/// <para>
+/// This API is experimental, unsupported, and subject to change or removal in any release.
+/// </para>
+/// </remarks>
+/// <example>
+/// The descriptor for a model exposing <c>Address</c> and <c>Orders</c>:
+/// <code>
+/// new BindableTypeDescriptor
+/// {
+///     Type = typeof(LoginModel),
+///     Members =
+///     [
+///         new BindableMemberDescriptor
+///         {
+///             Name = "Address",
+///             MemberType = typeof(Address),
+///             GetValue = static target =&gt; ((LoginModel)target).Address,
+///         },
+///     ],
+/// }
+/// </code>
+/// </example>
+[Experimental("ASPNETCORE9004", UrlFormat = "https://aka.ms/aspnet/analyzer/{0}")]
+public sealed class BindableTypeDescriptor
+{
+    /// <summary>
+    /// Gets the type being described.
+    /// </summary>
+    public required Type Type { get; init; }
+
+    /// <summary>
+    /// Gets the describable instance fields and properties of <see cref="Type"/>.
+    /// </summary>
+    /// <remarks>
+    /// Covers fields as well as properties, because a model may expose either and the expression walk
+    /// does not distinguish between them.
+    /// </remarks>
+    public IReadOnlyList<BindableMemberDescriptor> Members { get; init; } = [];
+
+    /// <summary>
+    /// Gets the single-argument indexers declared on <see cref="Type"/>.
+    /// </summary>
+    /// <remarks>
+    /// Keyed by index type, because a type may declare both <c>this[int]</c> and <c>this[string]</c>.
+    /// Array indexing needs no descriptor.
+    /// </remarks>
+    public IReadOnlyList<BindableIndexerDescriptor> Indexers { get; init; } = [];
+}

--- a/src/Components/Components/src/Infrastructure/IBindableTypeResolver.cs
+++ b/src/Components/Components/src/Infrastructure/IBindableTypeResolver.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Components.Infrastructure;
+
+namespace Microsoft.AspNetCore.Components;
+
+/// <summary>
+/// Provides the compile-time description of a form model type, used to evaluate a binding expression
+/// without compiling a delegate.
+/// </summary>
+internal interface IBindableTypeResolver
+{
+    /// <summary>
+    /// Looks up the descriptor for a type appearing in a binding expression chain.
+    /// </summary>
+    bool TryGetBindableTypeDescriptor(Type type, [NotNullWhen(true)] out BindableTypeDescriptor? descriptor);
+}

--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.csproj
@@ -11,6 +11,8 @@
     <DefineConstants>$(DefineConstants);COMPONENTS</DefineConstants>
     <!-- TODO: Address Native AOT analyzer warnings https://github.com/dotnet/aspnetcore/issues/45473 -->
     <EnableAOTAnalyzer>false</EnableAOTAnalyzer>
+    <!-- This assembly declares the experimental Blazor Native AOT binding metadata model and consumes it internally. -->
+    <NoWarn>$(NoWarn);ASPNETCORE9004</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -32,6 +32,30 @@ Microsoft.AspNetCore.Components.NavigationOptions.RelativeToCurrentUri.get -> bo
 Microsoft.AspNetCore.Components.NavigationOptions.RelativeToCurrentUri.init -> void
 Microsoft.AspNetCore.Components.IComponentPropertyActivator
 Microsoft.AspNetCore.Components.IComponentPropertyActivator.GetActivator(System.Type! componentType) -> System.Action<System.IServiceProvider!, Microsoft.AspNetCore.Components.IComponent!>!
+Microsoft.AspNetCore.Components.Infrastructure.BindableIndexerDescriptor
+Microsoft.AspNetCore.Components.Infrastructure.BindableIndexerDescriptor.BindableIndexerDescriptor() -> void
+Microsoft.AspNetCore.Components.Infrastructure.BindableIndexerDescriptor.GetValue.get -> System.Func<object!, object?, object?>!
+Microsoft.AspNetCore.Components.Infrastructure.BindableIndexerDescriptor.GetValue.init -> void
+Microsoft.AspNetCore.Components.Infrastructure.BindableIndexerDescriptor.IndexType.get -> System.Type!
+Microsoft.AspNetCore.Components.Infrastructure.BindableIndexerDescriptor.IndexType.init -> void
+Microsoft.AspNetCore.Components.Infrastructure.BindableIndexerDescriptor.ValueType.get -> System.Type!
+Microsoft.AspNetCore.Components.Infrastructure.BindableIndexerDescriptor.ValueType.init -> void
+Microsoft.AspNetCore.Components.Infrastructure.BindableMemberDescriptor
+Microsoft.AspNetCore.Components.Infrastructure.BindableMemberDescriptor.BindableMemberDescriptor() -> void
+Microsoft.AspNetCore.Components.Infrastructure.BindableMemberDescriptor.GetValue.get -> System.Func<object!, object?>!
+Microsoft.AspNetCore.Components.Infrastructure.BindableMemberDescriptor.GetValue.init -> void
+Microsoft.AspNetCore.Components.Infrastructure.BindableMemberDescriptor.MemberType.get -> System.Type!
+Microsoft.AspNetCore.Components.Infrastructure.BindableMemberDescriptor.MemberType.init -> void
+Microsoft.AspNetCore.Components.Infrastructure.BindableMemberDescriptor.Name.get -> string!
+Microsoft.AspNetCore.Components.Infrastructure.BindableMemberDescriptor.Name.init -> void
+Microsoft.AspNetCore.Components.Infrastructure.BindableTypeDescriptor
+Microsoft.AspNetCore.Components.Infrastructure.BindableTypeDescriptor.BindableTypeDescriptor() -> void
+Microsoft.AspNetCore.Components.Infrastructure.BindableTypeDescriptor.Indexers.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.Infrastructure.BindableIndexerDescriptor!>!
+Microsoft.AspNetCore.Components.Infrastructure.BindableTypeDescriptor.Indexers.init -> void
+Microsoft.AspNetCore.Components.Infrastructure.BindableTypeDescriptor.Members.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.Infrastructure.BindableMemberDescriptor!>!
+Microsoft.AspNetCore.Components.Infrastructure.BindableTypeDescriptor.Members.init -> void
+Microsoft.AspNetCore.Components.Infrastructure.BindableTypeDescriptor.Type.get -> System.Type!
+Microsoft.AspNetCore.Components.Infrastructure.BindableTypeDescriptor.Type.init -> void
 *REMOVED*Microsoft.AspNetCore.Components.ResourceAsset.ResourceAsset(string! url, System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.ResourceAssetProperty!>? properties) -> void
 *REMOVED*Microsoft.AspNetCore.Components.Routing.Router.PreferExactMatches.get -> bool
 *REMOVED*Microsoft.AspNetCore.Components.Routing.Router.PreferExactMatches.set -> void

--- a/src/Components/Components/src/RenderHandle.cs
+++ b/src/Components/Components/src/RenderHandle.cs
@@ -26,6 +26,8 @@ public readonly struct RenderHandle
     internal ComponentsActivitySource? ComponentActivitySource => _renderer?.ComponentActivitySource;
     internal SectionRegistry SectionRegistry => _renderer?.SectionRegistry ?? throw new InvalidOperationException("No renderer has been initialized.");
 
+    internal IBindableTypeResolver? BindableTypeResolver => _renderer?.BindableTypeResolver;
+
     /// <summary>
     /// Gets the <see cref="Components.Dispatcher" /> associated with the component.
     /// </summary>

--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -118,7 +118,11 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
         ServiceProviderCascadingValueSuppliers = serviceProvider.GetService<ICascadingValueSupplier>() is null
             ? Array.Empty<ICascadingValueSupplier>()
             : serviceProvider.GetServices<ICascadingValueSupplier>().ToArray();
+
+        BindableTypeResolver = serviceProvider.GetService<IBindableTypeResolver>();
     }
+
+    internal IBindableTypeResolver? BindableTypeResolver { get; }
 
     internal ComponentsMetrics? ComponentMetrics => _componentsMetrics;
     internal ComponentsActivitySource? ComponentActivitySource => _componentsActivitySource;

--- a/src/Components/Components/test/BindConverterTest.cs
+++ b/src/Components/Components/test/BindConverterTest.cs
@@ -3,7 +3,10 @@
 
 using System.ComponentModel;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.DotNet.RemoteExecutor;
 
 namespace Microsoft.AspNetCore.Components;
 
@@ -369,12 +372,199 @@ public class BindConverterTest
         Assert.Null(actual);
     }
 
-    private enum SomeLetters
+    [Theory]
+    [InlineData("A", SomeLetters.A)]
+    [InlineData("Q", SomeLetters.Q)]
+    public void ConvertToEnumDynamicCodeSafe_ParsesDefinedValues(string text, SomeLetters expected)
+    {
+        var successfullyConverted = BindConverter.ConvertToEnumDynamicCodeSafe<SomeLetters>(text, CultureInfo.InvariantCulture, out var actual);
+
+        Assert.True(successfullyConverted);
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ConvertToEnumDynamicCodeSafe_TreatsEmptyAsDefault(string text)
+    {
+        var successfullyConverted = BindConverter.ConvertToEnumDynamicCodeSafe<SomeLetters>(text, CultureInfo.InvariantCulture, out var actual);
+
+        Assert.True(successfullyConverted);
+        Assert.Equal(default, actual);
+    }
+
+    [Theory]
+    [InlineData("Z")]
+    [InlineData("42")]
+    public void ConvertToEnumDynamicCodeSafe_RejectsUndefinedValues(string text)
+    {
+        var successfullyConverted = BindConverter.ConvertToEnumDynamicCodeSafe<SomeLetters>(text, CultureInfo.InvariantCulture, out var actual);
+
+        Assert.False(successfullyConverted);
+        Assert.Equal(default, actual);
+    }
+
+    [Fact]
+    public void ConvertToEnumDynamicCodeSafe_MatchesTheDynamicCodePath()
+    {
+        foreach (var text in new[] { "A", "B", "C", "Q", "Z", "", "3" })
+        {
+            var expectedSuccess = BindConverter.TryConvertTo<SomeLetters>(text, CultureInfo.InvariantCulture, out var expected);
+            var actualSuccess = BindConverter.ConvertToEnumDynamicCodeSafe<SomeLetters>(text, CultureInfo.InvariantCulture, out var actual);
+
+            Assert.Equal(expectedSuccess, actualSuccess);
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Fact]
+    public void ConvertToNullableEnumDynamicCodeSafe_ParsesDefinedValues()
+    {
+        var successfullyConverted = BindConverter.ConvertToNullableEnumDynamicCodeSafe<SomeLetters?>("C", CultureInfo.InvariantCulture, out var actual);
+
+        Assert.True(successfullyConverted);
+        Assert.Equal(SomeLetters.C, actual);
+    }
+
+    [Fact]
+    public void ConvertToNullableEnumDynamicCodeSafe_TreatsEmptyAsNull()
+    {
+        var successfullyConverted = BindConverter.ConvertToNullableEnumDynamicCodeSafe<SomeLetters?>("", CultureInfo.InvariantCulture, out var actual);
+
+        Assert.True(successfullyConverted);
+        Assert.Null(actual);
+    }
+
+    [Fact]
+    public void ConvertToNullableEnumDynamicCodeSafe_RejectsUndefinedValues()
+    {
+        var successfullyConverted = BindConverter.ConvertToNullableEnumDynamicCodeSafe<SomeLetters?>("Z", CultureInfo.InvariantCulture, out var actual);
+
+        Assert.False(successfullyConverted);
+        Assert.Null(actual);
+    }
+
+    [Fact]
+    public void ConvertToNullableEnumDynamicCodeSafe_MatchesTheDynamicCodePath()
+    {
+        foreach (var text in new[] { "A", "B", "C", "Q", "Z", "", "3" })
+        {
+            var expectedSuccess = BindConverter.TryConvertTo<SomeLetters?>(text, CultureInfo.InvariantCulture, out var expected);
+            var actualSuccess = BindConverter.ConvertToNullableEnumDynamicCodeSafe<SomeLetters?>(text, CultureInfo.InvariantCulture, out var actual);
+
+            Assert.Equal(expectedSuccess, actualSuccess);
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Fact]
+    public void ArrayConversionAndFormatting_PreserveExistingSemantics()
+    {
+        Assert.True(BindConverter.TryConvertTo<int[]>(
+            new[] { "1", "2" },
+            CultureInfo.InvariantCulture,
+            out var numbers));
+        Assert.Equal([1, 2], numbers);
+        Assert.Equal("[\"1\", \"2\"]", BindConverter.FormatValue(numbers, CultureInfo.InvariantCulture));
+
+        Assert.True(BindConverter.TryConvertTo<int?[]>(
+            new[] { "1", "" },
+            CultureInfo.InvariantCulture,
+            out var nullableNumbers));
+        Assert.Equal([1, null], nullableNumbers);
+
+        Assert.False(BindConverter.TryConvertTo<int[]>(
+            new[] { "1", "not-a-number" },
+            CultureInfo.InvariantCulture,
+            out _));
+        Assert.False(BindConverter.TryConvertTo<int[]>(
+            "not-an-array",
+            CultureInfo.InvariantCulture,
+            out _));
+    }
+
+    [ConditionalFact]
+    [RemoteExecutionSupported]
+    public void ArrayConversionAndFormatting_WorkWithoutDynamicCode()
+    {
+        var options = new RemoteInvokeOptions();
+        options.RuntimeConfigurationOptions.Add(
+            "System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported",
+            false.ToString());
+
+        using var remoteHandle = RemoteExecutor.Invoke(static () =>
+        {
+            Assert.False(RuntimeFeature.IsDynamicCodeSupported);
+            TypeDescriptor.RegisterType<Person>();
+
+            Assert.True(BindConverter.TryConvertTo<int[]>(
+                new[] { "1", "2" },
+                CultureInfo.InvariantCulture,
+                out var numbers));
+            Assert.Equal([1, 2], numbers);
+            Assert.Equal("[\"1\", \"2\"]", BindConverter.FormatValue(numbers, CultureInfo.InvariantCulture));
+
+            Assert.True(BindConverter.TryConvertTo<int?[]>(
+                new[] { "1", "" },
+                CultureInfo.InvariantCulture,
+                out var nullableNumbers));
+            Assert.Equal([1, null], nullableNumbers);
+
+            Assert.True(BindConverter.TryConvertTo<SomeLetters[]>(
+                new[] { "A", "Q" },
+                CultureInfo.InvariantCulture,
+                out var letters));
+            Assert.Equal([SomeLetters.A, SomeLetters.Q], letters);
+            Assert.False(BindConverter.TryConvertTo<SomeLetters[]>(
+                new[] { "A", "Z" },
+                CultureInfo.InvariantCulture,
+                out _));
+
+            Assert.True(BindConverter.TryConvertTo<Person[]>(
+                new[] { """{"Name":"Ada","Age":36}""" },
+                CultureInfo.InvariantCulture,
+                out var people));
+            Assert.Equal("Ada", Assert.Single(people).Name);
+            Assert.Contains("Ada", Assert.IsType<string>(BindConverter.FormatValue(people, CultureInfo.InvariantCulture)));
+
+            Assert.True(BindConverter.TryConvertTo<int[][]>(
+                new[] { new[] { "1", "2" }, new[] { "3" } },
+                CultureInfo.InvariantCulture,
+                out var nested));
+            Assert.Equal([1, 2], nested[0]);
+            Assert.Equal([3], nested[1]);
+            Assert.NotNull(BindConverter.FormatValue(nested, CultureInfo.InvariantCulture));
+
+            Assert.False(BindConverter.TryConvertTo<int[]>(
+                new[] { "invalid" },
+                CultureInfo.InvariantCulture,
+                out _));
+            Assert.False(BindConverter.TryConvertTo<int[]>(
+                "not-an-array",
+                CultureInfo.InvariantCulture,
+                out _));
+
+            Assert.Throws<InvalidOperationException>(() =>
+                BindConverter.TryConvertTo<Unconvertible[]>(
+                    Array.Empty<string>(),
+                    CultureInfo.InvariantCulture,
+                    out _));
+            Assert.Throws<InvalidOperationException>(() =>
+                BindConverter.FormatValue(Array.Empty<Unconvertible>(), CultureInfo.InvariantCulture));
+        }, options);
+    }
+
+    public enum SomeLetters
     {
         A,
         B,
         C,
         Q,
+    }
+
+    private sealed class Unconvertible
+    {
     }
 
     [TypeConverter(typeof(PersonConverter))]

--- a/src/Components/Endpoints/gen/DiagnosticDescriptors.cs
+++ b/src/Components/Endpoints/gen/DiagnosticDescriptors.cs
@@ -9,6 +9,15 @@ internal static class DiagnosticDescriptors
 {
     private const string Category = "BlazorNativeAot";
 
+    public static readonly DiagnosticDescriptor BindableModelNotDescribed = new(
+        id: "BLAZORAOT002",
+        title: "Form model cannot be described completely",
+        messageFormat: "'{0}' cannot be described for Native AOT because {1}",
+        category: Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "The Blazor Native AOT metadata generator describes a form model and every type reachable from it, so that a binding expression can be walked instead of compiled.");
+
     public static readonly DiagnosticDescriptor MetadataContextMustBePartial = new(
         id: "BLAZORAOT003",
         title: "Metadata context declaration must be partial",

--- a/src/Components/Endpoints/gen/Emitters/RazorComponentsMetadataGenerator.Emitter.cs
+++ b/src/Components/Endpoints/gen/Emitters/RazorComponentsMetadataGenerator.Emitter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.Text;
 using Microsoft.AspNetCore.Components.Endpoints.Generators.Models;
@@ -13,6 +14,9 @@ namespace Microsoft.AspNetCore.Components.Endpoints.Generators;
 public sealed partial class RazorComponentsMetadataGenerator
 {
     private const string GeneratorName = "Microsoft.AspNetCore.Components.Endpoints.Generators.RazorComponentsMetadataGenerator";
+    private const string BindableTypeDescriptorType = "global::Microsoft.AspNetCore.Components.Infrastructure.BindableTypeDescriptor";
+    private const string BindableMemberDescriptorType = "global::Microsoft.AspNetCore.Components.Infrastructure.BindableMemberDescriptor";
+    private const string BindableIndexerDescriptorType = "global::Microsoft.AspNetCore.Components.Infrastructure.BindableIndexerDescriptor";
     private const string JSInvokableDescriptorType = "global::Microsoft.JSInterop.Infrastructure.JSInvokableMethodDescriptor";
     private const string ReadOnlyListType = "global::System.Collections.Generic.IReadOnlyList";
     private const string JsonResolverType = "global::System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver";
@@ -91,6 +95,9 @@ public sealed partial class RazorComponentsMetadataGenerator
         writer.OpenBrace();
 
         writer.WriteLine("/// <inheritdoc />");
+        writer.WriteLine($"public override {ReadOnlyListType}<{BindableTypeDescriptorType}> BindableTypes => __Descriptors.BindableTypes;");
+        writer.WriteLine();
+        writer.WriteLine("/// <inheritdoc />");
         writer.WriteLine($"public override {ReadOnlyListType}<{JSInvokableDescriptorType}> JSInvokableMethods => __Descriptors.JSInvokableMethods;");
         if (!model.DeclaresJsonTypeInfoResolver)
         {
@@ -100,13 +107,29 @@ public sealed partial class RazorComponentsMetadataGenerator
         }
 
         writer.WriteLine();
+        writer.WriteLine(
+            "[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(" +
+            "\"Trimming\", \"IL2110\", Justification = " +
+            "\"Generated bindable descriptors intentionally store statically analyzable member access delegates.\")]");
+        writer.WriteLine(
+            "[global::System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage(" +
+            "\"Trimming\", \"IL2111\", Justification = " +
+            "\"Generated bindable descriptors intentionally store statically analyzable member access delegates.\")]");
         writer.WriteLine("private static class __Descriptors");
         writer.OpenBrace();
+        EmitBindableTypes(writer, model.BindableTypes);
+        writer.WriteLine();
         EmitJSInvokableMethods(
             writer,
             model.JSInvokableMethods,
             model.BuiltInJSInvokableDescriptorAssemblies);
         writer.CloseBrace();
+
+        if (NeedsBindableAccessors(model))
+        {
+            writer.WriteLine();
+            EmitBindableAccessors(writer, model);
+        }
 
         if (!model.JSInvokableMethods.IsDefaultOrEmpty)
         {
@@ -129,10 +152,81 @@ public sealed partial class RazorComponentsMetadataGenerator
         return writer.ToString();
     }
 
+    private static void EmitBindableTypes(CodeWriter writer, ImmutableArray<BindableTypeModel> bindableTypes)
+    {
+        if (bindableTypes.IsDefaultOrEmpty)
+        {
+            writer.WriteLine($"internal static readonly {BindableTypeDescriptorType}[] BindableTypes = [];");
+            return;
+        }
+
+        writer.WriteLine($"internal static readonly {BindableTypeDescriptorType}[] BindableTypes =");
+        writer.OpenBrace();
+
+        for (var i = 0; i < bindableTypes.Length; i++)
+        {
+            EmitBindableType(writer, bindableTypes[i], i);
+        }
+
+        writer.CloseBraceWithSemicolon();
+    }
+
+    private static void EmitBindableType(CodeWriter writer, BindableTypeModel bindable, int index)
+    {
+        var type = bindable.TypeFullyQualifiedName;
+
+        writer.WriteLine($"new {BindableTypeDescriptorType}");
+        writer.OpenBrace();
+        writer.WriteLine($"Type = typeof({type}),");
+
+        if (!bindable.Members.IsDefaultOrEmpty)
+        {
+            writer.WriteLine($"Members = new {BindableMemberDescriptorType}[]");
+            writer.OpenBrace();
+            for (var i = 0; i < bindable.Members.Length; i++)
+            {
+                var member = bindable.Members[i];
+                var read = member.RequiresGetAccessor
+                    ? $"__Accessors.GetBindable_{index}_{i}(({type})__owner)"
+                    : $"(({type})__owner).{member.Name}";
+
+                writer.WriteLine($"new {BindableMemberDescriptorType}");
+                writer.OpenBrace();
+                writer.WriteLine($"Name = {SymbolHelpers.ToStringLiteral(member.Name)},");
+                writer.WriteLine($"MemberType = typeof({member.MemberTypeFullyQualifiedName}),");
+                writer.WriteLine($"GetValue = static __owner => {read},");
+                writer.CloseBraceWithComma();
+            }
+
+            writer.CloseBraceWithComma();
+        }
+
+        if (!bindable.Indexers.IsDefaultOrEmpty)
+        {
+            writer.WriteLine($"Indexers = new {BindableIndexerDescriptorType}[]");
+            writer.OpenBrace();
+            foreach (var indexer in bindable.Indexers)
+            {
+                writer.WriteLine($"new {BindableIndexerDescriptorType}");
+                writer.OpenBrace();
+                writer.WriteLine($"IndexType = typeof({indexer.IndexTypeFullyQualifiedName}),");
+                writer.WriteLine($"ValueType = typeof({indexer.ValueTypeFullyQualifiedName}),");
+                writer.WriteLine(
+                    $"GetValue = static (__owner, __index) => (({type})__owner)" +
+                    $"[({indexer.IndexTypeFullyQualifiedName})__index!],");
+                writer.CloseBraceWithComma();
+            }
+
+            writer.CloseBraceWithComma();
+        }
+
+        writer.CloseBraceWithComma();
+    }
+
     private static void EmitJSInvokableMethods(
         CodeWriter writer,
-        System.Collections.Immutable.ImmutableArray<JSInvokableMethodModel> methods,
-        System.Collections.Immutable.ImmutableArray<string> builtInDescriptorAssemblies)
+        ImmutableArray<JSInvokableMethodModel> methods,
+        ImmutableArray<string> builtInDescriptorAssemblies)
     {
         writer.WriteLine($"internal static readonly {JSInvokableDescriptorType}[] JSInvokableMethods =");
         writer.OpenBracket();
@@ -177,6 +271,80 @@ public sealed partial class RazorComponentsMetadataGenerator
                 "[global::System.Runtime.CompilerServices.UnsafeAccessorType(" +
                 $"{SymbolHelpers.ToStringLiteral($"{BuiltInJSInvokableDescriptorProviderType}, {builtInDescriptorAssemblies[i]}")})] object? target);");
         }
+    }
+
+    private static bool NeedsBindableAccessors(MetadataContextModel model)
+    {
+        foreach (var bindable in model.BindableTypes)
+        {
+            foreach (var member in bindable.Members)
+            {
+                if (member.RequiresGetAccessor)
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static void EmitBindableAccessors(CodeWriter writer, MetadataContextModel model)
+    {
+        writer.WriteLine("private static class __Accessors");
+        writer.OpenBrace();
+
+        for (var b = 0; b < model.BindableTypes.Length; b++)
+        {
+            var bindable = model.BindableTypes[b];
+            for (var i = 0; i < bindable.Members.Length; i++)
+            {
+                var member = bindable.Members[i];
+                if (!member.RequiresGetAccessor)
+                {
+                    continue;
+                }
+
+                if (member.IsField)
+                {
+                    writer.WriteLine(
+                        "[global::System.Runtime.CompilerServices.UnsafeAccessor(" +
+                        "global::System.Runtime.CompilerServices.UnsafeAccessorKind.Field, Name = " +
+                        $"{SymbolHelpers.ToStringLiteral(member.Name)})]");
+                    writer.WriteLine(
+                        $"internal static extern ref {member.MemberTypeFullyQualifiedName} " +
+                        $"GetBindableField_{b}_{i}({bindable.TypeFullyQualifiedName} target);");
+                    writer.WriteLine(
+                        $"internal static {member.MemberTypeFullyQualifiedName} GetBindable_{b}_{i}" +
+                        $"({bindable.TypeFullyQualifiedName} target) => GetBindableField_{b}_{i}(target);");
+                }
+                else
+                {
+                    EmitAccessor(
+                        writer,
+                        $"get_{member.Name}",
+                        $"GetBindable_{b}_{i}",
+                        bindable.TypeFullyQualifiedName,
+                        member.MemberTypeFullyQualifiedName);
+                }
+            }
+        }
+
+        writer.CloseBrace();
+    }
+
+    private static void EmitAccessor(
+        CodeWriter writer,
+        string memberName,
+        string accessorName,
+        string targetType,
+        string valueType)
+    {
+        writer.WriteLine(
+            "[global::System.Runtime.CompilerServices.UnsafeAccessor(" +
+            "global::System.Runtime.CompilerServices.UnsafeAccessorKind.Method, Name = " +
+            $"{SymbolHelpers.ToStringLiteral(memberName)})]");
+        writer.WriteLine($"internal static extern {valueType} {accessorName}({targetType} target);");
     }
 
     private static void EmitJSInvocations(CodeWriter writer, MetadataContextModel model)

--- a/src/Components/Endpoints/gen/Models/MetadataContextModel.cs
+++ b/src/Components/Endpoints/gen/Models/MetadataContextModel.cs
@@ -13,6 +13,7 @@ internal sealed record class MetadataContextModel(
     string TypeKeyword,
     bool DeclaresJsonTypeInfoResolver,
     ImmutableArray<string> BuiltInJSInvokableDescriptorAssemblies,
+    ImmutableArray<BindableTypeModel> BindableTypes,
     ImmutableArray<JSInvokableMethodModel> JSInvokableMethods)
 {
     public bool Equals(MetadataContextModel? other)
@@ -25,6 +26,7 @@ internal sealed record class MetadataContextModel(
                BuiltInJSInvokableDescriptorAssemblies,
                other.BuiltInJSInvokableDescriptorAssemblies) &&
            ModelComparer.SequenceEqual(ContainingTypes, other.ContainingTypes) &&
+           ModelComparer.SequenceEqual(BindableTypes, other.BindableTypes) &&
            ModelComparer.SequenceEqual(JSInvokableMethods, other.JSInvokableMethods);
 
     public override int GetHashCode()
@@ -34,6 +36,7 @@ internal sealed record class MetadataContextModel(
         hash = ModelComparer.Combine(hash, TypeName);
         hash = ModelComparer.Combine(hash, TypeKeyword);
         hash = ModelComparer.AddRange(hash, BuiltInJSInvokableDescriptorAssemblies);
+        hash = ModelComparer.AddRange(hash, BindableTypes);
         return ModelComparer.AddRange(hash, JSInvokableMethods);
     }
 }
@@ -59,6 +62,36 @@ internal sealed record class ContainingTypeModel(
         return ModelComparer.AddRange(hash, ConstraintClauses);
     }
 }
+
+internal sealed record class BindableTypeModel(
+    string TypeFullyQualifiedName,
+    ImmutableArray<BindableMemberModel> Members,
+    ImmutableArray<BindableIndexerModel> Indexers)
+{
+    public bool Equals(BindableTypeModel? other)
+        => other is not null &&
+           string.Equals(TypeFullyQualifiedName, other.TypeFullyQualifiedName, StringComparison.Ordinal) &&
+           ModelComparer.SequenceEqual(Members, other.Members) &&
+           ModelComparer.SequenceEqual(Indexers, other.Indexers);
+
+    public override int GetHashCode()
+    {
+        var hash = ModelComparer.Combine(0, TypeFullyQualifiedName);
+        hash = ModelComparer.AddRange(hash, Members);
+        hash = ModelComparer.AddRange(hash, Indexers);
+        return hash;
+    }
+}
+
+internal sealed record class BindableMemberModel(
+    string Name,
+    string MemberTypeFullyQualifiedName,
+    bool IsField,
+    bool RequiresGetAccessor);
+
+internal sealed record class BindableIndexerModel(
+    string IndexTypeFullyQualifiedName,
+    string ValueTypeFullyQualifiedName);
 
 internal sealed record class JSInvokableMethodModel(
     string AssemblyName,

--- a/src/Components/Endpoints/gen/RazorComponentsMetadataGenerator.Bindables.cs
+++ b/src/Components/Endpoints/gen/RazorComponentsMetadataGenerator.Bindables.cs
@@ -1,0 +1,202 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using Microsoft.AspNetCore.Components.Endpoints.Generators.Models;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.Components.Endpoints.Generators;
+
+public sealed partial class RazorComponentsMetadataGenerator
+{
+    // Describes every type named by a [BindableModel] on the context, and every type reachable from it
+    // through instance members and single-argument indexers. One attribute per EditForm model therefore
+    // covers every expression that form can produce, including `row.Name` inside a loop over a
+    // collection property, which is the shape that otherwise forces Expression.Compile.
+    private static ImmutableArray<BindableTypeModel> CollectBindableTypes(
+        INamedTypeSymbol contextType,
+        WellKnownTypes types,
+        ImmutableArray<DiagnosticInfo>.Builder diagnostics,
+        CancellationToken cancellationToken)
+    {
+        if (types.BindableModelAttribute is null)
+        {
+            return ImmutableArray<BindableTypeModel>.Empty;
+        }
+
+        var generatedIn = contextType.ContainingAssembly;
+        var roots = new List<INamedTypeSymbol>();
+
+        foreach (var attribute in contextType.GetAttributes())
+        {
+            if (!SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, types.BindableModelAttribute))
+            {
+                continue;
+            }
+
+            foreach (var named in attribute.NamedArguments)
+            {
+                if (string.Equals(named.Key, "ModelType", StringComparison.Ordinal) &&
+                    named.Value.Value is INamedTypeSymbol modelType)
+                {
+                    roots.Add(modelType);
+                }
+            }
+        }
+
+        if (roots.Count == 0)
+        {
+            return ImmutableArray<BindableTypeModel>.Empty;
+        }
+
+        var results = new Dictionary<string, BindableTypeModel>(StringComparer.Ordinal);
+        var visited = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        var queue = new Queue<INamedTypeSymbol>();
+
+        foreach (var root in roots)
+        {
+            if (!TypeAccessibility.IsNameable(root, generatedIn))
+            {
+                diagnostics.Add(new DiagnosticInfo(
+                    DiagnosticDescriptors.BindableModelNotDescribed.Id,
+                    root.FullName(),
+                    "it is not accessible from the application"));
+                continue;
+            }
+
+            queue.Enqueue(root);
+        }
+
+        while (queue.Count > 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var type = queue.Dequeue();
+            if (!visited.Add(type) || IsLeafType(type))
+            {
+                continue;
+            }
+
+            var members = ImmutableArray.CreateBuilder<BindableMemberModel>();
+            var indexers = ImmutableArray.CreateBuilder<BindableIndexerModel>();
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+
+            for (var current = type; current is { SpecialType: not SpecialType.System_Object }; current = current.BaseType)
+            {
+                foreach (var member in current.GetMembers())
+                {
+                    switch (member)
+                    {
+                        case IPropertySymbol { IsStatic: false, IsIndexer: true } indexer
+                            when indexer.Parameters.Length == 1 && indexer.GetMethod is not null:
+                            if (TypeAccessibility.IsDirectlyAccessible(indexer.GetMethod, generatedIn) &&
+                                TypeAccessibility.IsNameable(indexer.Parameters[0].Type, generatedIn) &&
+                                TypeAccessibility.IsNameable(indexer.Type, generatedIn))
+                            {
+                                indexers.Add(new BindableIndexerModel(
+                                    indexer.Parameters[0].Type.FullName(),
+                                    indexer.Type.FullName()));
+                                Enqueue(indexer.Type, queue);
+                            }
+
+                            break;
+
+                        case IPropertySymbol { IsStatic: false, IsIndexer: false, CanBeReferencedByName: true, GetMethod: not null } property:
+                            if (seen.Add(property.Name) && TypeAccessibility.IsNameable(property.Type, generatedIn))
+                            {
+                                members.Add(new BindableMemberModel(
+                                    property.Name,
+                                    property.Type.FullName(),
+                                    IsField: false,
+                                    RequiresGetAccessor: !TypeAccessibility.IsDirectlyAccessible(property.GetMethod, generatedIn)));
+                                Enqueue(property.Type, queue);
+                            }
+
+                            break;
+
+                        case IFieldSymbol { IsStatic: false, IsImplicitlyDeclared: false, CanBeReferencedByName: true, AssociatedSymbol: null } field:
+                            if (seen.Add(field.Name) && TypeAccessibility.IsNameable(field.Type, generatedIn))
+                            {
+                                members.Add(new BindableMemberModel(
+                                    field.Name,
+                                    field.Type.FullName(),
+                                    IsField: true,
+                                    RequiresGetAccessor: !TypeAccessibility.IsDirectlyAccessible(field, generatedIn)));
+                                Enqueue(field.Type, queue);
+                            }
+
+                            break;
+                    }
+                }
+            }
+
+            var name = type.FullName();
+            if (!results.ContainsKey(name))
+            {
+                results.Add(name, new BindableTypeModel(name, members.ToImmutable(), indexers.ToImmutable()));
+            }
+        }
+
+        var ordered = ImmutableArray.CreateBuilder<BindableTypeModel>(results.Count);
+        foreach (var key in Sorted(results.Keys))
+        {
+            ordered.Add(results[key]);
+        }
+
+        return ordered.ToImmutable();
+    }
+
+    private static void Enqueue(ITypeSymbol type, Queue<INamedTypeSymbol> queue)
+    {
+        // An expression walks into the element type of a collection as often as into a property, so a
+        // generic argument is followed as eagerly as a member type.
+        if (type is IArrayTypeSymbol array)
+        {
+            Enqueue(array.ElementType, queue);
+            return;
+        }
+
+        if (type is not INamedTypeSymbol named)
+        {
+            return;
+        }
+
+        if (!IsLeafType(named))
+        {
+            queue.Enqueue(named);
+        }
+
+        foreach (var argument in named.TypeArguments)
+        {
+            Enqueue(argument, queue);
+        }
+    }
+
+    // The walk stops at framework primitives: they are the leaves of every form model, describing them
+    // would multiply the generated output, and no binding expression reaches through them.
+    private static bool IsLeafType(INamedTypeSymbol type)
+    {
+        if (type.SpecialType is not SpecialType.None)
+        {
+            return true;
+        }
+
+        if (type.TypeKind is TypeKind.Enum or TypeKind.Delegate or TypeKind.Interface)
+        {
+            return true;
+        }
+
+        var containingAssembly = type.ContainingAssembly;
+        return containingAssembly is not null && SymbolHelpers.IsFrameworkAssembly(containingAssembly);
+    }
+
+    private static IEnumerable<string> Sorted(IEnumerable<string> values)
+    {
+        var list = new List<string>(values);
+        list.Sort(StringComparer.Ordinal);
+        return list;
+    }
+}

--- a/src/Components/Endpoints/gen/RazorComponentsMetadataGenerator.cs
+++ b/src/Components/Endpoints/gen/RazorComponentsMetadataGenerator.cs
@@ -82,6 +82,7 @@ public sealed partial class RazorComponentsMetadataGenerator : IIncrementalGener
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            var bindableTypes = CollectBindableTypes(contextType, types, diagnostics, cancellationToken);
             models.Add(new MetadataContextModel(
                 Namespace: contextType.ContainingNamespace is { IsGlobalNamespace: false } ns ? ns.ToDisplayString() : null,
                 ContainingTypes: GetContainingTypeNames(contextType),
@@ -89,6 +90,7 @@ public sealed partial class RazorComponentsMetadataGenerator : IIncrementalGener
                 TypeKeyword: contextType.IsRecord ? "record" : "class",
                 DeclaresJsonTypeInfoResolver: DeclaresMember(contextType, "JsonTypeInfoResolver"),
                 BuiltInJSInvokableDescriptorAssemblies: builtInJSInvokableDescriptorAssemblies,
+                BindableTypes: bindableTypes,
                 JSInvokableMethods: jsInvokableMethods));
         }
 
@@ -136,7 +138,10 @@ public sealed partial class RazorComponentsMetadataGenerator : IIncrementalGener
             var nonPartialType = GetFirstNonPartialType(symbol, cancellationToken);
             if (nonPartialType is not null)
             {
-                diagnostics.Add(new DiagnosticInfo(nonPartialType.FullName()));
+                diagnostics.Add(new DiagnosticInfo(
+                    DiagnosticDescriptors.MetadataContextMustBePartial.Id,
+                    nonPartialType.FullName(),
+                    string.Empty));
                 continue;
             }
 
@@ -261,9 +266,17 @@ public sealed partial class RazorComponentsMetadataGenerator : IIncrementalGener
         public override int GetHashCode() => ModelComparer.AddRange(0, Models);
     }
 
-    internal sealed record class DiagnosticInfo(string TypeName)
+    internal sealed record class DiagnosticInfo(string Id, string Argument0, string Argument1)
     {
         public Diagnostic ToDiagnostic()
-            => Diagnostic.Create(DiagnosticDescriptors.MetadataContextMustBePartial, Location.None, TypeName);
+        {
+            var descriptor = Id switch
+            {
+                "BLAZORAOT002" => DiagnosticDescriptors.BindableModelNotDescribed,
+                _ => DiagnosticDescriptors.MetadataContextMustBePartial,
+            };
+
+            return Diagnostic.Create(descriptor, Location.None, Argument0, Argument1);
+        }
     }
 }

--- a/src/Components/Endpoints/gen/WellKnownTypes.cs
+++ b/src/Components/Endpoints/gen/WellKnownTypes.cs
@@ -9,10 +9,12 @@ internal sealed class WellKnownTypes
 {
     public const string ComponentsAssemblyName = "Microsoft.AspNetCore.Components";
     public const string MetadataContextMetadataName = "Microsoft.AspNetCore.Components.Web.RazorComponentsMetadataContext";
+    public const string BindableModelAttributeMetadataName = "Microsoft.AspNetCore.Components.Web.BindableModelAttribute";
 
     private WellKnownTypes(Compilation compilation)
     {
         MetadataContext = compilation.GetTypeByMetadataName(MetadataContextMetadataName);
+        BindableModelAttribute = compilation.GetTypeByMetadataName(BindableModelAttributeMetadataName);
         JSInvokableAttribute = compilation.GetTypeByMetadataName("Microsoft.JSInterop.JSInvokableAttribute");
         Task = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task");
         TaskOfT = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
@@ -21,6 +23,7 @@ internal sealed class WellKnownTypes
     }
 
     public INamedTypeSymbol? MetadataContext { get; }
+    public INamedTypeSymbol? BindableModelAttribute { get; }
     public INamedTypeSymbol? JSInvokableAttribute { get; }
     public INamedTypeSymbol? Task { get; }
     public INamedTypeSymbol? TaskOfT { get; }

--- a/src/Components/Endpoints/src/FormMapping/FormDataMapperOptions.cs
+++ b/src/Components/Endpoints/src/FormMapping/FormDataMapperOptions.cs
@@ -14,14 +14,10 @@ internal sealed class FormDataMapperOptions
     private readonly ConcurrentDictionary<Type, FormDataConverter> _converters = new();
     private readonly List<IFormDataConverterFactory> _factories = new();
 
-    [RequiresDynamicCode(FormMappingHelpers.RequiresDynamicCodeMessage)]
-    [RequiresUnreferencedCode(FormMappingHelpers.RequiresUnreferencedCodeMessage)]
     public FormDataMapperOptions() : this(NullLoggerFactory.Instance)
-    {        
+    {
     }
 
-    [RequiresDynamicCode(FormMappingHelpers.RequiresDynamicCodeMessage)]
-    [RequiresUnreferencedCode(FormMappingHelpers.RequiresUnreferencedCodeMessage)]
     public FormDataMapperOptions(ILoggerFactory loggerFactory)
     {
         _converters = new(WellKnownConverters.Converters);

--- a/src/Components/Endpoints/test/Binding/FormDataMapperTests.cs
+++ b/src/Components/Endpoints/test/Binding/FormDataMapperTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;
 using Microsoft.AspNetCore.Components.Forms;
@@ -18,6 +19,23 @@ namespace Microsoft.AspNetCore.Components.Endpoints.FormMapping;
 
 public class FormDataMapperTests
 {
+    [Fact]
+    public void Constructors_DoNotRequireDynamicCodeOrUnreferencedCode()
+    {
+        foreach (var constructor in typeof(FormDataMapperOptions).GetConstructors())
+        {
+            Assert.Null(constructor.GetCustomAttribute<RequiresDynamicCodeAttribute>());
+            Assert.Null(constructor.GetCustomAttribute<RequiresUnreferencedCodeAttribute>());
+        }
+
+        var resolveConverter = typeof(FormDataMapperOptions).GetMethod(
+            nameof(FormDataMapperOptions.ResolveConverter),
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            [typeof(Type)]);
+        Assert.NotNull(resolveConverter?.GetCustomAttribute<RequiresDynamicCodeAttribute>());
+        Assert.NotNull(resolveConverter?.GetCustomAttribute<RequiresUnreferencedCodeAttribute>());
+    }
+
     [Theory]
     [MemberData(nameof(PrimitiveTypesData))]
     public void CanDeserialize_PrimitiveTypes(string value, Type type, object expected)

--- a/src/Components/Endpoints/test/DependencyInjection/ComponentJsonMetadataIsolationTest.cs
+++ b/src/Components/Endpoints/test/DependencyInjection/ComponentJsonMetadataIsolationTest.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Endpoints;
+using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.DotNet.RemoteExecutor;
@@ -60,6 +61,8 @@ public class ComponentJsonMetadataIsolationTest
 
     public sealed class FirstContext : RazorComponentsMetadataContext
     {
+        public override IReadOnlyList<BindableTypeDescriptor> BindableTypes => [];
+
         public override IReadOnlyList<JSInvokableMethodDescriptor> JSInvokableMethods => [];
 
         public override IJsonTypeInfoResolver JsonTypeInfoResolver => FirstJsonContext.Default;
@@ -67,6 +70,8 @@ public class ComponentJsonMetadataIsolationTest
 
     public sealed class SecondContext : RazorComponentsMetadataContext
     {
+        public override IReadOnlyList<BindableTypeDescriptor> BindableTypes => [];
+
         public override IReadOnlyList<JSInvokableMethodDescriptor> JSInvokableMethods => [];
 
         public override IJsonTypeInfoResolver JsonTypeInfoResolver => SecondJsonContext.Default;

--- a/src/Components/Endpoints/test/Microsoft.AspNetCore.Components.Endpoints.Generators.Tests/Microsoft.AspNetCore.Components.Endpoints.Generators.Tests.csproj
+++ b/src/Components/Endpoints/test/Microsoft.AspNetCore.Components.Endpoints.Generators.Tests/Microsoft.AspNetCore.Components.Endpoints.Generators.Tests.csproj
@@ -34,8 +34,10 @@
     <ProjectReference Include="..\..\gen\Microsoft.AspNetCore.Components.Endpoints.Generators.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Using Remove="Xunit" />
-  </ItemGroup>
+  <Target Name="RemoveXunitGlobalUsing" BeforeTargets="GenerateGlobalUsings">
+    <ItemGroup>
+      <Using Remove="Xunit" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/Components/Endpoints/test/Microsoft.AspNetCore.Components.Endpoints.Generators.Tests/RazorComponentsMetadataGeneratorBindableTests.cs
+++ b/src/Components/Endpoints/test/Microsoft.AspNetCore.Components.Endpoints.Generators.Tests/RazorComponentsMetadataGeneratorBindableTests.cs
@@ -1,0 +1,171 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Endpoints.Generators.Tests;
+
+[TestClass]
+public sealed class RazorComponentsMetadataGeneratorBindableTests : RazorComponentsMetadataGeneratorTestBase
+{
+    [TestMethod]
+    public void PublicAndPrivatePropertiesAndFields_EmitWorkingMemberDescriptors()
+    {
+        var result = RunGenerator("""
+            namespace TestComponents;
+
+            public sealed class FormModel
+            {
+                public string Name { get; set; } = "Ada";
+                public int Count = 3;
+                private string Secret { get; } = "property";
+                private int _code = 42;
+            }
+            """, HostFor("TestComponents.FormModel"));
+
+        var source = GetGeneratedSource(result);
+        Assert.Contains("Name = \"get_Secret\"", source);
+        Assert.Contains("UnsafeAccessorKind.Field, Name = \"_code\"", source);
+
+        var context = LoadContext(result, out var loaded);
+        using (loaded)
+        {
+            var descriptor = Assert.ContainsSingle(context.BindableTypes);
+            var model = Activator.CreateInstance(descriptor.Type)!;
+            Assert.AreEqual("Ada", Assert.ContainsSingle(member => member.Name == "Name", descriptor.Members).GetValue(model));
+            Assert.AreEqual(3, Assert.ContainsSingle(member => member.Name == "Count", descriptor.Members).GetValue(model));
+            Assert.AreEqual("property", Assert.ContainsSingle(member => member.Name == "Secret", descriptor.Members).GetValue(model));
+            Assert.AreEqual(42, Assert.ContainsSingle(member => member.Name == "_code", descriptor.Members).GetValue(model));
+        }
+    }
+
+    [TestMethod]
+    public void SingleArgumentIndexer_EmitsTypesAndWorkingGetter()
+    {
+        var result = RunGenerator("""
+            namespace TestComponents;
+
+            public sealed class IndexedModel
+            {
+                public string this[int index] => $"item-{index}";
+            }
+            """, HostFor("TestComponents.IndexedModel"));
+
+        var context = LoadContext(result, out var loaded);
+        using (loaded)
+        {
+            var descriptor = Assert.ContainsSingle(context.BindableTypes);
+            var indexer = Assert.ContainsSingle(descriptor.Indexers);
+            Assert.AreEqual(typeof(int), indexer.IndexType);
+            Assert.AreEqual(typeof(string), indexer.ValueType);
+            Assert.AreEqual("item-5", indexer.GetValue(Activator.CreateInstance(descriptor.Type)!, 5));
+        }
+    }
+
+    [TestMethod]
+    public void InheritedHiddenMembers_UseMostDerivedMemberOnce()
+    {
+        var result = RunGenerator("""
+            namespace TestComponents;
+
+            public class BaseModel
+            {
+                public string Shared { get; } = "base";
+                public int Unique { get; } = 9;
+            }
+
+            public sealed class DerivedModel : BaseModel
+            {
+                public new int Shared { get; } = 11;
+            }
+            """, HostFor("TestComponents.DerivedModel"));
+
+        var context = LoadContext(result, out var loaded);
+        using (loaded)
+        {
+            var descriptor = Assert.ContainsSingle(context.BindableTypes);
+            Assert.HasCount(2, descriptor.Members);
+            var model = Activator.CreateInstance(descriptor.Type)!;
+            var shared = Assert.ContainsSingle(member => member.Name == "Shared", descriptor.Members);
+            Assert.AreEqual(typeof(int), shared.MemberType);
+            Assert.AreEqual(11, shared.GetValue(model));
+            Assert.AreEqual(9, Assert.ContainsSingle(member => member.Name == "Unique", descriptor.Members).GetValue(model));
+        }
+    }
+
+    [TestMethod]
+    public void TransitiveCyclicGraph_DescribesApplicationTypesOnceInStableOrder()
+    {
+        var result = RunGenerator("""
+            namespace TestComponents;
+
+            public sealed class Root
+            {
+                public Child? Child { get; set; }
+                public ArrayOnly[] Items { get; set; } = [];
+                public System.Collections.Generic.List<CollectionOnly> Collection { get; set; } = [];
+            }
+
+            public sealed class Child
+            {
+                public Root? Parent { get; set; }
+            }
+
+            public sealed class ArrayOnly
+            {
+                public string Value { get; set; } = "";
+            }
+
+            public sealed class CollectionOnly
+            {
+                public int Value { get; set; }
+            }
+            """, HostFor("TestComponents.Root"));
+
+        var context = LoadContext(result, out var loaded);
+        using (loaded)
+        {
+            CollectionAssert.AreEqual(
+                new[] { "TestComponents.ArrayOnly", "TestComponents.Child", "TestComponents.CollectionOnly", "TestComponents.Root" },
+                context.BindableTypes.Select(descriptor => descriptor.Type.FullName).ToArray());
+            Assert.AreEqual(context.BindableTypes.Count, context.BindableTypes.Select(descriptor => descriptor.Type).Distinct().Count());
+            Assert.DoesNotContain(descriptor => descriptor.Type == typeof(string), context.BindableTypes);
+        }
+    }
+
+    [TestMethod]
+    public void UnsupportedAndInaccessibleMembers_AreOmittedAndOutputCompiles()
+    {
+        var result = RunGenerator("""
+            namespace TestComponents;
+
+            internal sealed class HiddenValue
+            {
+            }
+
+            public sealed class OddModel
+            {
+                internal HiddenValue Hidden { get; } = new();
+                public string this[int row, int column] => $"{row}:{column}";
+                public string this[string key] { set { } }
+                public int Supported { get; } = 5;
+            }
+            """, HostFor("TestComponents.OddModel"));
+
+        var context = LoadContext(result, out var loaded);
+        using (loaded)
+        {
+            var descriptor = Assert.ContainsSingle(context.BindableTypes);
+            Assert.AreEqual("Supported", Assert.ContainsSingle(descriptor.Members).Name);
+            Assert.IsEmpty(descriptor.Indexers);
+        }
+    }
+
+    private static string HostFor(string modelType)
+        => $$"""
+            namespace TestHost;
+
+            [Microsoft.AspNetCore.Components.Web.BindableModel(ModelType = typeof({{modelType}}))]
+            public sealed partial class TestMetadata : Microsoft.AspNetCore.Components.Web.RazorComponentsMetadataContext
+            {
+            }
+            """;
+}

--- a/src/Components/Server/test/Circuits/RemoteJSRuntimeMetadataTest.cs
+++ b/src/Components/Server/test/Circuits/RemoteJSRuntimeMetadataTest.cs
@@ -6,6 +6,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.InternalTesting;
@@ -263,6 +264,8 @@ public class RemoteJSRuntimeMetadataTest
 
     public abstract class TestContext : RazorComponentsMetadataContext
     {
+        public override IReadOnlyList<BindableTypeDescriptor> BindableTypes => [];
+
         public override IJsonTypeInfoResolver? JsonTypeInfoResolver => null;
 
         protected static JSInvokableMethodDescriptor CreateDescriptor(

--- a/src/Components/Server/test/ProtectedBrowserStorageSerializerOptionsTest.cs
+++ b/src/Components/Server/test/ProtectedBrowserStorageSerializerOptionsTest.cs
@@ -6,6 +6,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop.Infrastructure;
@@ -108,6 +109,8 @@ public class ProtectedBrowserStorageSerializerOptionsTest
 
     private sealed class StubContext(IJsonTypeInfoResolver? resolver) : RazorComponentsMetadataContext
     {
+        public override IReadOnlyList<BindableTypeDescriptor> BindableTypes => [];
+
         public override IReadOnlyList<JSInvokableMethodDescriptor> JSInvokableMethods => [];
 
         public override IJsonTypeInfoResolver? JsonTypeInfoResolver { get; } = resolver;

--- a/src/Components/Shared/src/ExpressionFormatting/ExpressionFormatter.cs
+++ b/src/Components/Shared/src/ExpressionFormatting/ExpressionFormatter.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using Microsoft.AspNetCore.Components.HotReload;
 
@@ -252,22 +253,22 @@ internal static class ExpressionFormatter
 
         if (memberType == typeof(int))
         {
-            var func = CompileMemberEvaluator<int>(memberExpression);
+            var func = CreateMemberEvaluator<int>(memberExpression);
             return (object closure, ref ReverseStringBuilder builder) => builder.InsertFront(func.Invoke(closure));
         }
         else if (memberType == typeof(string))
         {
-            var func = CompileMemberEvaluator<string>(memberExpression);
+            var func = CreateMemberEvaluator<string>(memberExpression);
             return (object closure, ref ReverseStringBuilder builder) => builder.InsertFront(func.Invoke(closure));
         }
         else if (typeof(ISpanFormattable).IsAssignableFrom(memberType))
         {
-            var func = CompileMemberEvaluator<ISpanFormattable>(memberExpression);
+            var func = CreateMemberEvaluator<ISpanFormattable>(memberExpression);
             return (object closure, ref ReverseStringBuilder builder) => builder.InsertFront(func.Invoke(closure));
         }
         else if (typeof(IFormattable).IsAssignableFrom(memberType))
         {
-            var func = CompileMemberEvaluator<IFormattable>(memberExpression);
+            var func = CreateMemberEvaluator<IFormattable>(memberExpression);
             return (object closure, ref ReverseStringBuilder builder) => builder.InsertFront(func.Invoke(closure));
         }
         else
@@ -275,6 +276,29 @@ internal static class ExpressionFormatter
             throw new InvalidOperationException($"Cannot format an index argument of type '{memberType}'.");
         }
 
+        static Func<object, TResult> CreateMemberEvaluator<TResult>(MemberExpression memberExpression)
+        {
+            // The index of a form field is read off the closure the compiler generated for the binding
+            // expression. When the runtime cannot generate code, read it through the member the expression
+            // node already carries; Roslyn emits that member as a metadata token, so it survives trimming.
+            if (!RuntimeFeature.IsDynamicCodeSupported)
+            {
+                return memberExpression.Member switch
+                {
+                    PropertyInfo property => closure => (TResult)property.GetValue(closure)!,
+                    FieldInfo field => closure => (TResult)field.GetValue(closure)!,
+                    var member => throw new InvalidOperationException(
+                        $"Cannot read an index argument from a {member.GetType().Name}."),
+                };
+            }
+
+            return CompileMemberEvaluator<TResult>(memberExpression);
+        }
+
+        [UnconditionalSuppressMessage(
+            "AOT",
+            "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.",
+            Justification = "Guarded by RuntimeFeature.IsDynamicCodeSupported.")]
         static Func<object, TResult> CompileMemberEvaluator<TResult>(MemberExpression memberExpression)
         {
             var parameterExpression = Expression.Parameter(typeof(object));

--- a/src/Components/Web/src/Forms/BindingExpressionEvaluator.cs
+++ b/src/Components/Web/src/Forms/BindingExpressionEvaluator.cs
@@ -1,0 +1,114 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.AspNetCore.Components.Forms;
+
+namespace Microsoft.AspNetCore.Components.Web;
+
+/// <summary>
+/// Evaluates the member-access chain a <c>@bind</c> or <c>For</c> expression is built from without
+/// compiling a delegate, so that form binding works when the runtime cannot generate code.
+/// </summary>
+/// <remarks>
+/// Each hop is read through the <see cref="MemberInfo"/> the expression node already carries. A node
+/// that cannot be evaluated any deeper is anchored at the edit context's model when its static type is
+/// compatible. Only shapes the walk does not recognize fall back to
+/// <see cref="FieldIdentifier.Create{TField}(Expression{Func{TField}})"/>, which behaves exactly as before.
+/// </remarks>
+internal static class BindingExpressionEvaluator
+{
+    private const string NonNullMessage = "The provided expression must evaluate to a non-null value.";
+
+    public static FieldIdentifier CreateFieldIdentifier<TField>(
+        Expression<Func<TField>> accessor,
+        object? anchorModel)
+    {
+        ArgumentNullException.ThrowIfNull(accessor);
+
+        return TryParse(accessor.Body, anchorModel, out var model, out var fieldName)
+            ? new FieldIdentifier(model, fieldName)
+            : FieldIdentifier.Create(accessor);
+    }
+
+    private static bool TryParse(
+        Expression body,
+        object? anchorModel,
+        out object model,
+        out string fieldName)
+    {
+        model = null!;
+        fieldName = null!;
+
+        if (body is UnaryExpression { NodeType: ExpressionType.Convert } unary && unary.Type == typeof(object))
+        {
+            body = unary.Operand;
+        }
+
+        switch (body)
+        {
+            case MemberExpression member:
+                fieldName = member.Member.Name;
+                return TryEvaluate(member.Expression, anchorModel, out model);
+            case MethodCallExpression call when ExpressionFormatter.IsSingleArgumentIndexer(call):
+                fieldName = ExpressionFormatter.FormatIndexArgument(call.Arguments[0]);
+                return TryEvaluate(call.Object, anchorModel, out model);
+            case BinaryExpression { NodeType: ExpressionType.ArrayIndex } arrayIndex:
+                fieldName = ExpressionFormatter.FormatIndexArgument(arrayIndex.Right);
+                return TryEvaluate(arrayIndex.Left, anchorModel, out model);
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryEvaluate(
+        Expression? node,
+        object? anchorModel,
+        out object value)
+    {
+        value = null!;
+
+        switch (node)
+        {
+            case null:
+                return false;
+            case ConstantExpression constant:
+                value = constant.Value ?? throw new ArgumentException(NonNullMessage);
+                return true;
+            case MemberExpression member
+                when TryEvaluate(member.Expression, anchorModel, out var memberTarget):
+                value = ReadMember(memberTarget, member) ?? throw new ArgumentException(NonNullMessage);
+                return true;
+            case MethodCallExpression call
+                when ExpressionFormatter.IsSingleArgumentIndexer(call)
+                    && TryEvaluate(call.Object, anchorModel, out var indexerTarget)
+                    && TryEvaluate(call.Arguments[0], anchorModel, out var index):
+                value = call.Method.Invoke(indexerTarget, [index]) ?? throw new ArgumentException(NonNullMessage);
+                return true;
+            case BinaryExpression { NodeType: ExpressionType.ArrayIndex } arrayIndex
+                when TryEvaluate(arrayIndex.Left, anchorModel, out var array)
+                    && TryEvaluate(arrayIndex.Right, anchorModel, out var arrayIndexValue):
+                value = ((Array)array).GetValue((int)arrayIndexValue) ?? throw new ArgumentException(NonNullMessage);
+                return true;
+        }
+
+        if (anchorModel is not null && node.Type.IsInstanceOfType(anchorModel))
+        {
+            value = anchorModel;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static object? ReadMember(object target, MemberExpression member)
+        => member.Member switch
+        {
+            PropertyInfo property => property.GetValue(target),
+            FieldInfo field => field.GetValue(target),
+            _ => throw new ArgumentException(
+                $"The provided expression contains a {member.Member.GetType().Name} which is not supported. " +
+                $"{nameof(FieldIdentifier)} only supports simple member accessors (fields, properties) of an object."),
+        };
+}

--- a/src/Components/Web/src/Forms/BindingExpressionEvaluator.cs
+++ b/src/Components/Web/src/Forms/BindingExpressionEvaluator.cs
@@ -4,6 +4,7 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Infrastructure;
 
 namespace Microsoft.AspNetCore.Components.Web;
 
@@ -12,9 +13,10 @@ namespace Microsoft.AspNetCore.Components.Web;
 /// compiling a delegate, so that form binding works when the runtime cannot generate code.
 /// </summary>
 /// <remarks>
-/// Each hop is read through the <see cref="MemberInfo"/> the expression node already carries. A node
-/// that cannot be evaluated any deeper is anchored at the edit context's model when its static type is
-/// compatible. Only shapes the walk does not recognize fall back to
+/// Each hop is read through a <see cref="BindableTypeDescriptor"/> when the application described the
+/// model graph, and through the <see cref="MemberInfo"/> the expression node already carries otherwise.
+/// A node that cannot be evaluated any deeper is anchored at the edit context's model when its static
+/// type is compatible. Only shapes the walk does not recognize fall back to
 /// <see cref="FieldIdentifier.Create{TField}(Expression{Func{TField}})"/>, which behaves exactly as before.
 /// </remarks>
 internal static class BindingExpressionEvaluator
@@ -23,11 +25,12 @@ internal static class BindingExpressionEvaluator
 
     public static FieldIdentifier CreateFieldIdentifier<TField>(
         Expression<Func<TField>> accessor,
-        object? anchorModel)
+        object? anchorModel,
+        IBindableTypeResolver? resolver = null)
     {
         ArgumentNullException.ThrowIfNull(accessor);
 
-        return TryParse(accessor.Body, anchorModel, out var model, out var fieldName)
+        return TryParse(accessor.Body, anchorModel, resolver, out var model, out var fieldName)
             ? new FieldIdentifier(model, fieldName)
             : FieldIdentifier.Create(accessor);
     }
@@ -35,6 +38,7 @@ internal static class BindingExpressionEvaluator
     private static bool TryParse(
         Expression body,
         object? anchorModel,
+        IBindableTypeResolver? resolver,
         out object model,
         out string fieldName)
     {
@@ -50,13 +54,13 @@ internal static class BindingExpressionEvaluator
         {
             case MemberExpression member:
                 fieldName = member.Member.Name;
-                return TryEvaluate(member.Expression, anchorModel, out model);
+                return TryEvaluate(member.Expression, anchorModel, resolver, out model);
             case MethodCallExpression call when ExpressionFormatter.IsSingleArgumentIndexer(call):
                 fieldName = ExpressionFormatter.FormatIndexArgument(call.Arguments[0]);
-                return TryEvaluate(call.Object, anchorModel, out model);
+                return TryEvaluate(call.Object, anchorModel, resolver, out model);
             case BinaryExpression { NodeType: ExpressionType.ArrayIndex } arrayIndex:
                 fieldName = ExpressionFormatter.FormatIndexArgument(arrayIndex.Right);
-                return TryEvaluate(arrayIndex.Left, anchorModel, out model);
+                return TryEvaluate(arrayIndex.Left, anchorModel, resolver, out model);
             default:
                 return false;
         }
@@ -65,6 +69,7 @@ internal static class BindingExpressionEvaluator
     private static bool TryEvaluate(
         Expression? node,
         object? anchorModel,
+        IBindableTypeResolver? resolver,
         out object value)
     {
         value = null!;
@@ -77,18 +82,18 @@ internal static class BindingExpressionEvaluator
                 value = constant.Value ?? throw new ArgumentException(NonNullMessage);
                 return true;
             case MemberExpression member
-                when TryEvaluate(member.Expression, anchorModel, out var memberTarget):
-                value = ReadMember(memberTarget, member) ?? throw new ArgumentException(NonNullMessage);
+                when TryEvaluate(member.Expression, anchorModel, resolver, out var memberTarget):
+                value = ReadMember(memberTarget, member, resolver) ?? throw new ArgumentException(NonNullMessage);
                 return true;
             case MethodCallExpression call
                 when ExpressionFormatter.IsSingleArgumentIndexer(call)
-                    && TryEvaluate(call.Object, anchorModel, out var indexerTarget)
-                    && TryEvaluate(call.Arguments[0], anchorModel, out var index):
-                value = call.Method.Invoke(indexerTarget, [index]) ?? throw new ArgumentException(NonNullMessage);
+                    && TryEvaluate(call.Object, anchorModel, resolver, out var indexerTarget)
+                    && TryEvaluate(call.Arguments[0], anchorModel, resolver, out var index):
+                value = ReadIndexer(indexerTarget, index, call, resolver) ?? throw new ArgumentException(NonNullMessage);
                 return true;
             case BinaryExpression { NodeType: ExpressionType.ArrayIndex } arrayIndex
-                when TryEvaluate(arrayIndex.Left, anchorModel, out var array)
-                    && TryEvaluate(arrayIndex.Right, anchorModel, out var arrayIndexValue):
+                when TryEvaluate(arrayIndex.Left, anchorModel, resolver, out var array)
+                    && TryEvaluate(arrayIndex.Right, anchorModel, resolver, out var arrayIndexValue):
                 value = ((Array)array).GetValue((int)arrayIndexValue) ?? throw new ArgumentException(NonNullMessage);
                 return true;
         }
@@ -102,8 +107,21 @@ internal static class BindingExpressionEvaluator
         return false;
     }
 
-    private static object? ReadMember(object target, MemberExpression member)
-        => member.Member switch
+    private static object? ReadMember(object target, MemberExpression member, IBindableTypeResolver? resolver)
+    {
+        if (resolver is not null &&
+            resolver.TryGetBindableTypeDescriptor(member.Expression!.Type, out var descriptor))
+        {
+            foreach (var described in descriptor.Members)
+            {
+                if (string.Equals(described.Name, member.Member.Name, StringComparison.Ordinal))
+                {
+                    return described.GetValue(target);
+                }
+            }
+        }
+
+        return member.Member switch
         {
             PropertyInfo property => property.GetValue(target),
             FieldInfo field => field.GetValue(target),
@@ -111,4 +129,27 @@ internal static class BindingExpressionEvaluator
                 $"The provided expression contains a {member.Member.GetType().Name} which is not supported. " +
                 $"{nameof(FieldIdentifier)} only supports simple member accessors (fields, properties) of an object."),
         };
+    }
+
+    private static object? ReadIndexer(
+        object target,
+        object index,
+        MethodCallExpression call,
+        IBindableTypeResolver? resolver)
+    {
+        if (resolver is not null &&
+            resolver.TryGetBindableTypeDescriptor(call.Object!.Type, out var descriptor))
+        {
+            var indexType = call.Arguments[0].Type;
+            foreach (var described in descriptor.Indexers)
+            {
+                if (described.IndexType == indexType)
+                {
+                    return described.GetValue(target, index);
+                }
+            }
+        }
+
+        return call.Method.Invoke(target, [index]);
+    }
 }

--- a/src/Components/Web/src/Forms/InputBase.cs
+++ b/src/Components/Web/src/Forms/InputBase.cs
@@ -263,7 +263,8 @@ public abstract class InputBase<TValue> : ComponentBase, IDisposable
 
             FieldIdentifier = BindingExpressionEvaluator.CreateFieldIdentifier(
                 ValueExpression,
-                CascadedEditContext?.Model);
+                CascadedEditContext?.Model,
+                Handle.BindableTypeResolver);
 
             if (CascadedEditContext != null)
             {

--- a/src/Components/Web/src/Forms/InputBase.cs
+++ b/src/Components/Web/src/Forms/InputBase.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.AspNetCore.Components.Forms.Mapping;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace Microsoft.AspNetCore.Components.Forms;
 
@@ -260,7 +261,9 @@ public abstract class InputBase<TValue> : ComponentBase, IDisposable
                     $"parameter. Normally this is provided automatically when using 'bind-Value'.");
             }
 
-            FieldIdentifier = FieldIdentifier.Create(ValueExpression);
+            FieldIdentifier = BindingExpressionEvaluator.CreateFieldIdentifier(
+                ValueExpression,
+                CascadedEditContext?.Model);
 
             if (CascadedEditContext != null)
             {

--- a/src/Components/Web/src/Forms/InputSelect.cs
+++ b/src/Components/Web/src/Forms/InputSelect.cs
@@ -36,6 +36,10 @@ public class InputSelect<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
     [DisallowNull] public ElementReference? Element { get; protected set; }
 
     /// <inheritdoc />
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "TValue is statically closed for each InputSelect instantiation, so any array type used by BindConverter is available to Native AOT.")]
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         builder.OpenElement(0, "select");

--- a/src/Components/Web/src/Forms/ValidationMessage.cs
+++ b/src/Components/Web/src/Forms/ValidationMessage.cs
@@ -3,6 +3,7 @@
 
 using System.Linq.Expressions;
 using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.Web;
 
 namespace Microsoft.AspNetCore.Components.Forms;
 
@@ -55,7 +56,7 @@ public class ValidationMessage<TValue> : ComponentBase, IDisposable
         }
         else if (For != _previousFieldAccessor)
         {
-            _fieldIdentifier = FieldIdentifier.Create(For);
+            _fieldIdentifier = BindingExpressionEvaluator.CreateFieldIdentifier(For, CurrentEditContext.Model);
             _previousFieldAccessor = For;
         }
 

--- a/src/Components/Web/src/Forms/ValidationMessage.cs
+++ b/src/Components/Web/src/Forms/ValidationMessage.cs
@@ -56,7 +56,10 @@ public class ValidationMessage<TValue> : ComponentBase, IDisposable
         }
         else if (For != _previousFieldAccessor)
         {
-            _fieldIdentifier = BindingExpressionEvaluator.CreateFieldIdentifier(For, CurrentEditContext.Model);
+            _fieldIdentifier = BindingExpressionEvaluator.CreateFieldIdentifier(
+                For,
+                CurrentEditContext.Model,
+                Handle.BindableTypeResolver);
             _previousFieldAccessor = For;
         }
 

--- a/src/Components/Web/src/Metadata/BindableModelAttribute.cs
+++ b/src/Components/Web/src/Metadata/BindableModelAttribute.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.Components.Web;
+
+/// <summary>
+/// Names a form model type, from which the Blazor Native AOT metadata source generator derives the
+/// whole bindable graph. Applied to a <see cref="RazorComponentsMetadataContext"/>, once per model.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The generator emits a <see cref="Components.Infrastructure.BindableTypeDescriptor"/> for the named
+/// type and for every type reachable from it through instance fields, instance properties and
+/// single-argument indexers, stopping at framework primitives. One attribute per <c>EditForm</c> model
+/// therefore covers every expression that form can produce.
+/// </para>
+/// <para>
+/// Naming the type explicitly is a requirement rather than a convenience: source generators all run
+/// against the same input compilation and cannot observe each other's output, so the Razor-generated
+/// component types are not in the compilation this generator sees. Models are declared in ordinary C#
+/// and are visible, which is why the attribute names the model rather than the component.
+/// </para>
+/// <para>
+/// This API is experimental, unsupported, and subject to change or removal in any release.
+/// </para>
+/// </remarks>
+[Experimental("ASPNETCORE9004", UrlFormat = "https://aka.ms/aspnet/analyzer/{0}")]
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+public sealed class BindableModelAttribute : Attribute
+{
+    /// <summary>
+    /// Gets the form model type to describe.
+    /// </summary>
+    public required Type ModelType { get; init; }
+}

--- a/src/Components/Web/src/Metadata/ComponentBindableTypeResolver.cs
+++ b/src/Components/Web/src/Metadata/ComponentBindableTypeResolver.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Components.Infrastructure;
+
+namespace Microsoft.AspNetCore.Components.Web;
+
+internal sealed class ComponentBindableTypeResolver : IBindableTypeResolver
+{
+    private readonly Dictionary<Type, BindableTypeDescriptor> _bindableTypesByType = [];
+
+    public ComponentBindableTypeResolver(IEnumerable<RazorComponentsMetadataContext> contexts)
+    {
+        foreach (var context in contexts)
+        {
+            foreach (var descriptor in context.BindableTypes)
+            {
+                _bindableTypesByType[descriptor.Type] = descriptor;
+            }
+        }
+    }
+
+    public bool TryGetBindableTypeDescriptor(
+        Type type,
+        [NotNullWhen(true)] out BindableTypeDescriptor? descriptor)
+        => _bindableTypesByType.TryGetValue(type, out descriptor);
+}

--- a/src/Components/Web/src/Metadata/ComponentMetadataServiceCollectionExtensions.cs
+++ b/src/Components/Web/src/Metadata/ComponentMetadataServiceCollectionExtensions.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Extensions.DependencyInjection;
 public static class ComponentMetadataServiceCollectionExtensions
 {
     /// <summary>
-    /// Registers a <see cref="RazorComponentsMetadataContext"/> so the framework consults its JSON
-    /// contracts before falling back to reflection.
+    /// Registers a <see cref="RazorComponentsMetadataContext"/> so the framework consults its generated
+    /// binding accessors and JSON contracts before falling back to reflection.
     /// </summary>
     /// <typeparam name="TContext">The metadata context type.</typeparam>
     /// <param name="services">The <see cref="IServiceCollection"/>.</param>
@@ -38,6 +38,9 @@ public static class ComponentMetadataServiceCollectionExtensions
             services.Configure<ComponentJsonMetadataOptions>(options => options.Resolvers.Add(resolver));
         }
         services.AddSingleton<RazorComponentsMetadataContext>(context);
+        services.TryAddSingleton<ComponentBindableTypeResolver>();
+        services.TryAddSingleton<IBindableTypeResolver>(
+            static services => services.GetRequiredService<ComponentBindableTypeResolver>());
 
         return services;
     }

--- a/src/Components/Web/src/Metadata/RazorComponentsMetadataContext.cs
+++ b/src/Components/Web/src/Metadata/RazorComponentsMetadataContext.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.JSInterop.Infrastructure;
 
 namespace Microsoft.AspNetCore.Components.Web;
@@ -32,6 +33,11 @@ public abstract class RazorComponentsMetadataContext
     protected RazorComponentsMetadataContext()
     {
     }
+
+    /// <summary>
+    /// Gets the described form model types, which supply the accessors a binding expression walks.
+    /// </summary>
+    public abstract IReadOnlyList<BindableTypeDescriptor> BindableTypes { get; }
 
     /// <summary>
     /// Gets the described <see cref="Microsoft.JSInterop.JSInvokableAttribute"/> methods.

--- a/src/Components/Web/src/Microsoft.AspNetCore.Components.Web.csproj
+++ b/src/Components/Web/src/Microsoft.AspNetCore.Components.Web.csproj
@@ -10,6 +10,8 @@
     <IsTrimmable>true</IsTrimmable>
     <!-- TODO: Address Native AOT analyzer warnings https://github.com/dotnet/aspnetcore/issues/45473 -->
     <EnableAOTAnalyzer>false</EnableAOTAnalyzer>
+    <!-- This assembly declares the experimental Blazor Native AOT metadata context and consumes it internally. -->
+    <NoWarn>$(NoWarn);ASPNETCORE9004</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -76,7 +76,12 @@ Microsoft.AspNetCore.Components.Forms.Label<TValue>.ChildContent.set -> void
 Microsoft.AspNetCore.Components.Forms.Label<TValue>.For.get -> System.Linq.Expressions.Expression<System.Func<TValue>!>?
 Microsoft.AspNetCore.Components.Forms.Label<TValue>.For.set -> void
 Microsoft.AspNetCore.Components.Forms.Label<TValue>.Label() -> void
+Microsoft.AspNetCore.Components.Web.BindableModelAttribute
+Microsoft.AspNetCore.Components.Web.BindableModelAttribute.BindableModelAttribute() -> void
+Microsoft.AspNetCore.Components.Web.BindableModelAttribute.ModelType.get -> System.Type!
+Microsoft.AspNetCore.Components.Web.BindableModelAttribute.ModelType.init -> void
 Microsoft.AspNetCore.Components.Web.RazorComponentsMetadataContext
+abstract Microsoft.AspNetCore.Components.Web.RazorComponentsMetadataContext.BindableTypes.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.Infrastructure.BindableTypeDescriptor!>!
 abstract Microsoft.AspNetCore.Components.Web.RazorComponentsMetadataContext.JSInvokableMethods.get -> System.Collections.Generic.IReadOnlyList<Microsoft.JSInterop.Infrastructure.JSInvokableMethodDescriptor!>!
 abstract Microsoft.AspNetCore.Components.Web.RazorComponentsMetadataContext.JsonTypeInfoResolver.get -> System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver?
 Microsoft.AspNetCore.Components.Web.RazorComponentsMetadataContext.RazorComponentsMetadataContext() -> void

--- a/src/Components/Web/test/Forms/BindingExpressionEvaluatorTest.cs
+++ b/src/Components/Web/test/Forms/BindingExpressionEvaluatorTest.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Linq.Expressions;
+using Microsoft.AspNetCore.Components.Forms;
+
+#nullable enable annotations
+
+namespace Microsoft.AspNetCore.Components.Web;
+
+public class BindingExpressionEvaluatorTest
+{
+    [Fact]
+    public void CreateFieldIdentifier_ResolvesASingleHop()
+    {
+        var model = new LoginModel();
+
+        var identifier = BindingExpressionEvaluator.CreateFieldIdentifier(() => model.Email, model);
+
+        Assert.Same(model, identifier.Model);
+        Assert.Equal(nameof(LoginModel.Email), identifier.FieldName);
+    }
+
+    [Fact]
+    public void CreateFieldIdentifier_ResolvesANestedChain()
+    {
+        var model = new LoginModel { Address = new Address() };
+
+        var identifier = BindingExpressionEvaluator.CreateFieldIdentifier(() => model.Address.Street, model);
+
+        Assert.Same(model.Address, identifier.Model);
+        Assert.Equal(nameof(Address.Street), identifier.FieldName);
+    }
+
+    [Fact]
+    public void CreateFieldIdentifier_ResolvesAnIndexer()
+    {
+        var model = new LoginModel { Orders = [new Order(), new Order()] };
+
+        var identifier = BindingExpressionEvaluator.CreateFieldIdentifier(() => model.Orders[1].Total, model);
+
+        Assert.Same(model.Orders[1], identifier.Model);
+        Assert.Equal(nameof(Order.Total), identifier.FieldName);
+    }
+
+    [Fact]
+    public void CreateFieldIdentifier_ResolvesAnArrayIndex()
+    {
+        var model = new LoginModel { Tags = ["a", "b"] };
+
+        var identifier = BindingExpressionEvaluator.CreateFieldIdentifier(() => model.Tags[0], model);
+
+        Assert.Same(model.Tags, identifier.Model);
+        Assert.Equal("0", identifier.FieldName);
+    }
+
+    [Fact]
+    public void CreateFieldIdentifier_AnchorsAtTheModelWhenTheChainCannotBeEvaluated()
+    {
+        var anchored = new LoginModel();
+        var chain = BuildUnevaluatableChain();
+
+        var identifier = BindingExpressionEvaluator.CreateFieldIdentifier(chain, anchored);
+
+        Assert.Same(anchored, identifier.Model);
+        Assert.Equal(nameof(LoginModel.Email), identifier.FieldName);
+    }
+
+    [Fact]
+    public void CreateFieldIdentifier_MatchesFieldIdentifierCreateForTheSameExpression()
+    {
+        var model = new LoginModel { Address = new Address() };
+        Expression<Func<string?>> accessor = () => model.Address.Street;
+
+        var walked = BindingExpressionEvaluator.CreateFieldIdentifier(accessor, model);
+        var compiled = FieldIdentifier.Create(accessor);
+
+        Assert.Equal(compiled, walked);
+    }
+
+    [Fact]
+    public void CreateFieldIdentifier_ThrowsWhenAHopEvaluatesToNull()
+    {
+        var model = new LoginModel();
+
+        Assert.Throws<ArgumentException>(
+            () => BindingExpressionEvaluator.CreateFieldIdentifier(() => model.Address!.Street, model));
+    }
+
+    private static Expression<Func<string?>> BuildUnevaluatableChain()
+    {
+        var parameter = Expression.Parameter(typeof(LoginModel), "m");
+        var body = Expression.Property(parameter, nameof(LoginModel.Email));
+        return Expression.Lambda<Func<string?>>(body);
+    }
+
+    private sealed class LoginModel
+    {
+        public string? Email { get; set; }
+
+        public Address? Address { get; set; }
+
+        public List<Order> Orders { get; set; } = [];
+
+        public string[] Tags { get; set; } = [];
+    }
+
+    private sealed class Address
+    {
+        public string? Street { get; set; }
+    }
+
+    private sealed class Order
+    {
+        public decimal Total { get; set; }
+    }
+}

--- a/src/Components/Web/test/Forms/BindingExpressionEvaluatorTest.cs
+++ b/src/Components/Web/test/Forms/BindingExpressionEvaluatorTest.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Infrastructure;
 
 #nullable enable annotations
 
@@ -22,6 +24,19 @@ public class BindingExpressionEvaluatorTest
     }
 
     [Fact]
+    public void CreateFieldIdentifier_ResolvesANestedChainThroughDescriptors()
+    {
+        var model = new LoginModel { Address = new Address() };
+        var resolver = new StubResolver(LoginModelDescriptor);
+
+        var identifier = BindingExpressionEvaluator.CreateFieldIdentifier(() => model.Address.Street, model, resolver);
+
+        Assert.Same(model.Address, identifier.Model);
+        Assert.Equal(nameof(Address.Street), identifier.FieldName);
+        Assert.Contains(typeof(LoginModel), resolver.LookedUp);
+    }
+
+    [Fact]
     public void CreateFieldIdentifier_ResolvesANestedChain()
     {
         var model = new LoginModel { Address = new Address() };
@@ -30,6 +45,18 @@ public class BindingExpressionEvaluatorTest
 
         Assert.Same(model.Address, identifier.Model);
         Assert.Equal(nameof(Address.Street), identifier.FieldName);
+    }
+
+    [Fact]
+    public void CreateFieldIdentifier_ResolvesAnIndexerThroughADescriptor()
+    {
+        var model = new LoginModel { Orders = [new Order(), new Order()] };
+        var resolver = new StubResolver(LoginModelDescriptor, OrderListDescriptor);
+
+        var identifier = BindingExpressionEvaluator.CreateFieldIdentifier(() => model.Orders[1].Total, model, resolver);
+
+        Assert.Same(model.Orders[1], identifier.Model);
+        Assert.Equal(nameof(Order.Total), identifier.FieldName);
     }
 
     [Fact]
@@ -92,6 +119,55 @@ public class BindingExpressionEvaluatorTest
         var parameter = Expression.Parameter(typeof(LoginModel), "m");
         var body = Expression.Property(parameter, nameof(LoginModel.Email));
         return Expression.Lambda<Func<string?>>(body);
+    }
+
+    private static BindableTypeDescriptor LoginModelDescriptor { get; } = new()
+    {
+        Type = typeof(LoginModel),
+        Members =
+        [
+            new BindableMemberDescriptor
+            {
+                Name = nameof(LoginModel.Address),
+                MemberType = typeof(Address),
+                GetValue = static target => ((LoginModel)target).Address,
+            },
+            new BindableMemberDescriptor
+            {
+                Name = nameof(LoginModel.Orders),
+                MemberType = typeof(List<Order>),
+                GetValue = static target => ((LoginModel)target).Orders,
+            },
+        ],
+    };
+
+    private static BindableTypeDescriptor OrderListDescriptor { get; } = new()
+    {
+        Type = typeof(List<Order>),
+        Indexers =
+        [
+            new BindableIndexerDescriptor
+            {
+                IndexType = typeof(int),
+                ValueType = typeof(Order),
+                GetValue = static (target, index) => ((List<Order>)target)[(int)index!],
+            },
+        ],
+    };
+
+    private sealed class StubResolver(params BindableTypeDescriptor[] descriptors) : IBindableTypeResolver
+    {
+        private readonly Dictionary<Type, BindableTypeDescriptor> _descriptors = descriptors.ToDictionary(d => d.Type);
+
+        public List<Type> LookedUp { get; } = [];
+
+        public bool TryGetBindableTypeDescriptor(
+            Type type,
+            [NotNullWhen(true)] out BindableTypeDescriptor? descriptor)
+        {
+            LookedUp.Add(type);
+            return _descriptors.TryGetValue(type, out descriptor);
+        }
     }
 
     private sealed class LoginModel

--- a/src/Components/Web/test/Metadata/ComponentMetadataServiceCollectionExtensionsTest.cs
+++ b/src/Components/Web/test/Metadata/ComponentMetadataServiceCollectionExtensionsTest.cs
@@ -27,6 +27,9 @@ public class ComponentMetadataServiceCollectionExtensionsTest
         var resolver = provider.GetRequiredService<IComponentJsonMetadataResolver>().JsonTypeInfoResolver!;
         Assert.NotNull(resolver.GetTypeInfo(typeof(FirstPayload), new JsonSerializerOptions()));
         Assert.NotNull(resolver.GetTypeInfo(typeof(SecondPayload), new JsonSerializerOptions()));
+        var bindableResolver = provider.GetRequiredService<IBindableTypeResolver>();
+        Assert.True(bindableResolver.TryGetBindableTypeDescriptor(typeof(FirstPayload), out _));
+        Assert.True(bindableResolver.TryGetBindableTypeDescriptor(typeof(SecondPayload), out _));
         Assert.Collection(
             provider.GetServices<RazorComponentsMetadataContext>(),
             context => Assert.IsType<FirstContext>(context),
@@ -40,15 +43,21 @@ public class ComponentMetadataServiceCollectionExtensionsTest
         services.AddComponentMetadata<FirstContext>();
         using var firstProvider = services.BuildServiceProvider();
         var firstResolver = firstProvider.GetRequiredService<IComponentJsonMetadataResolver>().JsonTypeInfoResolver!;
+        var firstBindableResolver = firstProvider.GetRequiredService<IBindableTypeResolver>();
 
         services.AddComponentMetadata<SecondContext>();
         using var secondProvider = services.BuildServiceProvider();
         var secondResolver = secondProvider.GetRequiredService<IComponentJsonMetadataResolver>().JsonTypeInfoResolver!;
+        var secondBindableResolver = secondProvider.GetRequiredService<IBindableTypeResolver>();
 
         Assert.NotNull(firstResolver.GetTypeInfo(typeof(FirstPayload), new JsonSerializerOptions()));
         Assert.Null(firstResolver.GetTypeInfo(typeof(SecondPayload), new JsonSerializerOptions()));
         Assert.NotNull(secondResolver.GetTypeInfo(typeof(FirstPayload), new JsonSerializerOptions()));
         Assert.NotNull(secondResolver.GetTypeInfo(typeof(SecondPayload), new JsonSerializerOptions()));
+        Assert.True(firstBindableResolver.TryGetBindableTypeDescriptor(typeof(FirstPayload), out _));
+        Assert.False(firstBindableResolver.TryGetBindableTypeDescriptor(typeof(SecondPayload), out _));
+        Assert.True(secondBindableResolver.TryGetBindableTypeDescriptor(typeof(FirstPayload), out _));
+        Assert.True(secondBindableResolver.TryGetBindableTypeDescriptor(typeof(SecondPayload), out _));
     }
 
     [Fact]
@@ -62,7 +71,13 @@ public class ComponentMetadataServiceCollectionExtensionsTest
 
     public sealed class FirstContext : RazorComponentsMetadataContext
     {
-        public override IReadOnlyList<BindableTypeDescriptor> BindableTypes => [];
+        public override IReadOnlyList<BindableTypeDescriptor> BindableTypes =>
+        [
+            new()
+            {
+                Type = typeof(FirstPayload),
+            },
+        ];
 
         public override IReadOnlyList<JSInvokableMethodDescriptor> JSInvokableMethods => [];
 
@@ -71,7 +86,13 @@ public class ComponentMetadataServiceCollectionExtensionsTest
 
     public sealed class SecondContext : RazorComponentsMetadataContext
     {
-        public override IReadOnlyList<BindableTypeDescriptor> BindableTypes => [];
+        public override IReadOnlyList<BindableTypeDescriptor> BindableTypes =>
+        [
+            new()
+            {
+                Type = typeof(SecondPayload),
+            },
+        ];
 
         public override IReadOnlyList<JSInvokableMethodDescriptor> JSInvokableMethods => [];
 

--- a/src/Components/Web/test/Metadata/ComponentMetadataServiceCollectionExtensionsTest.cs
+++ b/src/Components/Web/test/Metadata/ComponentMetadataServiceCollectionExtensionsTest.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop.Infrastructure;
 
@@ -61,6 +62,8 @@ public class ComponentMetadataServiceCollectionExtensionsTest
 
     public sealed class FirstContext : RazorComponentsMetadataContext
     {
+        public override IReadOnlyList<BindableTypeDescriptor> BindableTypes => [];
+
         public override IReadOnlyList<JSInvokableMethodDescriptor> JSInvokableMethods => [];
 
         public override IJsonTypeInfoResolver JsonTypeInfoResolver => FirstJsonContext.Default;
@@ -68,6 +71,8 @@ public class ComponentMetadataServiceCollectionExtensionsTest
 
     public sealed class SecondContext : RazorComponentsMetadataContext
     {
+        public override IReadOnlyList<BindableTypeDescriptor> BindableTypes => [];
+
         public override IReadOnlyList<JSInvokableMethodDescriptor> JSInvokableMethods => [];
 
         public override IJsonTypeInfoResolver JsonTypeInfoResolver => SecondJsonContext.Default;

--- a/src/Components/Web/test/Microsoft.AspNetCore.Components.Web.Tests.csproj
+++ b/src/Components/Web/test/Microsoft.AspNetCore.Components.Web.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <RootNamespace>Microsoft.AspNetCore.Components</RootNamespace>
+    <NoWarn>$(NoWarn);ASPNETCORE9004</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Components/WebAssembly/WebAssembly/test/Services/WebAssemblyHostSerializationContextTest.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/Services/WebAssemblyHostSerializationContextTest.cs
@@ -5,6 +5,7 @@
 
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -42,6 +43,8 @@ public class WebAssemblyHostSerializationContextTest
 
     public sealed class FirstContext : RazorComponentsMetadataContext
     {
+        public override IReadOnlyList<BindableTypeDescriptor> BindableTypes => [];
+
         public override IReadOnlyList<JSInvokableMethodDescriptor> JSInvokableMethods => [];
 
         public override IJsonTypeInfoResolver JsonTypeInfoResolver => FirstJsonContext.Default;
@@ -49,6 +52,8 @@ public class WebAssemblyHostSerializationContextTest
 
     public sealed class SecondContext : RazorComponentsMetadataContext
     {
+        public override IReadOnlyList<BindableTypeDescriptor> BindableTypes => [];
+
         public override IReadOnlyList<JSInvokableMethodDescriptor> JSInvokableMethods => [];
 
         public override IJsonTypeInfoResolver JsonTypeInfoResolver => SecondJsonContext.Default;


### PR DESCRIPTION
## Overview

Stack layer 3/6 for #68332, stacked on #68296. Across six commits and 39 files, this change removes runtime generic closure from enum/array binding, evaluates supported form expressions without compiling them, and extends the existing application metadata generator with bindable model graphs and accessors.

The cross-cutting constraint is **generated first, reflection last**: described models use statically analyzable delegates, while undescribed models and unsupported expression shapes keep the existing compatibility fallback. This layer does not add component metadata, framework providers, strict-mode switches, or general FormMapping Native AOT support; the generator surface remains `JsonTypeInfoResolver`, `JSInvokableMethods`, and `BindableTypes` only.

## Design

Applications opt a normal C# model into generation explicitly. The explicit model root is required because source generators cannot observe Razor types produced by another generator in the same compilation; ordinary model types are visible and can seed the complete reachable graph.

```csharp
// src/Components/Web/src/Metadata/BindableModelAttribute.cs
// One declaration names a form root; the generator follows its fields, properties,
// collection element types, array elements, and single-argument indexers transitively.
[Experimental("ASPNETCORE9004", UrlFormat = "https://aka.ms/aspnet/analyzer/{0}")]
[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
public sealed class BindableModelAttribute : Attribute
{
    public required Type ModelType { get; init; }
}
```

The generated contract describes only the model-side hops a binding expression may traverse. The component-side prefix is deliberately not described: the evaluator anchors the walk at the `EditContext.Model`, reducing metadata and avoiding a dependency on generated component types.

```csharp
// src/Components/Components/src/Infrastructure/BindableTypeDescriptor.cs
// Members cover fields and properties; indexers are matched by their argument type.
// Arrays need no descriptor because the evaluator can use Array.GetValue directly.
[Experimental("ASPNETCORE9004", UrlFormat = "https://aka.ms/aspnet/analyzer/{0}")]
public sealed class BindableTypeDescriptor
{
    public required Type Type { get; init; }
    public IReadOnlyList<BindableMemberDescriptor> Members { get; init; } = [];
    public IReadOnlyList<BindableIndexerDescriptor> Indexers { get; init; } = [];
}
```

`BindableMemberDescriptor` carries `Name`, `MemberType`, and `Func<object, object?> GetValue`; `BindableIndexerDescriptor` carries `IndexType`, `ValueType`, and `Func<object, object?, object?> GetValue`. These sibling contracts use delegates rather than `MemberInfo`, so generated access is statically analyzable and private members can be bridged with generated `UnsafeAccessor` methods.

The existing metadata context gains the bindable list at the same point it is first emitted and consumed:

```csharp
// src/Components/Web/src/Metadata/RazorComponentsMetadataContext.cs
public abstract class RazorComponentsMetadataContext
{
    public abstract IReadOnlyList<BindableTypeDescriptor> BindableTypes { get; }
    public abstract IReadOnlyList<JSInvokableMethodDescriptor> JSInvokableMethods { get; }
    public abstract IJsonTypeInfoResolver? JsonTypeInfoResolver { get; }
}
```

The rejected alternatives were runtime `MakeGenericMethod`/`Expression.Compile` (not available under Native AOT), describing component roots (unnecessary and unavailable to this generator layer), and removing reflection entirely (would break the default compatibility contract).

## Implementation

`BindConverter` retains its existing specialized generic delegates when dynamic code is available, but selects non-generic enum APIs and reflectionless array construction otherwise. Enum and nullable-enum parsing are one equivalence class; array parsing and formatting are the second.

```csharp
// src/Components/Components/src/BindConverter.cs
// JIT keeps the existing closed generic fast path. Native AOT does not attempt to
// manufacture a missing generic instantiation at runtime.
if (typeof(T).IsEnum)
{
    if (RuntimeFeature.IsDynamicCodeSupported)
    {
        var method = _convertToEnum ??= typeof(BindConverter).GetMethod(
            nameof(ConvertToEnum), BindingFlags.NonPublic | BindingFlags.Static)!;
        parser = method.MakeGenericMethod(typeof(T)).CreateDelegate(typeof(BindParser<T>), target: null);
    }
    else
    {
        parser = (BindParser<T>)ConvertToEnumDynamicCodeSafe<T>;
    }
}
else if (typeof(T).IsArray)
{
    if (RuntimeFeature.IsDynamicCodeSupported)
    {
        // Existing typed array converter construction — unchanged.
        var method = _makeArrayTypeConverter ??= typeof(ParserDelegateCache).GetMethod(
            nameof(MakeArrayTypeConverter), BindingFlags.NonPublic | BindingFlags.Static)!;
        parser = (Delegate)method.MakeGenericMethod(typeof(T).GetElementType()!).Invoke(null, null)!;
    }
    else
    {
        EnsureCanParseElementType(typeof(T).GetElementType()!);
        parser = (BindParser<T>)ConvertToArrayDynamicCodeSafe;
    }
}
```

The AOT array path preserves the exact runtime array type—including nested and non-vector array shapes—then converts each element through the same non-generic element dispatcher. Formatting mirrors the same branch and JSON-escapes each formatted element. Nullable enums use the same non-generic `Enum.TryParse(Type, ...)` pattern after recovering `Nullable.GetUnderlyingType(typeof(T))`; `InputSelect<TValue>` contains only the narrow closed-path suppression beside its array binder.

```csharp
// src/Components/Components/src/BindConverter.cs
private static bool ConvertToArrayDynamicCodeSafe<T>(
    object? obj,
    CultureInfo? culture,
    [MaybeNullWhen(false)] out T value)
{
    if (obj is not Array initialArray)
    {
        value = default;
        return false;
    }

    var arrayType = typeof(T);
    var elementType = arrayType.GetElementType()!;
    var convertedArray = Array.CreateInstanceFromArrayType(arrayType, initialArray.Length);
    for (var i = 0; i < initialArray.Length; i++)
    {
        if (!TryConvertElement(initialArray.GetValue(i), elementType, culture, out var converted))
        {
            value = default;
            return false;
        }

        convertedArray.SetValue(converted, i);
    }

    value = (T)(object)convertedArray;
    return true;
}
```

`InputBase<TValue>` and `ValidationMessage<TValue>` now enter through one evaluator. It recognizes member access, single-argument indexers, and array indexing; unsupported shapes still call `FieldIdentifier.Create`, preserving previous behavior. Captured index values also avoid `Expression.Compile` when dynamic code is unavailable by reading the `PropertyInfo` or `FieldInfo` already embedded in the expression.

```csharp
// src/Components/Web/src/Forms/BindingExpressionEvaluator.cs
// For model.Address.Street, the walk anchors at model, reads Address, and returns
// FieldIdentifier(model.Address, "Street"). Descriptors win; reflection is the fallback.
private static object? ReadMember(
    object target,
    MemberExpression member,
    IBindableTypeResolver? resolver)
{
    if (resolver is not null &&
        resolver.TryGetBindableTypeDescriptor(member.Expression!.Type, out var descriptor))
    {
        foreach (var described in descriptor.Members)
        {
            if (string.Equals(described.Name, member.Member.Name, StringComparison.Ordinal))
            {
                return described.GetValue(target);
            }
        }
    }

    return member.Member switch
    {
        PropertyInfo property => property.GetValue(target),
        FieldInfo field => field.GetValue(target),
        _ => throw new ArgumentException(
            $"The provided expression contains a {member.Member.GetType().Name} which is not supported. " +
            $"{nameof(FieldIdentifier)} only supports simple member accessors (fields, properties) of an object."),
    };
}
```

Generation follows the full bindable graph breadth-first, deduplicates cycles and inherited hidden members, follows array elements and generic type arguments, and stops at primitive/framework leaves. Directly accessible members become direct delegates; inaccessible properties and fields use generated `UnsafeAccessor` bridges. Single-argument indexers are emitted as typed delegates, while unsupported/inaccessible members are omitted with a targeted diagnostic for an inaccessible root.

```csharp
// src/Components/Endpoints/gen/RazorComponentsMetadataGenerator.Bindables.cs
// Root -> Child -> Root terminates because visited deduplicates symbols.
// List<Order> enqueues both the collection type and Order, so row.Name is covered.
var results = new Dictionary<string, BindableTypeModel>(StringComparer.Ordinal);
var visited = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
var queue = new Queue<INamedTypeSymbol>();

while (queue.Count > 0)
{
    var type = queue.Dequeue();
    if (!visited.Add(type) || IsLeafType(type))
    {
        continue;
    }

    // Collect instance fields, properties, and one-argument indexers.
    // Enqueue their value types, array elements, and generic arguments.
}
```

Registration composes multiple metadata contexts once into a type-keyed resolver. The renderer carries that resolver through `RenderHandle`, so form components use generated descriptors without introducing a process-static registry; later providers do not mutate an already-built service provider.

```csharp
// src/Components/Web/src/Metadata/ComponentBindableTypeResolver.cs
internal sealed class ComponentBindableTypeResolver : IBindableTypeResolver
{
    private readonly Dictionary<Type, BindableTypeDescriptor> _bindableTypesByType = [];

    public ComponentBindableTypeResolver(IEnumerable<RazorComponentsMetadataContext> contexts)
    {
        foreach (var context in contexts)
        {
            foreach (var descriptor in context.BindableTypes)
            {
                _bindableTypesByType[descriptor.Type] = descriptor;
            }
        }
    }

    public bool TryGetBindableTypeDescriptor(
        Type type,
        [NotNullWhen(true)] out BindableTypeDescriptor? descriptor)
        => _bindableTypesByType.TryGetValue(type, out descriptor);
}
```

## Outcome

| Equivalence class | What is covered | Validation |
|---|---|---|
| Enum and nullable-enum conversion | Defined/undefined values, empty input semantics, parity with the dynamic-code path | `BindConverterTest`: 41 passed |
| Array parsing and formatting | Primitive, enum, nullable, nested, multidimensional/runtime array shapes; Endpoints converter construction remains annotation-safe | `FormDataMapperTests`: 282 passed |
| Expression walking | Single/nested members, fields, captured indexes, list indexers, arrays, model anchoring, null hops, and fallback parity with `FieldIdentifier.Create` | `BindingExpressionEvaluatorTest`: 9 passed |
| Generated bindable graphs | Public/private fields and properties, `UnsafeAccessor`, indexers, inheritance/hiding, transitive arrays/collections, cycles, stable ordering, unsupported members, and per-provider resolver isolation | Repository `Test` target on MSTest/MTP: 15 passed, including all 5 bindable generator scenarios |
| Trimming/linkability | Binding changes introduce no new linker diagnostics in the Components WebAssembly surface | `WasmLinkerTest` build: 0 warnings, 0 errors |

The result is an AOT-safe path for the binding scenarios this layer owns, while default JIT behavior and reflection fallback remain intact.