### PR TITLE
Use TLS channel binding in Negotiate authentication

### DIFF
--- a/src/Security/Authentication/Negotiate/src/Internal/INegotiateStateFactory.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/INegotiateStateFactory.cs
@@ -6,5 +6,5 @@ namespace Microsoft.AspNetCore.Authentication.Negotiate;
 // For testing
 internal interface INegotiateStateFactory
 {
-    INegotiateState CreateInstance();
+    INegotiateState CreateInstance(ReadOnlyMemory<byte> channelBindingToken);
 }

--- a/src/Security/Authentication/Negotiate/src/Internal/NegotiateChannelBinding.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/NegotiateChannelBinding.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using System.Security.Authentication.ExtendedProtection;
+
+namespace Microsoft.AspNetCore.Authentication.Negotiate;
+
+internal sealed class NegotiateChannelBinding : ChannelBinding
+{
+    public NegotiateChannelBinding(ReadOnlyMemory<byte> channelBindingToken)
+    {
+        var bytes = channelBindingToken.ToArray();
+        Size = bytes.Length;
+        SetHandle(Marshal.AllocHGlobal(Size));
+        Marshal.Copy(bytes, 0, handle, Size);
+    }
+
+    public override int Size { get; }
+
+    protected override bool ReleaseHandle()
+    {
+        Marshal.FreeHGlobal(handle);
+        return true;
+    }
+}

