### PR TITLE
[Blazor] Support Aspire Dashboard on Native AOT

### DIFF
--- a/AspNetCore.slnx
+++ b/AspNetCore.slnx
@@ -117,6 +117,8 @@
     <Project Path="src/Components/Testing/src/Microsoft.AspNetCore.Components.Testing.csproj" />
     <Project Path="src/Components/Testing/tasks/Microsoft.AspNetCore.Components.Testing.Tasks.csproj" />
     <Project Path="src/Components/Testing/test/Microsoft.AspNetCore.Components.Testing.Tests.csproj" />
+    <Project Path="src/Components/Testing/testassets/NativeAotTestApp.E2E.Tests/NativeAotTestApp.E2E.Tests.csproj" />
+    <Project Path="src/Components/Testing/testassets/NativeAotTestApp/NativeAotTestApp.csproj" />
     <Project Path="src/Components/Testing/testassets/TestApp.Client/TestApp.Client.csproj" />
     <Project Path="src/Components/Testing/testassets/TestApp.E2E.Tests/TestApp.E2E.Tests.csproj" />
     <Project Path="src/Components/Testing/testassets/TestApp/TestApp.csproj" />

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -33,6 +33,7 @@
                "
       Exclude="$(RepoRoot)src\Components\WebAssembly\testassets\WasmLinkerTest\*.*proj;
                $(RepoRoot)src\Components\WebView\Samples\PhotinoPlatform\testassets\PhotinoTestApp\*.*proj;
+               $(RepoRoot)src\Components\Testing\testassets\NativeAotTestApp.E2E.Tests\NativeAotTestApp.E2E.Tests.csproj;
                $(RepoRoot)src\Components\Testing\testassets\TestApp.E2E.Tests\TestApp.E2E.Tests.csproj;
                $(RepoRoot)src\Http\Routing\test\testassets\RoutingSandbox\*.*proj;
                $(RepoRoot)src\Security\Authentication\Negotiate\test\testassets\Negotiate.Client\*.*proj;

--- a/src/Components/Components/src/BindConverter.cs
+++ b/src/Components/Components/src/BindConverter.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Components.HotReload;
@@ -1651,6 +1652,55 @@ public static class BindConverter
         return true;
     }
 
+    internal static bool ConvertToEnumDynamicCodeSafe<T>(
+        object? obj,
+        CultureInfo? _,
+        [MaybeNullWhen(false)] out T value)
+    {
+        var text = (string?)obj;
+        if (string.IsNullOrEmpty(text))
+        {
+            value = default!;
+            return true;
+        }
+
+        if (!Enum.TryParse(typeof(T), text, out var converted)
+            || converted is null
+            || !Enum.IsDefined(typeof(T), converted))
+        {
+            value = default;
+            return false;
+        }
+
+        value = (T)converted;
+        return true;
+    }
+
+    internal static bool ConvertToNullableEnumDynamicCodeSafe<T>(
+        object? obj,
+        CultureInfo? _,
+        [MaybeNullWhen(false)] out T value)
+    {
+        var text = (string?)obj;
+        if (string.IsNullOrEmpty(text))
+        {
+            value = default!;
+            return true;
+        }
+
+        var underlyingType = Nullable.GetUnderlyingType(typeof(T))!;
+        if (!Enum.TryParse(underlyingType, text, out var converted)
+            || converted is null
+            || !Enum.IsDefined(underlyingType, converted))
+        {
+            value = default;
+            return false;
+        }
+
+        value = (T)converted;
+        return true;
+    }
+
     /// <summary>
     /// Attempts to convert a value to a value of type <typeparamref name="T"/>.
     /// </summary>
@@ -1997,15 +2047,29 @@ public static class BindConverter
                 }
                 else if (typeof(T).IsEnum)
                 {
-                    // We have to deal invoke this dynamically to work around the type constraint on Enum.TryParse.
-                    var method = _convertToEnum ??= typeof(BindConverter).GetMethod(nameof(ConvertToEnum), BindingFlags.NonPublic | BindingFlags.Static)!;
-                    parser = method.MakeGenericMethod(typeof(T)).CreateDelegate(typeof(BindParser<T>), target: null);
+                    if (RuntimeFeature.IsDynamicCodeSupported)
+                    {
+                        // We have to deal invoke this dynamically to work around the type constraint on Enum.TryParse.
+                        var method = _convertToEnum ??= typeof(BindConverter).GetMethod(nameof(ConvertToEnum), BindingFlags.NonPublic | BindingFlags.Static)!;
+                        parser = method.MakeGenericMethod(typeof(T)).CreateDelegate(typeof(BindParser<T>), target: null);
+                    }
+                    else
+                    {
+                        parser = (BindParser<T>)ConvertToEnumDynamicCodeSafe<T>;
+                    }
                 }
                 else if (Nullable.GetUnderlyingType(typeof(T)) is Type innerType && innerType.IsEnum)
                 {
-                    // We have to deal invoke this dynamically to work around the type constraint on Enum.TryParse.
-                    var method = _convertToNullableEnum ??= typeof(BindConverter).GetMethod(nameof(ConvertToNullableEnum), BindingFlags.NonPublic | BindingFlags.Static)!;
-                    parser = method.MakeGenericMethod(innerType).CreateDelegate(typeof(BindParser<T>), target: null);
+                    if (RuntimeFeature.IsDynamicCodeSupported)
+                    {
+                        // We have to deal invoke this dynamically to work around the type constraint on Enum.TryParse.
+                        var method = _convertToNullableEnum ??= typeof(BindConverter).GetMethod(nameof(ConvertToNullableEnum), BindingFlags.NonPublic | BindingFlags.Static)!;
+                        parser = method.MakeGenericMethod(innerType).CreateDelegate(typeof(BindParser<T>), target: null);
+                    }
+                    else
+                    {
+                        parser = (BindParser<T>)ConvertToNullableEnumDynamicCodeSafe<T>;
+                    }
                 }
                 else if (typeof(T).IsArray)
                 {

--- a/src/Components/Components/src/PersistentState/PersistentServicesRegistry.cs
+++ b/src/Components/Components/src/PersistentState/PersistentServicesRegistry.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Components.HotReload;
 using Microsoft.AspNetCore.Components.Reflection;
 using Microsoft.AspNetCore.Internal;
@@ -15,7 +17,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Components.Infrastructure;
 
-internal sealed class PersistentServicesRegistry
+internal sealed partial class PersistentServicesRegistry
 {
     private static readonly string _registryKey = typeof(PersistentServicesRegistry).FullName!;
     private static readonly RootTypeCache _persistentServiceTypeCache = new();
@@ -88,7 +90,21 @@ internal sealed class PersistentServicesRegistry
             subscriptions.Add((
                 state.RegisterOnPersisting(() =>
                 {
-                    state.PersistAsJson(_registryKey, _registrations);
+                    var registrations = new PersistentServiceRegistration[_registrations.Length];
+                    for (var i = 0; i < _registrations.Length; i++)
+                    {
+                        registrations[i] = new PersistentServiceRegistration
+                        {
+                            Assembly = _registrations[i].Assembly,
+                            FullTypeName = _registrations[i].FullTypeName,
+                        };
+                    }
+
+                    state.PersistAsBytes(
+                        _registryKey,
+                        JsonSerializer.SerializeToUtf8Bytes(
+                            registrations,
+                            PersistentServicesRegistryJsonContext.Default.PersistentServiceRegistrationArray));
                     return Task.CompletedTask;
                 }, RenderMode),
                 default));
@@ -115,10 +131,12 @@ internal sealed class PersistentServicesRegistry
     [UnconditionalSuppressMessage("Trimming",
         "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
         Justification = "Types registered for persistence are preserved in the API call to register them and typically live in assemblies that aren't trimmed.")]
-    [DynamicDependency(LinkerFlags.JsonSerialized, typeof(PersistentServiceRegistration))]
     private void UpdateRegistrations(PersistentComponentState state)
     {
-        if (state.TryTakeFromJson<PersistentServiceRegistration[]>(_registryKey, out var registry) && registry != null)
+        if (state.TryTakeBytes(_registryKey, out var data) &&
+            JsonSerializer.Deserialize(
+                data,
+                PersistentServicesRegistryJsonContext.Default.PersistentServiceRegistrationArray) is { } registry)
         {
             _registrations = ResolveRegistrations(_registrations.Concat(registry));
         }
@@ -251,4 +269,10 @@ internal sealed class PersistentServicesRegistry
 
         private string GetDebuggerDisplay() => $"{Assembly}::{FullTypeName}";
     }
+
+    [JsonSourceGenerationOptions(
+        PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true)]
+    [JsonSerializable(typeof(PersistentServiceRegistration[]))]
+    private sealed partial class PersistentServicesRegistryJsonContext : JsonSerializerContext;
 }

--- a/src/Components/Components/test/BindConverterTest.cs
+++ b/src/Components/Components/test/BindConverterTest.cs
@@ -369,6 +369,65 @@ public class BindConverterTest
         Assert.Null(actual);
     }
 
+    [Theory]
+    [InlineData("A")]
+    [InlineData("Q")]
+    public void ConvertToEnumDynamicCodeSafe_ParsesDefinedValues(string text)
+    {
+        var success = BindConverter.ConvertToEnumDynamicCodeSafe<SomeLetters>(
+            text,
+            CultureInfo.InvariantCulture,
+            out var actual);
+
+        Assert.True(success);
+        Assert.Equal(Enum.Parse<SomeLetters>(text), actual);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("Z")]
+    [InlineData("42")]
+    public void ConvertToEnumDynamicCodeSafe_MatchesDynamicCodePath(string text)
+    {
+        var expectedSuccess = BindConverter.TryConvertTo<SomeLetters>(
+            text,
+            CultureInfo.InvariantCulture,
+            out var expected);
+        var actualSuccess = BindConverter.ConvertToEnumDynamicCodeSafe<SomeLetters>(
+            text,
+            CultureInfo.InvariantCulture,
+            out var actual);
+
+        Assert.Equal(expectedSuccess, actualSuccess);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ConvertToNullableEnumDynamicCodeSafe_ParsesDefinedValue()
+    {
+        var success = BindConverter.ConvertToNullableEnumDynamicCodeSafe<SomeLetters?>(
+            "C",
+            CultureInfo.InvariantCulture,
+            out var actual);
+
+        Assert.True(success);
+        Assert.Equal(SomeLetters.C, actual);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("Z")]
+    public void ConvertToNullableEnumDynamicCodeSafe_HandlesEmptyAndInvalidValues(string text)
+    {
+        var success = BindConverter.ConvertToNullableEnumDynamicCodeSafe<SomeLetters?>(
+            text,
+            CultureInfo.InvariantCulture,
+            out var actual);
+
+        Assert.Equal(text.Length == 0, success);
+        Assert.Null(actual);
+    }
+
     private enum SomeLetters
     {
         A,

--- a/src/Components/Components/test/PersistentState/PersistentServicesRegistryTest.cs
+++ b/src/Components/Components/test/PersistentState/PersistentServicesRegistryTest.cs
@@ -651,6 +651,59 @@ public class PersistentServicesRegistryTest
 
         public IComponentRenderMode GetRenderModeOrDefault() => null;
     }
+
+    [Fact]
+    public async Task PersistStateAsync_PersistsAndRestoresEmptyServiceRegistry()
+    {
+        var componentRenderMode = new TestRenderMode();
+        var persistenceManager = new ComponentStatePersistenceManager(
+            NullLogger<ComponentStatePersistenceManager>.Instance,
+            new ServiceCollection().BuildServiceProvider());
+        persistenceManager.SetPlatformRenderMode(componentRenderMode);
+        var testStore = new TestStore(new Dictionary<string, byte[]>());
+
+        await persistenceManager.RestoreStateAsync(
+            new TestStore(new Dictionary<string, byte[]>()),
+            RestoreContext.InitialValue);
+
+        await persistenceManager.PersistStateAsync(testStore, new TestRenderer());
+
+        var persistedRegistry = Assert.Single(testStore.State);
+        Assert.Equal(typeof(PersistentServicesRegistry).FullName, persistedRegistry.Key);
+        Assert.Equal("[]", System.Text.Encoding.UTF8.GetString(persistedRegistry.Value));
+
+        var restoringManager = new ComponentStatePersistenceManager(
+            NullLogger<ComponentStatePersistenceManager>.Instance,
+            new ServiceCollection().BuildServiceProvider());
+
+        await restoringManager.RestoreStateAsync(testStore, RestoreContext.InitialValue);
+
+        var restoredRegistry = Assert.IsType<PersistentServicesRegistry>(restoringManager.ServicesRegistry);
+        Assert.Empty(restoredRegistry.Registrations);
+        Assert.Empty(testStore.State);
+    }
+
+    [Fact]
+    public async Task RestoreStateAsync_RestoresPreviousRegistryWireFormat()
+    {
+        var assembly = typeof(TestService).Assembly.GetName().Name;
+        var fullTypeName = typeof(TestService).FullName;
+        var state = new Dictionary<string, byte[]>
+        {
+            [typeof(PersistentServicesRegistry).FullName] =
+                System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(new[] { new { assembly, fullTypeName } }),
+        };
+        var persistenceManager = new ComponentStatePersistenceManager(
+            NullLogger<ComponentStatePersistenceManager>.Instance,
+            new ServiceCollection().AddScoped<TestService>().BuildServiceProvider());
+
+        await persistenceManager.RestoreStateAsync(new TestStore(state), RestoreContext.InitialValue);
+
+        var registry = Assert.IsType<PersistentServicesRegistry>(persistenceManager.ServicesRegistry);
+        var registration = Assert.Single(registry.Registrations);
+        Assert.Equal(assembly, registration.Assembly);
+        Assert.Equal(fullTypeName, registration.FullTypeName);
+    }
 }
 
 static file class ComponentStatePersistenceManagerExtensions

--- a/src/Components/Forms/src/FieldIdentifier.cs
+++ b/src/Components/Forms/src/FieldIdentifier.cs
@@ -135,6 +135,9 @@ public readonly struct FieldIdentifier : IEquatable<FieldIdentifier>
                     case MemberExpression member when member.Expression is ConstantExpression:
                         model = GetModelFromMemberAccess(member);
                         break;
+                    case not null when !RuntimeFeature.IsDynamicCodeSupported:
+                        model = GetModelFromExpression(memberExpression.Expression);
+                        break;
                     case not null:
                         // It would be great to cache this somehow, but it's unclear there's a reasonable way to do
                         // so, given that it embeds captured values such as "this". We could consider special-casing
@@ -175,6 +178,11 @@ public readonly struct FieldIdentifier : IEquatable<FieldIdentifier>
         {
             case ConstantExpression model:
                 value = model.Value ?? throw new ArgumentException("The provided expression must evaluate to a non-null value.");
+                if (!RuntimeFeature.IsDynamicCodeSupported)
+                {
+                    return GetMemberValue(value, member.Member) ??
+                        throw new ArgumentException("The provided expression must evaluate to a non-null value.");
+                }
                 accessor = cache.GetOrAdd((value.GetType(), member.Member), CreateAccessor);
                 break;
             default:
@@ -214,6 +222,11 @@ public readonly struct FieldIdentifier : IEquatable<FieldIdentifier>
 
     private static object GetModelFromIndexer(Expression methodCallExpression)
     {
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            return GetModelFromExpression(methodCallExpression);
+        }
+
         object model;
         var methodCallObjectLambda = Expression.Lambda(typeof(Func<object?>), methodCallExpression!);
         var methodCallObjectLambdaCompiled = (Func<object?>)methodCallObjectLambda.Compile();
@@ -225,6 +238,67 @@ public readonly struct FieldIdentifier : IEquatable<FieldIdentifier>
         model = result;
         return model;
     }
