### PR TITLE
[Blazor] Validate component metadata under Native AOT

### DIFF
--- a/src/Components/Endpoints/gen/DiagnosticDescriptors.cs
+++ b/src/Components/Endpoints/gen/DiagnosticDescriptors.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Components.Endpoints.Generators;
@@ -20,6 +21,9 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "The Blazor Native AOT metadata generator only describes a component when every member it needs is reachable from the generated code.");
+
+    public static readonly DiagnosticDescriptor ComponentNotFullyDescribedError =
+        CreateError(ComponentNotFullyDescribed);
 
     // A [BindableModel] named something the generator cannot walk, so any @bind expression rooted at
     // it falls back to the MemberInfo walk.
@@ -52,5 +56,20 @@ internal static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "Endpoint-visible component attributes must be reconstructable so generated metadata preserves routing, authorization, caching, and rendering behavior.");
+
+    public static readonly DiagnosticDescriptor ComponentAttributeNotDescribedError =
+        CreateError(ComponentAttributeNotDescribed);
+
+    private static DiagnosticDescriptor CreateError(DiagnosticDescriptor descriptor)
+        => new(
+            descriptor.Id,
+            descriptor.Title,
+            descriptor.MessageFormat,
+            descriptor.Category,
+            DiagnosticSeverity.Error,
+            descriptor.IsEnabledByDefault,
+            descriptor.Description,
+            descriptor.HelpLinkUri,
+            descriptor.CustomTags.ToArray());
 
 }

--- a/src/Components/Endpoints/gen/Emitters/RazorComponentsMetadataGenerator.Emitter.cs
+++ b/src/Components/Endpoints/gen/Emitters/RazorComponentsMetadataGenerator.Emitter.cs
@@ -30,11 +30,14 @@ public sealed partial class RazorComponentsMetadataGenerator
     private const string BuiltInJSInvokableDescriptorProviderType =
         "Microsoft.JSInterop.Infrastructure.BuiltInJSInvokableMethodDescriptors";
 
-    private static void Emit(SourceProductionContext context, GenerationResult result)
+    private static void Emit(
+        SourceProductionContext context,
+        GenerationResult result,
+        bool reflectionEnabledByDefault)
     {
         foreach (var diagnostic in result.Diagnostics)
         {
-            context.ReportDiagnostic(diagnostic.ToDiagnostic());
+            context.ReportDiagnostic(diagnostic.ToDiagnostic(reflectionEnabledByDefault));
         }
 
         foreach (var model in result.Models)

--- a/src/Components/Endpoints/gen/RazorComponentsMetadataGenerator.cs
+++ b/src/Components/Endpoints/gen/RazorComponentsMetadataGenerator.cs
@@ -48,6 +48,9 @@ public sealed partial class RazorComponentsMetadataGenerator : IIncrementalGener
     private static bool IsBuiltInDescriptorAssembly(string assemblyName)
         => BuiltInDescriptorAssemblies.Contains(assemblyName, StringComparer.Ordinal);
 
+    private const string ReflectionEnabledByDefaultPropertyName =
+        "build_property.RazorComponentsReflectionEnabledByDefault";
+
     /// <inheritdoc />
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
@@ -80,7 +83,14 @@ public sealed partial class RazorComponentsMetadataGenerator : IIncrementalGener
             .Combine(candidates)
             .Select(static (pair, cancellationToken) => Build(pair.Left, pair.Right, cancellationToken));
 
-        context.RegisterSourceOutput(models, static (spc, result) => Emit(spc, result));
+        var reflectionEnabledByDefault = context.AnalyzerConfigOptionsProvider
+            .Select(static (provider, _) =>
+                !provider.GlobalOptions.TryGetValue(ReflectionEnabledByDefaultPropertyName, out var value) ||
+                !string.Equals(value, "false", StringComparison.OrdinalIgnoreCase));
+
+        context.RegisterSourceOutput(
+            models.Combine(reflectionEnabledByDefault),
+            static (spc, pair) => Emit(spc, pair.Left, pair.Right));
     }
 
     // Cheap syntactic filter: a class declaration that has a base list. The semantic check that the
