### PR TITLE
Improve HTTP header parser recovery performance

### DIFF
--- a/src/Http/Headers/src/BaseHeaderParser.cs
+++ b/src/Http/Headers/src/BaseHeaderParser.cs
@@ -57,6 +57,7 @@ internal abstract class BaseHeaderParser<T> : HttpHeaderParser<T>
 
         if (length == 0)
         {
+            parsedLength = current - startIndex;
             return false;
         }
 

--- a/src/Http/Headers/src/MediaTypeHeaderValue.cs
+++ b/src/Http/Headers/src/MediaTypeHeaderValue.cs
@@ -576,6 +576,11 @@ public class MediaTypeHeaderValue
             return 0;
         }
 
+        if (!mediaType.HasValue)
+        {
+            return mediaTypeLength;
+        }
+
         var current = startIndex + mediaTypeLength;
         current = current + HttpRuleParser.GetWhitespaceLength(input, current);
         MediaTypeHeaderValue? mediaTypeHeader;
@@ -622,7 +627,7 @@ public class MediaTypeHeaderValue
         // Parse the separator between type and subtype
         if ((current >= input.Length) || (input[current] != '/'))
         {
-            return 0;
+            return current - startIndex;
         }
         current++; // skip delimiter.
         current = current + HttpRuleParser.GetWhitespaceLength(input, current);
@@ -632,7 +637,7 @@ public class MediaTypeHeaderValue
 
         if (subtypeLength == 0)
         {
-            return 0;
+            return current - startIndex;
         }
 
         // If there is no whitespace between <type> and <subtype> in <type>/<subtype> get the media type using

--- a/src/Http/Headers/src/SetCookieHeaderValue.cs
+++ b/src/Http/Headers/src/SetCookieHeaderValue.cs
@@ -500,7 +500,7 @@ public class SetCookieHeaderValue
         // = (no spaces)
         if (!ReadEqualsSign(input, ref offset))
         {
-            return 0;
+            return offset - startIndex;
         }
 
         // value or "quoted value"

--- a/src/Http/Headers/src/StringWithQualityHeaderValue.cs
+++ b/src/Http/Headers/src/StringWithQualityHeaderValue.cs
@@ -218,7 +218,7 @@ public class StringWithQualityHeaderValue
         // If we found a ';' separator, it must be followed by a quality information
         if (!TryReadQuality(input, result, ref current))
         {
-            return 0;
+            return current - startIndex;
         }
 
         parsedValue = result;

--- a/src/Http/Headers/test/EntityTagHeaderValueTest.cs
+++ b/src/Http/Headers/test/EntityTagHeaderValueTest.cs
@@ -509,6 +509,21 @@ public class EntityTagHeaderValueTest
         Assert.Equal(1, parser.GetParsedValueLengthCallCount);
     }
 
+    [Theory]
+    [InlineData(16)]
+    [InlineData(256)]
+    [InlineData(4096)]
+    public void TryParseValues_PathologicalSeparatorsSkipPreviouslyScannedInput(int separatorCount)
+    {
+        var parser = new CountingEntityTagParser(supportsMultipleValues: true);
+        var input = $"{new string(',', separatorCount)}@, \"tag\"";
+
+        Assert.True(parser.PublicTryParseValues(new[] { input }, out var results));
+
+        Assert.Equal(3, parser.GetParsedValueLengthCallCount);
+        Assert.Equal(new[] { new EntityTagHeaderValue("\"tag\"") }, results);
+    }
+
     private sealed class CountingEntityTagParser : BaseHeaderParser<EntityTagHeaderValue>
     {
         public CountingEntityTagParser(bool supportsMultipleValues) : base(supportsMultipleValues) { }

--- a/src/Http/Headers/test/MediaTypeHeaderValueTest.cs
+++ b/src/Http/Headers/test/MediaTypeHeaderValueTest.cs
@@ -632,6 +632,32 @@ public class MediaTypeHeaderValueTest
         Assert.Equal(expectedResults, results);
     }
 
+    [Theory]
+    [InlineData(16)]
+    [InlineData(256)]
+    [InlineData(4096)]
+    public void ParseList_TokenWithoutSlashRecoversFollowingValue(int tokenLength)
+    {
+        var input = $"{new string('a', tokenLength)}, text/plain";
+
+        var result = MediaTypeHeaderValue.ParseList(new[] { input });
+
+        Assert.Equal(new[] { new MediaTypeHeaderValue("text/plain") }, result);
+    }
+
+    [Theory]
+    [InlineData(16, "")]
+    [InlineData(256, " ")]
+    [InlineData(4096, "   ")]
+    public void ParseList_MissingSubtypeRecoversFollowingValue(int tokenLength, string whitespace)
+    {
+        var input = $"{new string('a', tokenLength)}/{whitespace}, text/plain";
+
+        var result = MediaTypeHeaderValue.ParseList(new[] { input });
+
+        Assert.Equal(new[] { new MediaTypeHeaderValue("text/plain") }, result);
+    }
+
     [Fact]
     public void ParseStrictList_WithSomeInvalidValues_Throws()
     {

--- a/src/Http/Headers/test/SetCookieHeaderValueTest.cs
+++ b/src/Http/Headers/test/SetCookieHeaderValueTest.cs
@@ -464,6 +464,19 @@ public class SetCookieHeaderValueTest
     }
 
     [Theory]
