### PR TITLE
Validate the query component of the HTTP/2 and HTTP/3 :path pseudo-header

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -340,7 +340,7 @@ internal abstract partial class Http2Stream : HttpProtocol, IThreadPoolWorkItem,
         var queryIndex = path.IndexOf('?');
         QueryString = queryIndex == -1 ? string.Empty : path.Substring(queryIndex);
 
-        if (HttpCharacters.ContainsInvalidQueryChar(QueryString))
+        if (queryIndex != -1 && HttpCharacters.ContainsInvalidQueryChar(QueryString))
         {
             ResetAndAbort(new ConnectionAbortedException(CoreStrings.FormatHttp2StreamErrorPathInvalid(RawTarget)), Http2ErrorCode.PROTOCOL_ERROR);
             return false;

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -339,6 +339,12 @@ internal abstract partial class Http2Stream : HttpProtocol, IThreadPoolWorkItem,
         var queryIndex = path.IndexOf('?');
         QueryString = queryIndex == -1 ? string.Empty : path.Substring(queryIndex);
 
+        if (HttpCharacters.IndexOfInvalidQueryChar(QueryString) >= 0)
+        {
+            ResetAndAbort(new ConnectionAbortedException(CoreStrings.FormatHttp2StreamErrorPathInvalid(RawTarget)), Http2ErrorCode.PROTOCOL_ERROR);
+            return false;
+        }
+
         var pathSegment = queryIndex == -1 ? path.AsSpan() : path.AsSpan(0, queryIndex);
 
         return TryValidatePath(pathSegment);

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -336,6 +336,7 @@ internal abstract partial class Http2Stream : HttpProtocol, IThreadPoolWorkItem,
             return false;
         }
 
+        // :path carries both the path and query components - https://www.rfc-editor.org/rfc/rfc9113#section-8.3.1
         var queryIndex = path.IndexOf('?');
         QueryString = queryIndex == -1 ? string.Empty : path.Substring(queryIndex);
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -336,11 +336,11 @@ internal abstract partial class Http2Stream : HttpProtocol, IThreadPoolWorkItem,
             return false;
         }
 
-        // :path carries both the path and query components - https://www.rfc-editor.org/rfc/rfc9113#section-8.3.1
+        // https://www.rfc-editor.org/rfc/rfc9113#section-8.3.1
         var queryIndex = path.IndexOf('?');
         QueryString = queryIndex == -1 ? string.Empty : path.Substring(queryIndex);
 
-        if (HttpCharacters.IndexOfInvalidQueryChar(QueryString) >= 0)
+        if (HttpCharacters.ContainsInvalidQueryChar(QueryString))
         {
             ResetAndAbort(new ConnectionAbortedException(CoreStrings.FormatHttp2StreamErrorPathInvalid(RawTarget)), Http2ErrorCode.PROTOCOL_ERROR);
             return false;

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -1114,11 +1114,11 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
             return false;
         }
 
-        // :path carries both the path and query components - https://www.rfc-editor.org/rfc/rfc9114#section-4.3.1
+        // https://www.rfc-editor.org/rfc/rfc9114#section-4.3.1
         var queryIndex = path.IndexOf('?');
         QueryString = queryIndex == -1 ? string.Empty : path.Substring(queryIndex);
 
-        if (HttpCharacters.IndexOfInvalidQueryChar(QueryString) >= 0)
+        if (HttpCharacters.ContainsInvalidQueryChar(QueryString))
         {
             Abort(new ConnectionAbortedException(CoreStrings.FormatHttp3StreamErrorPathInvalid(RawTarget)), Http3ErrorCode.ProtocolError);
             return false;

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -1114,6 +1114,7 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
             return false;
         }
 
+        // :path carries both the path and query components - https://www.rfc-editor.org/rfc/rfc9114#section-4.3.1
         var queryIndex = path.IndexOf('?');
         QueryString = queryIndex == -1 ? string.Empty : path.Substring(queryIndex);
 

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -1118,7 +1118,7 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
         var queryIndex = path.IndexOf('?');
         QueryString = queryIndex == -1 ? string.Empty : path.Substring(queryIndex);
 