@@ -343,13 +353,15 @@ public sealed partial class RazorComponentsMetadataGenerator : IIncrementalGener
     // key stays free of Location objects, which are not value-equatable across compilations.
     internal sealed record class DiagnosticInfo(string Id, string Argument0, string Argument1)
     {
-        public Diagnostic ToDiagnostic()
+        public Diagnostic ToDiagnostic(bool reflectionEnabledByDefault)
         {
-            var descriptor = Id switch
+            var descriptor = (Id, reflectionEnabledByDefault) switch
             {
-                "BLAZORAOT002" => DiagnosticDescriptors.BindableModelNotDescribed,
-                "BLAZORAOT003" => DiagnosticDescriptors.MetadataContextMustBePartial,
-                "BLAZORAOT004" => DiagnosticDescriptors.ComponentAttributeNotDescribed,
+                ("BLAZORAOT001", false) => DiagnosticDescriptors.ComponentNotFullyDescribedError,
+                ("BLAZORAOT004", false) => DiagnosticDescriptors.ComponentAttributeNotDescribedError,
+                ("BLAZORAOT002", _) => DiagnosticDescriptors.BindableModelNotDescribed,
+                ("BLAZORAOT003", _) => DiagnosticDescriptors.MetadataContextMustBePartial,
+                ("BLAZORAOT004", _) => DiagnosticDescriptors.ComponentAttributeNotDescribed,
                 _ => DiagnosticDescriptors.ComponentNotFullyDescribed,
             };
 

--- a/src/Components/Endpoints/test/Microsoft.AspNetCore.Components.Endpoints.Generators.Tests/RazorComponentsMetadataGeneratorDiagnosticTests.cs
+++ b/src/Components/Endpoints/test/Microsoft.AspNetCore.Components.Endpoints.Generators.Tests/RazorComponentsMetadataGeneratorDiagnosticTests.cs
@@ -10,7 +10,11 @@ namespace Microsoft.AspNetCore.Components.Endpoints.Generators.Tests;
 public sealed class RazorComponentsMetadataGeneratorDiagnosticTests : RazorComponentsMetadataGeneratorTestBase
 {
     [TestMethod]
-    public void BlazorAot001_IncompleteParameter_ReportsWarning()
+    [DataRow(null, DiagnosticSeverity.Warning)]
+    [DataRow(false, DiagnosticSeverity.Error)]
+    public void BlazorAot001_IncompleteParameter_SeverityFollowsReflectionMode(
+        bool? reflectionEnabledByDefault,
+        DiagnosticSeverity expectedSeverity)
     {
         var result = RunGenerator("""
             namespace TestComponents;
@@ -21,9 +25,10 @@ public sealed class RazorComponentsMetadataGeneratorDiagnosticTests : RazorCompo
                 private int ReadOnly { get; } = 1;
             }
             """,
+            razorComponentsReflectionEnabledByDefault: reflectionEnabledByDefault,
             expectedDiagnosticIds: ["BLAZORAOT001"]);
 
-        var diagnostic = AssertDiagnostic(result, "BLAZORAOT001", DiagnosticSeverity.Warning);
+        var diagnostic = AssertDiagnostic(result, "BLAZORAOT001", expectedSeverity);
         StringAssert.Contains(diagnostic.GetMessage(CultureInfo.InvariantCulture), "TestComponents.BrokenComponent");
         StringAssert.Contains(diagnostic.GetMessage(CultureInfo.InvariantCulture), "missing a getter or a setter");
 
@@ -137,7 +142,12 @@ public sealed class RazorComponentsMetadataGeneratorDiagnosticTests : RazorCompo
     }
 
     [TestMethod]
-    public void BlazorAot004_PartialAssembly_ReportsWarning()
+    [DataRow(null, DiagnosticSeverity.Warning)]
+    [DataRow(true, DiagnosticSeverity.Warning)]
+    [DataRow(false, DiagnosticSeverity.Error)]
+    public void BlazorAot004_PartialAssembly_SeverityFollowsReflectionMode(
+        bool? reflectionEnabledByDefault,
+        DiagnosticSeverity expectedSeverity)
     {
         var result = RunGenerator("""
             namespace TestComponents;
@@ -159,9 +169,10 @@ public sealed class RazorComponentsMetadataGeneratorDiagnosticTests : RazorCompo
                 }
             }
             """,
+            razorComponentsReflectionEnabledByDefault: reflectionEnabledByDefault,
             expectedDiagnosticIds: ["BLAZORAOT004"]);
 
-        AssertDiagnostic(result, "BLAZORAOT004", DiagnosticSeverity.Warning);
+        AssertDiagnostic(result, "BLAZORAOT004", expectedSeverity);
         StringAssert.Contains(GetGeneratedSource(result), "ValidComponent");
         Assert.IsFalse(GetGeneratedSource(result).Contains("OmittedComponent", StringComparison.Ordinal));
     }

--- a/src/Components/Endpoints/test/Microsoft.AspNetCore.Components.Endpoints.Generators.Tests/RazorComponentsMetadataGeneratorTestBase.cs
+++ b/src/Components/Endpoints/test/Microsoft.AspNetCore.Components.Endpoints.Generators.Tests/RazorComponentsMetadataGeneratorTestBase.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.JSInterop;
 using Microsoft.JSInterop.Infrastructure;
 
@@ -40,6 +41,7 @@ public abstract class RazorComponentsMetadataGeneratorTestBase
         bool assertUpdatedCompilation = true,
         string? referencedAssemblyName = null,
         string? hostAssemblyName = null,
+        bool? razorComponentsReflectionEnabledByDefault = null,
         IReadOnlyCollection<string>? hostFrameworkAssemblyNames = null,
         params string[] expectedDiagnosticIds)
     {
@@ -66,7 +68,8 @@ public abstract class RazorComponentsMetadataGeneratorTestBase
 
         GeneratorDriver driver = CSharpGeneratorDriver.Create(
             generators: [new RazorComponentsMetadataGenerator().AsSourceGenerator()],
-            parseOptions: ParseOptions);
+            parseOptions: ParseOptions,
+            optionsProvider: new TestAnalyzerConfigOptionsProvider(razorComponentsReflectionEnabledByDefault));
         driver = driver.RunGeneratorsAndUpdateCompilation(
             hostCompilation,
             out var updatedCompilation,
@@ -309,6 +312,46 @@ public abstract class RazorComponentsMetadataGeneratorTestBase
         }
 
         protected override Assembly? Load(AssemblyName assemblyName) => null;
+    }
+
+    private sealed class TestAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
+    {
+        private static readonly AnalyzerConfigOptions Empty = new TestAnalyzerConfigOptions(null);
+        private readonly AnalyzerConfigOptions _globalOptions;
+
+        public TestAnalyzerConfigOptionsProvider(bool? reflectionEnabledByDefault)
+        {
+            _globalOptions = new TestAnalyzerConfigOptions(reflectionEnabledByDefault);
+        }
+
+        public override AnalyzerConfigOptions GlobalOptions => _globalOptions;
+
+        public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => Empty;
+
+        public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => Empty;
+    }
+
+    private sealed class TestAnalyzerConfigOptions : AnalyzerConfigOptions
+    {
+        private readonly bool? _reflectionEnabledByDefault;
+
+        public TestAnalyzerConfigOptions(bool? reflectionEnabledByDefault)
+        {
+            _reflectionEnabledByDefault = reflectionEnabledByDefault;
+        }
+
+        public override bool TryGetValue(string key, out string value)
+        {
+            if (_reflectionEnabledByDefault.HasValue &&
+                key == "build_property.RazorComponentsReflectionEnabledByDefault")
+            {
+                value = _reflectionEnabledByDefault.Value.ToString();
+                return true;
+            }
+
+            value = null!;
+            return false;
+        }
     }
 
 }