--- a/src/Security/Authentication/Negotiate/src/Internal/NegotiateChannelBinding.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/NegotiateChannelBinding.cs
@@ -10,6 +10,8 @@ internal sealed class NegotiateChannelBinding : ChannelBinding
 {
     public NegotiateChannelBinding(ReadOnlyMemory<byte> channelBindingToken)
     {
+        // ITlsConnectionFeature exposes managed bytes, but NegotiateAuthentication requires
+        // a ChannelBinding handle that remains valid throughout the authentication exchange.
         var bytes = channelBindingToken.ToArray();
         Size = bytes.Length;
         SetHandle(Marshal.AllocHGlobal(Size));

--- a/src/Security/Authentication/Negotiate/src/Internal/NegotiateChannelBinding.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/NegotiateChannelBinding.cs
@@ -8,14 +8,14 @@ namespace Microsoft.AspNetCore.Authentication.Negotiate;
 
 internal sealed class NegotiateChannelBinding : ChannelBinding
 {
-    public NegotiateChannelBinding(ReadOnlyMemory<byte> channelBindingToken)
+    public unsafe NegotiateChannelBinding(ReadOnlyMemory<byte> channelBindingToken)
     {
         // ITlsConnectionFeature exposes managed bytes, but NegotiateAuthentication requires
         // a ChannelBinding handle that remains valid throughout the authentication exchange.
-        var bytes = channelBindingToken.ToArray();
-        Size = bytes.Length;
+        Size = channelBindingToken.Length;
         SetHandle(Marshal.AllocHGlobal(Size));
-        Marshal.Copy(bytes, 0, handle, Size);
+        using var pinnedToken = channelBindingToken.Pin();
+        Buffer.MemoryCopy(pinnedToken.Pointer, (void*)handle, Size, Size);
     }
 
     public override int Size { get; }

--- a/src/Security/Authentication/Negotiate/src/Internal/NegotiateState.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/NegotiateState.cs
@@ -26,6 +26,7 @@ internal sealed class NegotiateState : INegotiateState
         }
         catch
         {
+            // NegotiateAuthentication construction can fail after the binding has been allocated.
             _channelBinding?.Dispose();
             throw;
         }

--- a/src/Security/Authentication/Negotiate/src/Internal/NegotiateState.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/NegotiateState.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Security;
+using System.Security.Authentication.ExtendedProtection;
 using System.Security.Claims;
 using System.Security.Principal;
 
@@ -9,12 +10,25 @@ namespace Microsoft.AspNetCore.Authentication.Negotiate;
 
 internal sealed class NegotiateState : INegotiateState
 {
-    private static readonly NegotiateAuthenticationServerOptions _serverOptions = new();
+    private readonly ChannelBinding? _channelBinding;
     private readonly NegotiateAuthentication _instance;
 
-    public NegotiateState()
+    public NegotiateState(ReadOnlyMemory<byte> channelBindingToken)
     {
-        _instance = new NegotiateAuthentication(_serverOptions);
+        _channelBinding = channelBindingToken.IsEmpty ? null : new NegotiateChannelBinding(channelBindingToken);
+
+        try
+        {
+            _instance = new NegotiateAuthentication(new NegotiateAuthenticationServerOptions
+            {
+                Binding = _channelBinding,
+            });
+        }
+        catch
+        {
+            _channelBinding?.Dispose();
+            throw;
+        }
     }
 
     public string? GetOutgoingBlob(string incomingBlob, out BlobErrorType status, out Exception? error)
@@ -65,7 +79,14 @@ internal sealed class NegotiateState : INegotiateState
 
     public void Dispose()
     {
-        _instance.Dispose();
+        try
+        {
+            _instance.Dispose();
+        }
+        finally
+        {
+            _channelBinding?.Dispose();
+        }
     }
 
     private static bool IsCredentialError(NegotiateAuthenticationStatusCode error)

--- a/src/Security/Authentication/Negotiate/src/Internal/NegotiateState.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/NegotiateState.cs
@@ -10,6 +10,7 @@ namespace Microsoft.AspNetCore.Authentication.Negotiate;
 
 internal sealed class NegotiateState : INegotiateState
 {
+    private static readonly NegotiateAuthenticationServerOptions _serverOptions = new();
     private readonly ChannelBinding? _channelBinding;
     private readonly NegotiateAuthentication _instance;
 
@@ -19,10 +20,10 @@ internal sealed class NegotiateState : INegotiateState
 
         try
         {
-            _instance = new NegotiateAuthentication(new NegotiateAuthenticationServerOptions
-            {
-                Binding = _channelBinding,
-            });
+            var serverOptions = _channelBinding is null
+                ? _serverOptions
+                : new NegotiateAuthenticationServerOptions { Binding = _channelBinding };
+            _instance = new NegotiateAuthentication(serverOptions);
         }
         catch
         {

--- a/src/Security/Authentication/Negotiate/src/Internal/NegotiateStateFactory.cs
+++ b/src/Security/Authentication/Negotiate/src/Internal/NegotiateStateFactory.cs
@@ -5,8 +5,8 @@ namespace Microsoft.AspNetCore.Authentication.Negotiate;
 
 internal sealed class NegotiateStateFactory : INegotiateStateFactory
 {
-    public INegotiateState CreateInstance()
+    public INegotiateState CreateInstance(ReadOnlyMemory<byte> channelBindingToken)
     {
-        return new NegotiateState();
+        return new NegotiateState(channelBindingToken);
     }
 }

--- a/src/Security/Authentication/Negotiate/src/Microsoft.AspNetCore.Authentication.Negotiate.csproj
+++ b/src/Security/Authentication/Negotiate/src/Microsoft.AspNetCore.Authentication.Negotiate.csproj
@@ -6,6 +6,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>aspnetcore;authentication;security</PackageTags>
     <IsTrimmable>true</IsTrimmable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Security/Authentication/Negotiate/src/NegotiateHandler.cs
+++ b/src/Security/Authentication/Negotiate/src/NegotiateHandler.cs
@@ -131,10 +131,7 @@ public class NegotiateHandler : AuthenticationHandler<NegotiateOptions>, IAuthen
                 persistence?.State = null;
             }
 
-            if (_negotiateState is null)
-            {
-                _negotiateState = Options.StateFactory.CreateInstance(GetChannelBindingToken());
-            }
+            _negotiateState ??= Options.StateFactory.CreateInstance(GetChannelBindingToken());
 
             var outgoing = _negotiateState.GetOutgoingBlob(token, out var errorType, out var exception);
             if (errorType != BlobErrorType.None)

--- a/src/Security/Authentication/Negotiate/src/NegotiateHandler.cs
+++ b/src/Security/Authentication/Negotiate/src/NegotiateHandler.cs
@@ -3,11 +3,13 @@
 
 using System.Diagnostics;
 using System.Linq;
+using System.Security.Authentication.ExtendedProtection;
 using System.Security.Claims;
 using System.Security.Principal;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
@@ -129,7 +131,7 @@ public class NegotiateHandler : AuthenticationHandler<NegotiateOptions>, IAuthen
                 persistence?.State = null;
             }
 
-            _negotiateState ??= Options.StateFactory.CreateInstance();
+            _negotiateState ??= Options.StateFactory.CreateInstance(GetChannelBindingToken());
 
             var outgoing = _negotiateState.GetOutgoingBlob(token, out var errorType, out var exception);
             if (errorType != BlobErrorType.None)
@@ -406,6 +408,18 @@ public class NegotiateHandler : AuthenticationHandler<NegotiateOptions>, IAuthen
     {
         return Context.Features.Get<IConnectionItemsFeature>()?.Items
             ?? throw new NotSupportedException($"Negotiate authentication requires a server that supports {nameof(IConnectionItemsFeature)} like Kestrel.");
+    }
+
+    private ReadOnlyMemory<byte> GetChannelBindingToken()
+    {
+        if (Request.IsHttps &&
+            Context.Features.Get<ITlsConnectionFeature>() is { } tlsConnectionFeature &&
+            tlsConnectionFeature.TryGetChannelBindingBytes(ChannelBindingKind.Endpoint, out var channelBindingToken))
+        {
+            return channelBindingToken;
+        }
+
+        return default;
     }
 
     private void RegisterForConnectionDispose(IDisposable authState)

--- a/src/Security/Authentication/Negotiate/src/NegotiateHandler.cs
+++ b/src/Security/Authentication/Negotiate/src/NegotiateHandler.cs
@@ -131,7 +131,10 @@ public class NegotiateHandler : AuthenticationHandler<NegotiateOptions>, IAuthen
                 persistence?.State = null;
             }
 
-            _negotiateState ??= Options.StateFactory.CreateInstance(GetChannelBindingToken());
+            if (_negotiateState is null)
+            {
+                _negotiateState = Options.StateFactory.CreateInstance(GetChannelBindingToken());
+            }
 
             var outgoing = _negotiateState.GetOutgoingBlob(token, out var errorType, out var exception);
             if (errorType != BlobErrorType.None)

--- a/src/Security/Authentication/Negotiate/test/Negotiate.Test/EventTests.cs
+++ b/src/Security/Authentication/Negotiate/test/Negotiate.Test/EventTests.cs
@@ -482,7 +482,7 @@ public class EventTests
 
     private class TestNegotiateStateFactory : INegotiateStateFactory
     {
-        public INegotiateState CreateInstance() => new TestNegotiateState();
+        public INegotiateState CreateInstance(ReadOnlyMemory<byte> channelBindingToken) => new TestNegotiateState();
     }
 
     private class TestNegotiateState : INegotiateState

--- a/src/Security/Authentication/Negotiate/test/Negotiate.Test/NegotiateChannelBindingTests.cs
+++ b/src/Security/Authentication/Negotiate/test/Negotiate.Test/NegotiateChannelBindingTests.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.AspNetCore.Authentication.Negotiate;
+
+public class NegotiateChannelBindingTests
+{
+    [Fact]
+    public void Constructor_CopiesChannelBindingToken()
+    {
+        var channelBindingToken = new byte[] { 0x01, 0x23, 0x45, 0x67 };
+
+        using var channelBinding = new NegotiateChannelBinding(channelBindingToken);
+        channelBindingToken[0] = 0xff;
+        var copiedToken = new byte[channelBinding.Size];
+        Marshal.Copy(channelBinding.DangerousGetHandle(), copiedToken, 0, copiedToken.Length);
+
+        Assert.Equal(new byte[] { 0x01, 0x23, 0x45, 0x67 }, copiedToken);
+    }
+}

--- a/src/Security/Authentication/Negotiate/test/Negotiate.Test/NegotiateHandlerTests.cs
+++ b/src/Security/Authentication/Negotiate/test/Negotiate.Test/NegotiateHandlerTests.cs
@@ -1,13 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Security.Authentication.ExtendedProtection;
 using System.Security.Claims;
+using System.Security.Cryptography.X509Certificates;
 using System.Security.Principal;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Caching.Memory;
@@ -121,6 +124,74 @@ public class NegotiateHandlerTests
         var server = host.GetTestServer();
         var testConnection = new TestConnection();
         await NtlmStage1And2Auth(server, testConnection);
+    }
+
+    [Fact]
+    public async Task NtlmStage1And2Auth_HttpsEndpointChannelBinding_UsesSingleStateAndReadsChannelBindingOnce()
+    {
+        var expectedToken = new byte[] { 0x01, 0x23, 0x45, 0x67 };
+        var factory = new TestNegotiateStateFactory();
+        using var host = await CreateHostAsync(options => options.StateFactory = factory);
+        var server = host.GetTestServer();
+        var connection = new TestConnection
+        {
+            IsHttps = true,
+            HasTlsConnectionFeature = true,
+            ChannelBindingAvailable = true,
+            ChannelBindingToken = expectedToken,
+        };
+
+        await NtlmStage1Auth(server, connection);
+
+        Assert.Equal(ChannelBindingKind.Endpoint, Assert.Single(connection.RequestedKinds));
+        Assert.Equal(expectedToken, Assert.Single(factory.ChannelBindingTokens).ToArray());
+        Assert.Equal(1, factory.CreateCount);
+        Assert.Single(factory.CreatedStates);
+
+        connection.ChannelBindingAvailable = false;
+        connection.ChannelBindingToken = new byte[] { 0x89 };
+        await NtlmStage2Auth(server, connection);
+
+        Assert.Single(factory.ChannelBindingTokens);
+        Assert.Equal(1, factory.CreateCount);
+        Assert.Single(factory.CreatedStates);
+        Assert.Equal(1, connection.ChannelBindingReadCount);
+        Assert.Equal(expectedToken, factory.ChannelBindingTokens[0].ToArray());
+    }
+
+    [Theory]
+    [InlineData(true, false, false, 0)]
+    [InlineData(true, true, false, 1)]
+    [InlineData(false, true, true, 0)]
+    public async Task NtlmStage1Auth_NoUsableChannelBinding_CreatesStateWithEmptyToken(
+        bool isHttps,
+        bool hasTlsConnectionFeature,
+        bool channelBindingAvailable,
+        int expectedTlsReads)
+    {
+        var factory = new TestNegotiateStateFactory();
+        using var host = await CreateHostAsync(options => options.StateFactory = factory);
+        var server = host.GetTestServer();
+        var connection = new TestConnection
+        {
+            IsHttps = isHttps,
+            HasTlsConnectionFeature = hasTlsConnectionFeature,
+            ChannelBindingAvailable = channelBindingAvailable,
+            ChannelBindingToken = new byte[] { 0x01 },
+        };
+
+        await NtlmStage1Auth(server, connection);
+
+        Assert.Single(factory.ChannelBindingTokens);
+        Assert.True(factory.ChannelBindingTokens[0].IsEmpty);
+        Assert.Equal(1, factory.CreateCount);
+        Assert.Single(factory.CreatedStates);
+        Assert.Equal(expectedTlsReads, connection.ChannelBindingReadCount);
+        Assert.Equal(expectedTlsReads, connection.RequestedKinds.Count);
+        if (expectedTlsReads == 1)
+        {
+            Assert.Equal(ChannelBindingKind.Endpoint, connection.RequestedKinds[0]);
+        }
     }
 
     [Theory]
@@ -498,22 +569,59 @@ public class NegotiateHandlerTests
             {
                 context.Features.Set<IConnectionItemsFeature>(connection);
                 context.Features.Set<IConnectionCompleteFeature>(connection);
+                if (connection.IsHttps)
+                {
+                    context.Request.Scheme = "https";
+                }
+                if (connection.HasTlsConnectionFeature)
+                {
+                    context.Features.Set<ITlsConnectionFeature>(connection);
+                }
             }
         });
     }
 