-        if (HttpCharacters.ContainsInvalidQueryChar(QueryString))
+        if (queryIndex != -1 && HttpCharacters.ContainsInvalidQueryChar(QueryString))
         {
             Abort(new ConnectionAbortedException(CoreStrings.FormatHttp3StreamErrorPathInvalid(RawTarget)), Http3ErrorCode.ProtocolError);
             return false;

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -1117,6 +1117,12 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
         var queryIndex = path.IndexOf('?');
         QueryString = queryIndex == -1 ? string.Empty : path.Substring(queryIndex);
 
+        if (HttpCharacters.IndexOfInvalidQueryChar(QueryString) >= 0)
+        {
+            Abort(new ConnectionAbortedException(CoreStrings.FormatHttp3StreamErrorPathInvalid(RawTarget)), Http3ErrorCode.ProtocolError);
+            return false;
+        }
+
         var pathSegment = queryIndex == -1 ? path.AsSpan() : path.AsSpan(0, queryIndex);
 
         return TryValidatePath(pathSegment);

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -391,6 +391,68 @@ public class Http2StreamTests : Http2TestBase
     }
 
     [Theory]
+    [InlineData("/a/path?q=a b")]
+    [InlineData("/a/path?q=a\tb")]
+    [InlineData("/a/path?q=a\u0001b")]
+    [InlineData("/a/path?q=a\u007Fb")]
+    [InlineData("/a/path? ")]
+    public async Task HEADERS_Received_QueryWithInvalidCharacter_Reset(string path)
+    {
+        await InitializeConnectionAsync(_noopApplication);
+
+        var headers = new[]
+        {
+            new KeyValuePair<string, string>(InternalHeaderNames.Method, "GET"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Path, path)
+        };
+        
+        await StartStreamAsync(1, headers, endStream: true);
+        await WaitForStreamErrorAsync(expectedStreamId: 1, Http2ErrorCode.PROTOCOL_ERROR, CoreStrings.FormatHttp2StreamErrorPathInvalid(path));
+        await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+    }
+
+    [Theory]
+    [InlineData("/a/path?")]
+    [InlineData("/a/path?a=b&c=d")]
+    [InlineData("/a/path?q=a%20b+c/d?e")]
+    [InlineData("/a/path?q=~!$'()*,;:@[]")]
+    public async Task HEADERS_Received_QueryWithValidCharacters_Accepted(string path)
+    {
+        var expectedQuery = path[path.IndexOf('?')..];
+
+        await InitializeConnectionAsync(context =>
+        {
+            Assert.Equal("/a/path", context.Request.Path.Value);
+            Assert.Equal(expectedQuery, context.Request.QueryString.Value);
+            Assert.Equal(path, context.Features.Get<IHttpRequestFeature>().RawTarget);
+            return Task.CompletedTask;
+        });
+
+        var headers = new[]
+        {
+            new KeyValuePair<string, string>(InternalHeaderNames.Method, "GET"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Path, path)
+        };
+        await SendHeadersAsync(1, Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM, headers);
+
+        var headersFrame = await ExpectAsync(Http2FrameType.HEADERS,
+            withLength: 36,
+            withFlags: (byte)(Http2HeadersFrameFlags.END_HEADERS | Http2HeadersFrameFlags.END_STREAM),
+            withStreamId: 1);
+
+        await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
+
+        _hpackDecoder.Decode(headersFrame.PayloadSequence, endHeaders: false, handler: this);
+
+        Assert.Equal(3, _decodedHeaders.Count);
+        Assert.Contains("date", _decodedHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal("200", _decodedHeaders[InternalHeaderNames.Status]);
+        Assert.Equal("0", _decodedHeaders["content-length"]);
+    }
+
+    [Theory]
     [InlineData("/", "/")]
     [InlineData("/a%5E", "/a^")]
     [InlineData("/a%E2%82%AC", "/a€")]

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -394,8 +394,11 @@ public class Http2StreamTests : Http2TestBase
     [InlineData("/a/path?q=a b")]
     [InlineData("/a/path?q=a\tb")]
     [InlineData("/a/path?q=a\u0001b")]
+    [InlineData("/a/path?q=a\u001Fb")]
     [InlineData("/a/path?q=a\u007Fb")]
     [InlineData("/a/path? ")]
+    [InlineData("/a/path?\t")]
+    [InlineData("/a/path? q=a")]
     public async Task HEADERS_Received_QueryWithInvalidCharacter_Reset(string path)
     {
         await InitializeConnectionAsync(_noopApplication);
@@ -406,17 +409,19 @@ public class Http2StreamTests : Http2TestBase
             new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
             new KeyValuePair<string, string>(InternalHeaderNames.Path, path)
         };
-        
+
         await StartStreamAsync(1, headers, endStream: true);
         await WaitForStreamErrorAsync(expectedStreamId: 1, Http2ErrorCode.PROTOCOL_ERROR, CoreStrings.FormatHttp2StreamErrorPathInvalid(path));
         await StopConnectionAsync(expectedLastStreamId: 1, ignoreNonGoAwayFrames: false);
     }
 
