### PR TITLE
Validate QPack static table index in QPackDecoder

### DIFF
--- a/src/Shared/runtime/Http3/QPack/QPackDecoder.cs
+++ b/src/Shared/runtime/Http3/QPack/QPackDecoder.cs
@@ -763,7 +763,7 @@ namespace System.Net.Http.QPack
         {
             if (index >= H3StaticTable.Count)
             {
-                throw new QPackDecodingException(SR.Format(SR.net_http_hpack_invalid_index, index));
+                throw new QPackDecodingException(SR.Format(SR.net_http_qpack_invalid_index, index));
             }
         }
 

--- a/src/Shared/runtime/Http3/QPack/QPackDecoder.cs
+++ b/src/Shared/runtime/Http3/QPack/QPackDecoder.cs
@@ -712,6 +712,8 @@ namespace System.Net.Http.QPack
 
         private void OnIndexedHeaderName(int index)
         {
+            ThrowIfInvalidStaticIndex(index);
+
             _headerStaticIndex = index;
             _state = State.HeaderValueLength;
         }
@@ -751,8 +753,18 @@ namespace System.Net.Http.QPack
 
         private void OnIndexedHeaderField(int index, IHttpStreamHeadersHandler handler)
         {
+            ThrowIfInvalidStaticIndex(index);
+
             handler.OnStaticIndexedHeader(index);
             _state = State.CompressedHeaders;
+        }
+
+        private static void ThrowIfInvalidStaticIndex(int index)
+        {
+            if (index >= H3StaticTable.Count)
+            {
+                throw new QPackDecodingException(SR.Format(SR.net_http_hpack_invalid_index, index));
+            }
         }
 
         private static void ThrowDynamicTableNotSupported()

--- a/src/Shared/runtime/SR.resx
+++ b/src/Shared/runtime/SR.resx
@@ -150,6 +150,9 @@
   <data name="net_http_invalid_header_name" xml:space="preserve">
     <value>Received an invalid header name: '{0}'.</value>
   </data>
+  <data name="net_http_qpack_invalid_index" xml:space="preserve">
+    <value>Invalid header index: {0} is outside of the static table.</value>
+  </data>
   <data name="net_http_qpack_no_dynamic_table" xml:space="preserve">
     <value>No dynamic table support</value>
   </data>

--- a/src/Shared/test/Shared.Tests/runtime/Http3/QPackDecoderTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http3/QPackDecoderTest.cs
@@ -340,6 +340,20 @@ namespace System.Net.Http.Unit.Tests.QPack
             Assert.Empty(_handler.DecodedHeaders);
         }
 
+        [Theory]
+        // Indexed Field Line - Static Table - Index 99 (out of range)
+        [InlineData(new byte[] { 0xff, 0x24 }, 99)]
+        // Literal Header Field With Name Reference - Static Table - Index 99 (out of range)
+        [InlineData(new byte[] { 0x5f, 0x54, 0x01, 0x61 }, 99)]
+        public void DecodesIndexOutsideStaticTable_Error(byte[] encoded, int index)
+        {
+            _decoder.Decode([0x00, 0x00], endHeaders: false, handler: _handler);
+
+            var exception = Assert.Throws<QPackDecodingException>(() => _decoder.Decode(encoded, endHeaders: true, handler: _handler));
+            Assert.Equal(SR.Format(SR.net_http_hpack_invalid_index, index), exception.Message);
+            Assert.Empty(_handler.DecodedHeaders);
+        }
+
         private static void TestDecodeWithoutIndexing(byte[] encoded, string expectedHeaderName, string expectedHeaderValue)
         {
             KeyValuePair<string, string>[] expectedValues = new[] { new KeyValuePair<string, string>(expectedHeaderName, expectedHeaderValue) };

--- a/src/Shared/test/Shared.Tests/runtime/Http3/QPackDecoderTest.cs
+++ b/src/Shared/test/Shared.Tests/runtime/Http3/QPackDecoderTest.cs
@@ -350,7 +350,7 @@ namespace System.Net.Http.Unit.Tests.QPack
             _decoder.Decode([0x00, 0x00], endHeaders: false, handler: _handler);
 
             var exception = Assert.Throws<QPackDecodingException>(() => _decoder.Decode(encoded, endHeaders: true, handler: _handler));
-            Assert.Equal(SR.Format(SR.net_http_hpack_invalid_index, index), exception.Message);
+            Assert.Equal(SR.Format(SR.net_http_qpack_invalid_index, index), exception.Message);
             Assert.Empty(_handler.DecodedHeaders);
         }
 


### PR DESCRIPTION
`QPackDecoder` passed the decoded static table index to the headers handler without validating it, so an index outside the table surfaced as `IndexOutOfRangeException` instead of `QPackDecodingException`.

Fixes #67981