-    private class TestConnection : IConnectionItemsFeature, IConnectionCompleteFeature
+    private class TestConnection : IConnectionItemsFeature, IConnectionCompleteFeature, ITlsConnectionFeature
     {
         public IDictionary<object, object> Items { get; set; } = new ConnectionItems();
+        public bool IsHttps { get; set; }
+        public bool HasTlsConnectionFeature { get; set; }
+        public bool ChannelBindingAvailable { get; set; }
+        public ReadOnlyMemory<byte> ChannelBindingToken { get; set; }
+        public int ChannelBindingReadCount { get; private set; }
+        public List<ChannelBindingKind> RequestedKinds { get; } = new();
+        public X509Certificate2 ClientCertificate { get; set; }
 
         public void OnCompleted(Func<object, Task> callback, object state)
         {
+        }
+
+        public Task<X509Certificate2> GetClientCertificateAsync(CancellationToken cancellationToken)
+            => Task.FromResult(ClientCertificate);
+
+        public bool TryGetChannelBindingBytes(ChannelBindingKind kind, out ReadOnlyMemory<byte> channelBindingToken)
+        {
+            ChannelBindingReadCount++;
+            RequestedKinds.Add(kind);
+            channelBindingToken = ChannelBindingAvailable ? ChannelBindingToken : default;
+            return ChannelBindingAvailable;
         }
     }
 
     private class TestNegotiateStateFactory : INegotiateStateFactory
     {
-        public INegotiateState CreateInstance() => new TestNegotiateState();
+        public int CreateCount { get; private set; }
+        public List<ReadOnlyMemory<byte>> ChannelBindingTokens { get; } = new();
+        public List<TestNegotiateState> CreatedStates { get; } = new();
+
+        public INegotiateState CreateInstance(ReadOnlyMemory<byte> channelBindingToken)
+        {
+            CreateCount++;
+            ChannelBindingTokens.Add(channelBindingToken.ToArray());
+            var state = new TestNegotiateState();
+            CreatedStates.Add(state);
+            return state;
+        }
     }
 
     private class TestNegotiateState : INegotiateState


### PR DESCRIPTION
- pass Kestrel's TLS endpoint channel binding token to managed `NegotiateAuthentication` contexts
- keep the owned channel binding alive for connection-scoped multi-round NTLM/Kerberos exchanges
- preserve existing behavior for non-HTTPS requests, unavailable channel bindings, and IIS/HTTP.sys server-integrated authentication deferral
- add focused tests for token forwarding, fallback behavior, multi-round state reuse, and channel binding ownership

Resolves #68315