--- a/src/Components/Testing/testassets/BlazorAotFeatures.E2E.Tests/BlazorAotFeatures.E2E.Tests.csproj
+++ b/src/Components/Testing/testassets/BlazorAotFeatures.E2E.Tests/BlazorAotFeatures.E2E.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <!-- Per-feature generated-metadata coverage for Blazor Server.
+  <!-- Per-feature Native AOT coverage for Blazor Server.
 
        Each AOT-sensitive feature is isolated on its own page and asserted independently, so a
        regression identifies the feature that broke.
@@ -9,8 +9,11 @@
        merely renders does not prove the generated descriptors, JS interop contracts and JSON
        resolvers are correct once the circuit is live.
 
-       This layer runs the matrix through the normal JIT build. The harness remains capable of
-       source-generating its startup integration for a later Native AOT lane. -->
+       Run against a JIT publish of the app (fast iteration):
+         dotnet build <this project> -p:UseIisNativeAssets=false -p:PublishAot=false -r win-x64
+       Run against the Native AOT binary (slow; this is what the asset exists for):
+         dotnet build <this project> -p:UseIisNativeAssets=false -r win-x64
+       then run the produced BlazorAotFeatures.E2E.Tests executable. -->
 
   <Import Project="../../eng/targets/Microsoft.AspNetCore.Components.Testing.props" />
 