+
+    private static object GetModelFromExpression(Expression expression)
+    {
+        object? value = expression switch
+        {
+            ConstantExpression constant => constant.Value,
+            MemberExpression member => GetMemberValue(
+                member.Expression is null ? null : GetModelFromExpression(member.Expression),
+                member.Member),
+            MethodCallExpression methodCall when ExpressionFormatter.IsSingleArgumentIndexer(methodCall) =>
+                methodCall.Method.Invoke(
+                    GetModelFromExpression(methodCall.Object!),
+                    [GetModelFromExpression(methodCall.Arguments[0])]),
+            BinaryExpression { NodeType: ExpressionType.ArrayIndex } arrayIndex =>
+                ((Array)GetModelFromExpression(arrayIndex.Left)).GetValue(
+                    (int)GetModelFromExpression(arrayIndex.Right)),
+            UnaryExpression
+            {
+                NodeType: ExpressionType.Convert or
+                    ExpressionType.ConvertChecked or
+                    ExpressionType.TypeAs,
+            } unary => EvaluateConversion(unary),
+            _ => throw new ArgumentException(
+                $"The provided expression contains a {expression.GetType().Name} which is not supported. " +
+                $"{nameof(FieldIdentifier)} only supports simple member accessors (fields, properties) of an object."),
+        };
+
+        return value ?? throw new ArgumentException("The provided expression must evaluate to a non-null value.");
+    }
+
+    private static object? EvaluateConversion(UnaryExpression expression)
+    {
+        var value = GetModelFromExpression(expression.Operand);
+        if (expression.Method is not null)
+        {
+            return expression.Method.Invoke(null, [value]);
+        }
+
+        if (expression.NodeType == ExpressionType.TypeAs)
+        {
+            return expression.Type.IsInstanceOfType(value) ? value : null;
+        }
+
+        if (expression.Type.IsInstanceOfType(value) ||
+            Nullable.GetUnderlyingType(expression.Type)?.IsInstanceOfType(value) == true)
+        {
+            return value;
+        }
+
+        throw new InvalidCastException($"Unable to cast object of type '{value.GetType()}' to type '{expression.Type}'.");
+    }
+
+    private static object? GetMemberValue(object? target, MemberInfo member)
+        => member switch
+        {
+            PropertyInfo property => property.GetValue(target),
+            FieldInfo field => field.GetValue(target),
+            _ => throw new ArgumentException(
+                $"The provided expression contains a {member.GetType().Name} which is not supported. " +
+                $"{nameof(FieldIdentifier)} only supports simple member accessors (fields, properties) of an object."),
+        };
 
     private static void ClearCache()
     {

--- a/src/Components/Server/src/CircuitOptions.cs
+++ b/src/Components/Server/src/CircuitOptions.cs
@@ -107,10 +107,13 @@ public sealed class CircuitOptions
     public TimeSpan JSInteropDefaultCallTimeout { get; set; } = TimeSpan.FromMinutes(1);
 
     /// <summary>
-    /// Gets the JSON metadata resolvers used by JavaScript interop for application-owned payloads.
+    /// Gets the JSON metadata resolvers used for application-owned circuit payloads.
     /// </summary>
+    /// <remarks>
+    /// Resolvers are queried in registration order before the reflection-based fallback.
+    /// </remarks>
     [Experimental("ASPNETCORE9004", UrlFormat = "https://aka.ms/aspnet/analyzer/{0}")]
-    public IList<IJsonTypeInfoResolver> JSInteropTypeInfoResolvers { get; } = new List<IJsonTypeInfoResolver>();
+    public IList<IJsonTypeInfoResolver> JsonTypeInfoResolvers { get; } = new List<IJsonTypeInfoResolver>();
 
     /// <summary>
     /// Gets or sets the maximum number of render batches that a circuit will buffer until an acknowledgement for the batch is

--- a/src/Components/Server/src/CircuitOptions.cs
+++ b/src/Components/Server/src/CircuitOptions.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.Extensions.Caching.Hybrid;
 
 namespace Microsoft.AspNetCore.Components.Server;
@@ -103,6 +105,12 @@ public sealed class CircuitOptions
     /// Defaults to <c>1 minute</c>.
     /// </value>
     public TimeSpan JSInteropDefaultCallTimeout { get; set; } = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Gets the JSON metadata resolvers used by JavaScript interop for application-owned payloads.
+    /// </summary>
+    [Experimental("ASPNETCORE9004", UrlFormat = "https://aka.ms/aspnet/analyzer/{0}")]
+    public IList<IJsonTypeInfoResolver> JSInteropTypeInfoResolvers { get; } = new List<IJsonTypeInfoResolver>();
 
     /// <summary>
     /// Gets or sets the maximum number of render batches that a circuit will buffer until an acknowledgement for the batch is

--- a/src/Components/Server/src/Circuits/CircuitOptionsJavaScriptInitializersConfiguration.cs
+++ b/src/Components/Server/src/Circuits/CircuitOptionsJavaScriptInitializersConfiguration.cs
@@ -2,12 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Components.Server.Circuits;
 
-internal sealed class CircuitOptionsJavaScriptInitializersConfiguration : IConfigureOptions<CircuitOptions>
+internal sealed partial class CircuitOptionsJavaScriptInitializersConfiguration : IConfigureOptions<CircuitOptions>
 {
     private readonly IWebHostEnvironment _environment;
 
@@ -21,12 +22,19 @@ internal sealed class CircuitOptionsJavaScriptInitializersConfiguration : IConfi
         var file = _environment.WebRootFileProvider.GetFileInfo($"{_environment.ApplicationName}.modules.json");
         if (file.Exists)
         {
-            var initializers = JsonSerializer.Deserialize<string[]>(file.CreateReadStream());
-            for (var i = 0; i < initializers.Length; i++)
+            var initializers = JsonSerializer.Deserialize(
+                file.CreateReadStream(),
+                JavaScriptInitializersManifestJsonContext.Default.StringArray);
+            if (initializers is not null)
             {
-                var initializer = initializers[i];
-                options.JavaScriptInitializers.Add(initializer);
+                for (var i = 0; i < initializers.Length; i++)
+                {
+                    options.JavaScriptInitializers.Add(initializers[i]);
+                }
             }
         }
     }
+
+    [JsonSerializable(typeof(string[]))]
+    private sealed partial class JavaScriptInitializersManifestJsonContext : JsonSerializerContext;
 }

--- a/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
@@ -49,9 +49,9 @@ internal partial class RemoteJSRuntime : JSRuntime
         ElementReferenceContext = new WebElementReferenceContext(this);
         JsonSerializerOptions.Converters.Add(new ElementReferenceJsonConverter(ElementReferenceContext));
 #pragma warning disable ASPNETCORE9004 // The framework implements this experimental extension point.
-        for (var i = _options.JSInteropTypeInfoResolvers.Count - 1; i >= 0; i--)
+        for (var i = _options.JsonTypeInfoResolvers.Count - 1; i >= 0; i--)
         {
-            JsonSerializerOptions.TypeInfoResolverChain.Insert(0, _options.JSInteropTypeInfoResolvers[i]);
+            JsonSerializerOptions.TypeInfoResolverChain.Insert(0, _options.JsonTypeInfoResolvers[i]);
         }
 #pragma warning restore ASPNETCORE9004
     }

--- a/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
@@ -48,6 +48,12 @@ internal partial class RemoteJSRuntime : JSRuntime
         DefaultAsyncTimeout = _options.JSInteropDefaultCallTimeout;
         ElementReferenceContext = new WebElementReferenceContext(this);
         JsonSerializerOptions.Converters.Add(new ElementReferenceJsonConverter(ElementReferenceContext));
+#pragma warning disable ASPNETCORE9004 // The framework implements this experimental extension point.
+        for (var i = _options.JSInteropTypeInfoResolvers.Count - 1; i >= 0; i--)
+        {
+            JsonSerializerOptions.TypeInfoResolverChain.Insert(0, _options.JSInteropTypeInfoResolvers[i]);
+        }
+#pragma warning restore ASPNETCORE9004
     }
 
     public JsonSerializerOptions ReadJsonSerializerOptions() => JsonSerializerOptions;

--- a/src/Components/Server/src/Circuits/RemoteNavigationInterception.cs
+++ b/src/Components/Server/src/Circuits/RemoteNavigationInterception.cs
@@ -35,6 +35,6 @@ internal sealed class RemoteNavigationInterception : INavigationInterception
                 "attempted during prerendering or while the client is disconnected.");
         }
 
-        await _jsRuntime.InvokeAsync<object>(Interop.EnableNavigationInterception, WebRendererId.Server);
+        await _jsRuntime.InvokeAsync<object>(Interop.EnableNavigationInterception, (int)WebRendererId.Server);
     }
 }