+    // https://www.rfc-editor.org/rfc/rfc3986#section-3.4
     [Theory]
     [InlineData("/a/path?")]
     [InlineData("/a/path?a=b&c=d")]
     [InlineData("/a/path?q=a%20b+c/d?e")]
     [InlineData("/a/path?q=~!$'()*,;:@[]")]
+    [InlineData("/a/path?q=<>\"\\^`{|}")]
     public async Task HEADERS_Received_QueryWithValidCharacters_Accepted(string path)
     {
         var expectedQuery = path[path.IndexOf('?')..];

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -228,8 +228,11 @@ public class Http3StreamTests : Http3TestBase
     [InlineData("/a/path?q=a b")]
     [InlineData("/a/path?q=a\tb")]
     [InlineData("/a/path?q=a\u0001b")]
+    [InlineData("/a/path?q=a\u001Fb")]
     [InlineData("/a/path?q=a\u007Fb")]
     [InlineData("/a/path? ")]
+    [InlineData("/a/path?\t")]
+    [InlineData("/a/path? q=a")]
     public async Task QueryWithInvalidCharacter_Reset(string path)
     {
         var headers = new[] { new KeyValuePair<string, string>(InternalHeaderNames.Method, "GET"),
@@ -244,11 +247,13 @@ public class Http3StreamTests : Http3TestBase
             CoreStrings.FormatHttp3StreamErrorPathInvalid(path));
     }
 
+    // https://www.rfc-editor.org/rfc/rfc3986#section-3.4
     [Theory]
     [InlineData("/a/path?")]
     [InlineData("/a/path?a=b&c=d")]
     [InlineData("/a/path?q=a%20b+c/d?e")]
     [InlineData("/a/path?q=~!$'()*,;:@[]")]
+    [InlineData("/a/path?q=<>\"\\^`{|}")]
     public async Task QueryWithValidCharacters_Accepted(string path)
     {
         var expectedQuery = path[path.IndexOf('?')..];

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -225,6 +225,55 @@ public class Http3StreamTests : Http3TestBase
     }
 
     [Theory]
+    [InlineData("/a/path?q=a b")]
+    [InlineData("/a/path?q=a\tb")]
+    [InlineData("/a/path?q=a\u0001b")]
+    [InlineData("/a/path?q=a\u007Fb")]
+    [InlineData("/a/path? ")]
+    public async Task QueryWithInvalidCharacter_Reset(string path)
+    {
+        var headers = new[] { new KeyValuePair<string, string>(InternalHeaderNames.Method, "GET"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Path, path)};
+
+        var requestStream = await Http3Api.InitializeConnectionAndStreamsAsync(_noopApplication, headers, endStream: true);
+
+        await requestStream.WaitForStreamErrorAsync(
+            Http3ErrorCode.ProtocolError,
+            AssertExpectedErrorMessages,
+            CoreStrings.FormatHttp3StreamErrorPathInvalid(path));
+    }
+
+    [Theory]
+    [InlineData("/a/path?")]
+    [InlineData("/a/path?a=b&c=d")]
+    [InlineData("/a/path?q=a%20b+c/d?e")]
+    [InlineData("/a/path?q=~!$'()*,;:@[]")]
+    public async Task QueryWithValidCharacters_Accepted(string path)
+    {
+        var expectedQuery = path[path.IndexOf('?')..];
+
+        var headers = new[] { new KeyValuePair<string, string>(InternalHeaderNames.Method, "GET"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Scheme, "http"),
+            new KeyValuePair<string, string>(InternalHeaderNames.Path, path)};
+
+        var requestStream = await Http3Api.InitializeConnectionAndStreamsAsync(context =>
+        {
+            Assert.Equal("/a/path", context.Request.Path.Value);
+            Assert.Equal(expectedQuery, context.Request.QueryString.Value);
+            Assert.Equal(path, context.Features.Get<IHttpRequestFeature>().RawTarget);
+            return Task.CompletedTask;
+        }, headers, endStream: true);
+
+        var responseHeaders = await requestStream.ExpectHeadersAsync();
+
+        Assert.Equal(3, responseHeaders.Count);
+        Assert.Contains("date", responseHeaders.Keys, StringComparer.OrdinalIgnoreCase);
+        Assert.Equal("200", responseHeaders[InternalHeaderNames.Status]);
+        Assert.Equal("0", responseHeaders["content-length"]);
+    }
+
+    [Theory]
     [InlineData("/", "/")]
     [InlineData("/a%5E", "/a^")]
     [InlineData("/a%E2%82%AC", "/a€")]

--- a/src/Shared/ServerInfrastructure/HttpCharacters.cs
+++ b/src/Shared/ServerInfrastructure/HttpCharacters.cs
@@ -38,6 +38,11 @@ internal static class HttpCharacters
         "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u000A\u000B\u000C\u000D\u000E\u000F\u0010" +
         "\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F\u007F");
 