@@ -50,6 +53,9 @@
       <E2EApp>true</E2EApp>
       <E2EAppMode>publish</E2EAppMode>
       <AdditionalProperties>UseIisNativeAssets=false</AdditionalProperties>
+      <AdditionalProperties Condition="'$(BlazorAotStrictMode)' == 'true'">UseIisNativeAssets=false;BlazorAotStrictMode=true</AdditionalProperties>
+      <E2ENativeAot>true</E2ENativeAot>
+      <E2ERuntimeIdentifier>$(RuntimeIdentifier)</E2ERuntimeIdentifier>
     </ProjectReference>
   </ItemGroup>
 

--- a/src/Components/test/testassets/BlazorAotFeatures/BlazorServerAotSample/BlazorServerAotSample.ILLink.Substitutions.xml
+++ b/src/Components/test/testassets/BlazorAotFeatures/BlazorServerAotSample/BlazorServerAotSample.ILLink.Substitutions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<linker>
+  <assembly fullname="Microsoft.AspNetCore.Components.Endpoints">
+    <type fullname="Microsoft.AspNetCore.Components.Endpoints.HttpContextFormValueMapper">
+      <method signature="System.Boolean CanMap(System.Type,System.String,System.String)" body="stub" value="false" />
+      <method signature="System.Void Map(Microsoft.AspNetCore.Components.Forms.Mapping.FormValueMappingContext)" body="remove" />
+      <method signature="Microsoft.AspNetCore.Components.Endpoints.HttpContextFormValueMapper/FormValueSupplier CreateDeserializer(System.Type)" body="remove" />
+    </type>
+  </assembly>
+</linker>

--- a/src/Components/test/testassets/BlazorAotFeatures/BlazorServerAotSample/BlazorServerAotSample.csproj
+++ b/src/Components/test/testassets/BlazorAotFeatures/BlazorServerAotSample/BlazorServerAotSample.csproj
@@ -5,18 +5,60 @@
     <IsShippingPackage>false</IsShippingPackage>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <UseIisNativeAssets>false</UseIisNativeAssets>
+    <!-- Native AOT: enabled here (scoped to this app; referenced framework projects don't inherit
+         it). Local `dotnet run` still JITs; `dotnet publish -r <rid>` produces the native app.
+         Enables the AOT/trim analyzers during build so per-feature blockers surface. -->
+    <PublishAot>true</PublishAot>
+    <!-- Reflection remains enabled by default for every Blazor application. This dedicated test asset
+         explicitly requests complete generated metadata so omissions are build errors. -->
+    <RazorComponentsReflectionEnabledByDefault>false</RazorComponentsReflectionEnabledByDefault>
+    <IlcTreatWarningsAsErrors>true</IlcTreatWarningsAsErrors>
     <!-- The metadata model is experimental; the sample opts into it deliberately. -->
     <NoWarn>$(NoWarn);ASPNETCORE9004</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(E2ECompileTestHarness)' == 'true'">