--- a/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
+++ b/src/Components/Server/src/Circuits/RemoteNavigationManager.cs
@@ -206,7 +206,7 @@ internal sealed partial class RemoteNavigationManager : NavigationManager, IHost
     {
         try
         {
-            await _jsRuntime.InvokeVoidAsync(Interop.SetHasLocationChangingListeners, WebRendererId.Server, value);
+            await _jsRuntime.InvokeVoidAsync(Interop.SetHasLocationChangingListeners, (int)WebRendererId.Server, value);
         }
         catch (JSDisconnectedException)
         {

--- a/src/Components/Server/src/Circuits/ServerComponentDeserializer.cs
+++ b/src/Components/Server/src/Circuits/ServerComponentDeserializer.cs
@@ -93,7 +93,8 @@ internal sealed partial class ServerComponentDeserializer : IServerComponentDese
 
     public bool TryDeserializeComponentDescriptorCollection(string serializedComponentRecords, out List<ComponentDescriptor> descriptors)
     {
-        var markers = JsonSerializer.Deserialize<IEnumerable<ComponentMarker>>(serializedComponentRecords, ServerComponentSerializationSettings.JsonSerializationOptions);
+        var markersTypeInfo = ServerComponentSerializationSettings.JsonSerializationOptions.GetTypeInfo(typeof(IEnumerable<ComponentMarker>));
+        var markers = (IEnumerable<ComponentMarker>)JsonSerializer.Deserialize(serializedComponentRecords, markersTypeInfo)!;
         descriptors = new List<ComponentDescriptor>();
         int lastSequence = -1;
 
@@ -256,9 +257,8 @@ internal sealed partial class ServerComponentDeserializer : IServerComponentDese
 
         try
         {
-            result = JsonSerializer.Deserialize<ServerComponent>(
-                unprotected,
-                ServerComponentSerializationSettings.JsonSerializationOptions);
+            var typeInfo = ServerComponentSerializationSettings.JsonSerializationOptions.GetTypeInfo(typeof(ServerComponent));
+            result = (ServerComponent)JsonSerializer.Deserialize(unprotected, typeInfo)!;
             return true;
         }
         catch (Exception e)

--- a/src/Components/Server/src/Circuits/ServerComponentDeserializer.cs
+++ b/src/Components/Server/src/Circuits/ServerComponentDeserializer.cs
@@ -299,9 +299,8 @@ internal sealed partial class ServerComponentDeserializer : IServerComponentDese
         int[]? seenComponentIdsStorage = null;
         try
         {
-            result = JsonSerializer.Deserialize<RootComponentOperationBatch>(
-                serializedComponentOperations,
-                ServerComponentSerializationSettings.JsonSerializationOptions);
+            var typeInfo = ServerComponentSerializationSettings.JsonSerializationOptions.GetTypeInfo(typeof(RootComponentOperationBatch));
+            result = (RootComponentOperationBatch)JsonSerializer.Deserialize(serializedComponentOperations, typeInfo)!;
             var operations = result.Operations;
 
             Span<int> seenSsrComponentIds = operations.Length <= 128

--- a/src/Components/Server/src/Circuits/ServerComponentJsonContext.Server.cs
+++ b/src/Components/Server/src/Circuits/ServerComponentJsonContext.Server.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace Microsoft.AspNetCore.Components;
+
+[JsonSerializable(typeof(RootComponentOperationBatch))]
+[JsonSerializable(typeof(RootComponentOperation))]
+internal sealed partial class ServerComponentJsonContext;

--- a/src/Components/Server/src/DependencyInjection/ComponentServiceCollectionExtensions.cs
+++ b/src/Components/Server/src/DependencyInjection/ComponentServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Components.Server.BlazorPack;
 using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.SignalR.Protocol;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Internal;
@@ -39,8 +40,15 @@ public static class ComponentServiceCollectionExtensions
 
         services.AddDataProtection();
 
-        services.TryAddScoped<ProtectedLocalStorage>();
-        services.TryAddScoped<ProtectedSessionStorage>();
+        services.TryAddScoped<ProtectedBrowserStorageJsonSerializerOptions>();
+        services.TryAddScoped(static services => new ProtectedLocalStorage(
+            services.GetRequiredService<IJSRuntime>(),
+            services.GetRequiredService<IDataProtectionProvider>(),
+            services.GetRequiredService<ProtectedBrowserStorageJsonSerializerOptions>().Options));
+        services.TryAddScoped(static services => new ProtectedSessionStorage(
+            services.GetRequiredService<IJSRuntime>(),
+            services.GetRequiredService<IDataProtectionProvider>(),
+            services.GetRequiredService<ProtectedBrowserStorageJsonSerializerOptions>().Options));
 
         // This call INTENTIONALLY uses the AddHubOptions on the SignalR builder, because it will merge
         // the global HubOptions before running the configure callback. We want to ensure that happens

--- a/src/Components/Server/src/ProtectedBrowserStorage/ProtectedBrowserStorage.cs
+++ b/src/Components/Server/src/ProtectedBrowserStorage/ProtectedBrowserStorage.cs
@@ -16,6 +16,7 @@ public abstract class ProtectedBrowserStorage
     private readonly string _storeName;
     private readonly IJSRuntime _jsRuntime;
     private readonly IDataProtectionProvider _dataProtectionProvider;
+    private readonly JsonSerializerOptions _serializerOptions;
     private readonly ConcurrentDictionary<string, IDataProtector> _cachedDataProtectorsByPurpose
         = new ConcurrentDictionary<string, IDataProtector>(StringComparer.Ordinal);
 
@@ -26,6 +27,15 @@ public abstract class ProtectedBrowserStorage
     /// <param name="jsRuntime">The <see cref="IJSRuntime"/>.</param>
     /// <param name="dataProtectionProvider">The <see cref="IDataProtectionProvider"/>.</param>
     private protected ProtectedBrowserStorage(string storeName, IJSRuntime jsRuntime, IDataProtectionProvider dataProtectionProvider)
+        : this(storeName, jsRuntime, dataProtectionProvider, JsonSerializerOptionsProvider.Options)
+    {
+    }
+
+    internal ProtectedBrowserStorage(
+        string storeName,
+        IJSRuntime jsRuntime,
+        IDataProtectionProvider dataProtectionProvider,
+        JsonSerializerOptions serializerOptions)
     {
         // Performing data protection on the client would give users a false sense of security, so we'll prevent this.
         if (OperatingSystem.IsBrowser())
@@ -38,6 +48,7 @@ public abstract class ProtectedBrowserStorage
         _storeName = storeName;
         _jsRuntime = jsRuntime ?? throw new ArgumentNullException(nameof(jsRuntime));
         _dataProtectionProvider = dataProtectionProvider ?? throw new ArgumentNullException(nameof(dataProtectionProvider));
+        _serializerOptions = serializerOptions ?? throw new ArgumentNullException(nameof(serializerOptions));
     }
 
     /// <summary>
@@ -122,7 +133,8 @@ public abstract class ProtectedBrowserStorage
 
     private string Protect(string purpose, object value)
     {
-        var json = JsonSerializer.Serialize(value, options: JsonSerializerOptionsProvider.Options);
+        var typeInfo = _serializerOptions.GetTypeInfo(value?.GetType() ?? typeof(object));
+        var json = JsonSerializer.Serialize(value, typeInfo);
         var protector = GetOrCreateCachedProtector(purpose);
 
         return protector.Protect(json);
@@ -133,7 +145,8 @@ public abstract class ProtectedBrowserStorage
         var protector = GetOrCreateCachedProtector(purpose);
         var json = protector.Unprotect(protectedJson);
 
-        return JsonSerializer.Deserialize<TValue>(json, options: JsonSerializerOptionsProvider.Options)!;
+        var typeInfo = _serializerOptions.GetTypeInfo(typeof(TValue));
+        return (TValue)JsonSerializer.Deserialize(json, typeInfo)!;
     }
 
     private ValueTask SetProtectedJsonAsync(string key, string protectedJson)

--- a/src/Components/Server/src/ProtectedBrowserStorage/ProtectedBrowserStorageJsonSerializerOptions.cs
+++ b/src/Components/Server/src/ProtectedBrowserStorage/ProtectedBrowserStorageJsonSerializerOptions.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+
+internal sealed class ProtectedBrowserStorageJsonSerializerOptions
+{
+    public ProtectedBrowserStorageJsonSerializerOptions(IOptions<CircuitOptions> circuitOptions)
+    {
+        Options = new JsonSerializerOptions(JsonSerializerOptionsProvider.Options);
+
+#pragma warning disable ASPNETCORE9004 // The framework implements this experimental extension point.
+        for (var i = circuitOptions.Value.JsonTypeInfoResolvers.Count - 1; i >= 0; i--)
+        {
+            Options.TypeInfoResolverChain.Insert(0, circuitOptions.Value.JsonTypeInfoResolvers[i]);
+        }
+#pragma warning restore ASPNETCORE9004
+    }
+
+    public JsonSerializerOptions Options { get; }
+}

--- a/src/Components/Server/src/ProtectedBrowserStorage/ProtectedLocalStorage.cs
+++ b/src/Components/Server/src/ProtectedBrowserStorage/ProtectedLocalStorage.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.JSInterop;
 
@@ -24,6 +25,14 @@ public sealed class ProtectedLocalStorage : ProtectedBrowserStorage
     /// <param name="dataProtectionProvider">The <see cref="IDataProtectionProvider"/>.</param>
     public ProtectedLocalStorage(IJSRuntime jsRuntime, IDataProtectionProvider dataProtectionProvider)
         : base("localStorage", jsRuntime, dataProtectionProvider)
+    {
+    }
+
+    internal ProtectedLocalStorage(
+        IJSRuntime jsRuntime,
+        IDataProtectionProvider dataProtectionProvider,
+        JsonSerializerOptions serializerOptions)
+        : base("localStorage", jsRuntime, dataProtectionProvider, serializerOptions)
     {
     }
 }

--- a/src/Components/Server/src/ProtectedBrowserStorage/ProtectedSessionStorage.cs
+++ b/src/Components/Server/src/ProtectedBrowserStorage/ProtectedSessionStorage.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.JSInterop;
 
@@ -24,6 +25,14 @@ public sealed class ProtectedSessionStorage : ProtectedBrowserStorage
     /// <param name="dataProtectionProvider">The <see cref="IDataProtectionProvider"/>.</param>
     public ProtectedSessionStorage(IJSRuntime jsRuntime, IDataProtectionProvider dataProtectionProvider)
         : base("sessionStorage", jsRuntime, dataProtectionProvider)
+    {
+    }
+
+    internal ProtectedSessionStorage(
+        IJSRuntime jsRuntime,
+        IDataProtectionProvider dataProtectionProvider,
+        JsonSerializerOptions serializerOptions)
+        : base("sessionStorage", jsRuntime, dataProtectionProvider, serializerOptions)
     {
     }
 }

--- a/src/Components/Server/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Server/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+Microsoft.AspNetCore.Components.Server.CircuitOptions.JSInteropTypeInfoResolvers.get -> System.Collections.Generic.IList<System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver!>!
 Microsoft.AspNetCore.Components.Server.Circuits.Circuit.RequestCircuitPauseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
 Microsoft.AspNetCore.Components.Server.ServerComponentsEndpointOptions.ConfigureConnection.get -> System.Action<Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions!>?
 Microsoft.AspNetCore.Components.Server.ServerComponentsEndpointOptions.ConfigureConnection.set -> void

--- a/src/Components/Server/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Server/src/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 #nullable enable
-Microsoft.AspNetCore.Components.Server.CircuitOptions.JSInteropTypeInfoResolvers.get -> System.Collections.Generic.IList<System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver!>!
+Microsoft.AspNetCore.Components.Server.CircuitOptions.JsonTypeInfoResolvers.get -> System.Collections.Generic.IList<System.Text.Json.Serialization.Metadata.IJsonTypeInfoResolver!>!
 Microsoft.AspNetCore.Components.Server.Circuits.Circuit.RequestCircuitPauseAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<bool>!
 Microsoft.AspNetCore.Components.Server.ServerComponentsEndpointOptions.ConfigureConnection.get -> System.Action<Microsoft.AspNetCore.Http.Connections.HttpConnectionDispatcherOptions!>?
 Microsoft.AspNetCore.Components.Server.ServerComponentsEndpointOptions.ConfigureConnection.set -> void

--- a/src/Components/Server/test/Circuits/CircuitOptionsJavaScriptInitializersConfigurationTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitOptionsJavaScriptInitializersConfigurationTest.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Server.Circuits;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Moq;
+
+namespace Microsoft.AspNetCore.Components.Server.Tests.Circuits;
+
+public class CircuitOptionsJavaScriptInitializersConfigurationTest
+{
+    [Fact]
+    public void Configure_ReadsJavaScriptInitializersFromManifest()
+    {
+        var file = new Mock<IFileInfo>();
+        file.SetupGet(f => f.Exists).Returns(true);
+        file.Setup(f => f.CreateReadStream()).Returns(
+            () => new MemoryStream("""["./first.js","./second.js"]"""u8.ToArray()));
+
+        var fileProvider = new Mock<IFileProvider>();
+        fileProvider.Setup(p => p.GetFileInfo("TestApp.modules.json")).Returns(file.Object);
+
+        var environment = new Mock<IWebHostEnvironment>();
+        environment.SetupGet(e => e.ApplicationName).Returns("TestApp");
+        environment.SetupGet(e => e.WebRootFileProvider).Returns(fileProvider.Object);
+
+        var options = new CircuitOptions();
+        var configuration = new CircuitOptionsJavaScriptInitializersConfiguration(environment.Object);
+
+        configuration.Configure(options);
+
+        Assert.Equal(["./first.js", "./second.js"], options.JavaScriptInitializers);
+    }
+}

--- a/src/Components/Server/test/PrerenderComponentApplicationStoreTest.cs
+++ b/src/Components/Server/test/PrerenderComponentApplicationStoreTest.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+
+namespace Microsoft.AspNetCore.Components.Server.Tests;
+
+public class PrerenderComponentApplicationStoreTest
+{
+    [Fact]
+    public async Task PersistStateAsync_SerializesAndRestoresState()
+    {
+        var store = new PrerenderComponentApplicationStore();
+        var state = new Dictionary<string, byte[]>
+        {
+            ["first"] = [1, 2, 3],
+            ["second"] = Encoding.UTF8.GetBytes("value"),
+        };
+
+        await store.PersistStateAsync(state);
+
+        var persistedState = Assert.IsType<string>(store.PersistedState);
+        var restoredStore = new PrerenderComponentApplicationStore(persistedState);
+        var restoredState = await restoredStore.GetPersistedStateAsync();
+
+        Assert.Equal(state, restoredState);
+    }
+}

--- a/src/Components/Server/test/ProtectedBrowserStorageTest.cs
+++ b/src/Components/Server/test/ProtectedBrowserStorageTest.cs
@@ -4,6 +4,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.JSInterop;
@@ -142,6 +143,31 @@ public class ProtectedBrowserStorageTest
         var invocation = jsRuntime.Invocations.Single();
         Assert.Equal("testStore.getItem", invocation.Identifier);
         Assert.Collection(invocation.Args, arg => Assert.Equal(keyName, arg));
+    }
+
+    [Fact]
+    public async Task SourceGeneratedOptions_RoundTripParameterizedType()
+    {
+        var jsRuntime = new TestJSRuntime
+        {
+            NextInvocationResult = new ValueTask<IJSVoidResult>(Mock.Of<IJSVoidResult>()),
+        };
+        var dataProtectionProvider = new TestDataProtectionProvider();
+        var options = new JsonSerializerOptions
+        {
+            TypeInfoResolver = ProtectedBrowserStorageTestJsonContext.Default,
+        };
+        var storage = new TestProtectedBrowserStorage("testStore", jsRuntime, dataProtectionProvider, options);
+
+        await storage.SetAsync("testKey", new ParameterizedTestModel(42));
+        var protectedJson = Assert.IsType<string>(jsRuntime.Invocations.Single().Args[1]);
+        jsRuntime.Invocations.Clear();
+        jsRuntime.NextInvocationResult = new ValueTask<string>(protectedJson);
+
+        var result = await storage.GetAsync<ParameterizedTestModel>("testKey");
+
+        Assert.True(result.Success);
+        Assert.Equal(42, result.Value.Value);
     }
 
     [Fact]
@@ -408,5 +434,27 @@ public class ProtectedBrowserStorageTest
             : base(storeName, jsRuntime, dataProtectionProvider)
         {
         }
+
+        public TestProtectedBrowserStorage(
+            string storeName,
+            IJSRuntime jsRuntime,
+            IDataProtectionProvider dataProtectionProvider,
+            JsonSerializerOptions serializerOptions)
+            : base(storeName, jsRuntime, dataProtectionProvider, serializerOptions)
+        {
+        }
     }
 }
+
+internal sealed class ParameterizedTestModel
+{
+    public ParameterizedTestModel(int value)
+    {
+        Value = value;
+    }
+
+    public int Value { get; }
+}
+
+[JsonSerializable(typeof(ParameterizedTestModel))]
+internal sealed partial class ProtectedBrowserStorageTestJsonContext : JsonSerializerContext;

--- a/src/Components/Shared/src/ExpressionFormatting/ExpressionFormatter.cs
+++ b/src/Components/Shared/src/ExpressionFormatting/ExpressionFormatter.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using Microsoft.AspNetCore.Components.HotReload;
 
@@ -252,22 +253,22 @@ internal static class ExpressionFormatter
 
         if (memberType == typeof(int))
         {
-            var func = CompileMemberEvaluator<int>(memberExpression);
+            var func = CreateMemberEvaluator<int>(memberExpression);
             return (object closure, ref ReverseStringBuilder builder) => builder.InsertFront(func.Invoke(closure));
         }
         else if (memberType == typeof(string))
         {
-            var func = CompileMemberEvaluator<string>(memberExpression);
+            var func = CreateMemberEvaluator<string>(memberExpression);
             return (object closure, ref ReverseStringBuilder builder) => builder.InsertFront(func.Invoke(closure));
         }
         else if (typeof(ISpanFormattable).IsAssignableFrom(memberType))
         {
-            var func = CompileMemberEvaluator<ISpanFormattable>(memberExpression);
+            var func = CreateMemberEvaluator<ISpanFormattable>(memberExpression);
             return (object closure, ref ReverseStringBuilder builder) => builder.InsertFront(func.Invoke(closure));
         }
         else if (typeof(IFormattable).IsAssignableFrom(memberType))
         {
-            var func = CompileMemberEvaluator<IFormattable>(memberExpression);
+            var func = CreateMemberEvaluator<IFormattable>(memberExpression);
             return (object closure, ref ReverseStringBuilder builder) => builder.InsertFront(func.Invoke(closure));
         }
         else
@@ -275,6 +276,26 @@ internal static class ExpressionFormatter
             throw new InvalidOperationException($"Cannot format an index argument of type '{memberType}'.");
         }
 
+        static Func<object, TResult> CreateMemberEvaluator<TResult>(MemberExpression memberExpression)
+        {
+            if (!RuntimeFeature.IsDynamicCodeSupported)
+            {
+                return memberExpression.Member switch
+                {
+                    PropertyInfo property => closure => (TResult)property.GetValue(closure)!,
+                    FieldInfo field => closure => (TResult)field.GetValue(closure)!,
+                    var member => throw new InvalidOperationException(
+                        $"Cannot read an index argument from a {member.GetType().Name}."),
+                };
+            }
+
+            return CompileMemberEvaluator<TResult>(memberExpression);
+        }
+
+        [UnconditionalSuppressMessage(
+            "AOT",
+            "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.",
+            Justification = "Guarded by RuntimeFeature.IsDynamicCodeSupported.")]
         static Func<object, TResult> CompileMemberEvaluator<TResult>(MemberExpression memberExpression)
         {
             var parameterExpression = Expression.Parameter(typeof(object));

--- a/src/Components/Shared/src/JsonSerializerOptionsProvider.cs
+++ b/src/Components/Shared/src/JsonSerializerOptionsProvider.cs
@@ -1,16 +1,34 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 
 namespace Microsoft.AspNetCore.Components;
 
 internal static class JsonSerializerOptionsProvider
 {
-    public static readonly JsonSerializerOptions Options = new()
+    public static readonly JsonSerializerOptions Options = CreateOptions();
+
+    private static JsonSerializerOptions CreateOptions()
     {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        PropertyNameCaseInsensitive = true,
-        IncludeFields = true,
-    };
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+            IncludeFields = true,
+        };
+
+        if (JsonSerializer.IsReflectionEnabledByDefault)
+        {
+            options.TypeInfoResolverChain.Add(CreateReflectionResolver());
+        }
+
+        return options;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Guarded by JsonSerializer.IsReflectionEnabledByDefault.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Guarded by JsonSerializer.IsReflectionEnabledByDefault.")]
+    private static DefaultJsonTypeInfoResolver CreateReflectionResolver() => new();
 }

--- a/src/Components/Testing/testassets/NativeAotTestApp.E2E.Tests/Fixtures/E2ETestAssembly.cs
+++ b/src/Components/Testing/testassets/NativeAotTestApp.E2E.Tests/Fixtures/E2ETestAssembly.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace NativeAotTestApp.E2E.Tests.Fixtures;
+
+public class E2ETestAssembly;

--- a/src/Components/Testing/testassets/NativeAotTestApp.E2E.Tests/Fixtures/TestRoot.cs
+++ b/src/Components/Testing/testassets/NativeAotTestApp.E2E.Tests/Fixtures/TestRoot.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Testing.Infrastructure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace NativeAotTestApp.E2E.Tests.Fixtures;
+
+[TestClass]
+public static class TestRoot
+{
+    public static ServerFactory<E2ETestAssembly> Servers { get; private set; } = null!;
+
+    [AssemblyInitialize]
+    public static async Task Init(TestContext _)
+    {
+        Servers = new ServerFactory<E2ETestAssembly>();
+        await Servers.InitializeAsync();
+    }
+
+    [AssemblyCleanup]
+    public static Task Cleanup() => Servers.DisposeAsync().AsTask();
+}

--- a/src/Components/Testing/testassets/NativeAotTestApp.E2E.Tests/NativeAotTestApp.E2E.Tests.csproj
+++ b/src/Components/Testing/testassets/NativeAotTestApp.E2E.Tests/NativeAotTestApp.E2E.Tests.csproj
@@ -6,8 +6,6 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
-    <RuntimeIdentifier>$(TargetRuntimeIdentifier)</RuntimeIdentifier>
-    <SelfContained>true</SelfContained>
     <EnableMSTestRunner>true</EnableMSTestRunner>
     <TestRunnerName>Microsoft.Testing.Platform</TestRunnerName>
     <TestCaptureOutput>false</TestCaptureOutput>
@@ -46,6 +44,15 @@
 
   <Import Project="../../eng/targets/Microsoft.AspNetCore.Components.Testing.targets"
           Condition="'$(_ImportComponentsTestingTargets)' == 'true'" />
+
+  <Target Name="_RestoreNativeAotTestApp"
+          BeforeTargets="PrepareE2EApps"
+          Condition="'$(_ImportComponentsTestingTargets)' == 'true'">
+    <MSBuild Projects="../NativeAotTestApp/NativeAotTestApp.csproj"
+             Targets="Restore"
+             Properties="Configuration=$(Configuration);E2ECompileTestHarness=true;RuntimeIdentifier=$(TargetRuntimeIdentifier);RestoreForce=true"
+             RemoveProperties="BuildProjectReferences;NoBuild" />
+  </Target>
 
   <Target Name="_PreparePublishedE2EApps"
           AfterTargets="Publish"