+    // Values are [0x00, 0x20] and 0x7F (https://www.rfc-editor.org/info/rfc9112/#section-3)
+    private static readonly SearchValues<char> _invalidQueryChars = SearchValues.Create(
+        "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u000A\u000B\u000C\u000D\u000E\u000F\u0010" +
+        "\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F\u0020\u007F");
+
     public static bool ContainsInvalidAuthorityChar(ReadOnlySpan<byte> span) => span.ContainsAnyExcept(_allowedAuthorityBytes);
 
     public static int IndexOfInvalidHostChar(ReadOnlySpan<char> span) => span.IndexOfAnyExcept(_allowedHostChars);
@@ -52,4 +57,7 @@ internal static class HttpCharacters
 
     // Follows field-value rules for chars <= 0x7F. Allows extended characters > 0x7F.
     public static int IndexOfInvalidFieldValueCharExtended(ReadOnlySpan<char> span) => span.IndexOfAny(_invalidFieldChars);
+
+    // Disallows CTL characters, SP and DEL in the query component of a request target.
+    public static int IndexOfInvalidQueryChar(ReadOnlySpan<char> span) => span.IndexOfAny(_invalidQueryChars);
 }

--- a/src/Shared/ServerInfrastructure/HttpCharacters.cs
+++ b/src/Shared/ServerInfrastructure/HttpCharacters.cs
@@ -38,7 +38,8 @@ internal static class HttpCharacters
         "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u000A\u000B\u000C\u000D\u000E\u000F\u0010" +
         "\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F\u007F");
 
-    // Values are [0x00, 0x20] and 0x7F (https://www.rfc-editor.org/info/rfc9112/#section-3)
+    // Values are [0x00, 0x20] and 0x7F
+    // same as _invalidFieldChars, but with 0x09 (HTAB) and 0x20 (SP): https://datatracker.ietf.org/doc/html/rfc9110#section-5.5
     private static readonly SearchValues<char> _invalidQueryChars = SearchValues.Create(
         "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u000A\u000B\u000C\u000D\u000E\u000F\u0010" +
         "\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F\u0020\u007F");