+    <DefineConstants>$(DefineConstants);E2E_COMPILE_TEST_HARNESS</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(BlazorAotStrictMode)' == 'true'">
+    <RuntimeHostConfigurationOption
+        Include="System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault"
+        Value="false"
+        Trim="true" />
+    <RuntimeHostConfigurationOption
+        Include="Microsoft.AspNetCore.Components.ComponentMetadata.IsReflectionEnabledByDefault"
+        Value="false"
+        Trim="true" />
+    <RuntimeHostConfigurationOption
+        Include="Microsoft.JSInterop.JSInvokableMethodResolution.IsReflectionEnabledByDefault"
+        Value="false"
+        Trim="true" />
+  </ItemGroup>
+
+  <!-- HTTP form mapping is not part of this feature matrix and remains unsupported under Native AOT.
+       Remove its private implementation only from the strict proof image without suppressing warnings. -->
+  <Target Name="AddStrictFormMappingSubstitutions"
+          BeforeTargets="WriteIlcRspFileForCompilation"
+          Condition="'$(BlazorAotStrictMode)' == 'true' and '$(PublishAot)' == 'true'">
+    <ItemGroup>
+      <IlcArg Include="--substitution:$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)BlazorServerAotSample.ILLink.Substitutions.xml'))" />
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
+    <CompilerVisibleProperty Include="RazorComponentsReflectionEnabledByDefault" />
+    <CompilerVisibleProperty Include="E2ECompileTestHarness" />
     <!-- The host contains NO Blazor/.razor code; all components live in the Pages library. -->
     <ProjectReference Include="..\BlazorServerAotSample.Pages\BlazorServerAotSample.Pages.csproj" />
     <!-- The metadata source generator runs here and walks the referenced Pages library, which is the
          only place the Razor-compiled component types are visible from. -->
     <ProjectReference Include="..\..\..\..\Endpoints\gen\Microsoft.AspNetCore.Components.Endpoints.Generators.csproj"
                       OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <!-- Source-tree equivalent of the package's buildTransitive analyzer hook. -->
+    <ProjectReference Include="..\..\..\..\Testing\nativeaot\Microsoft.AspNetCore.Components.Testing.NativeAot.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>
@@ -73,8 +115,6 @@
     <!-- The Kestrel meta references the Quic transport; UseKestrelCore never calls UseQuic, but under AOT
          the meta's type refs mean the Quic assembly must be present to load. Reference it explicitly. -->
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Quic" />
-    <Reference Include="Microsoft.AspNetCore.Server.IIS" />
-    <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />
     <Reference Include="Microsoft.AspNetCore.SignalR" />
     <Reference Include="Microsoft.AspNetCore.SignalR.Common" />
     <Reference Include="Microsoft.AspNetCore.SignalR.Core" />

--- a/src/Components/test/testassets/BlazorAotFeatures/BlazorServerAotSample/Program.cs
+++ b/src/Components/test/testassets/BlazorAotFeatures/BlazorServerAotSample/Program.cs
@@ -10,6 +10,7 @@
 // not exist in the compilation of the project that declares the .razor files, but they do exist in its
 // references.
 
+using System.Diagnostics.CodeAnalysis;
 using BlazorServerAotSample;
 using BlazorServerAotSample.Pages;
 using Microsoft.AspNetCore.Builder;
@@ -17,15 +18,16 @@ using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-#if NATIVE_TESTING
+#if E2E_COMPILE_TEST_HARNESS
 using Microsoft.AspNetCore.Components.Testing.NativeAot.Generated;
 #endif
 
-#if NATIVE_TESTING
 var builder = WebApplication.CreateSlimBuilder(args);