--- a/src/Components/Testing/testassets/NativeAotTestApp.E2E.Tests/NativeAotTestApp.E2E.Tests.csproj
+++ b/src/Components/Testing/testassets/NativeAotTestApp.E2E.Tests/NativeAotTestApp.E2E.Tests.csproj
@@ -1,0 +1,59 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../../eng/targets/Microsoft.AspNetCore.Components.Testing.props" />
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <RuntimeIdentifier>$(TargetRuntimeIdentifier)</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TestRunnerName>Microsoft.Testing.Platform</TestRunnerName>
+    <TestCaptureOutput>false</TestCaptureOutput>
+    <TestDependsOnPlaywright>true</TestDependsOnPlaywright>
+    <TestRunnerAdditionalArguments>--timeout 15m --maximum-failed-tests 25 --minimum-expected-tests 1</TestRunnerAdditionalArguments>
+    <IsPackable>false</IsPackable>
+    <DisablePackageReferenceRestrictions>true</DisablePackageReferenceRestrictions>
+    <NoWarn>$(NoWarn);NETSDK1023;MSTEST0001;NU1511</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="MSTest.TestFramework" />
+    <Reference Include="Microsoft.Testing.Extensions.TrxReport" />
+    <Reference Include="Microsoft.Playwright" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore.Components.Testing" />
+    <ProjectReference Include="../NativeAotTestApp/NativeAotTestApp.csproj">
+      <E2EApp>true</E2EApp>
+      <E2EAppMode>publish</E2EAppMode>
+      <E2ENativeAot>true</E2ENativeAot>
+      <E2ERuntimeIdentifier>$(TargetRuntimeIdentifier)</E2ERuntimeIdentifier>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../gen/Microsoft.AspNetCore.Components.Testing.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <Import Project="../../eng/targets/Microsoft.AspNetCore.Components.Testing.targets"
+          Condition="'$(_ImportComponentsTestingTargets)' == 'true'" />
+
+  <Target Name="_PreparePublishedE2EApps"
+          AfterTargets="Publish"
+          Condition="'$(_ImportComponentsTestingTargets)' == 'true'">
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="PrepareE2EApps"
+             Properties="_E2EIsPublishing=true;E2EAppMode=publish;PublishDir=$(PublishDir)"
+             RemoveProperties="NoBuild" />
+  </Target>
+
+</Project>

--- a/src/Components/Testing/testassets/NativeAotTestApp.E2E.Tests/NativeAotTestApp.E2E.Tests.csproj
+++ b/src/Components/Testing/testassets/NativeAotTestApp.E2E.Tests/NativeAotTestApp.E2E.Tests.csproj
@@ -50,7 +50,7 @@
           Condition="'$(_ImportComponentsTestingTargets)' == 'true'">
     <MSBuild Projects="../NativeAotTestApp/NativeAotTestApp.csproj"
              Targets="Restore"
-             Properties="Configuration=$(Configuration);E2ECompileTestHarness=true;RuntimeIdentifier=$(TargetRuntimeIdentifier);RestoreForce=true"
+             Properties="Configuration=$(Configuration);E2ECompileTestHarness=true;RestoreForce=true;AdditionalWarningsNotAsErrors=NU1510"
              RemoveProperties="BuildProjectReferences;NoBuild" />
   </Target>
 

--- a/src/Components/Testing/testassets/NativeAotTestApp.E2E.Tests/NativeAotTestApp.E2E.Tests.csproj
+++ b/src/Components/Testing/testassets/NativeAotTestApp.E2E.Tests/NativeAotTestApp.E2E.Tests.csproj
@@ -50,7 +50,7 @@
           Condition="'$(_ImportComponentsTestingTargets)' == 'true'">
     <MSBuild Projects="../NativeAotTestApp/NativeAotTestApp.csproj"
              Targets="Restore"
-             Properties="Configuration=$(Configuration);E2ECompileTestHarness=true;RestoreForce=true;AdditionalWarningsNotAsErrors=NU1510"
+             Properties="Configuration=$(Configuration);E2ECompileTestHarness=true;RestoreForce=true;RestoreRecursive=false"
              RemoveProperties="BuildProjectReferences;NoBuild" />
   </Target>
 

--- a/src/Components/Testing/testassets/NativeAotTestApp.E2E.Tests/Tests/NativeAotFeatureTests.cs
+++ b/src/Components/Testing/testassets/NativeAotTestApp.E2E.Tests/Tests/NativeAotFeatureTests.cs
@@ -1,0 +1,250 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Text;
+using Microsoft.AspNetCore.Components.Testing.Infrastructure;
+using Microsoft.AspNetCore.Components.Testing.Playwright;
+using Microsoft.Playwright;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NativeAotTestApp.Components;
+using NativeAotTestApp.E2E.Tests.Fixtures;
+
+namespace NativeAotTestApp.E2E.Tests.Tests;
+
+[UITest]
+public partial class NativeAotFeatureTests : BrowserTest
+{
+    private readonly ConcurrentQueue<string> _browserErrors = new();
+    private ServerInstance _server = null!;
+    private IPage _page = null!;
+
+    protected override async Task InitializeCoreAsync()
+    {
+        await base.InitializeCoreAsync();
+        _server = await StartServerAsync<App>(
+            TestRoot.Servers,
+            options =>
+            {
+                options.EnvironmentVariables["ASPNETCORE_DETAILEDERRORS"] = "true";
+                options.ReadinessTimeoutMs = 120_000;
+            });
+
+        var context = await NewContext(new BrowserNewContextOptions());
+        _page = await context.NewPageAsync();
+        _page.Console += (_, message) =>
+        {
+            if (message.Type == "error")
+            {
+                _browserErrors.Enqueue($"Console: {message.Text}");
+            }
+        };
+        _page.PageError += (_, message) => _browserErrors.Enqueue($"Page: {message}");
+        _page.WebSocket += (_, socket) =>
+            socket.SocketError += (_, message) => _browserErrors.Enqueue($"WebSocket: {message}");
+    }
+
+    [TestMethod]
+    public async Task InteractiveShell_RendersAndHandlesDynamicUi()
+    {
+        await GotoInteractiveAsync("/", "#menu-action");
+
+        await Expect(_page.Locator("#menu-panel h2")).ToHaveTextAsync("Resource menu");
+        await _page.Locator("#menu-action").ClickAsync();
+        await Expect(_page.Locator("#shell-result")).ToHaveTextAsync("menu:resources");
+
+        await _page.Locator("#dialog-tab").ClickAsync();
+        await Expect(_page.GetByRole(AriaRole.Dialog)).ToBeVisibleAsync();
+        await Expect(_page.Locator("#dialog-theme")).ToHaveTextAsync("native-theme");
+        await Expect(_page.Locator("#dialog-greeting")).ToHaveTextAsync("injected-greeting");
+        await _page.Locator("#dialog-value").FillAsync("restart");
+        await _page.Locator("#dialog-submit").ClickAsync();
+        await Expect(_page.Locator("#shell-result")).ToHaveTextAsync("dialog:restart");
+
+        await AssertHealthyAsync();
+    }
+
+    [TestMethod]
+    public async Task Forms_BindValidateAndSubmitDashboardInputMatrix()
+    {
+        await GotoInteractiveAsync("/forms", "form");
+
+        await _page.Locator("#form-submit").ClickAsync();
+        await Expect(_page.Locator(".validation-message")).ToContainTextAsync("required");
+        await Expect(_page.Locator("#form-result")).ToHaveTextAsync("(unsubmitted)");
+
+        await _page.Locator("#form-name").FillAsync("worker");
+        await _page.Locator("#form-count").FillAsync("12");
+        await _page.Locator("#form-enabled").CheckAsync();
+        await _page.Locator("#form-mode").SelectOptionAsync("Detailed");
+        await _page.Locator("#form-optional-mode").SelectOptionAsync("Compact");
+        await _page.Locator("#form-nested").FillAsync("west");
+        await _page.Locator("#form-list").FillAsync("resource-1");
+        await _page.Locator("#form-submit").ClickAsync();
+
+        await Expect(_page.Locator("#form-result"))
+            .ToHaveTextAsync("worker|12|True|Detailed|Compact|west|resource-1");
+        await AssertHealthyAsync();
+    }
+
+    [TestMethod]
+    public async Task JsInterop_ResolversAndCustomEventsRoundTrip()
+    {
+        await GotoInteractiveAsync("/interop", "#interop-run");
+
+        await _page.Locator("#interop-run").ClickAsync();
+
+        await Expect(_page.Locator("#interop-poco")).ToHaveTextAsync("counter:21|42");
+        await Expect(_page.Locator("#interop-dotnet")).ToHaveTextAsync("echo:dashboard");
+        await Expect(_page.Locator("#interop-element")).ToHaveTextAsync("interop-target");
+        await Expect(_page.Locator("#interop-wire")).ToHaveTextAsync("""{"someValue":"first"}""");
+        await Expect(_page.Locator("#interop-event")).ToHaveTextAsync("horizontal|0.4");
+        await AssertHealthyAsync();
+    }
+
+    [TestMethod]
+    public async Task ProtectedStorage_RestoresAcrossReload()
+    {
+        await GotoInteractiveAsync("/storage", "#storage-save");
+        var firstInstance = await _page.Locator("#storage-instance").TextContentAsync();
+
+        await _page.Locator("#storage-save").ClickAsync();
+        await Expect(_page.Locator("#storage-value")).ToHaveTextAsync("saved");
+        await Expect(_page.Locator("#storage-converter"))
+            .ToHaveTextAsync(new System.Text.RegularExpressions.Regex("[1-9][0-9]*\\|0"));
+
+        await _page.ReloadAsync();
+        await WaitForNativeCircuitAsync();
+
+        await Expect(_page.Locator("#storage-value")).ToHaveTextAsync("ada:36");
+        await Expect(_page.Locator("#storage-instance")).Not.ToHaveTextAsync(firstInstance!);
+        await Expect(_page.Locator("#storage-converter"))
+            .ToHaveTextAsync(new System.Text.RegularExpressions.Regex("[1-9][0-9]*\\|[1-9][0-9]*"));
+        await AssertHealthyAsync();
+    }
+
+    [TestMethod]
+    public async Task PersistentState_RestoresAcrossPrerender()
+    {
+        await _page.GotoAsync(_server.AppUrl + "/persistence");
+        var token = await _page.Locator("#persistence-token").TextContentAsync();
+        Assert.IsFalse(string.IsNullOrEmpty(token));
+
+        await WaitForNativeCircuitAsync();
+
+        await Expect(_page.Locator("#persistence-phase")).ToHaveTextAsync("circuit (restored)");
+        await Expect(_page.Locator("#persistence-token")).ToHaveTextAsync(token!);
+        await Expect(_page.Locator("#persistence-serializer"))
+            .ToHaveTextAsync(new System.Text.RegularExpressions.Regex("[1-9][0-9]*\\|[1-9][0-9]*"));
+        await AssertHealthyAsync();
+    }
+
+    [TestMethod]
+    public async Task Virtualize_ScrollsAndLoadsRows()
+    {
+        await GotoInteractiveAsync("/virtualization");
+
+        await Expect(_page.GetByText("row-0", new() { Exact = true })).ToBeVisibleAsync();
+        await Expect(_page.GetByText("row-400", new() { Exact = true })).ToHaveCountAsync(0);
+        await Expect(_page.Locator("#expression-created")).ToHaveTextAsync("1|1");
+        await Expect(_page.Locator("#expression-invoked")).ToHaveTextAsync("2|1");
+        await Expect(_page.Locator("#expression-value")).ToHaveTextAsync("10000");
+
+        await _page.Locator("#viewport").EvaluateAsync("element => element.scrollTop = 8000");
+
+        await Expect(_page.GetByText("row-400", new() { Exact = true }))
+            .ToBeVisibleAsync(new() { Timeout = 30_000 });
+        await AssertHealthyAsync();
+    }
+
+    [TestMethod]
+    public async Task InputFile_StreamsAndSubmitsFile()
+    {
+        await GotoInteractiveAsync("/file-upload", "form");
+        const string content = "native-aot-file";
+
+        await _page.Locator("#file-input").SetInputFilesAsync(new FilePayload
+        {
+            Name = "probe.txt",
+            MimeType = "text/plain",
+            Buffer = Encoding.UTF8.GetBytes(content),
+        });
+
+        await Expect(_page.Locator("#file-read"))
+            .ToHaveTextAsync($"probe.txt|{content}|{Encoding.UTF8.GetByteCount(content)}");
+        await _page.Locator("#file-submit").ClickAsync();
+        await Expect(_page.Locator("#file-result"))
+            .ToHaveTextAsync($"submitted:probe.txt:{content}:{Encoding.UTF8.GetByteCount(content)}");
+        await AssertHealthyAsync();
+    }
+
+    [TestMethod]
+    public async Task EnhancedNavigation_QueryAndHistoryRemainInteractive()
+    {
+        await GotoInteractiveAsync("/history?count=7&enabled=true", "#history-increment");
+
+        await Expect(_page.Locator("#history-count")).ToHaveTextAsync("7");
+        await Expect(_page.Locator("#history-enabled")).ToHaveTextAsync("True");
+        await _page.Locator("#history-increment").ClickAsync();
+        await Expect(_page.Locator("#history-clicks")).ToHaveTextAsync("1");
+
+        var nextNavigation = _page.WaitForEnhancedNavigationAsync();
+        await _page.Locator("#history-next").ClickAsync();
+        await nextNavigation;
+        await WaitForNativeCircuitAsync();
+        await _page.WaitForInteractiveAsync("#history-increment");
+        await Expect(_page.Locator("#history-count")).ToHaveTextAsync("11");
+        await Expect(_page.Locator("#history-enabled")).ToHaveTextAsync("False");
+        await _page.Locator("#history-increment").ClickAsync();
+        await Expect(_page.Locator("#history-clicks")).ToHaveTextAsync("2");
+
+        var backNavigation = _page.WaitForEnhancedNavigationAsync();
+        await _page.GoBackAsync();
+        await backNavigation;
+        await WaitForNativeCircuitAsync();
+        await _page.WaitForInteractiveAsync("#history-increment");
+        await Expect(_page.Locator("#history-count")).ToHaveTextAsync("7");
+        await _page.Locator("#history-increment").ClickAsync();
+        await Expect(_page.Locator("#history-clicks")).ToHaveTextAsync("3");
+
+        var forwardNavigation = _page.WaitForEnhancedNavigationAsync();
+        await _page.GoForwardAsync();
+        await forwardNavigation;
+        await WaitForNativeCircuitAsync();
+        await _page.WaitForInteractiveAsync("#history-increment");
+        await Expect(_page.Locator("#history-count")).ToHaveTextAsync("11");
+        await _page.Locator("#history-increment").ClickAsync();
+        await Expect(_page.Locator("#history-clicks")).ToHaveTextAsync("4");
+        await AssertHealthyAsync();
+    }
+
+    private async Task GotoInteractiveAsync(string path, string? interactiveSelector = null)
+    {
+        await _page.GotoAsync(_server.AppUrl + path);
+        await WaitForNativeCircuitAsync();
+
+        if (interactiveSelector is not null)
+        {
+            await _page.WaitForInteractiveAsync(interactiveSelector);
+        }
+    }
+
+    private async Task WaitForNativeCircuitAsync()
+    {
+        await _page.WaitForBlazorAsync();
+        await Expect(_page.Locator("#runtime-mode"))
+            .ToHaveAttributeAsync("data-dynamic-code-supported", "false");
+        await Expect(_page.Locator("#runtime-mode"))
+            .ToHaveAttributeAsync("data-circuit-attached", "true");
+    }
+
+    private async Task AssertHealthyAsync()
+    {
+        await Expect(_page.Locator("#blazor-error-ui")).ToBeHiddenAsync();
+        Assert.AreEqual(
+            0,
+            _browserErrors.Count,
+            string.Join(Environment.NewLine, _browserErrors));
+    }
+}