+    [InlineData(16)]
+    [InlineData(256)]
+    [InlineData(4096)]
+    public void SetCookieHeaderValue_ParseList_NameWithoutEqualsRecoversFollowingValue(int nameLength)
+    {
+        var input = $"{new string('a', nameLength)}, valid=value";
+
+        var result = SetCookieHeaderValue.ParseList(new[] { input });
+
+        Assert.Equal(new[] { new SetCookieHeaderValue("valid", "value") }, result);
+    }
+
+    [Theory]
     [MemberData(nameof(ListWithInvalidSetCookieHeaderDataSet))]
     public void SetCookieHeaderValue_ParseStrictList_ThrowsForAnyInvalidValues(
 #pragma warning disable xUnit1026 // Theory methods should use all of their parameters

--- a/src/Http/Headers/test/StringWithQualityHeaderValueTest.cs
+++ b/src/Http/Headers/test/StringWithQualityHeaderValueTest.cs
@@ -384,6 +384,19 @@ public class StringWithQualityHeaderValueTest
         Assert.Equal(expectedResults, results);
     }
 
+    [Theory]
+    [InlineData(16)]
+    [InlineData(256)]
+    [InlineData(4096)]
+    public void ParseList_InvalidQualitySuffixRecoversFollowingValue(int tokenLength)
+    {
+        var input = $"{new string('a', tokenLength)};, valid;q=0.5";
+
+        var result = StringWithQualityHeaderValue.ParseList(new[] { input });
+
+        Assert.Equal(new[] { new StringWithQualityHeaderValue("valid", 0.5) }, result);
+    }
+
     [Fact]
     public void ParseStrictList_WithSomeInvalidValues_Throws()
     {

--- a/src/Http/Http/perf/Microbenchmarks/HeaderParserListBenchmarks.cs
+++ b/src/Http/Http/perf/Microbenchmarks/HeaderParserListBenchmarks.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.Net.Http.Headers;
+
+namespace Microsoft.AspNetCore.Http;
+
+public class HeaderParserListBenchmarks
+{
+    private string[] _entityTagValues = null!;
+    private string[] _mediaTypeMissingSlashValues = null!;
+    private string[] _mediaTypeMissingSubtypeValues = null!;
+    private string[] _setCookieValues = null!;
+    private string[] _stringWithQualityValues = null!;
+
+    [Params(16, 256, 4096, 32768)]
+    public int Length { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _entityTagValues = [new string(',', Length - 1) + "@"];
+        _mediaTypeMissingSlashValues = [new string('a', Length)];
+        _mediaTypeMissingSubtypeValues = [new string('a', Length - 1) + "/"];
+        _setCookieValues = [new string('a', Length)];
+        _stringWithQualityValues = [new string('a', Length - 1) + ";"];
+    }
+
+    [Benchmark]
+    public int EntityTagSeparators()
+    {
+        return EntityTagHeaderValue.ParseList(_entityTagValues).Count;
+    }
+
+    [Benchmark]
+    public int MediaTypeMissingSlash()
+    {
+        return MediaTypeHeaderValue.ParseList(_mediaTypeMissingSlashValues).Count;
+    }
+
+    [Benchmark]
+    public int MediaTypeMissingSubtype()
+    {
+        return MediaTypeHeaderValue.ParseList(_mediaTypeMissingSubtypeValues).Count;
+    }
+
+    [Benchmark]
+    public int SetCookieMissingEquals()
+    {
+        return SetCookieHeaderValue.ParseList(_setCookieValues).Count;
+    }
+
+    [Benchmark]
+    public int StringWithQualityInvalidSuffix()
+    {
+        return StringWithQualityHeaderValue.ParseList(_stringWithQualityValues).Count;
+    }
+}


### PR DESCRIPTION
Fixes #68305

## Summary

- report consumed malformed spans from additional HTTP header parser failure paths
- preserve forgiving-list recovery of subsequent valid values
- add regression coverage for shared separators, media types, Set-Cookie, and quality values
- add BenchmarkDotNet coverage through 32,768-character inputs

## Validation

- `dotnet test .\src\Http\Headers\test\Microsoft.Net.Http.Headers.Tests.csproj -c Release --no-restore`
- `dotnet build .\src\Http\Http\perf\Microbenchmarks\Microsoft.AspNetCore.Http.Microbenchmarks.csproj -c Release --no-restore -p:UseIisNativeAssets=false`
- BenchmarkDotNet validation for `HeaderParserListBenchmarks`