-#else
-var builder = WebApplication.CreateBuilder(args);
-#endif
+
+// CreateSlimBuilder wires Kestrel core, the sockets transport and routing, but - unlike the non-slim
+// builder - it does not load the static web assets manifest. Blazor Server serves
+// _framework/blazor.web.js as a static web asset, so the manifest is loaded explicitly.
+builder.WebHost.UseStaticWebAssets();
 
 if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("ASPNETCORE_URLS")))
 {
@@ -38,11 +40,10 @@ builder.Services.AddKeyedSingleton<IGreetingService, GreetingService>("aot-key")
 builder.Services.AddSingleton<ProtectedBrowserStorageSerializer<Theme>, ThemeSerializer>();
 AddSessionSupport(builder.Services);
 
-#if NATIVE_TESTING
-// CreateSlimBuilder does not execute hosting startups, so the harness the testing source generator
-// baked into this compilation is registered explicitly. The symbol is defined only when the E2E
-// harness is building this application, so a normal build has neither the code nor the call.
-builder.Services.AddNativeTestHarness();
+#if E2E_COMPILE_TEST_HARNESS
+// CreateSlimBuilder does not execute hosting startups, so register the shared source-generated
+// Native AOT harness explicitly. The extension is emitted only for the nested E2E publish.
+builder.Services.AddE2ETestHarness();
 #endif
 
 var app = builder.Build();
@@ -55,6 +56,12 @@ app.MapRazorComponents<App>()
 
 await app.RunAsync();
 
+// AddRazorComponents and AddInteractiveServerComponents keep their [RequiresUnreferencedCode] gates:
+// they correctly warn an application that has not described its components. This one has, so the
+// warning is suppressed at the call site rather than by de-annotating the framework.
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "Every path this application exercises is covered by the descriptors in " +
+        "SampleMetadata, which replace the reflection fallbacks these gates warn about.")]
 static void AddInteractiveServerBlazor(IServiceCollection services)
 {
     services.AddComponentMetadata<SampleMetadata>();
@@ -65,6 +72,8 @@ static void AddInteractiveServerBlazor(IServiceCollection services)
         });
 }
 