--- a/src/Components/Testing/testassets/NativeAotTestApp/Components/App.razor
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Components/App.razor
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" />
+    <HeadOutlet />
+</head>
+
+<body>
+    <Routes />
+    <div id="blazor-error-ui" style="display:none">An unhandled error has occurred.</div>
+    <script src="@Assets["_framework/blazor.web.js"]"></script>
+</body>
+
+</html>

--- a/src/Components/Testing/testassets/NativeAotTestApp/Components/EventHandlers.cs
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Components/EventHandlers.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using NativeAotTestApp.Models;
+
+namespace NativeAotTestApp.Components;
+
+[EventHandler("onsplitprobe", typeof(SplitEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
+public static class EventHandlers;

--- a/src/Components/Testing/testassets/NativeAotTestApp/Components/Layout/MainLayout.razor
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Components/Layout/MainLayout.razor
@@ -1,0 +1,3 @@
+@inherits LayoutComponentBase
+
+@Body

--- a/src/Components/Testing/testassets/NativeAotTestApp/Components/Pages/FileUpload.razor
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Components/Pages/FileUpload.razor
@@ -1,0 +1,33 @@
+@page "/file-upload"
+@rendermode InteractiveServer
+
+<NativeAotStatus />
+<h1>Input file streaming</h1>
+
+<EditForm Model="_upload" OnValidSubmit="Submit">
+    <InputFile id="file-input" OnChange="ReadFileAsync" />
+    <button id="file-submit" type="submit" disabled="@(_upload.Length == 0)">Submit</button>
+</EditForm>
+
+<p id="file-read">@_upload.Name|@_upload.Content|@_upload.Length</p>
+<p id="file-result">@_result</p>
+
+@code {
+    private readonly UploadState _upload = new();
+    private string _result = "(unsubmitted)";
+
+    private async Task ReadFileAsync(InputFileChangeEventArgs args)
+    {
+        var file = args.File;
+        await using var stream = file.OpenReadStream(1024);
+        using var reader = new StreamReader(stream);
+        _upload.Name = file.Name;
+        _upload.Content = await reader.ReadToEndAsync();
+        _upload.Length = file.Size;
+    }
+
+    private void Submit()
+    {
+        _result = $"submitted:{_upload.Name}:{_upload.Content}:{_upload.Length}";
+    }
+}

--- a/src/Components/Testing/testassets/NativeAotTestApp/Components/Pages/Forms.razor
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Components/Pages/Forms.razor
@@ -1,0 +1,51 @@
+@page "/forms"
+@rendermode InteractiveServer
+
+<NativeAotStatus />
+<h1>Dashboard input matrix</h1>
+
+<EditForm Model="Model" OnValidSubmit="HandleValidSubmit">
+    <DataAnnotationsValidator />
+
+    <label>Name <InputText id="form-name" @bind-Value="Model.Name" /></label>
+    <ValidationMessage For="() => Model.Name" />
+
+    <label>Count <InputNumber id="form-count" @bind-Value="Model.Count" /></label>
+    <label>Enabled <InputCheckbox id="form-enabled" @bind-Value="Model.Enabled" /></label>
+
+    <label>
+        Mode
+        <InputSelect id="form-mode" @bind-Value="Model.Mode">
+            <option value="Compact">Compact</option>
+            <option value="Detailed">Detailed</option>
+        </InputSelect>
+    </label>
+
+    <label>
+        Optional mode
+        <InputSelect id="form-optional-mode" @bind-Value="Model.OptionalMode">
+            <option value="">(none)</option>
+            <option value="Compact">Compact</option>
+            <option value="Detailed">Detailed</option>
+        </InputSelect>
+    </label>
+
+    <label>Nested label <InputText id="form-nested" @bind-Value="Model.Nested.Label" /></label>
+    <label>List value <InputText id="form-list" @bind-Value="Model.Items[0].Value" /></label>
+
+    <button id="form-submit" type="submit">Submit</button>
+</EditForm>
+
+<p id="form-result">@_result</p>
+
+@code {
+    private string _result = "(unsubmitted)";
+
+    public DashboardInput Model { get; } = new();
+
+    private void HandleValidSubmit()
+    {
+        _result = $"{Model.Name}|{Model.Count}|{Model.Enabled}|{Model.Mode}|{Model.OptionalMode}|" +
+            $"{Model.Nested.Label}|{Model.Items[0].Value}";
+    }
+}

--- a/src/Components/Testing/testassets/NativeAotTestApp/Components/Pages/History.razor
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Components/Pages/History.razor
@@ -1,0 +1,22 @@
+@page "/history"
+@rendermode InteractiveServer
+
+<NativeAotStatus />
+<h1>Enhanced navigation history</h1>
+
+<p id="history-count">@Count</p>
+<p id="history-enabled">@Enabled</p>
+<p id="history-clicks">@_clicks</p>
+
+<a id="history-next" href="/history?count=11&enabled=false">Next query</a>
+<button id="history-increment" @onclick="() => _clicks++">Increment</button>
+
+@code {
+    private int _clicks;
+
+    [Parameter, SupplyParameterFromQuery]
+    public int Count { get; set; }
+
+    [Parameter, SupplyParameterFromQuery]
+    public bool Enabled { get; set; }
+}

--- a/src/Components/Testing/testassets/NativeAotTestApp/Components/Pages/Interop.razor
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Components/Pages/Interop.razor
@@ -1,0 +1,71 @@
+@page "/interop"
+@rendermode InteractiveServer
+@implements IAsyncDisposable
+@inject IJSRuntime JS
+
+<NativeAotStatus />
+<h1>JS interop and custom events</h1>
+
+<div id="interop-target" @ref="_target" @onsplitprobe="HandleSplit">Interop target</div>
+<button id="interop-run" @onclick="RunAsync">Run interop</button>
+
+<p id="interop-poco">@_poco</p>
+<p id="interop-dotnet">@_dotNet</p>
+<p id="interop-element">@_element</p>
+<p id="interop-wire">@_wire</p>
+<p id="interop-event">@_customEvent</p>
+
+@code {
+    private DotNetObjectReference<Interop>? _self;
+    private ElementReference _target;
+    private string _poco = "";
+    private string _dotNet = "";
+    private string _element = "";
+    private string _wire = "";
+    private string _customEvent = "";
+
+    private async Task RunAsync()
+    {
+        _self ??= DotNetObjectReference.Create(this);
+
+        await JS.InvokeVoidAsync("eval", """
+            window.__nativeAotRoundTrip = p => ({ message: p.name + ':' + p.count, doubled: p.count * 2 });
+            window.__nativeAotDotNet = r => r.invokeMethodAsync('EchoFromJs', 'dashboard');
+            window.__nativeAotElement = e => e.id;
+            window.__nativeAotWire = p => JSON.stringify(p);
+            Blazor.registerCustomEventType('splitprobe', { createEventArgs: e => e.detail });
+            """);
+
+        var response = await JS.InvokeAsync<InteropResponse>(
+            "__nativeAotRoundTrip",
+            new InteropRequest("counter", 21));
+        _poco = $"{response.Message}|{response.Doubled}";
+        _dotNet = await JS.InvokeAsync<string>("__nativeAotDotNet", _self);
+        _element = await JS.InvokeAsync<string>("__nativeAotElement", _target);
+        _wire = await JS.InvokeAsync<string>(
+            "__nativeAotWire",
+            new ResolverOrderPayload { SomeValue = "first" });
+
+        await JS.InvokeVoidAsync("eval", """
+            document.querySelector('#interop-target').dispatchEvent(new CustomEvent('splitprobe', {
+                bubbles: true,
+                detail: { orientation: 'horizontal', ratio: 0.4 }
+            }));
+            """);
+    }
+
+    [JSInvokable]
+    public string EchoFromJs(string value) => $"echo:{value}";
+
+    private void HandleSplit(SplitEventArgs args)
+    {
+        _customEvent = $"{args.Orientation}|{args.Ratio.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _self?.Dispose();
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Components/Testing/testassets/NativeAotTestApp/Components/Pages/Persistence.razor
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Components/Pages/Persistence.razor
@@ -1,0 +1,22 @@
+@page "/persistence"
+@rendermode InteractiveServer
+
+<NativeAotStatus />
+<h1>Persistent component state</h1>
+
+<p id="persistence-phase">@(_restored ? "circuit (restored)" : "prerender (fresh)")</p>
+<p id="persistence-token">@State?.Token</p>
+<p id="persistence-serializer">@PersistenceSnapshotSerializer.PersistCount|@PersistenceSnapshotSerializer.RestoreCount</p>
+
+@code {
+    private bool _restored;
+
+    [PersistentState]
+    public PersistenceSnapshot? State { get; set; }
+
+    protected override void OnInitialized()
+    {
+        _restored = State is not null;
+        State ??= new PersistenceSnapshot(Guid.NewGuid().ToString("N"));
+    }
+}

--- a/src/Components/Testing/testassets/NativeAotTestApp/Components/Pages/Shell.razor
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Components/Pages/Shell.razor
@@ -1,0 +1,46 @@
+@page "/"
+@rendermode InteractiveServer
+
+<NativeAotStatus />
+<h1>Native AOT interactive shell</h1>
+
+<div role="tablist" aria-label="Dashboard surfaces">
+    <button id="menu-tab" role="tab" @onclick="ShowMenu">Menu</button>
+    <button id="dialog-tab" role="tab" @onclick="ShowDialog">Dialog</button>
+</div>
+
+<CascadingValue Value="@("native-theme")">
+    <DynamicComponent Type="_panelType" Parameters="_parameters" />
+</CascadingValue>
+<p id="shell-result">@_result</p>
+
+@code {
+    private Type _panelType = typeof(MenuPanel);
+    private IDictionary<string, object> _parameters = new Dictionary<string, object>();
+    private string _result = "(none)";
+
+    protected override void OnInitialized()
+    {
+        ShowMenu();
+    }
+
+    private void ShowMenu()
+    {
+        _panelType = typeof(MenuPanel);
+        _parameters = new Dictionary<string, object>
+        {
+            [nameof(MenuPanel.Title)] = "Resource menu",
+            [nameof(MenuPanel.OnSelect)] = EventCallback.Factory.Create<string>(this, value => _result = $"menu:{value}"),
+        };
+    }
+
+    private void ShowDialog()
+    {
+        _panelType = typeof(DialogPanel);
+        _parameters = new Dictionary<string, object>
+        {
+            [nameof(DialogPanel.Title)] = "Command input",
+            [nameof(DialogPanel.OnSubmit)] = EventCallback.Factory.Create<string>(this, value => _result = $"dialog:{value}"),
+        };
+    }
+}

--- a/src/Components/Testing/testassets/NativeAotTestApp/Components/Pages/Storage.razor
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Components/Pages/Storage.razor
@@ -1,0 +1,37 @@
+@page "/storage"
+@rendermode InteractiveServer
+@inject ProtectedSessionStorage SessionStorage
+
+<NativeAotStatus />
+<h1>Protected browser storage</h1>
+
+<button id="storage-save" @onclick="SaveAsync">Save</button>
+<p id="storage-value">@_value</p>
+<p id="storage-instance">@_instanceId</p>
+<p id="storage-converter">@StorageProfileConverter.WriteCount|@StorageProfileConverter.ReadCount</p>
+
+@code {
+    private const string Key = "native-aot-profile";
+    private static int s_nextInstanceId;
+    private readonly int _instanceId = Interlocked.Increment(ref s_nextInstanceId);
+    private string _value = "(missing)";
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            var result = await SessionStorage.GetAsync<StorageProfile>(Key);
+            if (result is { Success: true, Value: { } profile })
+            {
+                _value = $"{profile.Name}:{profile.Age}";
+                StateHasChanged();
+            }
+        }
+    }
+
+    private async Task SaveAsync()
+    {
+        await SessionStorage.SetAsync(Key, new StorageProfile("ada", 36));
+        _value = "saved";
+    }
+}

--- a/src/Components/Testing/testassets/NativeAotTestApp/Components/Pages/Virtualization.razor
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Components/Pages/Virtualization.razor
@@ -1,0 +1,48 @@
+@page "/virtualization"
+@rendermode InteractiveServer
+
+<NativeAotStatus />
+<h1>Virtualization and expressions</h1>
+
+<div id="viewport" style="height: 200px; overflow-y: auto;">
+    <Virtualize Items="_items" Context="item" ItemSize="20">
+        <div class="row" style="height:20px">@item</div>
+    </Virtualize>
+</div>
+
+<p id="expression-created">@_gettersCreated|@_settersCreated</p>
+<p id="expression-invoked">@_gettersInvoked|@_settersInvoked</p>
+<p id="expression-value">@_target.MaxItemCount</p>
+
+@code {
+    private readonly List<string> _items = [.. Enumerable.Range(0, 500).Select(i => $"row-{i}")];
+    private readonly ExpressionTarget _target = new();
+    private int _gettersCreated;
+    private int _settersCreated;
+    private int _gettersInvoked;
+    private int _settersInvoked;
+
+    protected override void OnInitialized()
+    {
+        var target = Expression.Constant(_target);
+        var property = Expression.Property(target, nameof(ExpressionTarget.MaxItemCount));
+        var getter = Expression.Lambda<Func<int>>(property).Compile();
+        _gettersCreated++;
+
+        var value = Expression.Parameter(typeof(int), "value");
+        var setter = Expression.Lambda<Action<int>>(Expression.Assign(property, value), value).Compile();
+        _settersCreated++;
+
+        _ = getter();
+        _gettersInvoked++;
+        setter(10_000);
+        _settersInvoked++;
+        _ = getter();
+        _gettersInvoked++;
+    }
+
+    private sealed class ExpressionTarget
+    {
+        public int MaxItemCount { get; set; }
+    }
+}

--- a/src/Components/Testing/testassets/NativeAotTestApp/Components/Routes.razor
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Components/Routes.razor
@@ -1,0 +1,6 @@
+<Router AppAssembly="typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)" />
+        <FocusOnNavigate RouteData="routeData" Selector="h1" />
+    </Found>
+</Router>

--- a/src/Components/Testing/testassets/NativeAotTestApp/Components/Shared/DialogPanel.razor
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Components/Shared/DialogPanel.razor
@@ -1,0 +1,22 @@
+@inject IGreetingService GreetingService
+
+<section id="dialog-panel" role="dialog" aria-label="Dynamic dialog">
+    <h2>@Title</h2>
+    <p id="dialog-theme">@Theme</p>
+    <p id="dialog-greeting">@GreetingService.Greeting</p>
+    <input id="dialog-value" @bind="_value" />
+    <button id="dialog-submit" @onclick="() => OnSubmit.InvokeAsync(_value)">Submit</button>
+</section>
+
+@code {
+    private string _value = "";
+
+    [Parameter, EditorRequired]
+    public string Title { get; set; } = "";
+
+    [Parameter]
+    public EventCallback<string> OnSubmit { get; set; }
+
+    [CascadingParameter]
+    public string Theme { get; set; } = "";
+}

--- a/src/Components/Testing/testassets/NativeAotTestApp/Components/Shared/MenuPanel.razor
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Components/Shared/MenuPanel.razor
@@ -1,0 +1,14 @@
+<section id="menu-panel">
+    <h2>@Title</h2>
+    <button id="menu-action" @onclick="SelectResources">Open resources</button>
+</section>
+
+@code {
+    [Parameter, EditorRequired]
+    public string Title { get; set; } = "";
+
+    [Parameter]
+    public EventCallback<string> OnSelect { get; set; }
+
+    private Task SelectResources() => OnSelect.InvokeAsync("resources");
+}

--- a/src/Components/Testing/testassets/NativeAotTestApp/Components/Shared/NativeAotStatus.razor
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Components/Shared/NativeAotStatus.razor
@@ -1,0 +1,17 @@
+<div id="runtime-mode"
+     data-dynamic-code-supported="@(RuntimeFeature.IsDynamicCodeSupported ? "true" : "false")"
+     data-circuit-attached="@(_circuitAttached ? "true" : "false")">
+</div>
+
+@code {
+    private bool _circuitAttached;
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _circuitAttached = true;
+            StateHasChanged();
+        }
+    }
+}

--- a/src/Components/Testing/testassets/NativeAotTestApp/Components/_Imports.razor
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Components/_Imports.razor
@@ -1,0 +1,16 @@
+@using System.ComponentModel.DataAnnotations
+@using System.Linq.Expressions
+@using System.Runtime.CompilerServices
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.JSInterop
+@using NativeAotTestApp.Components
+@using NativeAotTestApp.Components.Layout
+@using NativeAotTestApp.Components.Shared
+@using NativeAotTestApp.Models
+@using NativeAotTestApp.Services
+@using static Microsoft.AspNetCore.Components.Web.RenderMode

--- a/src/Components/Testing/testassets/NativeAotTestApp/Models/Contracts.cs
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Models/Contracts.cs
@@ -1,0 +1,117 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.ComponentModel.DataAnnotations;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Components;
+
+namespace NativeAotTestApp.Models;
+
+public sealed record InteropRequest(string Name, int Count);
+
+public sealed record InteropResponse(string Message, int Doubled);
+
+public sealed class ResolverOrderPayload
+{
+    public string SomeValue { get; set; } = "";
+}
+
+public sealed class SplitEventArgs : EventArgs
+{
+    public string Orientation { get; set; } = "";
+
+    public double Ratio { get; set; }
+}
+
+[JsonConverter(typeof(StorageProfileConverter))]
+public sealed record StorageProfile(string Name, int Age);
+
+public sealed class StorageProfileConverter : JsonConverter<StorageProfile>
+{
+    public static int ReadCount { get; private set; }
+
+    public static int WriteCount { get; private set; }
+
+    public override StorageProfile Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        ReadCount++;
+        var parts = reader.GetString()!.Split('|');
+
+        return new StorageProfile(parts[0], int.Parse(parts[1], System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    public override void Write(Utf8JsonWriter writer, StorageProfile value, JsonSerializerOptions options)
+    {
+        WriteCount++;
+        writer.WriteStringValue($"{value.Name}|{value.Age}");
+    }
+}
+
+public sealed record PersistenceSnapshot(string Token);
+
+public sealed class PersistenceSnapshotSerializer : PersistentComponentStateSerializer<PersistenceSnapshot>
+{
+    public static int PersistCount { get; private set; }
+
+    public static int RestoreCount { get; private set; }
+
+    public override void Persist(PersistenceSnapshot value, IBufferWriter<byte> writer)
+    {
+        PersistCount++;
+        writer.Write(Encoding.UTF8.GetBytes(value.Token));
+    }
+
+    public override PersistenceSnapshot Restore(ReadOnlySequence<byte> data)
+    {
+        RestoreCount++;
+
+        return new PersistenceSnapshot(Encoding.UTF8.GetString(data.ToArray()));
+    }
+}
+
+public sealed class DashboardInput
+{
+    [Required]
+    public string Name { get; set; } = "";
+
+    [Range(1, 100)]
+    public int Count { get; set; }
+
+    public bool Enabled { get; set; }
+
+    public InputMode Mode { get; set; }
+
+    public InputMode? OptionalMode { get; set; }
+
+    public NestedInput Nested { get; } = new();
+
+    public List<ListInput> Items { get; } = [new()];
+}
+
+public sealed class NestedInput
+{
+    public string Label { get; set; } = "";
+}
+
+public sealed class ListInput
+{
+    public string Value { get; set; } = "";
+}
+
+public enum InputMode
+{
+    Compact,
+    Detailed,
+}
+
+public sealed class UploadState
+{
+    public string Name { get; set; } = "";
+
+    public string Content { get; set; } = "";
+
+    public long Length { get; set; }
+}

--- a/src/Components/Testing/testassets/NativeAotTestApp/NativeAotTestApp.csproj
+++ b/src/Components/Testing/testassets/NativeAotTestApp/NativeAotTestApp.csproj
@@ -12,7 +12,7 @@
     <!-- This reflection-enabled test roots its complete application assembly. The framework entry
          points and dynamic component setters remain annotated for applications that do not. -->
     <NoWarn>$(NoWarn);ASPNETCORE9004;IL2026;IL2111;NU1511</NoWarn>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2057;IL2062;IL2065;IL2067;IL2072;IL2080;IL2101;IL2110;IL3050</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2057;IL2062;IL2065;IL2067;IL2072;IL2080;IL2101;IL2110;IL3050;NU1510</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(E2ECompileTestHarness)' == 'true'">

--- a/src/Components/Testing/testassets/NativeAotTestApp/NativeAotTestApp.csproj
+++ b/src/Components/Testing/testassets/NativeAotTestApp/NativeAotTestApp.csproj
@@ -1,0 +1,52 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PublishAot>true</PublishAot>
+    <SelfContained>true</SelfContained>
+    <RuntimeIdentifiers>$(TargetRuntimeIdentifier)</RuntimeIdentifiers>
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
+    <IlcTreatWarningsAsErrors>false</IlcTreatWarningsAsErrors>
+    <!-- This reflection-enabled test roots its complete application assembly. The framework entry
+         points and dynamic component setters remain annotated for applications that do not. -->
+    <NoWarn>$(NoWarn);ASPNETCORE9004;IL2026;IL2111;NU1511</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Native AOT must compile against the runtime pack produced by this repository, not the
+         baseline pack bundled with the bootstrapping SDK. -->
+    <FrameworkReference Update="Microsoft.AspNetCore.App"
+                        RuntimeFrameworkVersion="$(PackageVersion)" />
+    <Reference Include="Microsoft.AspNetCore" />
+    <Reference Include="Microsoft.AspNetCore.Antiforgery" />
+    <Reference Include="Microsoft.AspNetCore.Components" />
+    <Reference Include="Microsoft.AspNetCore.Components.Endpoints" />
+    <Reference Include="Microsoft.AspNetCore.Components.Forms" />
+    <Reference Include="Microsoft.AspNetCore.Components.Server" />
+    <Reference Include="Microsoft.AspNetCore.Components.Web" />
+    <Reference Include="Microsoft.AspNetCore.Hosting" />
+    <Reference Include="Microsoft.AspNetCore.Http" />
+    <Reference Include="Microsoft.AspNetCore.Http.Abstractions" />
+    <Reference Include="Microsoft.AspNetCore.Http.Features" />
+    <Reference Include="Microsoft.AspNetCore.Routing" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Core" />
+    <Reference Include="Microsoft.AspNetCore.StaticAssets" />
+    <Reference Include="Microsoft.Extensions.Hosting" />
+    <Reference Include="Microsoft.JSInterop" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\nativeaot\Microsoft.AspNetCore.Components.Testing.NativeAot.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="E2ECompileTestHarness" />
+    <TrimmerRootAssembly Include="$(AssemblyName)" />
+  </ItemGroup>
+
+</Project>

--- a/src/Components/Testing/testassets/NativeAotTestApp/NativeAotTestApp.csproj
+++ b/src/Components/Testing/testassets/NativeAotTestApp/NativeAotTestApp.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <PublishAot>true</PublishAot>
-    <SelfContained>true</SelfContained>
+    <UseAspNetCoreSharedRuntime>false</UseAspNetCoreSharedRuntime>
+    <DoNotApplyWorkaroundsToMicrosoftAspNetCoreApp>false</DoNotApplyWorkaroundsToMicrosoftAspNetCoreApp>
     <RuntimeIdentifiers>$(TargetRuntimeIdentifier)</RuntimeIdentifiers>
     <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
     <IlcTreatWarningsAsErrors>false</IlcTreatWarningsAsErrors>
@@ -14,28 +14,73 @@
     <NoWarn>$(NoWarn);ASPNETCORE9004;IL2026;IL2111;NU1511</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(E2ECompileTestHarness)' == 'true'">
+    <PublishAot>true</PublishAot>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+
   <ItemGroup>
-    <!-- Native AOT must compile against the runtime pack produced by this repository, not the
-         baseline pack bundled with the bootstrapping SDK. -->
-    <FrameworkReference Update="Microsoft.AspNetCore.App"
-                        RuntimeFrameworkVersion="$(PackageVersion)" />
     <Reference Include="Microsoft.AspNetCore" />
     <Reference Include="Microsoft.AspNetCore.Antiforgery" />
+    <Reference Include="Microsoft.AspNetCore.Authentication" />
+    <Reference Include="Microsoft.AspNetCore.Authentication.Abstractions" />
+    <Reference Include="Microsoft.AspNetCore.Authentication.Core" />
+    <Reference Include="Microsoft.AspNetCore.Authorization" />
+    <Reference Include="Microsoft.AspNetCore.Authorization.Policy" />
     <Reference Include="Microsoft.AspNetCore.Components" />
+    <Reference Include="Microsoft.AspNetCore.Components.Authorization" />
     <Reference Include="Microsoft.AspNetCore.Components.Endpoints" />
     <Reference Include="Microsoft.AspNetCore.Components.Forms" />
     <Reference Include="Microsoft.AspNetCore.Components.Server" />
     <Reference Include="Microsoft.AspNetCore.Components.Web" />
+    <Reference Include="Microsoft.AspNetCore.Connections.Abstractions" />
+    <Reference Include="Microsoft.AspNetCore.Cors" />
+    <Reference Include="Microsoft.AspNetCore.Cryptography.Internal" />
+    <Reference Include="Microsoft.AspNetCore.DataProtection" />
+    <Reference Include="Microsoft.AspNetCore.DataProtection.Abstractions" />
+    <Reference Include="Microsoft.AspNetCore.DataProtection.Extensions" />
+    <Reference Include="Microsoft.AspNetCore.Diagnostics" />
+    <Reference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" />
     <Reference Include="Microsoft.AspNetCore.Hosting" />
+    <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
+    <Reference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" />
+    <Reference Include="Microsoft.AspNetCore.HostFiltering" />
+    <Reference Include="Microsoft.AspNetCore.Html.Abstractions" />
     <Reference Include="Microsoft.AspNetCore.Http" />
     <Reference Include="Microsoft.AspNetCore.Http.Abstractions" />
+    <Reference Include="Microsoft.AspNetCore.Http.Extensions" />
     <Reference Include="Microsoft.AspNetCore.Http.Features" />
+    <Reference Include="Microsoft.AspNetCore.Http.Results" />
+    <Reference Include="Microsoft.AspNetCore.Http.Connections" />
+    <Reference Include="Microsoft.AspNetCore.Http.Connections.Common" />
+    <Reference Include="Microsoft.AspNetCore.HttpOverrides" />
+    <Reference Include="Microsoft.AspNetCore.Localization" />
+    <Reference Include="Microsoft.AspNetCore.Metadata" />
     <Reference Include="Microsoft.AspNetCore.Routing" />
+    <Reference Include="Microsoft.AspNetCore.Routing.Abstractions" />
+    <Reference Include="Microsoft.AspNetCore.Server.HttpSys" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
     <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Core" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.NamedPipes" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Quic" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" />
+    <Reference Include="Microsoft.AspNetCore.Server.IIS" />
+    <Reference Include="Microsoft.AspNetCore.Server.IISIntegration" />
+    <Reference Include="Microsoft.AspNetCore.SignalR" />
+    <Reference Include="Microsoft.AspNetCore.SignalR.Common" />
+    <Reference Include="Microsoft.AspNetCore.SignalR.Core" />
+    <Reference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" />
     <Reference Include="Microsoft.AspNetCore.StaticAssets" />
+    <Reference Include="Microsoft.AspNetCore.StaticFiles" />
+    <Reference Include="Microsoft.AspNetCore.WebUtilities" />
+    <Reference Include="Microsoft.AspNetCore.WebSockets" />
+    <Reference Include="Microsoft.Extensions.Features" />
     <Reference Include="Microsoft.Extensions.Hosting" />
+    <Reference Include="Microsoft.Extensions.Localization.Abstractions" />
+    <Reference Include="Microsoft.Extensions.ObjectPool" />
+    <Reference Include="Microsoft.Extensions.Validation" />
     <Reference Include="Microsoft.JSInterop" />
+    <Reference Include="Microsoft.Net.Http.Headers" />
   </ItemGroup>
 
   <ItemGroup>
@@ -48,5 +93,16 @@
     <CompilerVisibleProperty Include="E2ECompileTestHarness" />
     <TrimmerRootAssembly Include="$(AssemblyName)" />
   </ItemGroup>
+
+  <Target Name="_RootNativeAotInTreeReferences"
+          BeforeTargets="_PrepareTrimConfiguration"
+          DependsOnTargets="ResolveReferences"
+          Condition="'$(E2ECompileTestHarness)' == 'true'">
+    <ItemGroup>
+      <_NativeAotInTreeReference Include="@(ReferencePath)"
+                                 Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference'" />
+      <TrimmerRootAssembly Include="@(_NativeAotInTreeReference->'%(Filename)')" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/Components/Testing/testassets/NativeAotTestApp/NativeAotTestApp.csproj
+++ b/src/Components/Testing/testassets/NativeAotTestApp/NativeAotTestApp.csproj
@@ -12,6 +12,7 @@
     <!-- This reflection-enabled test roots its complete application assembly. The framework entry
          points and dynamic component setters remain annotated for applications that do not. -->
     <NoWarn>$(NoWarn);ASPNETCORE9004;IL2026;IL2111;NU1511</NoWarn>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2057;IL2062;IL2065;IL2067;IL2072;IL2080;IL2101;IL2110;IL3050</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(E2ECompileTestHarness)' == 'true'">
@@ -93,16 +94,5 @@
     <CompilerVisibleProperty Include="E2ECompileTestHarness" />
     <TrimmerRootAssembly Include="$(AssemblyName)" />
   </ItemGroup>
-
-  <Target Name="_RootNativeAotInTreeReferences"
-          BeforeTargets="_PrepareTrimConfiguration"
-          DependsOnTargets="ResolveReferences"
-          Condition="'$(E2ECompileTestHarness)' == 'true'">
-    <ItemGroup>
-      <_NativeAotInTreeReference Include="@(ReferencePath)"
-                                 Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ProjectReference'" />
-      <TrimmerRootAssembly Include="@(_NativeAotInTreeReference->'%(Filename)')" />
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/src/Components/Testing/testassets/NativeAotTestApp/NativeAotTestApp.csproj
+++ b/src/Components/Testing/testassets/NativeAotTestApp/NativeAotTestApp.csproj
@@ -12,7 +12,7 @@
     <!-- This reflection-enabled test roots its complete application assembly. The framework entry
          points and dynamic component setters remain annotated for applications that do not. -->
     <NoWarn>$(NoWarn);ASPNETCORE9004;IL2026;IL2111;NU1511</NoWarn>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2057;IL2062;IL2065;IL2067;IL2072;IL2080;IL2101;IL2110;IL3050;NU1510</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);IL2057;IL2062;IL2065;IL2067;IL2072;IL2080;IL2101;IL2110;IL3050</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(E2ECompileTestHarness)' == 'true'">

--- a/src/Components/Testing/testassets/NativeAotTestApp/Program.cs
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Program.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components;
+using NativeAotTestApp.Components;
+using NativeAotTestApp.Models;
+using NativeAotTestApp.Serialization;
+using NativeAotTestApp.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorComponents()
+    .AddInteractiveServerComponents(options =>
+    {
+#pragma warning disable ASPNETCORE9004
+        options.JsonTypeInfoResolvers.Add(NativeAotJsonContext.Default);
+        options.JsonTypeInfoResolvers.Add(ResolverFirstJsonContext.Default);
+        options.JsonTypeInfoResolvers.Add(ResolverSecondJsonContext.Default);
+#pragma warning restore ASPNETCORE9004
+    });
+builder.Services.AddSingleton<IGreetingService, GreetingService>();
+builder.Services.AddSingleton<PersistentComponentStateSerializer<PersistenceSnapshot>, PersistenceSnapshotSerializer>();
+
+var app = builder.Build();
+
+app.UseAntiforgery();
+app.MapStaticAssets();
+app.MapRazorComponents<App>()
+    .AddInteractiveServerRenderMode();
+
+app.Run();

--- a/src/Components/Testing/testassets/NativeAotTestApp/Serialization/NativeAotJsonContexts.cs
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Serialization/NativeAotJsonContexts.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+using NativeAotTestApp.Models;
+
+namespace NativeAotTestApp.Serialization;
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(InteropRequest))]
+[JsonSerializable(typeof(InteropResponse))]
+[JsonSerializable(typeof(SplitEventArgs))]
+[JsonSerializable(typeof(StorageProfile))]
+internal sealed partial class NativeAotJsonContext : JsonSerializerContext;
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(ResolverOrderPayload))]
+internal sealed partial class ResolverFirstJsonContext : JsonSerializerContext;
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSerializable(typeof(ResolverOrderPayload))]
+internal sealed partial class ResolverSecondJsonContext : JsonSerializerContext;