--- a/src/Shared/ServerInfrastructure/HttpCharacters.cs
+++ b/src/Shared/ServerInfrastructure/HttpCharacters.cs
@@ -33,16 +33,27 @@ internal static class HttpCharacters
     // HTAB, [VCHAR, SP]
     private static readonly SearchValues<char> _allowedFieldChars = SearchValues.Create("\t !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~" + AlphaNumeric);
 
-    // Values are [0x00, 0x1F] without 0x09 (HTAB) and with 0x7F.
-    private static readonly SearchValues<char> _invalidFieldChars = SearchValues.Create(
+    // CTL characters (RFC 5234 appendix B.1: %x00-1F / %x7F) excluding HTAB (0x09).
+    private const string ControlCharsExceptHtab =
         "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u000A\u000B\u000C\u000D\u000E\u000F\u0010" +
-        "\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F\u007F");
+        "\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F\u007F";
 
-    // Values are [0x00, 0x20] and 0x7F
-    // same as _invalidFieldChars, but with 0x09 (HTAB) and 0x20 (SP): https://datatracker.ietf.org/doc/html/rfc9110#section-5.5
-    private static readonly SearchValues<char> _invalidQueryChars = SearchValues.Create(
-        "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u000A\u000B\u000C\u000D\u000E\u000F\u0010" +
-        "\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001A\u001B\u001C\u001D\u001E\u001F\u0020\u007F");
+    private const string Htab = "\u0009";
+    private const string Sp = "\u0020";
+
+    // Values are [0x00, 0x1F] without 0x09 (HTAB) and with 0x7F.
+    private static readonly SearchValues<char> _invalidFieldChars = SearchValues.Create(ControlCharsExceptHtab);
+
+    // The query component of a request target is a URI component, so it follows the URI generic syntax grammar:
+    //   HTTP/2  ":path" = absolute-path [ "?" query ]  - https://www.rfc-editor.org/rfc/rfc9113#section-8.3.1
+    //   HTTP/3  ":path" = path-absolute [ "?" query ]  - https://www.rfc-editor.org/rfc/rfc9114#section-4.3.1
+    //   query   = *( pchar / "/" / "?" )               - https://www.rfc-editor.org/rfc/rfc3986#section-3.4
+    //   pchar   = unreserved / pct-encoded / sub-delims / ":" / "@"
+    //
+    // Rejected values are CTL ([0x00, 0x1F] and 0x7F, including 0x09 HTAB) and 0x20 (SP).
+    // Everything else is allowed, which is laxer than RFC 3986: < > " \ ^ ` { | } and non-ASCII are
+    // not valid query characters but are accepted for compatibility with existing clients.
+    private static readonly SearchValues<char> _invalidQueryChars = SearchValues.Create(ControlCharsExceptHtab + Htab + Sp);
 
     public static bool ContainsInvalidAuthorityChar(ReadOnlySpan<byte> span) => span.ContainsAnyExcept(_allowedAuthorityBytes);
 
@@ -59,6 +70,6 @@ internal static class HttpCharacters
     // Follows field-value rules for chars <= 0x7F. Allows extended characters > 0x7F.
     public static int IndexOfInvalidFieldValueCharExtended(ReadOnlySpan<char> span) => span.IndexOfAny(_invalidFieldChars);
 
-    // Disallows CTL characters, SP and DEL in the query component of a request target.
-    public static int IndexOfInvalidQueryChar(ReadOnlySpan<char> span) => span.IndexOfAny(_invalidQueryChars);
+    // Rejects CTL ([0x00, 0x1F] and 0x7F, including 0x09 HTAB) and 0x20 (SP).
+    public static bool ContainsInvalidQueryChar(ReadOnlySpan<char> span) => span.ContainsAny(_invalidQueryChars);
 }


### PR DESCRIPTION
see https://www.rfc-editor.org/info/rfc9112/#section-3 and https://www.rfc-editor.org/info/rfc3986#section-3.4

Fixes #67849