+[UnconditionalSuppressMessage("Trimming", "IL2026",
+    Justification = "This sample only stores generated-contract values through the session-backed component state feature.")]
 static void AddSessionSupport(IServiceCollection services)
 {
     services.AddDistributedMemoryCache();


### PR DESCRIPTION
## Overview

Layer 6 of 6 for the Native AOT metadata stack; depends on #68300 and completes the umbrella feature tracked by #68332. It turns the existing feature matrix into a strict Native AOT proof without adding a product API, runtime feature, provider, root, or scenario. The cross-cutting constraint is that the app must publish and run with the STJ, component-metadata, and JS-invokable reflection fallbacks disabled; incomplete generated metadata or any ILC warning fails the build.

## Design

There are no public API changes. The new contract is build-time and test-app-local: the application exposes `RazorComponentsReflectionEnabledByDefault` to the metadata generator, and the generator escalates only diagnostics whose runtime recovery requires component reflection.

```csharp
// src/Components/Endpoints/gen/RazorComponentsMetadataGenerator.cs
// Unset/true preserves warning-plus-reflection compatibility; false requires complete generated metadata.
private const string ReflectionEnabledByDefaultPropertyName =
    "build_property.RazorComponentsReflectionEnabledByDefault";

var reflectionEnabledByDefault = context.AnalyzerConfigOptionsProvider
    .Select(static (provider, _) =>
        !provider.GlobalOptions.TryGetValue(ReflectionEnabledByDefaultPropertyName, out var value) ||
        !string.Equals(value, "false", StringComparison.OrdinalIgnoreCase));

context.RegisterSourceOutput(
    models.Combine(reflectionEnabledByDefault),
    static (spc, pair) => Emit(spc, pair.Left, pair.Right));

// BLAZORAOT001 is incomplete component metadata; BLAZORAOT004 is the parallel endpoint-attribute case.
var descriptor = (Id, reflectionEnabledByDefault) switch
{
    ("BLAZORAOT001", false) => DiagnosticDescriptors.ComponentNotFullyDescribedError,
    ("BLAZORAOT004", false) => DiagnosticDescriptors.ComponentAttributeNotDescribedError,
    ("BLAZORAOT004", _) => DiagnosticDescriptors.ComponentAttributeNotDescribed,
    _ => DiagnosticDescriptors.ComponentNotFullyDescribed,
};
```

The dedicated feature app enables Native AOT analysis, requires complete generated component metadata, and promotes ILC warnings to errors. Runtime fallback removal remains separately gated by `BlazorAotStrictMode`, so the same scenarios retain ordinary compatibility coverage.

```xml
<!-- src/Components/test/testassets/BlazorAotFeatures/BlazorServerAotSample/BlazorServerAotSample.csproj -->
<PropertyGroup>
  <PublishAot>true</PublishAot>
  <RazorComponentsReflectionEnabledByDefault>false</RazorComponentsReflectionEnabledByDefault>
  <IlcTreatWarningsAsErrors>true</IlcTreatWarningsAsErrors>
</PropertyGroup>

<ItemGroup Condition="'$(BlazorAotStrictMode)' == 'true'">
  <!-- Three equivalent fallback classes are disabled independently. -->
  <RuntimeHostConfigurationOption
      Include="System.Text.Json.JsonSerializer.IsReflectionEnabledByDefault"
      Value="false" Trim="true" />
  <RuntimeHostConfigurationOption
      Include="Microsoft.AspNetCore.Components.ComponentMetadata.IsReflectionEnabledByDefault"
      Value="false" Trim="true" />
  <RuntimeHostConfigurationOption
      Include="Microsoft.JSInterop.JSInvokableMethodResolution.IsReflectionEnabledByDefault"
      Value="false" Trim="true" />
</ItemGroup>
```

A broad `NoWarn` or product suppression was deliberately rejected because it would weaken the zero-warning proof. HTTP form mapping is not exercised by this matrix and is not Native-AOT-supported here, so the strict test image removes only that private implementation through an app-owned ILC substitution; product assemblies and non-strict behavior are unchanged.

## Implementation

The test project uses the shared MSTest/Components.Testing harness introduced by #68289 and #67083. The app reference selects published Native AOT mode, provides the RID required by the shared target, and forwards strict mode through the standard `AdditionalProperties` contract.

```xml
<!-- src/Components/Testing/testassets/BlazorAotFeatures.E2E.Tests/BlazorAotFeatures.E2E.Tests.csproj -->
<ProjectReference Include="../../../test/testassets/BlazorAotFeatures/BlazorServerAotSample/BlazorServerAotSample.csproj">
  <E2EApp>true</E2EApp>
  <E2EAppMode>publish</E2EAppMode>
  <E2ENativeAot>true</E2ENativeAot>
  <E2ERuntimeIdentifier>$(RuntimeIdentifier)</E2ERuntimeIdentifier>
  <AdditionalProperties>UseIisNativeAssets=false</AdditionalProperties>
  <AdditionalProperties Condition="'$(BlazorAotStrictMode)' == 'true'">
    UseIisNativeAssets=false;BlazorAotStrictMode=true
  </AdditionalProperties>
</ProjectReference>
```

The shared target turns `E2ENativeAot` into `E2ECompileTestHarness=true` for the nested publish. In the source tree, the app references the shared Native AOT generator as an analyzer unconditionally so clean restore sees the project; generation itself remains property-gated. `CreateSlimBuilder` deliberately skips hosting startups, so the app invokes the shared generated extension explicitly only in that nested publish.

```xml
<!-- src/Components/test/testassets/BlazorAotFeatures/BlazorServerAotSample/BlazorServerAotSample.csproj -->
<PropertyGroup Condition="'$(E2ECompileTestHarness)' == 'true'">
  <DefineConstants>$(DefineConstants);E2E_COMPILE_TEST_HARNESS</DefineConstants>
</PropertyGroup>

<ItemGroup>
  <CompilerVisibleProperty Include="E2ECompileTestHarness" />
  <!-- Source-tree equivalent of the package's buildTransitive analyzer hook. -->
  <ProjectReference Include="../../../../Testing/nativeaot/Microsoft.AspNetCore.Components.Testing.NativeAot.csproj"
                    OutputItemType="Analyzer"
                    ReferenceOutputAssembly="false" />
</ItemGroup>
```

```csharp
// src/Components/test/testassets/BlazorAotFeatures/BlazorServerAotSample/Program.cs
var builder = WebApplication.CreateSlimBuilder(args);

// Slim hosting omits static-web-assets manifest loading; Blazor Server still needs blazor.web.js.
builder.WebHost.UseStaticWebAssets();

#if E2E_COMPILE_TEST_HARNESS
// Use the shared source-generated harness. No old xUnit or custom NativeTesting plumbing remains.
builder.Services.AddE2ETestHarness();
#endif

[UnconditionalSuppressMessage("Trimming", "IL2026",
    Justification = "Every path this application exercises is covered by the descriptors in " +
        "SampleMetadata, which replace the reflection fallbacks these gates warn about.")]
static void AddInteractiveServerBlazor(IServiceCollection services)
{
    services.AddComponentMetadata<SampleMetadata>();
    services.AddRazorComponents()
        .AddInteractiveServerComponents(options =>
        {
            options.RootComponents.RegisterForJavaScript<AotDynamicRoot>("aot-dynamic-root");
        });
}
```

The only excluded behavior class is the unsupported HTTP form mapper. The target is doubly gated on strict mode and Native AOT, and the substitution has three exact deltas: `CanMap` returns `false`; `Map` and `CreateDeserializer` have no bodies. This makes the code unreachable in the proof image without suppressing a warning code or claiming form-mapping support.

```xml
<!-- src/Components/test/testassets/BlazorAotFeatures/BlazorServerAotSample/BlazorServerAotSample.csproj -->
<Target Name="AddStrictFormMappingSubstitutions"
        BeforeTargets="WriteIlcRspFileForCompilation"
        Condition="'$(BlazorAotStrictMode)' == 'true' and '$(PublishAot)' == 'true'">
  <ItemGroup>
    <IlcArg Include="--substitution:$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)BlazorServerAotSample.ILLink.Substitutions.xml'))" />
  </ItemGroup>
</Target>
```

```xml
<!-- src/Components/test/testassets/BlazorAotFeatures/BlazorServerAotSample/BlazorServerAotSample.ILLink.Substitutions.xml -->
<linker>
  <assembly fullname="Microsoft.AspNetCore.Components.Endpoints">
    <type fullname="Microsoft.AspNetCore.Components.Endpoints.HttpContextFormValueMapper">
      <!-- The strict matrix never requests form mapping, so capability discovery returns false. -->
      <method signature="System.Boolean CanMap(System.Type,System.String,System.String)"
              body="stub" value="false" />
      <!-- Dynamic mapping and generic deserializer construction cannot be reached afterward. -->
      <method signature="System.Void Map(Microsoft.AspNetCore.Components.Forms.Mapping.FormValueMappingContext)"
              body="remove" />
      <method signature="Microsoft.AspNetCore.Components.Endpoints.HttpContextFormValueMapper/FormValueSupplier CreateDeserializer(System.Type)"
              body="remove" />
    </type>
  </assembly>
</linker>
```

## Outcome

| Equivalence class | Result | What it proves |
|---|---:|---|
| Repository build | 0 warnings, 0 errors | The stacked change remains compatible with the complete managed/native build graph. |
| Affected unit and generator suites | 3,592 passed, 8 skipped | Runtime, provider, serialization, JSInterop, WebAssembly, and generator behavior remains intact. |
| Generator severity matrix | 116/116 passed under MSTest | Warning/error escalation survived the shared-harness migration. |
| JIT feature matrix | 22/22 passed | Existing scenarios still work with default compatibility behavior. |
| JIT fallback witness | 1/1 passed | Undescribed component, JS method, and JSON payload reflection remains enabled by default. |
| Strict Native AOT publish | 0 compiler/ILC warnings, 0 errors | Shared `E2ENativeAot` publishing removes all three supported reflection fallbacks without hiding warning codes. |
| Strict Native AOT MSTest matrix | 21/21 passed | Every generated-only browser scenario runs through the shared harness; only the intentional `JitDefault` witness is excluded. |