--- a/src/Components/Testing/testassets/NativeAotTestApp/Services/GreetingService.cs
+++ b/src/Components/Testing/testassets/NativeAotTestApp/Services/GreetingService.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace NativeAotTestApp.Services;
+
+public interface IGreetingService
+{
+    string Greeting { get; }
+}
+
+public sealed class GreetingService : IGreetingService
+{
+    public string Greeting => "injected-greeting";
+}

--- a/src/Components/Web/src/WebEventData/WebEventData.cs
+++ b/src/Components/Web/src/WebEventData/WebEventData.cs
@@ -58,6 +58,8 @@ internal sealed class WebEventData
 
     public EventArgs EventArgs { get; }
 
+    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
+        Justification = "We are already using the appropriate overload")]
     private static EventArgs ParseEventArgsJson(
         Renderer renderer,
         JsonSerializerOptions jsonSerializerOptions,
@@ -74,13 +76,7 @@ internal sealed class WebEventData
 
             // For custom events, the args type is determined from the associated delegate
             var eventArgsType = renderer.GetEventArgsType(eventHandlerId);
-            if (eventArgsType == typeof(EventArgs))
-            {
-                return EventArgs.Empty;
-            }
-
-            var eventArgsTypeInfo = jsonSerializerOptions.GetTypeInfo(eventArgsType);
-            return (EventArgs)JsonSerializer.Deserialize(eventArgsJson, eventArgsTypeInfo)!;
+            return (EventArgs)JsonSerializer.Deserialize(eventArgsJson.GetRawText(), eventArgsType, jsonSerializerOptions)!;
         }
         catch (Exception e)
         {

--- a/src/Components/Web/src/WebEventData/WebEventData.cs
+++ b/src/Components/Web/src/WebEventData/WebEventData.cs
@@ -58,8 +58,6 @@ internal sealed class WebEventData
 
     public EventArgs EventArgs { get; }
 
-    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
-        Justification = "We are already using the appropriate overload")]
     private static EventArgs ParseEventArgsJson(
         Renderer renderer,
         JsonSerializerOptions jsonSerializerOptions,
@@ -76,7 +74,13 @@ internal sealed class WebEventData
 
             // For custom events, the args type is determined from the associated delegate
             var eventArgsType = renderer.GetEventArgsType(eventHandlerId);
-            return (EventArgs)JsonSerializer.Deserialize(eventArgsJson.GetRawText(), eventArgsType, jsonSerializerOptions)!;
+            if (eventArgsType == typeof(EventArgs))
+            {
+                return EventArgs.Empty;
+            }
+
+            var eventArgsTypeInfo = jsonSerializerOptions.GetTypeInfo(eventArgsType);
+            return (EventArgs)JsonSerializer.Deserialize(eventArgsJson, eventArgsTypeInfo)!;
         }
         catch (Exception e)
         {

--- a/src/Components/Web/src/WebRenderer.cs
+++ b/src/Components/Web/src/WebRenderer.cs
@@ -191,6 +191,10 @@ public abstract class WebRenderer : Renderer
 // 'Blazor._internal.attachWebRendererInterop'
 [JsonSerializable(typeof(object[]))]
 [JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(long))]
+[JsonSerializable(typeof(float))]
+[JsonSerializable(typeof(JsonElement))]
+[JsonSerializable(typeof(ChangeEventArgs))]
 [JsonSerializable(typeof(NavigationOptions))]
 [JsonSerializable(typeof(Dictionary<string, JSComponentConfigurationStore.JSComponentParameter[]>))]
 [JsonSerializable(typeof(Dictionary<string, List<string>>))]

--- a/src/Components/Web/src/WebRenderer.cs
+++ b/src/Components/Web/src/WebRenderer.cs
@@ -134,6 +134,12 @@ public abstract class WebRenderer : Renderer
         }
         else
         {
+            if (!jsonOptions.IsReadOnly &&
+                !jsonOptions.TypeInfoResolverChain.Contains(WebRendererSerializerContext.Default))
+            {
+                jsonOptions.TypeInfoResolverChain.Insert(0, WebRendererSerializerContext.Default);
+            }
+
             jsRuntime.InvokeVoidAsync(JSMethodIdentifier, args).Preserve();
         }
     }
@@ -185,6 +191,7 @@ public abstract class WebRenderer : Renderer
 // 'Blazor._internal.attachWebRendererInterop'
 [JsonSerializable(typeof(object[]))]
 [JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(NavigationOptions))]
 [JsonSerializable(typeof(Dictionary<string, JSComponentConfigurationStore.JSComponentParameter[]>))]
 [JsonSerializable(typeof(Dictionary<string, List<string>>))]
 internal sealed partial class WebRendererSerializerContext : JsonSerializerContext;

--- a/src/Components/Web/test/Rendering/WebRendererJsonResolverTest.cs
+++ b/src/Components/Web/test/Rendering/WebRendererJsonResolverTest.cs
@@ -1,0 +1,77 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Text.Json;
+using Microsoft.AspNetCore.Components.RenderTree;
+using Microsoft.AspNetCore.Components.Web.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.JSInterop;
+using Microsoft.JSInterop.Infrastructure;
+
+namespace Microsoft.AspNetCore.Components.Web;
+
+public class WebRendererJsonResolverTest
+{
+    [Fact]
+    public void OutOfProcessRendererAddsFrameworkInteropContracts()
+    {
+        var runtime = new CapturingJSRuntime();
+        using var services = new ServiceCollection()
+            .AddSingleton<IJSRuntime>(runtime)
+            .BuildServiceProvider();
+
+        using var renderer = new TestWebRenderer(services, runtime.Options);
+
+        Assert.Same(WebRendererSerializerContext.Default, runtime.Options.TypeInfoResolverChain[0]);
+        Assert.NotNull(runtime.Options.GetTypeInfo(typeof(NavigationOptions)));
+        Assert.Equal("Blazor._internal.attachWebRendererInterop", runtime.LastIdentifier);
+    }
+
+    private sealed class CapturingJSRuntime : JSRuntime
+    {
+        public JsonSerializerOptions Options => JsonSerializerOptions;
+
+        public string? LastIdentifier { get; private set; }
+
+        protected override void BeginInvokeJS(
+            long taskId,
+            string identifier,
+            string? argsJson,
+            JSCallResultType resultType,
+            long targetInstanceId)
+        {
+            LastIdentifier = identifier;
+        }
+
+        protected override void EndInvokeDotNet(
+            DotNetInvocationInfo invocationInfo,
+            in DotNetInvocationResult invocationResult)
+        {
+        }
+    }
+
+    private sealed class TestWebRenderer(
+        IServiceProvider services,
+        JsonSerializerOptions options)
+        : WebRenderer(
+            services,
+            NullLoggerFactory.Instance,
+            options,
+            new JSComponentInterop(new JSComponentConfigurationStore()))
+    {
+        public override Dispatcher Dispatcher { get; } = Dispatcher.CreateDefault();
+
+        protected override void AttachRootComponentToBrowser(int componentId, string domElementSelector)
+        {
+        }
+
+        protected override void HandleException(Exception exception)
+            => throw exception;
+
+        protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
+            => Task.CompletedTask;
+    }
+}

--- a/src/Components/Web/test/Rendering/WebRendererJsonResolverTest.cs
+++ b/src/Components/Web/test/Rendering/WebRendererJsonResolverTest.cs
@@ -26,7 +26,11 @@ public class WebRendererJsonResolverTest
         using var renderer = new TestWebRenderer(services, runtime.Options);
 
         Assert.Same(WebRendererSerializerContext.Default, runtime.Options.TypeInfoResolverChain[0]);
-        Assert.NotNull(runtime.Options.GetTypeInfo(typeof(NavigationOptions)));
+        Assert.NotNull(WebRendererSerializerContext.Default.GetTypeInfo(typeof(NavigationOptions)));
+        Assert.NotNull(WebRendererSerializerContext.Default.GetTypeInfo(typeof(float)));
+        Assert.NotNull(WebRendererSerializerContext.Default.GetTypeInfo(typeof(long)));
+        Assert.NotNull(WebRendererSerializerContext.Default.GetTypeInfo(typeof(JsonElement)));
+        Assert.NotNull(WebRendererSerializerContext.Default.GetTypeInfo(typeof(ChangeEventArgs)));
         Assert.Equal("Blazor._internal.attachWebRendererInterop", runtime.LastIdentifier);
     }
 

--- a/src/Components/Web/test/Rendering/WebRendererJsonResolverTest.cs
+++ b/src/Components/Web/test/Rendering/WebRendererJsonResolverTest.cs
@@ -26,11 +26,11 @@ public class WebRendererJsonResolverTest
         using var renderer = new TestWebRenderer(services, runtime.Options);
 
         Assert.Same(WebRendererSerializerContext.Default, runtime.Options.TypeInfoResolverChain[0]);
-        Assert.NotNull(WebRendererSerializerContext.Default.GetTypeInfo(typeof(NavigationOptions)));
-        Assert.NotNull(WebRendererSerializerContext.Default.GetTypeInfo(typeof(float)));
-        Assert.NotNull(WebRendererSerializerContext.Default.GetTypeInfo(typeof(long)));
-        Assert.NotNull(WebRendererSerializerContext.Default.GetTypeInfo(typeof(JsonElement)));
-        Assert.NotNull(WebRendererSerializerContext.Default.GetTypeInfo(typeof(ChangeEventArgs)));
+        Assert.NotNull(runtime.Options.GetTypeInfo(typeof(NavigationOptions)));
+        Assert.NotNull(runtime.Options.GetTypeInfo(typeof(float)));
+        Assert.NotNull(runtime.Options.GetTypeInfo(typeof(long)));
+        Assert.NotNull(runtime.Options.GetTypeInfo(typeof(JsonElement)));
+        Assert.NotNull(runtime.Options.GetTypeInfo(typeof(ChangeEventArgs)));
         Assert.Equal("Blazor._internal.attachWebRendererInterop", runtime.LastIdentifier);
     }
 

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/IPendingAsyncCall.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/IPendingAsyncCall.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+
+namespace Microsoft.JSInterop.Infrastructure;
+
+internal interface IPendingAsyncCall
+{
+    void Complete(JSRuntime runtime, ref Utf8JsonReader reader);
+
+    void Fail(Exception exception);
+
+    void Cancel(CancellationToken cancellationToken);
+}

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSInteropJsonTypeInfoResolver.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/JSInteropJsonTypeInfoResolver.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Microsoft.JSInterop.Infrastructure;
+
+// JS interop's custom converters own the complete JSON contract for their supported types. Supply
+// converter-backed metadata so applications don't need to register each closed generic or
+// implementation type with a source-generated context when reflection-based serialization is
+// disabled. IJSVoidResult is also framework-owned and only ever deserializes the JSON null value.
+internal sealed class JSInteropJsonTypeInfoResolver : IJsonTypeInfoResolver
+{
+    public static readonly JSInteropJsonTypeInfoResolver Instance = new();
+
+    private JSInteropJsonTypeInfoResolver()
+    {
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "JS interop types are handled by custom converters that don't serialize object graphs.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "JS interop types are handled by custom converters that don't require runtime code generation.")]
+    public JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options)
+    {
+        if (type == typeof(IJSVoidResult))
+        {
+            return JsonTypeInfo.CreateJsonTypeInfo(type, options);
+        }
+
+        foreach (var converter in options.Converters)
+        {
+            if (converter.CanConvert(type))
+            {
+                return JsonTypeInfo.CreateJsonTypeInfo(type, options);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/PendingAsyncCall.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/PendingAsyncCall.cs
@@ -21,10 +21,10 @@ internal sealed class PendingAsyncCall<[DynamicallyAccessedMembers(JsonSerialize
 
         runtime.ByteArraysToBeRevived.Clear();
 
-        _completion.SetResult(value!);
+        _completion.TrySetResult(value!);
     }
 
-    public void Fail(Exception exception) => _completion.SetException(exception);
+    public void Fail(Exception exception) => _completion.TrySetException(exception);
 
     public void Cancel(CancellationToken cancellationToken) => _completion.TrySetCanceled(cancellationToken);
 }

--- a/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/PendingAsyncCall.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/Infrastructure/PendingAsyncCall.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using static Microsoft.AspNetCore.Internal.LinkerFlags;
+
+namespace Microsoft.JSInterop.Infrastructure;
+
+internal sealed class PendingAsyncCall<[DynamicallyAccessedMembers(JsonSerialized)] TValue> : IPendingAsyncCall
+{
+    private readonly TaskCompletionSource<TValue> _completion = new();
+
+    public Task<TValue> Task => _completion.Task;
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "The result type is annotated on InvokeAsync and flows to TValue.")]
+    public void Complete(JSRuntime runtime, ref Utf8JsonReader reader)
+    {
+        var typeInfo = runtime.JsonSerializerOptions.GetTypeInfo(typeof(TValue));
+        var value = (TValue?)JsonSerializer.Deserialize(ref reader, typeInfo);
+
+        runtime.ByteArraysToBeRevived.Clear();
+
+        _completion.SetResult(value!);
+    }
+
+    public void Fail(Exception exception) => _completion.SetException(exception);
+
+    public void Cancel(CancellationToken cancellationToken) => _completion.TrySetCanceled(cancellationToken);
+}

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.JSInterop.Infrastructure;
 using static Microsoft.AspNetCore.Internal.LinkerFlags;
 
@@ -19,7 +20,7 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
 
     private long _nextObjectReferenceId; // Initial value of 0 signals no object, but we increment prior to assignment. The first tracked object should have id 1
     private long _nextPendingTaskId = 1; // Start at 1 because zero signals "no response needed"
-    private readonly ConcurrentDictionary<long, object> _pendingTasks = new();
+    private readonly ConcurrentDictionary<long, IPendingAsyncCall> _pendingTasks = new();
     private readonly ConcurrentDictionary<long, IDotNetObjectReference> _trackedRefsById = new();
     private readonly ConcurrentDictionary<long, CancellationTokenRegistration> _cancellationRegistrations = new();
 
@@ -44,7 +45,16 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
                     new ByteArrayJsonConverter(this),
                 }
         };
+
+        if (JsonSerializer.IsReflectionEnabledByDefault)
+        {
+            JsonSerializerOptions.TypeInfoResolverChain.Add(CreateReflectionResolver());
+        }
     }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "Guarded by JsonSerializer.IsReflectionEnabledByDefault.")]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = "Guarded by JsonSerializer.IsReflectionEnabledByDefault.")]
+    private static DefaultJsonTypeInfoResolver CreateReflectionResolver() => new();
 
     /// <summary>
     /// Gets the <see cref="System.Text.Json.JsonSerializerOptions"/> used to serialize and deserialize interop payloads.
@@ -129,25 +139,25 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
         object?[]? args)
     {
         var taskId = Interlocked.Increment(ref _nextPendingTaskId);
-        var tcs = new TaskCompletionSource<TValue>();
+        var pendingCall = new PendingAsyncCall<TValue>();
         if (cancellationToken.CanBeCanceled)
         {
             _cancellationRegistrations[taskId] = cancellationToken.Register(() =>
             {
-                tcs.TrySetCanceled(cancellationToken);
+                pendingCall.Cancel(cancellationToken);
                 CleanupTasksAndRegistrations(taskId);
             });
         }
-        _pendingTasks[taskId] = tcs;
+        _pendingTasks[taskId] = pendingCall;
 
         try
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                tcs.TrySetCanceled(cancellationToken);
+                pendingCall.Cancel(cancellationToken);
                 CleanupTasksAndRegistrations(taskId);
 
-                return new ValueTask<TValue>(tcs.Task);
+                return new ValueTask<TValue>(pendingCall.Task);
             }
 
             var argsJson = args is not null && args.Length != 0 ? JsonSerializer.Serialize(args, JsonSerializerOptions) : "[]";
@@ -164,7 +174,7 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
 
             BeginInvokeJS(invocationInfo);
 
-            return new ValueTask<TValue>(tcs.Task);
+            return new ValueTask<TValue>(pendingCall.Task);
         }
         catch
         {
@@ -273,7 +283,7 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "We enforce trimmer attributes for JSON deserialized types on InvokeAsync.")]
     internal bool EndInvokeJS(long taskId, bool succeeded, ref Utf8JsonReader jsonReader)
     {
-        if (!_pendingTasks.TryRemove(taskId, out var tcs))
+        if (!_pendingTasks.TryRemove(taskId, out var pendingCall))
         {
             // We should simply return if we can't find an id for the invocation.
             // This likely means that the method that initiated the call defined a timeout and stopped waiting.
@@ -286,16 +296,12 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
         {
             if (succeeded)
             {
-                var resultType = TaskGenericsUtil.GetTaskCompletionSourceResultType(tcs);
-
-                var result = JsonSerializer.Deserialize(ref jsonReader, resultType, JsonSerializerOptions);
-                ByteArraysToBeRevived.Clear();
-                TaskGenericsUtil.SetTaskCompletionSourceResult(tcs, result);
+                pendingCall.Complete(this, ref jsonReader);
             }
             else
             {
                 var exceptionText = jsonReader.GetString() ?? string.Empty;
-                TaskGenericsUtil.SetTaskCompletionSourceException(tcs, new JSException(exceptionText));
+                pendingCall.Fail(new JSException(exceptionText));
             }
 
             return true;
@@ -303,7 +309,7 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
         catch (Exception exception)
         {
             var message = $"An exception occurred executing JS interop: {exception.Message}. See InnerException for more details.";
-            TaskGenericsUtil.SetTaskCompletionSourceException(tcs, new JSException(message, exception));
+            pendingCall.Fail(new JSException(message, exception));
             return false;
         }
     }

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
@@ -45,6 +45,7 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
                     new ByteArrayJsonConverter(this),
                 }
         };
+        JsonSerializerOptions.TypeInfoResolverChain.Add(JSInteropJsonTypeInfoResolver.Instance);
 
         if (JsonSerializer.IsReflectionEnabledByDefault)
         {

--- a/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetObjectReferenceJsonConverterTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetObjectReferenceJsonConverterTest.cs
@@ -145,11 +145,8 @@ public class DotNetObjectReferenceJsonConverterTest
     [Fact]
     public void RuntimeProvidesConverterBackedTypeInfo()
     {
-        var typeInfo = JSInteropJsonTypeInfoResolver.Instance.GetTypeInfo(
-            typeof(DotNetObjectReference<TestModel>),
-            JsonSerializerOptions);
+        var typeInfo = JsonSerializerOptions.GetTypeInfo(typeof(DotNetObjectReference<TestModel>));
 
-        Assert.NotNull(typeInfo);
         Assert.Same(typeof(DotNetObjectReference<TestModel>), typeInfo.Type);
         Assert.IsType<DotNetObjectReferenceJsonConverter<TestModel>>(typeInfo.Converter);
     }
@@ -157,11 +154,8 @@ public class DotNetObjectReferenceJsonConverterTest
     [Fact]
     public void RuntimeProvidesVoidResultTypeInfo()
     {
-        var typeInfo = JSInteropJsonTypeInfoResolver.Instance.GetTypeInfo(
-            typeof(IJSVoidResult),
-            JsonSerializerOptions);
+        var typeInfo = JsonSerializerOptions.GetTypeInfo(typeof(IJSVoidResult));
 
-        Assert.NotNull(typeInfo);
         Assert.Null(JsonSerializer.Deserialize("null", typeInfo));
     }
 

--- a/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetObjectReferenceJsonConverterTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/Infrastructure/DotNetObjectReferenceJsonConverterTest.cs
@@ -142,6 +142,29 @@ public class DotNetObjectReferenceJsonConverterTest
         Assert.Equal(json1, json2);
     }
 
+    [Fact]
+    public void RuntimeProvidesConverterBackedTypeInfo()
+    {
+        var typeInfo = JSInteropJsonTypeInfoResolver.Instance.GetTypeInfo(
+            typeof(DotNetObjectReference<TestModel>),
+            JsonSerializerOptions);
+
+        Assert.NotNull(typeInfo);
+        Assert.Same(typeof(DotNetObjectReference<TestModel>), typeInfo.Type);
+        Assert.IsType<DotNetObjectReferenceJsonConverter<TestModel>>(typeInfo.Converter);
+    }
+
+    [Fact]
+    public void RuntimeProvidesVoidResultTypeInfo()
+    {
+        var typeInfo = JSInteropJsonTypeInfoResolver.Instance.GetTypeInfo(
+            typeof(IJSVoidResult),
+            JsonSerializerOptions);
+
+        Assert.NotNull(typeInfo);
+        Assert.Null(JsonSerializer.Deserialize("null", typeInfo));
+    }
+
     private class TestModel
     {
 

--- a/src/JSInterop/Microsoft.JSInterop/test/JSRuntimeTest.cs
+++ b/src/JSInterop/Microsoft.JSInterop/test/JSRuntimeTest.cs
@@ -83,6 +83,22 @@ public class JSRuntimeTest
     }
 
     [Fact]
+    public void PendingAsyncCall_CompletionAfterCancellationDoesNotThrow()
+    {
+        using var cts = new CancellationTokenSource();
+        var runtime = new TestJSRuntime();
+        var pendingCall = new PendingAsyncCall<string>();
+        var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes("\"result\""));
+
+        cts.Cancel();
+        pendingCall.Cancel(cts.Token);
+        pendingCall.Complete(runtime, ref reader);
+        pendingCall.Fail(new JSException("Failure"));
+
+        Assert.True(pendingCall.Task.IsCanceled);
+    }
+
+    [Fact]
     public async Task InvokeAsync_DoesNotStartWorkWhenCancellationHasBeenRequested()
     {
         // Arrange

--- a/src/Shared/Components/PrerenderComponentApplicationStore.cs
+++ b/src/Shared/Components/PrerenderComponentApplicationStore.cs
@@ -48,9 +48,13 @@ internal class PrerenderComponentApplicationStore : IPersistentComponentStateSto
         return Task.FromResult((IDictionary<string, byte[]>)ExistingState);
     }
 
-    [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode", Justification = "Simple serialize of primitive types.")]
-    protected virtual byte[] SerializeState(IReadOnlyDictionary<string, byte[]> state) =>
-        JsonSerializer.SerializeToUtf8Bytes(state);
+    protected virtual byte[] SerializeState(IReadOnlyDictionary<string, byte[]> state)
+    {
+        var dictionary = state as Dictionary<string, byte[]> ?? new Dictionary<string, byte[]>(state);
+        return JsonSerializer.SerializeToUtf8Bytes(
+            dictionary,
+            PrerenderComponentApplicationStoreSerializerContext.Default.DictionaryStringByteArray);
+    }
 
     public Task PersistStateAsync(IReadOnlyDictionary<string, byte[]> state)
     {
@@ -73,5 +77,5 @@ internal class PrerenderComponentApplicationStore : IPersistentComponentStateSto
         renderMode is null || renderMode is InteractiveWebAssemblyRenderMode || renderMode is InteractiveAutoRenderMode;
 }
 
-[JsonSerializable(typeof(Dictionary<string, byte[]>), GenerationMode = JsonSourceGenerationMode.Serialization)]
+[JsonSerializable(typeof(Dictionary<string, byte[]>))]
 internal sealed partial class PrerenderComponentApplicationStoreSerializerContext : JsonSerializerContext;

--- a/src/Shared/Components/ServerComponentSerializationSettings.cs
+++ b/src/Shared/Components/ServerComponentSerializationSettings.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 
 namespace Microsoft.AspNetCore.Components;
 
@@ -10,16 +12,50 @@ internal static class ServerComponentSerializationSettings
 {
     public const string DataProtectionProviderPurpose = "Microsoft.AspNetCore.Components.ComponentDescriptorSerializer,V1";
 
-    public static readonly JsonSerializerOptions JsonSerializationOptions =
-        new JsonSerializerOptions
+    public static readonly JsonSerializerOptions JsonSerializationOptions = CreateOptions();
+
+    private static JsonSerializerOptions CreateOptions()
+    {
+        var options = new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             PropertyNameCaseInsensitive = true,
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
         };
 
+        options.TypeInfoResolverChain.Add(ServerComponentJsonContext.Default);
+        if (JsonSerializer.IsReflectionEnabledByDefault)
+        {
+            options.TypeInfoResolverChain.Add(CreateReflectionResolver());
+        }
+
+        return options;
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
+        Justification = "Guarded by JsonSerializer.IsReflectionEnabledByDefault.")]
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling.",
+        Justification = "Guarded by JsonSerializer.IsReflectionEnabledByDefault.")]
+    private static DefaultJsonTypeInfoResolver CreateReflectionResolver() => new();
+
     // This setting is not configurable, but realistically we don't expect an app to take more than 30 seconds from when
     // it got rendered to when the circuit got started, and having an expiration on the serialized server-components helps
     // prevent old payloads from being replayed.
     public static readonly TimeSpan DataExpiration = TimeSpan.FromMinutes(5);
 }
+
+[JsonSerializable(typeof(ServerComponent))]
+[JsonSerializable(typeof(ComponentMarker))]
+[JsonSerializable(typeof(IEnumerable<ComponentMarker>))]
+[JsonSerializable(typeof(ComponentEndMarker))]
+[JsonSerializable(typeof(ComponentMarkerKey))]
+[JsonSerializable(typeof(ComponentParameter))]
+[JsonSerializable(typeof(ComponentParameter[]))]
+[JsonSerializable(typeof(IList<ComponentParameter>))]
+[JsonSerializable(typeof(IList<object>))]
+[JsonSerializable(typeof(object[]))]
+internal sealed partial class ServerComponentJsonContext : JsonSerializerContext;

--- a/src/Shared/Components/ServerComponentSerializer.cs
+++ b/src/Shared/Components/ServerComponentSerializer.cs
@@ -48,7 +48,8 @@ internal sealed class ServerComponentSerializer
             values,
             invocationId.Value);
 
-        var serializedServerComponentBytes = JsonSerializer.SerializeToUtf8Bytes(serverComponent, ServerComponentSerializationSettings.JsonSerializationOptions);
+        var typeInfo = ServerComponentSerializationSettings.JsonSerializationOptions.GetTypeInfo(typeof(ServerComponent));
+        var serializedServerComponentBytes = JsonSerializer.SerializeToUtf8Bytes(serverComponent, typeInfo);
         var protectedBytes = _dataProtector.Protect(serializedServerComponentBytes, dataExpiration);
         return (serverComponent.Sequence, Convert.ToBase64String(protectedBytes));
     }


### PR DESCRIPTION
## Overview

Enables the Aspire Dashboard to run as an Interactive Server application under Native AOT using narrow runtime fixes rather than the broader component-metadata/source-generator architecture. Reflection remains enabled for component discovery and activation; this PR does not change Blazor's trimming requirements or claim reflection-disabled/full-trimming support.

The live diff contains **61 framework and generic test files (+1843/-62)**. It contains no Aspire Dashboard source, FluentUI/Plotly/OTLP code, package pins, or vendored fixture artifacts.

## Design

The only new public contract lets an Interactive Server application compose source-generated JSON contexts into the circuit's `JsonSerializerOptions`:

```csharp
[Experimental("ASPNETCORE9004", UrlFormat = "https://aka.ms/aspnet/analyzer/{0}")]
public IList<IJsonTypeInfoResolver> JsonTypeInfoResolvers { get; } =
    new List<IJsonTypeInfoResolver>();
```

Application resolvers run in registration order before the reflection fallback and are shared by JS interop and protected browser storage. All other added metadata is internal and fixed: server component markers/root operations, web renderer arguments, prerender state, the JS initializer manifest, and converter-backed framework JS interop values.

Interactive forms retain their normal JIT fast paths, but avoid expression compilation and runtime generic enum closure when dynamic code is unavailable. The fallback evaluates the existing expression tree through field/property/index access, which covers the Dashboard's nested interactive edit models.

Explicitly excluded: source-generated component metadata/provider tables, generated JS-invokable dispatch, bindable graph generation, arbitrary third-party component support, reflection-disabled strict mode, array-valued `InputSelect<T[]>`, and SSR HTTP form mapping.

## Durable Native AOT browser coverage

This PR now commits a generic `NativeAotTestApp` and MTP/Playwright suite built on the current `Microsoft.AspNetCore.Components.Testing` `E2ENativeAot` harness. It does not copy the superseded harness from #68291 and has no Dashboard or FluentUI dependency.

The published `win-x64` Native AOT executable passes **8/8** scenarios:

- `InteractiveShell_RendersAndHandlesDynamicUi`: parameters, cascading values, injection, callbacks, conditional rendering, and `DynamicComponent` menu/dialog/tab-like UI.
- `Forms_BindValidateAndSubmitDashboardInputMatrix`: text, number, checkbox, enum and nullable enum, nested property, list index, failed validation, and successful interactive submit.
- `JsInterop_ResolversAndCustomEventsRoundTrip`: resolver ordering, app POCOs, `DotNetObjectReference`, `ElementReference`, and custom event args.
- `ProtectedStorage_RestoresAcrossReload`: an app source-generated contract with a custom converter across a browser reload/new circuit.
- `PersistentState_RestoresAcrossPrerender`: app state and a custom persistent-state serializer across prerender-to-circuit restoration.
- `Virtualize_ScrollsAndLoadsRows`: `Virtualize<T>`, float JS payloads, incremental rendering, and test-owned expression getter/setter delegates under Native AOT.
- `InputFile_StreamsAndSubmitsFile`: real browser selection, stream read, exact name/content/length, submit, and rerender.
- `EnhancedNavigation_QueryAndHistoryRemainInteractive`: typed `int`/`bool` query values, enhanced link navigation, back/forward, and continued circuit interaction.

Every scenario asserts a rendered `RuntimeFeature.IsDynamicCodeSupported == false` signal, a live Interactive Server circuit, concrete post-interaction state, hidden `#blazor-error-ui`, and no browser console, page, WebSocket, circuit, or JSON serialization errors.

Actual circuit pause/resume is not committed because the current canonical Components harness exposes no deterministic pause/resume driver for this fixture. The existing local Dashboard acceptance experiment proved `Blazor.pauseCircuit()`/`resumeCircuit()` can return true, but Dashboard resource selection is not opted into persisted state.

## Validation

| Coverage | Result |
|---|---:|
| Durable generic Native AOT browser suite | 8/8 passed |
| Focused existing JSInterop/Components/Forms/Web/Server tests | 163 passed |
| External local-only Dashboard Native AOT acceptance suite | 7/7 passed |

The richer uncommitted Dashboard acceptance suite exercised populated resources/list/details/graph; dynamic resource-command forms and file upload; structured correlated OTLP logs; a two-service parent/child trace with span hierarchy, status, events, links, attributes and related logs; sum/gauge/histogram metrics with concrete values and Plotly rendering; console logs; protected/unprotected storage reload; and direct `MaxItemCountHelper` interpreter instrumentation. Those Dashboard/FluentUI/OTLP assets remain deliberately outside this PR.

Native publish continues to report expected trim/AOT diagnostics from reflection-rooted Blazor paths. The test executable suppresses existing entry-point/static-analysis annotations only where its complete application assembly is explicitly rooted; no product trimming annotations, defaults, or requirements are changed.