### PR TITLE
[Blazor] Add Components.AI rich text rendering

### DIFF
--- a/AspNetCore.slnx
+++ b/AspNetCore.slnx
@@ -50,6 +50,8 @@
     <Project Path="src/Components/AI/src/Microsoft.AspNetCore.Components.AI.csproj" />
     <Project Path="src/Components/AI/test/Microsoft.AspNetCore.Components.AI.Tests.csproj" />
     <Project Path="src/Components/AI/testassets/AGUIDojoApi/AGUIDojoApi.csproj" />
+    <Project Path="src/Components/AI/testassets/AIApp/AIApp.csproj" />
+    <Project Path="src/Components/AI/testassets/AIApp.E2E.Tests/AIApp.E2E.Tests.csproj" />
     <Project Path="src/Components/AI/testassets/DojoClient/DojoClient.csproj" />
     <Project Path="src/Components/AI/testassets/DojoClient.E2E.Tests/DojoClient.E2E.Tests.csproj" />
   </Folder>

--- a/src/Components/AI/src/Blocks/RichContentBlock.cs
+++ b/src/Components/AI/src/Blocks/RichContentBlock.cs
@@ -19,9 +19,9 @@ public class RichContentBlock : ContentBlock
     public string RawText => _cachedText ??= string.Concat(_segments);
 
     /// <summary>
-    /// Gets the paragraphs of <see cref="RawText"/>, split on blank lines.
+    /// Gets the structured representation of <see cref="RawText"/>.
     /// </summary>
-    public IReadOnlyList<string> Paragraphs { get; internal set; } = Array.Empty<string>();
+    public IReadOnlyList<RichTextNode> Content { get; internal set; } = Array.Empty<RichTextNode>();
 
     /// <summary>
     /// Appends a text fragment to this block.
@@ -29,7 +29,17 @@ public class RichContentBlock : ContentBlock
     /// <param name="text">The fragment to append.</param>
     public void AppendText(string text)
     {
+        ArgumentNullException.ThrowIfNull(text);
+
         _segments.Add(text);
         _cachedText = null;
+    }
+
+    internal void ReplaceContent(string text, IReadOnlyList<RichTextNode> content)
+    {
+        _segments.Clear();
+        _segments.Add(text);
+        _cachedText = text;
+        Content = content;
     }
 }

--- a/src/Components/AI/src/Blocks/RichText/BlockQuoteNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/BlockQuoteNode.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a block quotation.
+/// </summary>
+public class BlockQuoteNode : RichTextNode;

--- a/src/Components/AI/src/Blocks/RichText/CodeBlockNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/CodeBlockNode.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a block of code.
+/// </summary>
+public class CodeBlockNode : RichTextNode
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="CodeBlockNode"/>.
+    /// </summary>
+    public CodeBlockNode()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="CodeBlockNode"/>.
+    /// </summary>
+    /// <param name="code">The code.</param>
+    /// <param name="language">The optional language identifier.</param>
+    public CodeBlockNode(string code, string? language = null)
+    {
+        ArgumentNullException.ThrowIfNull(code);
+        Code = code;
+        Language = language;
+    }
+
+    /// <summary>
+    /// Gets or sets the language identifier.
+    /// </summary>
+    public string? Language { get; set; }
+
+    /// <summary>
+    /// Gets or sets the code.
+    /// </summary>
+    public string Code { get; set; } = string.Empty;
+}

--- a/src/Components/AI/src/Blocks/RichText/DefinitionNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/DefinitionNode.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a link or image reference definition.
+/// </summary>
+public class DefinitionNode : RichTextNode
+{
+    /// <summary>
+    /// Gets or sets the reference label.
+    /// </summary>
+    public string Label { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the target URL.
+    /// </summary>
+    public string Url { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the optional title.
+    /// </summary>
+    public string? Title { get; set; }
+}

--- a/src/Components/AI/src/Blocks/RichText/EmphasisNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/EmphasisNode.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents emphasized text.
+/// </summary>
+public class EmphasisNode : RichTextNode;

--- a/src/Components/AI/src/Blocks/RichText/FootnoteDefinitionNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/FootnoteDefinitionNode.cs
@@ -6,6 +6,10 @@ namespace Microsoft.AspNetCore.Components.AI;
 /// <summary>
 /// Represents a footnote definition.
 /// </summary>
+/// <remarks>
+/// A mapper can use this node for labeled footnote content, such as content represented by
+/// a Markdig footnote container. The core library does not parse or resolve footnote syntax.
+/// </remarks>
 public class FootnoteDefinitionNode : RichTextNode
 {
     /// <summary>

--- a/src/Components/AI/src/Blocks/RichText/FootnoteDefinitionNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/FootnoteDefinitionNode.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a footnote definition.
+/// </summary>
+public class FootnoteDefinitionNode : RichTextNode
+{
+    /// <summary>
+    /// Gets or sets the footnote label.
+    /// </summary>
+    public string Label { get; set; } = string.Empty;
+}

--- a/src/Components/AI/src/Blocks/RichText/FootnoteNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/FootnoteNode.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents an inline footnote.
+/// </summary>
+public class FootnoteNode : RichTextNode;

--- a/src/Components/AI/src/Blocks/RichText/FootnoteNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/FootnoteNode.cs
@@ -4,6 +4,11 @@
 namespace Microsoft.AspNetCore.Components.AI;
 
 /// <summary>
-/// Represents an inline footnote.
+/// Represents footnote content supplied by an application's rich-text mapper.
 /// </summary>
+/// <remarks>
+/// Parsers model footnotes differently. For example, Markdig exposes footnote containers,
+/// links, and an end-of-document footnote group. A mapper can project those parser-specific
+/// objects into the footnote presentation nodes without introducing a parser dependency.
+/// </remarks>
 public class FootnoteNode : RichTextNode;

--- a/src/Components/AI/src/Blocks/RichText/FootnoteReferenceNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/FootnoteReferenceNode.cs
@@ -6,6 +6,10 @@ namespace Microsoft.AspNetCore.Components.AI;
 /// <summary>
 /// Represents a footnote reference.
 /// </summary>
+/// <remarks>
+/// A mapper can use this node for a reference such as a Markdig footnote link. The core
+/// library does not parse the reference or resolve its label.
+/// </remarks>
 public class FootnoteReferenceNode : RichTextNode
 {
     /// <summary>

--- a/src/Components/AI/src/Blocks/RichText/FootnoteReferenceNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/FootnoteReferenceNode.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a footnote reference.
+/// </summary>
+public class FootnoteReferenceNode : RichTextNode
+{
+    /// <summary>
+    /// Gets or sets the footnote label.
+    /// </summary>
+    public string Label { get; set; } = string.Empty;
+}

--- a/src/Components/AI/src/Blocks/RichText/HeadingNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/HeadingNode.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a heading.
+/// </summary>
+public class HeadingNode : RichTextNode
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="HeadingNode"/>.
+    /// </summary>
+    public HeadingNode()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="HeadingNode"/>.
+    /// </summary>
+    /// <param name="level">The heading level.</param>
+    public HeadingNode(int level)
+    {
+        Level = level;
+    }
+
+    /// <summary>
+    /// Gets or sets the heading level.
+    /// </summary>
+    public int Level { get; set; } = 1;
+}

--- a/src/Components/AI/src/Blocks/RichText/HtmlNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/HtmlNode.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents HTML source. The default renderer displays the source as text.
+/// </summary>
+public class HtmlNode : RichTextNode
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="HtmlNode"/>.
+    /// </summary>
+    public HtmlNode()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="HtmlNode"/>.
+    /// </summary>
+    /// <param name="value">The HTML source.</param>
+    public HtmlNode(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        Value = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the HTML source.
+    /// </summary>
+    public string Value { get; set; } = string.Empty;
+}

--- a/src/Components/AI/src/Blocks/RichText/ImageNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/ImageNode.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents an image.
+/// </summary>
+public class ImageNode : RichTextNode
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="ImageNode"/>.
+    /// </summary>
+    public ImageNode()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ImageNode"/>.
+    /// </summary>
+    /// <param name="url">The image URL.</param>
+    /// <param name="alt">The alternative text.</param>
+    /// <param name="title">The optional title.</param>
+    public ImageNode(string url, string? alt = null, string? title = null)
+    {
+        ArgumentNullException.ThrowIfNull(url);
+        Url = url;
+        Alt = alt;
+        Title = title;
+    }
+
+    /// <summary>
+    /// Gets or sets the image URL.
+    /// </summary>
+    public string Url { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the alternative text.
+    /// </summary>
+    public string? Alt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the optional title.
+    /// </summary>
+    public string? Title { get; set; }
+}

--- a/src/Components/AI/src/Blocks/RichText/ImageReferenceNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/ImageReferenceNode.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a reference-style image.
+/// </summary>
+public class ImageReferenceNode : RichTextNode
+{
+    /// <summary>
+    /// Gets or sets the reference label.
+    /// </summary>
+    public string Label { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the alternative text.
+    /// </summary>
+    public string? Alt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the reference syntax.
+    /// </summary>
+    public ReferenceKind ReferenceKind { get; set; }
+}

--- a/src/Components/AI/src/Blocks/RichText/InlineCodeNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/InlineCodeNode.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents inline code.
+/// </summary>
+public class InlineCodeNode : RichTextNode
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="InlineCodeNode"/>.
+    /// </summary>
+    public InlineCodeNode()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="InlineCodeNode"/>.
+    /// </summary>
+    /// <param name="code">The code.</param>
+    public InlineCodeNode(string code)
+    {
+        ArgumentNullException.ThrowIfNull(code);
+        Code = code;
+    }
+
+    /// <summary>
+    /// Gets or sets the code.
+    /// </summary>
+    public string Code { get; set; } = string.Empty;
+}

--- a/src/Components/AI/src/Blocks/RichText/LineBreakNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/LineBreakNode.cs
@@ -4,6 +4,11 @@
 namespace Microsoft.AspNetCore.Components.AI;
 
 /// <summary>
-/// Represents a line break.
+/// Represents a forced visual line break.
 /// </summary>
+/// <remarks>
+/// This node does not encode a parser-specific soft or hard line-ending distinction. A
+/// mapper from Markdig or any other parser decides whether a source line ending becomes
+/// whitespace, text, or a <see cref="LineBreakNode"/>.
+/// </remarks>
 public class LineBreakNode : RichTextNode;

--- a/src/Components/AI/src/Blocks/RichText/LineBreakNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/LineBreakNode.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a line break.
+/// </summary>
+public class LineBreakNode : RichTextNode;

--- a/src/Components/AI/src/Blocks/RichText/LinkNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/LinkNode.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a hyperlink.
+/// </summary>
+public class LinkNode : RichTextNode
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="LinkNode"/>.
+    /// </summary>
+    public LinkNode()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="LinkNode"/>.
+    /// </summary>
+    /// <param name="url">The link URL.</param>
+    /// <param name="title">The optional title.</param>
+    public LinkNode(string url, string? title = null)
+    {
+        ArgumentNullException.ThrowIfNull(url);
+        Url = url;
+        Title = title;
+    }
+
+    /// <summary>
+    /// Gets or sets the link URL.
+    /// </summary>
+    public string Url { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the optional title.
+    /// </summary>
+    public string? Title { get; set; }
+}

--- a/src/Components/AI/src/Blocks/RichText/LinkReferenceNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/LinkReferenceNode.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a reference-style link.
+/// </summary>
+public class LinkReferenceNode : RichTextNode
+{
+    /// <summary>
+    /// Gets or sets the reference label.
+    /// </summary>
+    public string Label { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the reference syntax.
+    /// </summary>
+    public ReferenceKind ReferenceKind { get; set; }
+}

--- a/src/Components/AI/src/Blocks/RichText/ListItemNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/ListItemNode.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a list item.
+/// </summary>
+public class ListItemNode : RichTextNode
+{
+    /// <summary>
+    /// Gets or sets the checked state when the item is a task.
+    /// </summary>
+    public bool? Checked { get; set; }
+}

--- a/src/Components/AI/src/Blocks/RichText/ListNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/ListNode.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents an ordered or unordered list.
+/// </summary>
+public class ListNode : RichTextNode
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="ListNode"/>.
+    /// </summary>
+    public ListNode()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ListNode"/>.
+    /// </summary>
+    /// <param name="ordered">Whether the list is ordered.</param>
+    /// <param name="start">The optional starting number.</param>
+    public ListNode(bool ordered, int? start = null)
+    {
+        Ordered = ordered;
+        Start = start;
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the list is ordered.
+    /// </summary>
+    public bool Ordered { get; set; }
+
+    /// <summary>
+    /// Gets or sets the starting number of an ordered list.
+    /// </summary>
+    public int? Start { get; set; }
+}

--- a/src/Components/AI/src/Blocks/RichText/ParagraphNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/ParagraphNode.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a paragraph.
+/// </summary>
+public class ParagraphNode : RichTextNode;

--- a/src/Components/AI/src/Blocks/RichText/ReferenceKind.cs
+++ b/src/Components/AI/src/Blocks/RichText/ReferenceKind.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Describes the syntax used by a reference.
+/// </summary>
+public enum ReferenceKind
+{
+    /// <summary>
+    /// A shortcut reference.
+    /// </summary>
+    Shortcut,
+
+    /// <summary>
+    /// A collapsed reference.
+    /// </summary>
+    Collapsed,
+
+    /// <summary>
+    /// A full reference.
+    /// </summary>
+    Full,
+}

--- a/src/Components/AI/src/Blocks/RichText/RichTextContent.cs
+++ b/src/Components/AI/src/Blocks/RichText/RichTextContent.cs
@@ -11,6 +11,8 @@ namespace Microsoft.AspNetCore.Components.AI;
 /// <remarks>
 /// Providers can emit a new snapshot as text streams. The block mapping pipeline replaces
 /// the previous snapshot without exposing a partially mutated tree to renderers.
+/// The constructor copies the top-level node list, but the nodes themselves remain shared.
+/// Callers must not mutate nodes after publishing the content.
 /// </remarks>
 public class RichTextContent : AIContent
 {
@@ -18,7 +20,10 @@ public class RichTextContent : AIContent
     /// Initializes a new instance of <see cref="RichTextContent"/>.
     /// </summary>
     /// <param name="text">The plain-text representation of the content.</param>
-    /// <param name="nodes">The structured nodes that represent <paramref name="text"/>.</param>
+    /// <param name="nodes">
+    /// The structured nodes that represent <paramref name="text"/>. The constructor copies this
+    /// list but does not clone the nodes.
+    /// </param>
     public RichTextContent(string text, IReadOnlyList<RichTextNode> nodes)
     {
         ArgumentNullException.ThrowIfNull(text);

--- a/src/Components/AI/src/Blocks/RichText/RichTextContent.cs
+++ b/src/Components/AI/src/Blocks/RichText/RichTextContent.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a complete snapshot of structured text in a streaming chat response.
+/// </summary>
+/// <remarks>
+/// Providers can emit a new snapshot as text streams. The block mapping pipeline replaces
+/// the previous snapshot without exposing a partially mutated tree to renderers.
+/// </remarks>
+public class RichTextContent : AIContent
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="RichTextContent"/>.
+    /// </summary>
+    /// <param name="text">The plain-text representation of the content.</param>
+    /// <param name="nodes">The structured nodes that represent <paramref name="text"/>.</param>
+    public RichTextContent(string text, IReadOnlyList<RichTextNode> nodes)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        ArgumentNullException.ThrowIfNull(nodes);
+
+        Text = text;
+        Nodes = [.. nodes];
+    }
+
+    /// <summary>
+    /// Gets the plain-text representation of the content.
+    /// </summary>
+    public string Text { get; }
+
+    /// <summary>
+    /// Gets the structured nodes that represent <see cref="Text"/>.
+    /// </summary>
+    public IReadOnlyList<RichTextNode> Nodes { get; }
+}

--- a/src/Components/AI/src/Blocks/RichText/RichTextNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/RichTextNode.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a node in structured conversational text.
+/// </summary>
+public abstract class RichTextNode
+{
+    private List<RichTextNode>? _children;
+
+    /// <summary>
+    /// Gets the child nodes.
+    /// </summary>
+    public IReadOnlyList<RichTextNode> Children =>
+        _children ?? (IReadOnlyList<RichTextNode>)Array.Empty<RichTextNode>();
+
+    /// <summary>
+    /// Adds a child node.
+    /// </summary>
+    /// <param name="child">The child to add.</param>
+    public void AddChild(RichTextNode child)
+    {
+        ArgumentNullException.ThrowIfNull(child);
+
+        _children ??= new();
+        _children.Add(child);
+    }
+}

--- a/src/Components/AI/src/Blocks/RichText/RichTextNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/RichTextNode.cs
@@ -6,6 +6,12 @@ namespace Microsoft.AspNetCore.Components.AI;
 /// <summary>
 /// Represents a node in structured conversational text.
 /// </summary>
+/// <remarks>
+/// This hierarchy describes presentation semantics and does not prescribe a source format
+/// or parser. Applications can map output from Markdig or any other parser into these nodes.
+/// The mapper is responsible for interpreting source syntax, resolving references, and
+/// deciding which presentation node represents each source construct.
+/// </remarks>
 public abstract class RichTextNode
 {
     private List<RichTextNode>? _children;

--- a/src/Components/AI/src/Blocks/RichText/StrikethroughNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/StrikethroughNode.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents struck-through text.
+/// </summary>
+public class StrikethroughNode : RichTextNode;

--- a/src/Components/AI/src/Blocks/RichText/StrongNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/StrongNode.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents strongly emphasized text.
+/// </summary>
+public class StrongNode : RichTextNode;

--- a/src/Components/AI/src/Blocks/RichText/TableCellNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/TableCellNode.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a table cell.
+/// </summary>
+public class TableCellNode : RichTextNode;

--- a/src/Components/AI/src/Blocks/RichText/TableColumnAlignment.cs
+++ b/src/Components/AI/src/Blocks/RichText/TableColumnAlignment.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Describes the alignment of a table column.
+/// </summary>
+public enum TableColumnAlignment
+{
+    /// <summary>
+    /// No alignment was specified.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Left-aligned.
+    /// </summary>
+    Left,
+
+    /// <summary>
+    /// Center-aligned.
+    /// </summary>
+    Center,
+
+    /// <summary>
+    /// Right-aligned.
+    /// </summary>
+    Right,
+}

--- a/src/Components/AI/src/Blocks/RichText/TableNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/TableNode.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a table.
+/// </summary>
+public class TableNode : RichTextNode
+{
+    /// <summary>
+    /// Gets or sets each column's alignment.
+    /// </summary>
+    public IReadOnlyList<TableColumnAlignment> Alignment { get; set; } =
+        Array.Empty<TableColumnAlignment>();
+}

--- a/src/Components/AI/src/Blocks/RichText/TableRowNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/TableRowNode.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a table row.
+/// </summary>
+public class TableRowNode : RichTextNode;

--- a/src/Components/AI/src/Blocks/RichText/TextNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/TextNode.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents plain text.
+/// </summary>
+public class TextNode : RichTextNode
+{
+    /// <summary>
+    /// Initializes a new instance of <see cref="TextNode"/>.
+    /// </summary>
+    public TextNode()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="TextNode"/>.
+    /// </summary>
+    /// <param name="text">The text.</param>
+    public TextNode(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        Text = text;
+    }
+
+    /// <summary>
+    /// Gets or sets the text.
+    /// </summary>
+    public string Text { get; set; } = string.Empty;
+}

--- a/src/Components/AI/src/Blocks/RichText/ThematicBreakNode.cs
+++ b/src/Components/AI/src/Blocks/RichText/ThematicBreakNode.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a thematic break.
+/// </summary>
+public class ThematicBreakNode : RichTextNode;

--- a/src/Components/AI/src/Components/MessageListContext.cs
+++ b/src/Components/AI/src/Components/MessageListContext.cs
@@ -90,7 +90,9 @@ public class MessageListContext
     {
         foreach (var node in nodes)
         {
+            builder.OpenRegion(0);
             RenderRichTextNode(builder, node);
+            builder.CloseRegion();
         }
     }
 

--- a/src/Components/AI/src/Components/MessageListContext.cs
+++ b/src/Components/AI/src/Components/MessageListContext.cs
@@ -321,7 +321,8 @@ public class MessageListContext
                 continue;
             }
 
-            builder.OpenElement(5, "tr");
+            builder.OpenRegion(5);
+            builder.OpenElement(0, "tr");
             var columnIndex = 0;
             foreach (var rowChild in row.Children)
             {
@@ -330,20 +331,23 @@ public class MessageListContext
                     continue;
                 }
 
-                builder.OpenElement(6, "td");
+                builder.OpenRegion(1);
+                builder.OpenElement(0, "td");
                 if (columnIndex < table.Alignment.Count &&
                     table.Alignment[columnIndex] != TableColumnAlignment.None)
                 {
                     builder.AddAttribute(
-                        7,
+                        1,
                         "class",
                         $"sc-ai-rich-text__table-cell--{table.Alignment[columnIndex].ToString().ToLowerInvariant()}");
                 }
                 RenderRichTextNodes(builder, cell.Children);
                 builder.CloseElement();
+                builder.CloseRegion();
                 columnIndex++;
             }
             builder.CloseElement();
+            builder.CloseRegion();
         }
 
         builder.CloseElement();

--- a/src/Components/AI/src/Components/MessageListContext.cs
+++ b/src/Components/AI/src/Components/MessageListContext.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.Extensions.AI;
 
 namespace Microsoft.AspNetCore.Components.AI;
@@ -47,7 +48,14 @@ public class MessageListContext
                     ? "sc-ai-message__content sc-ai-message__content--streaming"
                     : "sc-ai-message__content";
                 builder.AddAttribute(5, "class", contentClass);
-                builder.AddContent(6, rich.RawText);
+                if (rich.Content.Count > 0)
+                {
+                    RenderRichTextNodes(builder, rich.Content);
+                }
+                else
+                {
+                    builder.AddContent(6, rich.RawText);
+                }
                 builder.CloseElement(); // content div
                 builder.CloseElement(); // bubble div
                 builder.CloseElement(); // message div
@@ -74,5 +82,291 @@ public class MessageListContext
     {
         _registrations.Remove(registration);
         OnRegistrationsChanged?.Invoke();
+    }
+
+    private static void RenderRichTextNodes(
+        RenderTreeBuilder builder,
+        IReadOnlyList<RichTextNode> nodes)
+    {
+        foreach (var node in nodes)
+        {
+            RenderRichTextNode(builder, node);
+        }
+    }
+
+    private static void RenderRichTextNode(RenderTreeBuilder builder, RichTextNode node)
+    {
+        switch (node)
+        {
+            case TextNode text:
+                builder.AddContent(0, text.Text);
+                break;
+            case ParagraphNode:
+                RenderElement(builder, "p", "sc-ai-rich-text__paragraph", node.Children);
+                break;
+            case HeadingNode heading:
+                RenderElement(
+                    builder,
+                    $"h{Math.Clamp(heading.Level, 1, 6)}",
+                    "sc-ai-rich-text__heading",
+                    node.Children);
+                break;
+            case EmphasisNode:
+                RenderElement(builder, "em", null, node.Children);
+                break;
+            case StrongNode:
+                RenderElement(builder, "strong", null, node.Children);
+                break;
+            case StrikethroughNode:
+                RenderElement(builder, "s", null, node.Children);
+                break;
+            case InlineCodeNode inlineCode:
+                builder.OpenElement(0, "code");
+                builder.AddAttribute(1, "class", "sc-ai-rich-text__inline-code");
+                builder.AddContent(2, inlineCode.Code);
+                builder.CloseElement();
+                break;
+            case CodeBlockNode codeBlock:
+                builder.OpenElement(0, "pre");
+                builder.AddAttribute(1, "class", "sc-ai-rich-text__code-block");
+                builder.OpenElement(2, "code");
+                if (!string.IsNullOrEmpty(codeBlock.Language))
+                {
+                    builder.AddAttribute(3, "data-language", codeBlock.Language);
+                }
+                builder.AddContent(4, codeBlock.Code);
+                builder.CloseElement();
+                builder.CloseElement();
+                break;
+            case BlockQuoteNode:
+                RenderElement(builder, "blockquote", "sc-ai-rich-text__quote", node.Children);
+                break;
+            case LineBreakNode:
+                builder.OpenElement(0, "br");
+                builder.CloseElement();
+                break;
+            case ThematicBreakNode:
+                builder.OpenElement(0, "hr");
+                builder.AddAttribute(1, "class", "sc-ai-rich-text__thematic-break");
+                builder.CloseElement();
+                break;
+            case ListNode list:
+                builder.OpenElement(0, list.Ordered ? "ol" : "ul");
+                builder.AddAttribute(1, "class", "sc-ai-rich-text__list");
+                if (list.Ordered && list.Start is not null)
+                {
+                    builder.AddAttribute(2, "start", list.Start.Value);
+                }
+                RenderRichTextNodes(builder, list.Children);
+                builder.CloseElement();
+                break;
+            case ListItemNode item:
+                builder.OpenElement(0, "li");
+                builder.AddAttribute(1, "class", "sc-ai-rich-text__list-item");
+                if (item.Checked is not null)
+                {
+                    builder.OpenElement(2, "input");
+                    builder.AddAttribute(3, "type", "checkbox");
+                    builder.AddAttribute(4, "disabled", true);
+                    if (item.Checked.Value)
+                    {
+                        builder.AddAttribute(5, "checked", true);
+                    }
+                    builder.CloseElement();
+                }
+                RenderRichTextNodes(builder, item.Children);
+                builder.CloseElement();
+                break;
+            case LinkNode link:
+                RenderLink(builder, link);
+                break;
+            case ImageNode image:
+                RenderImage(builder, image);
+                break;
+            case DefinitionNode definition:
+                builder.OpenElement(0, "span");
+                builder.AddAttribute(1, "class", "sc-ai-rich-text__definition");
+                builder.AddContent(2, $"[{definition.Label}]: {definition.Url}");
+                builder.CloseElement();
+                break;
+            case LinkReferenceNode linkReference:
+                RenderReference(builder, linkReference.Label, linkReference.Children);
+                break;
+            case ImageReferenceNode imageReference:
+                builder.OpenElement(0, "span");
+                builder.AddAttribute(1, "class", "sc-ai-rich-text__image-reference");
+                builder.AddContent(2, imageReference.Alt ?? imageReference.Label);
+                builder.CloseElement();
+                break;
+            case FootnoteNode:
+                RenderElement(builder, "aside", "sc-ai-rich-text__footnote", node.Children);
+                break;
+            case FootnoteReferenceNode footnoteReference:
+                builder.OpenElement(0, "sup");
+                builder.AddAttribute(1, "class", "sc-ai-rich-text__footnote-reference");
+                builder.AddContent(2, footnoteReference.Label);
+                builder.CloseElement();
+                break;
+            case FootnoteDefinitionNode footnoteDefinition:
+                builder.OpenElement(0, "aside");
+                builder.AddAttribute(1, "class", "sc-ai-rich-text__footnote-definition");
+                builder.AddAttribute(2, "data-label", footnoteDefinition.Label);
+                RenderRichTextNodes(builder, footnoteDefinition.Children);
+                builder.CloseElement();
+                break;
+            case HtmlNode html:
+                builder.OpenElement(0, "code");
+                builder.AddAttribute(1, "class", "sc-ai-rich-text__html");
+                builder.AddContent(2, html.Value);
+                builder.CloseElement();
+                break;
+            case TableNode table:
+                RenderTable(builder, table);
+                break;
+            case TableRowNode:
+            case TableCellNode:
+                RenderRichTextNodes(builder, node.Children);
+                break;
+            default:
+                RenderRichTextNodes(builder, node.Children);
+                break;
+        }
+    }
+
+    private static void RenderElement(
+        RenderTreeBuilder builder,
+        string elementName,
+        string? className,
+        IReadOnlyList<RichTextNode> children)
+    {
+        builder.OpenElement(0, elementName);
+        if (className is not null)
+        {
+            builder.AddAttribute(1, "class", className);
+        }
+        RenderRichTextNodes(builder, children);
+        builder.CloseElement();
+    }
+
+    private static void RenderLink(RenderTreeBuilder builder, LinkNode link)
+    {
+        var safeUrl = GetSafeUrl(link.Url, allowMailTo: true);
+        if (safeUrl is null)
+        {
+            RenderRichTextNodes(builder, link.Children);
+            return;
+        }
+
+        builder.OpenElement(0, "a");
+        builder.AddAttribute(1, "href", safeUrl);
+        if (link.Title is not null)
+        {
+            builder.AddAttribute(2, "title", link.Title);
+        }
+        RenderRichTextNodes(builder, link.Children);
+        builder.CloseElement();
+    }
+
+    private static void RenderImage(RenderTreeBuilder builder, ImageNode image)
+    {
+        var safeUrl = GetSafeUrl(image.Url, allowMailTo: false);
+        if (safeUrl is null)
+        {
+            builder.AddContent(0, image.Alt);
+            return;
+        }
+
+        builder.OpenElement(0, "img");
+        builder.AddAttribute(1, "src", safeUrl);
+        builder.AddAttribute(2, "alt", image.Alt ?? string.Empty);
+        if (image.Title is not null)
+        {
+            builder.AddAttribute(3, "title", image.Title);
+        }
+        builder.CloseElement();
+    }
+
+    private static void RenderReference(
+        RenderTreeBuilder builder,
+        string label,
+        IReadOnlyList<RichTextNode> children)
+    {
+        builder.OpenElement(0, "span");
+        builder.AddAttribute(1, "class", "sc-ai-rich-text__link-reference");
+        if (children.Count > 0)
+        {
+            RenderRichTextNodes(builder, children);
+        }
+        else
+        {
+            builder.AddContent(2, label);
+        }
+        builder.CloseElement();
+    }
+
+    private static void RenderTable(RenderTreeBuilder builder, TableNode table)
+    {
+        builder.OpenElement(0, "div");
+        builder.AddAttribute(1, "class", "sc-ai-rich-text__table-container");
+        builder.OpenElement(2, "table");
+        builder.AddAttribute(3, "class", "sc-ai-rich-text__table");
+        builder.OpenElement(4, "tbody");
+
+        foreach (var child in table.Children)
+        {
+            if (child is not TableRowNode row)
+            {
+                continue;
+            }
+
+            builder.OpenElement(5, "tr");
+            var columnIndex = 0;
+            foreach (var rowChild in row.Children)
+            {
+                if (rowChild is not TableCellNode cell)
+                {
+                    continue;
+                }
+
+                builder.OpenElement(6, "td");
+                if (columnIndex < table.Alignment.Count &&
+                    table.Alignment[columnIndex] != TableColumnAlignment.None)
+                {
+                    builder.AddAttribute(
+                        7,
+                        "class",
+                        $"sc-ai-rich-text__table-cell--{table.Alignment[columnIndex].ToString().ToLowerInvariant()}");
+                }
+                RenderRichTextNodes(builder, cell.Children);
+                builder.CloseElement();
+                columnIndex++;
+            }
+            builder.CloseElement();
+        }
+
+        builder.CloseElement();
+        builder.CloseElement();
+        builder.CloseElement();
+    }
+
+    private static string? GetSafeUrl(string url, bool allowMailTo)
+    {
+        if (!Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri))
+        {
+            return null;
+        }
+
+        if (!uri.IsAbsoluteUri)
+        {
+            return url;
+        }
+
+        if (uri.Scheme is "http" or "https" ||
+            (allowMailTo && uri.Scheme == "mailto"))
+        {
+            return url;
+        }
+
+        return null;
     }
 }

--- a/src/Components/AI/src/Pipeline/BlockMappingPipeline.cs
+++ b/src/Components/AI/src/Pipeline/BlockMappingPipeline.cs
@@ -29,7 +29,10 @@ internal class BlockMappingPipeline
             _handlers.Add(registration.CreateEntry());
         }
 
-        // Built-in text handler is always last (fallback)
+        // Structured snapshots take precedence over the plain-text fallback.
+        _handlers.Add(new HandlerEntry<RichContentBlock>(new RichTextContentHandler()));
+
+        // Built-in plain-text handler is always last (fallback).
         _handlers.Add(new HandlerEntry<RichContentBlock>(new TextBlockHandler()));
     }
 

--- a/src/Components/AI/src/Pipeline/RichTextContentHandler.cs
+++ b/src/Components/AI/src/Pipeline/RichTextContentHandler.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.Extensions.AI;
+
 namespace Microsoft.AspNetCore.Components.AI;
 
 internal sealed class RichTextContentHandler : ContentBlockHandler<RichContentBlock>
@@ -14,7 +16,6 @@ internal sealed class RichTextContentHandler : ContentBlockHandler<RichContentBl
             if (content is RichTextContent richText)
             {
                 snapshot = richText;
-                context.MarkHandled(content);
             }
         }
 
@@ -23,6 +24,21 @@ internal sealed class RichTextContentHandler : ContentBlockHandler<RichContentBl
             return state.Id.Length > 0
                 ? BlockMappingResult<RichContentBlock>.Complete()
                 : BlockMappingResult<RichContentBlock>.Pass();
+        }
+
+        if (state.Id.Length > 0 &&
+            context.Update.MessageId is { Length: > 0 } messageId &&
+            !string.Equals(state.Id, messageId, StringComparison.Ordinal))
+        {
+            return BlockMappingResult<RichContentBlock>.Complete();
+        }
+
+        foreach (var content in context.UnhandledContents)
+        {
+            if (content is RichTextContent or TextContent)
+            {
+                context.MarkHandled(content);
+            }
         }
 
         state.ReplaceContent(snapshot.Text, snapshot.Nodes);

--- a/src/Components/AI/src/Pipeline/RichTextContentHandler.cs
+++ b/src/Components/AI/src/Pipeline/RichTextContentHandler.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+internal sealed class RichTextContentHandler : ContentBlockHandler<RichContentBlock>
+{
+    public override BlockMappingResult<RichContentBlock> Handle(
+        BlockMappingContext context, RichContentBlock state)
+    {
+        RichTextContent? snapshot = null;
+        foreach (var content in context.UnhandledContents)
+        {
+            if (content is RichTextContent richText)
+            {
+                snapshot = richText;
+                context.MarkHandled(content);
+            }
+        }
+
+        if (snapshot is null)
+        {
+            return state.Id.Length > 0
+                ? BlockMappingResult<RichContentBlock>.Complete()
+                : BlockMappingResult<RichContentBlock>.Pass();
+        }
+
+        state.ReplaceContent(snapshot.Text, snapshot.Nodes);
+
+        if (state.Id.Length == 0)
+        {
+            state.Id = context.Update.MessageId ?? Guid.NewGuid().ToString("N");
+            return BlockMappingResult<RichContentBlock>.Emit(state, state);
+        }
+
+        return BlockMappingResult<RichContentBlock>.Update(state);
+    }
+}

--- a/src/Components/AI/src/Pipeline/TextBlockHandler.cs
+++ b/src/Components/AI/src/Pipeline/TextBlockHandler.cs
@@ -50,11 +50,11 @@ internal sealed class TextBlockHandler : ContentBlockHandler<RichContentBlock>
         var rawText = state.RawText;
         if (rawText.Length == 0)
         {
-            state.Paragraphs = Array.Empty<string>();
+            state.Content = Array.Empty<RichTextNode>();
             return;
         }
 
-        var paragraphs = new List<string>();
+        var paragraphs = new List<RichTextNode>();
         var start = 0;
         while (start < rawText.Length)
         {
@@ -73,10 +73,10 @@ internal sealed class TextBlockHandler : ContentBlockHandler<RichContentBlock>
             start = breakIndex + 2;
         }
 
-        state.Paragraphs = paragraphs;
+        state.Content = paragraphs;
     }
 
-    private static void AddParagraph(List<string> paragraphs, ReadOnlySpan<char> text)
+    private static void AddParagraph(List<RichTextNode> paragraphs, ReadOnlySpan<char> text)
     {
         var trimmed = text.TrimEnd("\r\n".AsSpan());
         if (trimmed.Length == 0)
@@ -84,6 +84,8 @@ internal sealed class TextBlockHandler : ContentBlockHandler<RichContentBlock>
             return;
         }
 
-        paragraphs.Add(trimmed.ToString());
+        var paragraph = new ParagraphNode();
+        paragraph.AddChild(new TextNode(trimmed.ToString()));
+        paragraphs.Add(paragraph);
     }
 }

--- a/src/Components/AI/src/PublicAPI.Unshipped.txt
+++ b/src/Components/AI/src/PublicAPI.Unshipped.txt
@@ -38,6 +38,8 @@ Microsoft.AspNetCore.Components.AI.BlockMappingContext.UnhandledContentsEnumerat
 Microsoft.AspNetCore.Components.AI.BlockMappingContext.Update.get -> Microsoft.Extensions.AI.ChatResponseUpdate!
 Microsoft.AspNetCore.Components.AI.BlockMappingResult<TState>
 Microsoft.AspNetCore.Components.AI.BlockMappingResult<TState>.BlockMappingResult() -> void
+Microsoft.AspNetCore.Components.AI.BlockQuoteNode
+Microsoft.AspNetCore.Components.AI.BlockQuoteNode.BlockQuoteNode() -> void
 Microsoft.AspNetCore.Components.AI.BlockRenderer<TBlock>
 Microsoft.AspNetCore.Components.AI.BlockRenderer<TBlock>.BlockRenderer() -> void
 Microsoft.AspNetCore.Components.AI.BlockRenderer<TBlock>.ChildContent.get -> Microsoft.AspNetCore.Components.RenderFragment<TBlock!>?
@@ -65,6 +67,13 @@ Microsoft.AspNetCore.Components.AI.ChatPage.Placeholder.get -> string?
 Microsoft.AspNetCore.Components.AI.ChatPage.Placeholder.set -> void
 Microsoft.AspNetCore.Components.AI.ChatPage.WelcomeContent.get -> Microsoft.AspNetCore.Components.RenderFragment?
 Microsoft.AspNetCore.Components.AI.ChatPage.WelcomeContent.set -> void
+Microsoft.AspNetCore.Components.AI.CodeBlockNode
+Microsoft.AspNetCore.Components.AI.CodeBlockNode.Code.get -> string!
+Microsoft.AspNetCore.Components.AI.CodeBlockNode.Code.set -> void
+Microsoft.AspNetCore.Components.AI.CodeBlockNode.CodeBlockNode() -> void
+Microsoft.AspNetCore.Components.AI.CodeBlockNode.CodeBlockNode(string! code, string? language = null) -> void
+Microsoft.AspNetCore.Components.AI.CodeBlockNode.Language.get -> string?
+Microsoft.AspNetCore.Components.AI.CodeBlockNode.Language.set -> void
 Microsoft.AspNetCore.Components.AI.ContentBlock
 Microsoft.AspNetCore.Components.AI.ContentBlock.AuthorName.get -> string?
 Microsoft.AspNetCore.Components.AI.ContentBlock.ContentBlock() -> void
@@ -88,6 +97,84 @@ Microsoft.AspNetCore.Components.AI.ConversationTurn.ConversationTurn() -> void
 Microsoft.AspNetCore.Components.AI.ConversationTurn.Id.get -> string!
 Microsoft.AspNetCore.Components.AI.ConversationTurn.RequestBlocks.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.AI.ContentBlock!>!
 Microsoft.AspNetCore.Components.AI.ConversationTurn.ResponseBlocks.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.AI.ContentBlock!>!
+Microsoft.AspNetCore.Components.AI.DefinitionNode
+Microsoft.AspNetCore.Components.AI.DefinitionNode.DefinitionNode() -> void
+Microsoft.AspNetCore.Components.AI.DefinitionNode.Label.get -> string!
+Microsoft.AspNetCore.Components.AI.DefinitionNode.Label.set -> void
+Microsoft.AspNetCore.Components.AI.DefinitionNode.Title.get -> string?
+Microsoft.AspNetCore.Components.AI.DefinitionNode.Title.set -> void
+Microsoft.AspNetCore.Components.AI.DefinitionNode.Url.get -> string!
+Microsoft.AspNetCore.Components.AI.DefinitionNode.Url.set -> void
+Microsoft.AspNetCore.Components.AI.EmphasisNode
+Microsoft.AspNetCore.Components.AI.EmphasisNode.EmphasisNode() -> void
+Microsoft.AspNetCore.Components.AI.FootnoteDefinitionNode
+Microsoft.AspNetCore.Components.AI.FootnoteDefinitionNode.FootnoteDefinitionNode() -> void
+Microsoft.AspNetCore.Components.AI.FootnoteDefinitionNode.Label.get -> string!
+Microsoft.AspNetCore.Components.AI.FootnoteDefinitionNode.Label.set -> void
+Microsoft.AspNetCore.Components.AI.FootnoteNode
+Microsoft.AspNetCore.Components.AI.FootnoteNode.FootnoteNode() -> void
+Microsoft.AspNetCore.Components.AI.FootnoteReferenceNode
+Microsoft.AspNetCore.Components.AI.FootnoteReferenceNode.FootnoteReferenceNode() -> void
+Microsoft.AspNetCore.Components.AI.FootnoteReferenceNode.Label.get -> string!
+Microsoft.AspNetCore.Components.AI.FootnoteReferenceNode.Label.set -> void
+Microsoft.AspNetCore.Components.AI.HeadingNode
+Microsoft.AspNetCore.Components.AI.HeadingNode.HeadingNode() -> void
+Microsoft.AspNetCore.Components.AI.HeadingNode.HeadingNode(int level) -> void
+Microsoft.AspNetCore.Components.AI.HeadingNode.Level.get -> int
+Microsoft.AspNetCore.Components.AI.HeadingNode.Level.set -> void
+Microsoft.AspNetCore.Components.AI.HtmlNode
+Microsoft.AspNetCore.Components.AI.HtmlNode.HtmlNode() -> void
+Microsoft.AspNetCore.Components.AI.HtmlNode.HtmlNode(string! value) -> void
+Microsoft.AspNetCore.Components.AI.HtmlNode.Value.get -> string!
+Microsoft.AspNetCore.Components.AI.HtmlNode.Value.set -> void
+Microsoft.AspNetCore.Components.AI.ImageNode
+Microsoft.AspNetCore.Components.AI.ImageNode.Alt.get -> string?
+Microsoft.AspNetCore.Components.AI.ImageNode.Alt.set -> void
+Microsoft.AspNetCore.Components.AI.ImageNode.ImageNode() -> void
+Microsoft.AspNetCore.Components.AI.ImageNode.ImageNode(string! url, string? alt = null, string? title = null) -> void
+Microsoft.AspNetCore.Components.AI.ImageNode.Title.get -> string?
+Microsoft.AspNetCore.Components.AI.ImageNode.Title.set -> void
+Microsoft.AspNetCore.Components.AI.ImageNode.Url.get -> string!
+Microsoft.AspNetCore.Components.AI.ImageNode.Url.set -> void
+Microsoft.AspNetCore.Components.AI.ImageReferenceNode
+Microsoft.AspNetCore.Components.AI.ImageReferenceNode.Alt.get -> string?
+Microsoft.AspNetCore.Components.AI.ImageReferenceNode.Alt.set -> void
+Microsoft.AspNetCore.Components.AI.ImageReferenceNode.ImageReferenceNode() -> void
+Microsoft.AspNetCore.Components.AI.ImageReferenceNode.Label.get -> string!
+Microsoft.AspNetCore.Components.AI.ImageReferenceNode.Label.set -> void
+Microsoft.AspNetCore.Components.AI.ImageReferenceNode.ReferenceKind.get -> Microsoft.AspNetCore.Components.AI.ReferenceKind
+Microsoft.AspNetCore.Components.AI.ImageReferenceNode.ReferenceKind.set -> void
+Microsoft.AspNetCore.Components.AI.InlineCodeNode
+Microsoft.AspNetCore.Components.AI.InlineCodeNode.Code.get -> string!
+Microsoft.AspNetCore.Components.AI.InlineCodeNode.Code.set -> void
+Microsoft.AspNetCore.Components.AI.InlineCodeNode.InlineCodeNode() -> void
+Microsoft.AspNetCore.Components.AI.InlineCodeNode.InlineCodeNode(string! code) -> void
+Microsoft.AspNetCore.Components.AI.LineBreakNode
+Microsoft.AspNetCore.Components.AI.LineBreakNode.LineBreakNode() -> void
+Microsoft.AspNetCore.Components.AI.LinkNode
+Microsoft.AspNetCore.Components.AI.LinkNode.LinkNode() -> void
+Microsoft.AspNetCore.Components.AI.LinkNode.LinkNode(string! url, string? title = null) -> void
+Microsoft.AspNetCore.Components.AI.LinkNode.Title.get -> string?
+Microsoft.AspNetCore.Components.AI.LinkNode.Title.set -> void
+Microsoft.AspNetCore.Components.AI.LinkNode.Url.get -> string!
+Microsoft.AspNetCore.Components.AI.LinkNode.Url.set -> void
+Microsoft.AspNetCore.Components.AI.LinkReferenceNode
+Microsoft.AspNetCore.Components.AI.LinkReferenceNode.Label.get -> string!
+Microsoft.AspNetCore.Components.AI.LinkReferenceNode.Label.set -> void
+Microsoft.AspNetCore.Components.AI.LinkReferenceNode.LinkReferenceNode() -> void
+Microsoft.AspNetCore.Components.AI.LinkReferenceNode.ReferenceKind.get -> Microsoft.AspNetCore.Components.AI.ReferenceKind
+Microsoft.AspNetCore.Components.AI.LinkReferenceNode.ReferenceKind.set -> void
+Microsoft.AspNetCore.Components.AI.ListItemNode
+Microsoft.AspNetCore.Components.AI.ListItemNode.Checked.get -> bool?
+Microsoft.AspNetCore.Components.AI.ListItemNode.Checked.set -> void
+Microsoft.AspNetCore.Components.AI.ListItemNode.ListItemNode() -> void
+Microsoft.AspNetCore.Components.AI.ListNode
+Microsoft.AspNetCore.Components.AI.ListNode.ListNode() -> void
+Microsoft.AspNetCore.Components.AI.ListNode.ListNode(bool ordered, int? start = null) -> void
+Microsoft.AspNetCore.Components.AI.ListNode.Ordered.get -> bool
+Microsoft.AspNetCore.Components.AI.ListNode.Ordered.set -> void
+Microsoft.AspNetCore.Components.AI.ListNode.Start.get -> int?
+Microsoft.AspNetCore.Components.AI.ListNode.Start.set -> void
 Microsoft.AspNetCore.Components.AI.MessageInput
 Microsoft.AspNetCore.Components.AI.MessageInput.AgentContext.get -> Microsoft.AspNetCore.Components.AI.AgentContext!
 Microsoft.AspNetCore.Components.AI.MessageInput.AgentContext.set -> void
@@ -113,11 +200,49 @@ Microsoft.AspNetCore.Components.AI.MessageList.MessageList() -> void
 Microsoft.AspNetCore.Components.AI.MessageListContext
 Microsoft.AspNetCore.Components.AI.MessageListContext.MessageListContext() -> void
 Microsoft.AspNetCore.Components.AI.MessageListContext.RenderBlock(Microsoft.AspNetCore.Components.AI.ContentBlock! block) -> Microsoft.AspNetCore.Components.RenderFragment!
+Microsoft.AspNetCore.Components.AI.ParagraphNode
+Microsoft.AspNetCore.Components.AI.ParagraphNode.ParagraphNode() -> void
+Microsoft.AspNetCore.Components.AI.ReferenceKind
+Microsoft.AspNetCore.Components.AI.ReferenceKind.Collapsed = 1 -> Microsoft.AspNetCore.Components.AI.ReferenceKind
+Microsoft.AspNetCore.Components.AI.ReferenceKind.Full = 2 -> Microsoft.AspNetCore.Components.AI.ReferenceKind
+Microsoft.AspNetCore.Components.AI.ReferenceKind.Shortcut = 0 -> Microsoft.AspNetCore.Components.AI.ReferenceKind
 Microsoft.AspNetCore.Components.AI.RichContentBlock
 Microsoft.AspNetCore.Components.AI.RichContentBlock.AppendText(string! text) -> void
-Microsoft.AspNetCore.Components.AI.RichContentBlock.Paragraphs.get -> System.Collections.Generic.IReadOnlyList<string!>!
+Microsoft.AspNetCore.Components.AI.RichContentBlock.Content.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.AI.RichTextNode!>!
 Microsoft.AspNetCore.Components.AI.RichContentBlock.RawText.get -> string!
 Microsoft.AspNetCore.Components.AI.RichContentBlock.RichContentBlock() -> void
+Microsoft.AspNetCore.Components.AI.RichTextContent
+Microsoft.AspNetCore.Components.AI.RichTextContent.Nodes.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.AI.RichTextNode!>!
+Microsoft.AspNetCore.Components.AI.RichTextContent.RichTextContent(string! text, System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.AI.RichTextNode!>! nodes) -> void
+Microsoft.AspNetCore.Components.AI.RichTextContent.Text.get -> string!
+Microsoft.AspNetCore.Components.AI.RichTextNode
+Microsoft.AspNetCore.Components.AI.RichTextNode.AddChild(Microsoft.AspNetCore.Components.AI.RichTextNode! child) -> void
+Microsoft.AspNetCore.Components.AI.RichTextNode.Children.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.AI.RichTextNode!>!
+Microsoft.AspNetCore.Components.AI.RichTextNode.RichTextNode() -> void
+Microsoft.AspNetCore.Components.AI.StrikethroughNode
+Microsoft.AspNetCore.Components.AI.StrikethroughNode.StrikethroughNode() -> void
+Microsoft.AspNetCore.Components.AI.StrongNode
+Microsoft.AspNetCore.Components.AI.StrongNode.StrongNode() -> void
+Microsoft.AspNetCore.Components.AI.TableCellNode
+Microsoft.AspNetCore.Components.AI.TableCellNode.TableCellNode() -> void
+Microsoft.AspNetCore.Components.AI.TableColumnAlignment
+Microsoft.AspNetCore.Components.AI.TableColumnAlignment.Center = 2 -> Microsoft.AspNetCore.Components.AI.TableColumnAlignment
+Microsoft.AspNetCore.Components.AI.TableColumnAlignment.Left = 1 -> Microsoft.AspNetCore.Components.AI.TableColumnAlignment
+Microsoft.AspNetCore.Components.AI.TableColumnAlignment.None = 0 -> Microsoft.AspNetCore.Components.AI.TableColumnAlignment
+Microsoft.AspNetCore.Components.AI.TableColumnAlignment.Right = 3 -> Microsoft.AspNetCore.Components.AI.TableColumnAlignment
+Microsoft.AspNetCore.Components.AI.TableNode
+Microsoft.AspNetCore.Components.AI.TableNode.Alignment.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.AI.TableColumnAlignment>!
+Microsoft.AspNetCore.Components.AI.TableNode.Alignment.set -> void
+Microsoft.AspNetCore.Components.AI.TableNode.TableNode() -> void
+Microsoft.AspNetCore.Components.AI.TableRowNode
+Microsoft.AspNetCore.Components.AI.TableRowNode.TableRowNode() -> void
+Microsoft.AspNetCore.Components.AI.TextNode
+Microsoft.AspNetCore.Components.AI.TextNode.Text.get -> string!
+Microsoft.AspNetCore.Components.AI.TextNode.Text.set -> void
+Microsoft.AspNetCore.Components.AI.TextNode.TextNode() -> void
+Microsoft.AspNetCore.Components.AI.TextNode.TextNode(string! text) -> void
+Microsoft.AspNetCore.Components.AI.ThematicBreakNode
+Microsoft.AspNetCore.Components.AI.ThematicBreakNode.ThematicBreakNode() -> void
 Microsoft.AspNetCore.Components.AI.UIAgent
 Microsoft.AspNetCore.Components.AI.UIAgent.Dispose() -> void
 Microsoft.AspNetCore.Components.AI.UIAgent.SendMessageAsync(Microsoft.Extensions.AI.ChatMessage! message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Microsoft.AspNetCore.Components.AI.ContentBlock!>!

--- a/src/Components/AI/src/wwwroot/ai-chat.css
+++ b/src/Components/AI/src/wwwroot/ai-chat.css
@@ -162,6 +162,70 @@
     white-space: pre-wrap;
 }
 
+.sc-ai-rich-text__paragraph,
+.sc-ai-rich-text__heading,
+.sc-ai-rich-text__quote,
+.sc-ai-rich-text__list,
+.sc-ai-rich-text__code-block,
+.sc-ai-rich-text__table-container {
+    margin-block: 0 0.75em;
+}
+
+.sc-ai-message__content > :last-child {
+    margin-bottom: 0;
+}
+
+.sc-ai-rich-text__heading {
+    line-height: 1.25;
+}
+
+.sc-ai-rich-text__inline-code,
+.sc-ai-rich-text__code-block {
+    font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+    background: var(--sc-ai-color-surface-hover);
+    border-radius: var(--sc-ai-border-radius-sm);
+}
+
+.sc-ai-rich-text__inline-code {
+    padding: 0.1em 0.3em;
+}
+
+.sc-ai-rich-text__code-block {
+    overflow-x: auto;
+    padding: var(--sc-ai-spacing-sm);
+}
+
+.sc-ai-rich-text__quote {
+    border-left: 0.25rem solid var(--sc-ai-color-border);
+    padding-left: var(--sc-ai-spacing-md);
+}
+
+.sc-ai-rich-text__list-item > .sc-ai-rich-text__paragraph {
+    display: inline;
+}
+
+.sc-ai-rich-text__table-container {
+    overflow-x: auto;
+}
+
+.sc-ai-rich-text__table {
+    border-collapse: collapse;
+    width: 100%;
+}
+
+.sc-ai-rich-text__table td {
+    border: 1px solid var(--sc-ai-color-border);
+    padding: var(--sc-ai-spacing-xs) var(--sc-ai-spacing-sm);
+}
+
+.sc-ai-rich-text__table-cell--center {
+    text-align: center;
+}
+
+.sc-ai-rich-text__table-cell--right {
+    text-align: right;
+}
+
 /* Streaming cursor */
 .sc-ai-message__content--streaming::after {
     content: "";

--- a/src/Components/AI/test/Blocks/RichTextContentTests.cs
+++ b/src/Components/AI/test/Blocks/RichTextContentTests.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Blocks;
+
+public class RichTextContentTests
+{
+    [Fact]
+    public void Constructor_CopiesNodeList()
+    {
+        var nodes = new List<RichTextNode>
+        {
+            new ParagraphNode(),
+        };
+
+        var content = new RichTextContent("text", nodes);
+        nodes.Clear();
+
+        Assert.Single(content.Nodes);
+        Assert.Equal("text", content.Text);
+    }
+
+    [Fact]
+    public void Constructor_NullTextThrows()
+    {
+        Assert.Throws<ArgumentNullException>(
+            () => new RichTextContent(null!, Array.Empty<RichTextNode>()));
+    }
+
+    [Fact]
+    public void Constructor_NullNodesThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() => new RichTextContent("text", null!));
+    }
+}

--- a/src/Components/AI/test/Blocks/RichTextNodeTests.cs
+++ b/src/Components/AI/test/Blocks/RichTextNodeTests.cs
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Blocks;
+
+public class RichTextNodeTests
+{
+    [Fact]
+    public void AddChild_BuildsNestedTree()
+    {
+        var paragraph = new ParagraphNode();
+        paragraph.AddChild(new TextNode("Hello "));
+        var emphasis = new EmphasisNode();
+        emphasis.AddChild(new TextNode("world"));
+        paragraph.AddChild(emphasis);
+
+        Assert.Equal(2, paragraph.Children.Count);
+        Assert.Equal("Hello ", Assert.IsType<TextNode>(paragraph.Children[0]).Text);
+        Assert.Equal(
+            "world",
+            Assert.IsType<TextNode>(Assert.Single(
+                Assert.IsType<EmphasisNode>(paragraph.Children[1]).Children)).Text);
+    }
+
+    [Fact]
+    public void AddChild_NullThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() => new ParagraphNode().AddChild(null!));
+    }
+
+    [Fact]
+    public void Constructors_PreserveValues()
+    {
+        Assert.Equal("text", new TextNode("text").Text);
+        Assert.Equal(3, new HeadingNode(3).Level);
+
+        var codeBlock = new CodeBlockNode("var value = 1;", "csharp");
+        Assert.Equal("var value = 1;", codeBlock.Code);
+        Assert.Equal("csharp", codeBlock.Language);
+
+        var link = new LinkNode("https://example.com", "Example");
+        Assert.Equal("https://example.com", link.Url);
+        Assert.Equal("Example", link.Title);
+
+        var image = new ImageNode("/image.svg", "alt text", "Image");
+        Assert.Equal("/image.svg", image.Url);
+        Assert.Equal("alt text", image.Alt);
+        Assert.Equal("Image", image.Title);
+
+        Assert.Equal("code", new InlineCodeNode("code").Code);
+        Assert.Equal("<strong>text</strong>", new HtmlNode("<strong>text</strong>").Value);
+    }
+
+    [Fact]
+    public void ListAndTableMetadata_PreserveValues()
+    {
+        var list = new ListNode(ordered: true, start: 5);
+        Assert.True(list.Ordered);
+        Assert.Equal(5, list.Start);
+
+        var item = new ListItemNode { Checked = true };
+        Assert.True(item.Checked);
+
+        var table = new TableNode
+        {
+            Alignment =
+            [
+                TableColumnAlignment.Left,
+                TableColumnAlignment.Center,
+                TableColumnAlignment.Right,
+            ],
+        };
+        Assert.Equal(3, table.Alignment.Count);
+    }
+
+    [Fact]
+    public void ReferenceMetadata_PreserveValues()
+    {
+        var definition = new DefinitionNode
+        {
+            Label = "docs",
+            Url = "https://example.com",
+            Title = "Documentation",
+        };
+        Assert.Equal("docs", definition.Label);
+        Assert.Equal("https://example.com", definition.Url);
+        Assert.Equal("Documentation", definition.Title);
+
+        var link = new LinkReferenceNode
+        {
+            Label = "docs",
+            ReferenceKind = ReferenceKind.Full,
+        };
+        Assert.Equal("docs", link.Label);
+        Assert.Equal(ReferenceKind.Full, link.ReferenceKind);
+
+        var image = new ImageReferenceNode
+        {
+            Label = "logo",
+            Alt = "Logo",
+            ReferenceKind = ReferenceKind.Collapsed,
+        };
+        Assert.Equal("logo", image.Label);
+        Assert.Equal("Logo", image.Alt);
+        Assert.Equal(ReferenceKind.Collapsed, image.ReferenceKind);
+
+        Assert.Equal("note", new FootnoteReferenceNode { Label = "note" }.Label);
+        Assert.Equal("note", new FootnoteDefinitionNode { Label = "note" }.Label);
+    }
+}

--- a/src/Components/AI/test/Components/MessageListTests.cs
+++ b/src/Components/AI/test/Components/MessageListTests.cs
@@ -70,6 +70,32 @@ public class MessageListTests
     }
 
     [Fact]
+    public async Task RichTextContent_RendersStructuredNodesAndEncodesUnsafeContent()
+    {
+        var cut = RenderMessageList(_ => EmitRichTextResponse());
+        var context = GetAgentContext(cut);
+
+        await cut.InvokeAsync(() => context.SendMessageAsync("Format this"));
+
+        var html = cut.GetHtml();
+        Assert.Contains("<h2", html);
+        Assert.Contains("<strong>structured</strong>", html);
+        Assert.Contains("<em>rich text</em>", html);
+        Assert.Contains("<s>obsolete</s>", html);
+        Assert.Contains("class=\"sc-ai-rich-text__inline-code\"", html);
+        Assert.Contains("<blockquote", html);
+        Assert.Contains("<ul", html);
+        Assert.Contains("type=\"checkbox\"", html);
+        Assert.Contains("<pre", html);
+        Assert.Contains("<table", html);
+        Assert.Contains("href=\"https://example.com/docs\"", html);
+        Assert.DoesNotContain("href=\"javascript:", html);
+        Assert.Contains("&lt;script&gt;alert(", html);
+        Assert.Contains("&lt;/script&gt;", html);
+        Assert.DoesNotContain("<script>", html);
+    }
+
+    [Fact]
     public void EmptyConversation_RendersEmptyContent()
     {
         var cut = RenderMessageList(
@@ -160,6 +186,75 @@ public class MessageListTests
                 builder.CloseComponent();
             });
         });
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitRichTextResponse()
+    {
+        var heading = Node<HeadingNode>(new TextNode("Components.AI"));
+        heading.Level = 2;
+        var paragraph = Node<ParagraphNode>(
+            new TextNode("Render "),
+            Node<StrongNode>(new TextNode("structured")),
+            new TextNode(" "),
+            Node<EmphasisNode>(new TextNode("rich text")),
+            new TextNode(" and "),
+            Node<StrikethroughNode>(new TextNode("obsolete")),
+            new TextNode(" markup with "),
+            new InlineCodeNode("C#"),
+            new TextNode("."));
+        var safeLink = new LinkNode("https://example.com/docs");
+        safeLink.AddChild(new TextNode("Documentation"));
+        var unsafeLink = new LinkNode("javascript:alert('unsafe')");
+        unsafeLink.AddChild(new TextNode("Unsafe"));
+        var list = new ListNode();
+        list.AddChild(Node<ListItemNode>(Node<ParagraphNode>(new TextNode("First item"))));
+        var checkedItem = Node<ListItemNode>(Node<ParagraphNode>(new TextNode("Completed item")));
+        checkedItem.Checked = true;
+        list.AddChild(checkedItem);
+        var table = new TableNode
+        {
+            Alignment = [TableColumnAlignment.Left, TableColumnAlignment.Right],
+        };
+        table.AddChild(Node<TableRowNode>(
+            Node<TableCellNode>(new TextNode("Feature")),
+            Node<TableCellNode>(new TextNode("Status"))));
+
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "rich-text",
+            Contents =
+            [
+                new RichTextContent(
+                    "Components.AI structured rich text",
+                    [
+                        heading,
+                        paragraph,
+                        Node<BlockQuoteNode>(
+                            Node<ParagraphNode>(new TextNode("Streaming snapshot"))),
+                        list,
+                        new CodeBlockNode("Console.WriteLine(\"Hello\");", "csharp"),
+                        safeLink,
+                        unsafeLink,
+                        table,
+                        new HtmlNode("<script>alert('unsafe')</script>"),
+                    ]),
+            ],
+        };
+
+        await Task.CompletedTask;
+    }
+
+    private static TNode Node<TNode>(params RichTextNode[] children)
+        where TNode : RichTextNode, new()
+    {
+        var node = new TNode();
+        foreach (var child in children)
+        {
+            node.AddChild(child);
+        }
+
+        return node;
     }
 
     private static async Task WaitForHtmlAsync(

--- a/src/Components/AI/test/Components/MessageListTests.cs
+++ b/src/Components/AI/test/Components/MessageListTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Components.AI.Tests.TestFramework;
 using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
 using Microsoft.Extensions.AI;
@@ -93,6 +94,31 @@ public class MessageListTests
         Assert.Contains("&lt;script&gt;alert(", html);
         Assert.Contains("&lt;/script&gt;", html);
         Assert.DoesNotContain("<script>", html);
+    }
+
+    [Fact]
+    public async Task StreamingRichTextContent_ReplacesHeterogeneousSiblings()
+    {
+        var gate = new TaskCompletionSource();
+        var cut = RenderMessageList(ct => EmitStreamingRichTextResponse(gate.Task, ct));
+        var context = GetAgentContext(cut);
+
+        var sendTask = cut.InvokeAsync(() => context.SendMessageAsync("Format this"));
+
+        await WaitForHtmlAsync(cut, "Initial paragraph");
+        var initialHtml = cut.GetHtml();
+        Assert.Contains("<p", initialHtml);
+        Assert.DoesNotContain("Final heading", initialHtml);
+
+        gate.SetResult();
+        await sendTask;
+
+        var finalHtml = cut.GetHtml();
+        Assert.Contains("<h3", finalHtml);
+        Assert.Contains("Final heading", finalHtml);
+        Assert.Contains("<ul", finalHtml);
+        Assert.Contains("Final list item", finalHtml);
+        Assert.DoesNotContain("Initial paragraph", finalHtml);
     }
 
     [Fact]
@@ -243,6 +269,44 @@ public class MessageListTests
         };
 
         await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitStreamingRichTextResponse(
+        Task gate,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "streaming-rich-text",
+            Contents =
+            [
+                new RichTextContent(
+                    "Initial paragraph",
+                    [Node<ParagraphNode>(new TextNode("Initial paragraph"))]),
+            ],
+        };
+
+        await gate.WaitAsync(cancellationToken);
+
+        var heading = Node<HeadingNode>(new TextNode("Final heading"));
+        heading.Level = 3;
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "streaming-rich-text",
+            Contents =
+            [
+                new RichTextContent(
+                    "Final heading\n\nFinal list item",
+                    [
+                        heading,
+                        Node<ListNode>(
+                            Node<ListItemNode>(
+                                Node<ParagraphNode>(new TextNode("Final list item")))),
+                    ]),
+            ],
+        };
     }
 
     private static TNode Node<TNode>(params RichTextNode[] children)

--- a/src/Components/AI/test/Engine/UIAgentTests.cs
+++ b/src/Components/AI/test/Engine/UIAgentTests.cs
@@ -39,7 +39,8 @@ public class UIAgentTests
         var rich = Assert.IsType<RichContentBlock>(
             Assert.Single(blocks.Where(b => b.Role == ChatRole.Assistant)));
         Assert.Equal("Hello world!", rich.RawText);
-        Assert.Equal(["Hello world!"], rich.Paragraphs);
+        var paragraph = Assert.IsType<ParagraphNode>(Assert.Single(rich.Content));
+        Assert.Equal("Hello world!", Assert.IsType<TextNode>(Assert.Single(paragraph.Children)).Text);
     }
 
     [Fact]

--- a/src/Components/AI/test/Pipeline/BlockMappingPipelineTests.cs
+++ b/src/Components/AI/test/Pipeline/BlockMappingPipelineTests.cs
@@ -49,6 +49,57 @@ public class BlockMappingPipelineTests
     }
 
     [Fact]
+    public async Task Process_RichTextSnapshots_ReplaceTreeOnSameBlock()
+    {
+        var pipeline = CreatePipeline();
+        var firstNodes = new RichTextNode[]
+        {
+            CreateNode<HeadingNode>(new TextNode("Partial")),
+        };
+        var finalNodes = new RichTextNode[]
+        {
+            CreateNode<HeadingNode>(new TextNode("Complete")),
+            CreateNode<ParagraphNode>(new TextNode("Formatted response")),
+        };
+
+        var blocks = await ProcessAsync(
+            pipeline,
+            CreateRichTextUpdate("msg-1", "Partial", firstNodes));
+        var moreBlocks = await ProcessAsync(
+            pipeline,
+            CreateRichTextUpdate("msg-1", "Complete\n\nFormatted response", finalNodes));
+
+        Assert.Empty(moreBlocks);
+        var block = Assert.IsType<RichContentBlock>(Assert.Single(blocks));
+        Assert.Equal("Complete\n\nFormatted response", block.RawText);
+        Assert.Equal(finalNodes, block.Content);
+        Assert.Equal("Partial", Assert.IsType<TextNode>(Assert.Single(firstNodes[0].Children)).Text);
+    }
+
+    [Fact]
+    public async Task Process_RichTextSnapshot_NotifiesSubscribers()
+    {
+        var pipeline = CreatePipeline();
+        var blocks = await ProcessAsync(
+            pipeline,
+            CreateRichTextUpdate(
+                "msg-1",
+                "Partial",
+                [CreateNode<ParagraphNode>(new TextNode("Partial"))]));
+        var changeCount = 0;
+        using var subscription = blocks[0].OnChanged(() => changeCount++);
+
+        await ProcessAsync(
+            pipeline,
+            CreateRichTextUpdate(
+                "msg-1",
+                "Complete",
+                [CreateNode<ParagraphNode>(new TextNode("Complete"))]));
+
+        Assert.Equal(1, changeCount);
+    }
+
+    [Fact]
     public async Task Process_UpdateWithoutText_CompletesActiveBlock()
     {
         var pipeline = CreatePipeline();
@@ -107,6 +158,28 @@ public class BlockMappingPipelineTests
         MessageId = messageId,
         Contents = [new TextContent(text)],
     };
+
+    private static ChatResponseUpdate CreateRichTextUpdate(
+        string messageId,
+        string text,
+        IReadOnlyList<RichTextNode> nodes) => new()
+        {
+            Role = ChatRole.Assistant,
+            MessageId = messageId,
+            Contents = [new RichTextContent(text, nodes)],
+        };
+
+    private static TNode CreateNode<TNode>(params RichTextNode[] children)
+        where TNode : RichTextNode, new()
+    {
+        var node = new TNode();
+        foreach (var child in children)
+        {
+            node.AddChild(child);
+        }
+
+        return node;
+    }
 
     private static async Task<List<ContentBlock>> ProcessAsync(
         BlockMappingPipeline pipeline, ChatResponseUpdate update)

--- a/src/Components/AI/test/Pipeline/BlockMappingPipelineTests.cs
+++ b/src/Components/AI/test/Pipeline/BlockMappingPipelineTests.cs
@@ -100,6 +100,57 @@ public class BlockMappingPipelineTests
     }
 
     [Fact]
+    public async Task Process_RichTextSnapshotsWithDifferentMessageIds_EmitSeparateBlocks()
+    {
+        var pipeline = CreatePipeline();
+
+        var firstBlocks = await ProcessAsync(
+            pipeline,
+            CreateRichTextUpdate(
+                "msg-1",
+                "First",
+                [CreateNode<ParagraphNode>(new TextNode("First"))]));
+        var secondBlocks = await ProcessAsync(
+            pipeline,
+            CreateRichTextUpdate(
+                "msg-2",
+                "Second",
+                [CreateNode<ParagraphNode>(new TextNode("Second"))]));
+
+        var firstBlock = Assert.IsType<RichContentBlock>(Assert.Single(firstBlocks));
+        var secondBlock = Assert.IsType<RichContentBlock>(Assert.Single(secondBlocks));
+        Assert.Equal("msg-1", firstBlock.Id);
+        Assert.Equal("First", firstBlock.RawText);
+        Assert.Equal(BlockLifecycleState.Inactive, firstBlock.LifecycleState);
+        Assert.Equal("msg-2", secondBlock.Id);
+        Assert.Equal("Second", secondBlock.RawText);
+    }
+
+    [Fact]
+    public async Task Process_RichTextSnapshotWithTextFallback_EmitsSingleBlock()
+    {
+        var pipeline = CreatePipeline();
+        var update = new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "msg-1",
+            Contents =
+            [
+                new RichTextContent(
+                    "Formatted",
+                    [CreateNode<ParagraphNode>(new TextNode("Formatted"))]),
+                new TextContent("Formatted"),
+            ],
+        };
+
+        var blocks = await ProcessAsync(pipeline, update);
+
+        var block = Assert.IsType<RichContentBlock>(Assert.Single(blocks));
+        Assert.Equal("Formatted", block.RawText);
+        Assert.IsType<ParagraphNode>(Assert.Single(block.Content));
+    }
+
+    [Fact]
     public async Task Process_UpdateWithoutText_CompletesActiveBlock()
     {
         var pipeline = CreatePipeline();

--- a/src/Components/AI/test/Pipeline/TextBlockHandlerParagraphTests.cs
+++ b/src/Components/AI/test/Pipeline/TextBlockHandlerParagraphTests.cs
@@ -13,7 +13,7 @@ public class TextBlockHandlerParagraphTests
 
         TextBlockHandler.RebuildParagraphs(block);
 
-        Assert.Equal("Hello world", Assert.Single(block.Paragraphs));
+        Assert.Equal("Hello world", GetParagraphText(Assert.Single(block.Content)));
     }
 
     [Fact]
@@ -24,7 +24,7 @@ public class TextBlockHandlerParagraphTests
 
         TextBlockHandler.RebuildParagraphs(block);
 
-        Assert.Equal(["First", "Second"], block.Paragraphs);
+        Assert.Equal(["First", "Second"], block.Content.Select(GetParagraphText));
     }
 
     [Fact]
@@ -35,7 +35,7 @@ public class TextBlockHandlerParagraphTests
 
         TextBlockHandler.RebuildParagraphs(block);
 
-        Assert.Equal("Hello", Assert.Single(block.Paragraphs));
+        Assert.Equal("Hello", GetParagraphText(Assert.Single(block.Content)));
     }
 
     [Fact]
@@ -46,7 +46,7 @@ public class TextBlockHandlerParagraphTests
 
         TextBlockHandler.RebuildParagraphs(block);
 
-        Assert.Equal(["First", "Second"], block.Paragraphs);
+        Assert.Equal(["First", "Second"], block.Content.Select(GetParagraphText));
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class TextBlockHandlerParagraphTests
 
         TextBlockHandler.RebuildParagraphs(block);
 
-        Assert.Empty(block.Paragraphs);
+        Assert.Empty(block.Content);
     }
 
     [Fact]
@@ -67,6 +67,12 @@ public class TextBlockHandlerParagraphTests
 
         TextBlockHandler.RebuildParagraphs(block);
 
-        Assert.Equal("First\nSecond", Assert.Single(block.Paragraphs));
+        Assert.Equal("First\nSecond", GetParagraphText(Assert.Single(block.Content)));
+    }
+
+    private static string GetParagraphText(RichTextNode node)
+    {
+        var paragraph = Assert.IsType<ParagraphNode>(node);
+        return Assert.IsType<TextNode>(Assert.Single(paragraph.Children)).Text;
     }
 }

--- a/src/Components/AI/testassets/AGUIDojoApi/ScriptedChatClient.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/ScriptedChatClient.cs
@@ -30,7 +30,14 @@ internal sealed class ScriptedChatClient : IChatClient
         }
 
         var messageId = Guid.NewGuid().ToString("N");
-        var answer = $"You said: {prompt}. This is the scripted dojo agent answering without a live model.";
+        var answer = $"""
+            ## Agentic response
+
+            You said: **{prompt}**.
+
+            - Streams over AG-UI SSE
+            - Renders `structured` assistant content
+            """;
 
         foreach (var token in answer.Split(' '))
         {

--- a/src/Components/AI/testassets/AIApp.E2E.Tests/AIApp.E2E.Tests.csproj
+++ b/src/Components/AI/testassets/AIApp.E2E.Tests/AIApp.E2E.Tests.csproj
@@ -1,0 +1,54 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../../../Testing/eng/targets/Microsoft.AspNetCore.Components.Testing.props" />
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TestRunnerName>Microsoft.Testing.Platform</TestRunnerName>
+    <TestCaptureOutput>false</TestCaptureOutput>
+    <TestDependsOnPlaywright>true</TestDependsOnPlaywright>
+    <TestRunnerAdditionalArguments>--timeout 15m --maximum-failed-tests 25 --minimum-expected-tests 1 --filter "TestCategory!=Quarantined"</TestRunnerAdditionalArguments>
+    <IsPackable>false</IsPackable>
+    <DisablePackageReferenceRestrictions>true</DisablePackageReferenceRestrictions>
+    <NoWarn>$(NoWarn);NETSDK1023;MSTEST0001</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="MSTest.TestFramework" />
+    <Reference Include="Microsoft.Testing.Extensions.TrxReport" />
+    <Reference Include="Microsoft.Playwright" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore.Components.Testing" />
+    <ProjectReference Include="../AIApp/AIApp.csproj">
+      <E2EApp>true</E2EApp>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../Testing/gen/Microsoft.AspNetCore.Components.Testing.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+  <Import Project="../../../Testing/eng/targets/Microsoft.AspNetCore.Components.Testing.targets"
+          Condition="'$(_ImportComponentsTestingTargets)' == 'true'" />
+
+  <Target Name="_PreparePublishedE2EApps"
+          AfterTargets="Publish"
+          Condition="'$(_ImportComponentsTestingTargets)' == 'true'">
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="PrepareE2EApps"
+             Properties="_E2EIsPublishing=true;E2EAppMode=publish;PublishDir=$(PublishDir)"
+             RemoveProperties="NoBuild" />
+  </Target>
+
+</Project>

--- a/src/Components/AI/testassets/AIApp.E2E.Tests/Fixtures/E2ETestAssembly.cs
+++ b/src/Components/AI/testassets/AIApp.E2E.Tests/Fixtures/E2ETestAssembly.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace AIApp.E2E.Tests.Fixtures;
+
+public class E2ETestAssembly;

--- a/src/Components/AI/testassets/AIApp.E2E.Tests/Fixtures/TestRoot.cs
+++ b/src/Components/AI/testassets/AIApp.E2E.Tests/Fixtures/TestRoot.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Testing.Infrastructure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AIApp.E2E.Tests.Fixtures;
+
+[TestClass]
+public static class TestRoot
+{
+    public static ServerFactory<E2ETestAssembly> Servers { get; private set; } = null!;
+
+    [AssemblyInitialize]
+    public static async Task Init(TestContext _)
+    {
+        Servers = new ServerFactory<E2ETestAssembly>();
+        await Servers.InitializeAsync();
+    }
+
+    [AssemblyCleanup]
+    public static Task Cleanup() => Servers.DisposeAsync().AsTask();
+}

--- a/src/Components/AI/testassets/AIApp.E2E.Tests/Tests/RichTextTests.cs
+++ b/src/Components/AI/testassets/AIApp.E2E.Tests/Tests/RichTextTests.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using AIApp.Components;
+using AIApp.E2E.Tests.Fixtures;
+using Microsoft.AspNetCore.Components.Testing.Infrastructure;
+using Microsoft.AspNetCore.Components.Testing.Playwright;
+using Microsoft.Playwright;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AIApp.E2E.Tests.Tests;
+
+[UITest]
+public partial class RichTextTests : BrowserTest
+{
+    [TestMethod]
+    public async Task RichText_RendersTheStructuredContentMatrix()
+    {
+        var server = await StartServerAsync<App>(TestRoot.Servers);
+        var context = await NewContext(new BrowserNewContextOptions().WithServerRouting(server));
+        var page = await context.NewPageAsync();
+        await page.GotoAsync($"{server.TestUrl}/rich-text");
+        await page.WaitForInteractiveAsync("textarea.sc-ai-input__textarea");
+
+        await page.FillAsync("textarea.sc-ai-input__textarea", "Render rich text");
+        await page.ClickAsync("button.sc-ai-input__send");
+
+        var assistant = page.Locator(".sc-ai-message--assistant .sc-ai-message__content");
+        await Expect(assistant.Locator("h2")).ToHaveTextAsync("Components.AI rich text");
+        await Expect(assistant.Locator("strong")).ToHaveTextAsync("strong");
+        await Expect(assistant.Locator("em")).ToHaveTextAsync("emphasized");
+        await Expect(assistant.Locator("s")).ToHaveTextAsync("struck-through");
+        await Expect(assistant.Locator("code").First).ToHaveTextAsync("C#");
+        await Expect(assistant.Locator("blockquote"))
+            .ToContainTextAsync("Streaming never exposes a partial tree.");
+        await Expect(assistant.Locator("li")).ToHaveCountAsync(2);
+        await Expect(assistant.Locator("input[type=checkbox]")).ToBeCheckedAsync();
+        await Expect(assistant.Locator("pre code"))
+            .ToHaveTextAsync("Console.WriteLine(\"Rich text\");");
+        await Expect(assistant.Locator("table tr")).ToHaveCountAsync(2);
+        await Expect(assistant.GetByRole(AriaRole.Link, new() { Name = "Components documentation" }))
+            .ToHaveAttributeAsync("href", "https://learn.microsoft.com/aspnet/core/blazor/");
+        await Expect(assistant.GetByAltText("Decorative rich text sample")).ToBeVisibleAsync();
+        await Expect(assistant.Locator("sup")).ToHaveTextAsync("snapshot");
+        await Expect(assistant).ToContainTextAsync("<mark>Encoded HTML source</mark>");
+        await Expect(assistant.Locator("mark")).ToHaveCountAsync(0);
+    }
+}

--- a/src/Components/AI/testassets/AIApp/AIApp.csproj
+++ b/src/Components/AI/testassets/AIApp/AIApp.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
+    <NoWarn>$(NoWarn);NU1511</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore" />
+    <Reference Include="Microsoft.AspNetCore.Antiforgery" />
+    <Reference Include="Microsoft.AspNetCore.Components" />
+    <Reference Include="Microsoft.AspNetCore.Components.AI" />
+    <Reference Include="Microsoft.AspNetCore.Components.Endpoints" />
+    <Reference Include="Microsoft.AspNetCore.Components.Server" />
+    <Reference Include="Microsoft.AspNetCore.Components.Web" />
+    <Reference Include="Microsoft.AspNetCore.Hosting" />
+    <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
+    <Reference Include="Microsoft.AspNetCore.Http" />
+    <Reference Include="Microsoft.AspNetCore.Http.Abstractions" />
+    <Reference Include="Microsoft.AspNetCore.Http.Features" />
+    <Reference Include="Microsoft.AspNetCore.Routing" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel" />
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Core" />
+    <Reference Include="Microsoft.AspNetCore.StaticAssets" />
+    <Reference Include="Microsoft.Extensions.AI" />
+    <Reference Include="Microsoft.Extensions.Hosting" />
+    <Reference Include="Microsoft.JSInterop" />
+  </ItemGroup>
+
+</Project>

--- a/src/Components/AI/testassets/AIApp/Components/App.razor
+++ b/src/Components/AI/testassets/AIApp/Components/App.razor
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" />
+    <link rel="stylesheet" href="@Assets["_content/Microsoft.AspNetCore.Components.AI/ai-chat.css"]" />
+    <link rel="stylesheet" href="@Assets["app.css"]" />
+    <ImportMap />
+    <HeadOutlet />
+</head>
+
+<body>
+    <Routes />
+    <script src="@Assets["_framework/blazor.web.js"]"></script>
+</body>
+
+</html>

--- a/src/Components/AI/testassets/AIApp/Components/Pages/Home.razor
+++ b/src/Components/AI/testassets/AIApp/Components/Pages/Home.razor
@@ -1,0 +1,7 @@
+@page "/"
+
+<PageTitle>Components.AI test app</PageTitle>
+
+<h1>Components.AI test app</h1>
+
+<p><a href="/rich-text">Rich text rendering</a></p>

--- a/src/Components/AI/testassets/AIApp/Components/Pages/RichText.razor
+++ b/src/Components/AI/testassets/AIApp/Components/Pages/RichText.razor
@@ -1,0 +1,166 @@
+@page "/rich-text"
+@rendermode InteractiveServer
+@implements IDisposable
+@using System.Runtime.CompilerServices
+
+<PageTitle>Rich text rendering</PageTitle>
+
+<h1>Rich text rendering</h1>
+
+<ChatPage Agent="_agent" Placeholder="Request rich text" data-scenario="rich-text">
+    <WelcomeContent>
+        <p>Send a message to render the structured content matrix.</p>
+    </WelcomeContent>
+</ChatPage>
+
+@code {
+    private readonly UIAgent _agent = new(new RichTextChatClient());
+
+    public void Dispose() => _agent.Dispose();
+
+    private sealed class RichTextChatClient : IChatClient
+    {
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            yield return CreateUpdate(
+                "Components.AI rich text",
+                [
+                    Node<HeadingNode>(new TextNode("Components.AI rich text"), heading => heading.Level = 2),
+                    Node<ParagraphNode>(
+                        new TextNode("Streaming "),
+                        Node<StrongNode>(new TextNode("structured content"))),
+                ]);
+
+            await Task.Yield();
+            cancellationToken.ThrowIfCancellationRequested();
+
+            yield return CreateUpdate("Complete structured content", CreateContentMatrix());
+        }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => GetStreamingResponseAsync(messages, options, cancellationToken)
+                .ToChatResponseAsync(cancellationToken);
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => serviceType == typeof(IChatClient) ? this : null;
+
+        public void Dispose()
+        {
+        }
+
+        private static ChatResponseUpdate CreateUpdate(
+            string text,
+            IReadOnlyList<RichTextNode> nodes)
+            => new()
+            {
+                Role = ChatRole.Assistant,
+                MessageId = "aiapp-rich-text",
+                Contents = [new RichTextContent(text, nodes)],
+            };
+
+        private static IReadOnlyList<RichTextNode> CreateContentMatrix()
+        {
+            var safeLink = Node<LinkNode>(
+                new TextNode("Components documentation"),
+                link =>
+                {
+                    link.Url = "https://learn.microsoft.com/aspnet/core/blazor/";
+                    link.Title = "Blazor documentation";
+                });
+            var image = new ImageNode("/rich-text-image.svg", "Decorative rich text sample");
+            var task = Node<ListItemNode>(
+                Node<ParagraphNode>(new TextNode("Structured snapshots")));
+            task.Checked = true;
+            var table = new TableNode
+            {
+                Alignment = [TableColumnAlignment.Left, TableColumnAlignment.Right],
+            };
+            table.AddChild(Node<TableRowNode>(
+                Node<TableCellNode>(new TextNode("Node")),
+                Node<TableCellNode>(new TextNode("Rendered as"))));
+            table.AddChild(Node<TableRowNode>(
+                Node<TableCellNode>(new TextNode("StrongNode")),
+                Node<TableCellNode>(new TextNode("strong"))));
+
+            var footnoteDefinition = Node<FootnoteDefinitionNode>(
+                Node<ParagraphNode>(new TextNode("Snapshots replace the complete tree.")));
+            footnoteDefinition.Label = "snapshot";
+
+            return
+            [
+                Node<HeadingNode>(
+                    new TextNode("Components.AI rich text"),
+                    heading => heading.Level = 2),
+                Node<ParagraphNode>(
+                    new TextNode("Render "),
+                    Node<StrongNode>(new TextNode("strong")),
+                    new TextNode(", "),
+                    Node<EmphasisNode>(new TextNode("emphasized")),
+                    new TextNode(", and "),
+                    Node<StrikethroughNode>(new TextNode("struck-through")),
+                    new TextNode(" text with "),
+                    new InlineCodeNode("C#"),
+                    new TextNode(" and "),
+                    safeLink,
+                    new TextNode(".")),
+                Node<BlockQuoteNode>(
+                    Node<ParagraphNode>(new TextNode("Streaming never exposes a partial tree."))),
+                Node<ListNode>(
+                    Node<ListItemNode>(Node<ParagraphNode>(new TextNode("Headings and paragraphs"))),
+                    task),
+                new CodeBlockNode("Console.WriteLine(\"Rich text\");", "csharp"),
+                new ThematicBreakNode(),
+                table,
+                image,
+                Node<ParagraphNode>(
+                    new TextNode("Snapshot semantics"),
+                    new FootnoteReferenceNode { Label = "snapshot" }),
+                footnoteDefinition,
+                new DefinitionNode
+                {
+                    Label = "components",
+                    Url = "https://learn.microsoft.com/aspnet/core/blazor/",
+                    Title = "Components",
+                },
+                new ImageReferenceNode
+                {
+                    Label = "sample",
+                    Alt = "Image reference fallback",
+                    ReferenceKind = ReferenceKind.Collapsed,
+                },
+                new HtmlNode("<mark>Encoded HTML source</mark>"),
+            ];
+        }
+
+        private static TNode Node<TNode>(params RichTextNode[] children)
+            where TNode : RichTextNode, new()
+            => Node<TNode>(children, configure: null);
+
+        private static TNode Node<TNode>(
+            RichTextNode child,
+            Action<TNode> configure)
+            where TNode : RichTextNode, new()
+            => Node<TNode>([child], configure);
+
+        private static TNode Node<TNode>(
+            RichTextNode[] children,
+            Action<TNode>? configure)
+            where TNode : RichTextNode, new()
+        {
+            var node = new TNode();
+            configure?.Invoke(node);
+            foreach (var child in children)
+            {
+                node.AddChild(child);
+            }
+
+            return node;
+        }
+    }
+}

--- a/src/Components/AI/testassets/AIApp/Components/Routes.razor
+++ b/src/Components/AI/testassets/AIApp/Components/Routes.razor
@@ -1,0 +1,6 @@
+<Router AppAssembly="typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" />
+        <FocusOnNavigate RouteData="routeData" Selector="h1" />
+    </Found>
+</Router>

--- a/src/Components/AI/testassets/AIApp/Components/_Imports.razor
+++ b/src/Components/AI/testassets/AIApp/Components/_Imports.razor
@@ -1,0 +1,8 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components.AI
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
+@using Microsoft.Extensions.AI
+@using AIApp
+@using AIApp.Components

--- a/src/Components/AI/testassets/AIApp/Program.cs
+++ b/src/Components/AI/testassets/AIApp/Program.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using AIApp.Components;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorComponents()
+    .AddInteractiveServerComponents();
+
+var app = builder.Build();
+
+app.UseAntiforgery();
+app.MapStaticAssets();
+app.MapRazorComponents<App>()
+    .AddInteractiveServerRenderMode();
+
+app.Run();

--- a/src/Components/AI/testassets/AIApp/wwwroot/app.css
+++ b/src/Components/AI/testassets/AIApp/wwwroot/app.css
@@ -1,0 +1,9 @@
+html,
+body {
+    margin: 0;
+    font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+body > h1 {
+    padding-inline: 1.5rem;
+}

--- a/src/Components/AI/testassets/AIApp/wwwroot/rich-text-image.svg
+++ b/src/Components/AI/testassets/AIApp/wwwroot/rich-text-image.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+  <rect width="48" height="48" rx="8" fill="#512bd4"/>
+  <path d="M12 14h24v4H12zm0 8h18v4H12zm0 8h21v4H12z" fill="#fff"/>
+</svg>

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Baselines/AgenticChatRichText.recording.json
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Baselines/AgenticChatRichText.recording.json
@@ -1,0 +1,23 @@
+{
+  "calls": [
+    {
+      "prompt": "Show a formatted Blazor overview",
+      "frames": [
+        {
+          "name": "structure",
+          "chunks": [
+            "## Blazor components\n\n",
+            "Blazor renders **interactive UI** with `C#`.\n\n"
+          ]
+        },
+        {
+          "name": "complete",
+          "chunks": [
+            "- [Server rendering](https://learn.microsoft.com/aspnet/core/blazor/)\n",
+            "- WebAssembly rendering"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/DojoModelOverrides.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/DojoModelOverrides.cs
@@ -14,6 +14,9 @@ internal class DojoModelOverrides
     public static void AgenticChat(IServiceCollection services)
         => AddRecordedModel(services, "AgenticChat.recording.json");
 
+    public static void AgenticChatRichText(IServiceCollection services)
+        => AddRecordedModel(services, "AgenticChatRichText.recording.json");
+
     private static void AddRecordedModel(IServiceCollection services, string recordingFileName)
     {
         services.AddSingleton(_ => RecordedScript.Load(recordingFileName));

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/AgenticChatRichTextScenarioTests.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/AgenticChatRichTextScenarioTests.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using AGUIDojoApi;
+using DojoClient.E2E.Tests.Fixtures;
+using DojoClient.E2E.Tests.ServiceOverrides;
+using Microsoft.AspNetCore.Components.Testing.Infrastructure;
+using Microsoft.AspNetCore.Components.Testing.Playwright;
+using Microsoft.Playwright;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DojoClient.E2E.Tests.Tests;
+
+[UITest]
+public partial class AgenticChatRichTextScenarioTests : BrowserTest
+{
+    private const string PromptText = "Show a formatted Blazor overview";
+
+    [TestMethod]
+    public async Task AgenticChat_RendersFormattedAssistantResponseOverAgui()
+    {
+        var api = await StartServerAsync<AGUIDojoApiAssembly>(TestRoot.Servers, options =>
+        {
+            options.ConfigureServices<DojoModelOverrides>(
+                nameof(DojoModelOverrides.AgenticChatRichText));
+        });
+        var ui = await StartServerAsync<global::DojoClient.Components.App>(
+            TestRoot.Servers,
+            options => options.EnvironmentVariables["AGUI_DOJO_API_URL"] = api.AppUrl);
+        var checkpoints = new ApiCheckpointClient(api);
+        var context = await NewContext(new BrowserNewContextOptions().WithServerRouting(ui));
+        var page = await context.NewPageAsync();
+        await page.GotoAsync($"{ui.TestUrl}/agentic_chat");
+        await page.WaitForInteractiveAsync("textarea.sc-ai-input__textarea");
+
+        var prompt = $"{PromptText} ({Guid.NewGuid():N})";
+        await page.FillAsync("textarea.sc-ai-input__textarea", prompt);
+        await page.ClickAsync("button.sc-ai-input__send");
+
+        var assistant = page.Locator(".sc-ai-message--assistant .sc-ai-message__content");
+        await Expect(assistant.Locator("h2")).ToHaveTextAsync("Blazor components");
+        await Expect(assistant.Locator("strong")).ToHaveTextAsync("interactive UI");
+        await Expect(assistant.Locator("code")).ToHaveTextAsync("C#");
+        await Expect(assistant.Locator("li")).ToHaveCountAsync(0);
+
+        await checkpoints.ReleaseAsync(prompt, "structure");
+
+        await Expect(assistant.Locator("li")).ToHaveCountAsync(2);
+        await Expect(assistant.GetByRole(AriaRole.Link, new() { Name = "Server rendering" }))
+            .ToHaveAttributeAsync(
+                "href",
+                "https://learn.microsoft.com/aspnet/core/blazor/");
+        await Expect(page.Locator(".sc-ai-message__content--streaming")).Not.ToBeVisibleAsync();
+    }
+}

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/FormattedChatClientTests.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/FormattedChatClientTests.cs
@@ -35,9 +35,29 @@ public class FormattedChatClientTests
 
         var updates = await CollectAsync(client);
 
+        Assert.AreEqual("message-1", updates[0].MessageId);
+        Assert.AreEqual("message-2", updates[1].MessageId);
+        Assert.AreEqual("message-1", updates[2].MessageId);
         Assert.AreEqual("First", GetRichText(updates[0]).Text);
         Assert.AreEqual("Second", GetRichText(updates[1]).Text);
         Assert.AreEqual("First continued", GetRichText(updates[2]).Text);
+    }
+
+    [TestMethod]
+    public async Task FormattedUpdates_PreserveTextInConversationHistory()
+    {
+        using var innerClient = new RecordingChatClient();
+        using var client = new FormattedChatClient(innerClient);
+        using var agent = new UIAgent(client);
+
+        await CollectAsync(agent, "First question");
+        await CollectAsync(agent, "Second question");
+
+        Assert.AreEqual(2, innerClient.Requests.Count);
+        Assert.AreEqual(3, innerClient.Requests[1].Count);
+        Assert.AreEqual("First question", innerClient.Requests[1][0].Text);
+        Assert.AreEqual("Answer 1", innerClient.Requests[1][1].Text);
+        Assert.AreEqual("Second question", innerClient.Requests[1][2].Text);
     }
 
     [TestMethod]
@@ -87,10 +107,7 @@ public class FormattedChatClientTests
 
     private static RichTextContent GetRichText(ChatResponseUpdate update)
     {
-        Assert.AreEqual(1, update.Contents.Count);
-        var content = update.Contents[0];
-        Assert.IsInstanceOfType(content, typeof(RichTextContent));
-        return (RichTextContent)content;
+        return update.Contents.OfType<RichTextContent>().Single();
     }
 
     private static async Task<List<ChatResponseUpdate>> CollectAsync(IChatClient client)
@@ -102,6 +119,13 @@ public class FormattedChatClientTests
         }
 
         return updates;
+    }
+
+    private static async Task CollectAsync(UIAgent agent, string text)
+    {
+        await foreach (var _ in agent.SendMessageAsync(new ChatMessage(ChatRole.User, text)))
+        {
+        }
     }
 
     private sealed class TestChatClient(IReadOnlyList<ChatResponseUpdate> updates) : IChatClient
@@ -117,6 +141,36 @@ public class FormattedChatClientTests
                 yield return update;
                 await Task.Yield();
             }
+        }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => GetStreamingResponseAsync(messages, options, cancellationToken)
+                .ToChatResponseAsync(cancellationToken);
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => serviceType == typeof(IChatClient) ? this : null;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class RecordingChatClient : IChatClient
+    {
+        public List<IReadOnlyList<ChatMessage>> Requests { get; } = [];
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            Requests.Add(messages.ToList());
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return CreateTextUpdate($"message-{Requests.Count}", $"Answer {Requests.Count}");
+            await Task.Yield();
         }
 
         public Task<ChatResponse> GetResponseAsync(

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/FormattedChatClientTests.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/FormattedChatClientTests.cs
@@ -1,0 +1,136 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using DojoClient.Formatting;
+using Microsoft.AspNetCore.Components.AI;
+using Microsoft.Extensions.AI;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DojoClient.E2E.Tests.Tests;
+
+[TestClass]
+public class FormattedChatClientTests
+{
+    [TestMethod]
+    public async Task TextUpdatesWithSameMessageId_AreCoalesced()
+    {
+        using var client = CreateClient(
+            CreateTextUpdate("message-1", "Hello"),
+            CreateTextUpdate("message-1", " world"));
+
+        var updates = await CollectAsync(client);
+
+        Assert.AreEqual("Hello", GetRichText(updates[0]).Text);
+        Assert.AreEqual("Hello world", GetRichText(updates[1]).Text);
+    }
+
+    [TestMethod]
+    public async Task TextUpdatesWithDifferentMessageIds_AreIndependent()
+    {
+        using var client = CreateClient(
+            CreateTextUpdate("message-1", "First"),
+            CreateTextUpdate("message-2", "Second"),
+            CreateTextUpdate("message-1", " continued"));
+
+        var updates = await CollectAsync(client);
+
+        Assert.AreEqual("First", GetRichText(updates[0]).Text);
+        Assert.AreEqual("Second", GetRichText(updates[1]).Text);
+        Assert.AreEqual("First continued", GetRichText(updates[2]).Text);
+    }
+
+    [TestMethod]
+    public async Task TextUpdatesWithoutMessageId_AreNotCoalesced()
+    {
+        var text = new TextContent("Unidentified");
+        using var client = CreateClient(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents = [text],
+        });
+
+        var updates = await CollectAsync(client);
+
+        Assert.AreEqual(1, updates.Count);
+        Assert.AreEqual(1, updates[0].Contents.Count);
+        Assert.AreSame(text, updates[0].Contents[0]);
+    }
+
+    [TestMethod]
+    public async Task NonTextUpdates_ArePassedThrough()
+    {
+        var content = new AIContent();
+        using var client = CreateClient(new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "message-1",
+            Contents = [content],
+        });
+
+        var updates = await CollectAsync(client);
+
+        Assert.AreEqual(1, updates.Count);
+        Assert.AreEqual(1, updates[0].Contents.Count);
+        Assert.AreSame(content, updates[0].Contents[0]);
+    }
+
+    private static FormattedChatClient CreateClient(params ChatResponseUpdate[] updates)
+        => new(new TestChatClient(updates));
+
+    private static ChatResponseUpdate CreateTextUpdate(string messageId, string text) => new()
+    {
+        Role = ChatRole.Assistant,
+        MessageId = messageId,
+        Contents = [new TextContent(text)],
+    };
+
+    private static RichTextContent GetRichText(ChatResponseUpdate update)
+    {
+        Assert.AreEqual(1, update.Contents.Count);
+        var content = update.Contents[0];
+        Assert.IsInstanceOfType(content, typeof(RichTextContent));
+        return (RichTextContent)content;
+    }
+
+    private static async Task<List<ChatResponseUpdate>> CollectAsync(IChatClient client)
+    {
+        var updates = new List<ChatResponseUpdate>();
+        await foreach (var update in client.GetStreamingResponseAsync([]))
+        {
+            updates.Add(update);
+        }
+
+        return updates;
+    }
+
+    private sealed class TestChatClient(IReadOnlyList<ChatResponseUpdate> updates) : IChatClient
+    {
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            foreach (var update in updates)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                yield return update;
+                await Task.Yield();
+            }
+        }
+
+        public Task<ChatResponse> GetResponseAsync(
+            IEnumerable<ChatMessage> messages,
+            ChatOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => GetStreamingResponseAsync(messages, options, cancellationToken)
+                .ToChatResponseAsync(cancellationToken);
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => serviceType == typeof(IChatClient) ? this : null;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/FormattedChatClientTests.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/FormattedChatClientTests.cs
@@ -44,23 +44,6 @@ public class FormattedChatClientTests
     }
 
     [TestMethod]
-    public async Task FormattedUpdates_PreserveTextInConversationHistory()
-    {
-        using var innerClient = new RecordingChatClient();
-        using var client = new FormattedChatClient(innerClient);
-        using var agent = new UIAgent(client);
-
-        await CollectAsync(agent, "First question");
-        await CollectAsync(agent, "Second question");
-
-        Assert.AreEqual(2, innerClient.Requests.Count);
-        Assert.AreEqual(3, innerClient.Requests[1].Count);
-        Assert.AreEqual("First question", innerClient.Requests[1][0].Text);
-        Assert.AreEqual("Answer 1", innerClient.Requests[1][1].Text);
-        Assert.AreEqual("Second question", innerClient.Requests[1][2].Text);
-    }
-
-    [TestMethod]
     public async Task TextUpdatesWithoutMessageId_AreNotCoalesced()
     {
         var text = new TextContent("Unidentified");
@@ -121,13 +104,6 @@ public class FormattedChatClientTests
         return updates;
     }
 
-    private static async Task CollectAsync(UIAgent agent, string text)
-    {
-        await foreach (var _ in agent.SendMessageAsync(new ChatMessage(ChatRole.User, text)))
-        {
-        }
-    }
-
     private sealed class TestChatClient(IReadOnlyList<ChatResponseUpdate> updates) : IChatClient
     {
         public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
@@ -158,33 +134,4 @@ public class FormattedChatClientTests
         }
     }
 
-    private sealed class RecordingChatClient : IChatClient
-    {
-        public List<IReadOnlyList<ChatMessage>> Requests { get; } = [];
-
-        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options = null,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
-        {
-            Requests.Add(messages.ToList());
-            cancellationToken.ThrowIfCancellationRequested();
-            yield return CreateTextUpdate($"message-{Requests.Count}", $"Answer {Requests.Count}");
-            await Task.Yield();
-        }
-
-        public Task<ChatResponse> GetResponseAsync(
-            IEnumerable<ChatMessage> messages,
-            ChatOptions? options = null,
-            CancellationToken cancellationToken = default)
-            => GetStreamingResponseAsync(messages, options, cancellationToken)
-                .ToChatResponseAsync(cancellationToken);
-
-        public object? GetService(Type serviceType, object? serviceKey = null)
-            => serviceType == typeof(IChatClient) ? this : null;
-
-        public void Dispose()
-        {
-        }
-    }
 }

--- a/src/Components/AI/testassets/DojoClient/DojoClient.csproj
+++ b/src/Components/AI/testassets/DojoClient/DojoClient.csproj
@@ -37,4 +37,8 @@
     <Reference Include="Microsoft.AspNetCore.Components.AI" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="DojoClient.E2E.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Components/AI/testassets/DojoClient/Formatting/FormattedChatClient.cs
+++ b/src/Components/AI/testassets/DojoClient/Formatting/FormattedChatClient.cs
@@ -20,13 +20,19 @@ internal sealed class FormattedChatClient : DelegatingChatClient
         ChatOptions? options = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
-        var text = new StringBuilder();
+        var textByMessageId = new Dictionary<string, StringBuilder>(StringComparer.Ordinal);
 
         await foreach (var update in base.GetStreamingResponseAsync(
             messages,
             options,
             cancellationToken).ConfigureAwait(false))
         {
+            if (string.IsNullOrEmpty(update.MessageId))
+            {
+                yield return update;
+                continue;
+            }
+
             var firstTextIndex = -1;
             var chunks = new List<string>();
             for (var i = 0; i < update.Contents.Count; i++)
@@ -53,6 +59,12 @@ internal sealed class FormattedChatClient : DelegatingChatClient
 
             if (firstTextIndex >= 0)
             {
+                if (!textByMessageId.TryGetValue(update.MessageId, out var text))
+                {
+                    text = new StringBuilder();
+                    textByMessageId.Add(update.MessageId, text);
+                }
+
                 foreach (var chunk in chunks)
                 {
                     text.Append(chunk);

--- a/src/Components/AI/testassets/DojoClient/Formatting/FormattedChatClient.cs
+++ b/src/Components/AI/testassets/DojoClient/Formatting/FormattedChatClient.cs
@@ -49,14 +49,6 @@ internal sealed class FormattedChatClient : DelegatingChatClient
                 chunks.Add(textContent.Text ?? string.Empty);
             }
 
-            for (var i = update.Contents.Count - 1; i >= 0; i--)
-            {
-                if (update.Contents[i] is TextContent)
-                {
-                    update.Contents.RemoveAt(i);
-                }
-            }
-
             if (firstTextIndex >= 0)
             {
                 if (!textByMessageId.TryGetValue(update.MessageId, out var text))

--- a/src/Components/AI/testassets/DojoClient/Formatting/FormattedChatClient.cs
+++ b/src/Components/AI/testassets/DojoClient/Formatting/FormattedChatClient.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.AspNetCore.Components.AI;
+using Microsoft.Extensions.AI;
+
+namespace DojoClient.Formatting;
+
+internal sealed class FormattedChatClient : DelegatingChatClient
+{
+    internal FormattedChatClient(IChatClient innerClient)
+        : base(innerClient)
+    {
+    }
+
+    public override async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+        IEnumerable<ChatMessage> messages,
+        ChatOptions? options = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var text = new StringBuilder();
+
+        await foreach (var update in base.GetStreamingResponseAsync(
+            messages,
+            options,
+            cancellationToken).ConfigureAwait(false))
+        {
+            var firstTextIndex = -1;
+            var chunks = new List<string>();
+            for (var i = 0; i < update.Contents.Count; i++)
+            {
+                if (update.Contents[i] is not TextContent textContent)
+                {
+                    continue;
+                }
+
+                if (firstTextIndex < 0)
+                {
+                    firstTextIndex = i;
+                }
+                chunks.Add(textContent.Text ?? string.Empty);
+            }
+
+            for (var i = update.Contents.Count - 1; i >= 0; i--)
+            {
+                if (update.Contents[i] is TextContent)
+                {
+                    update.Contents.RemoveAt(i);
+                }
+            }
+
+            if (firstTextIndex >= 0)
+            {
+                foreach (var chunk in chunks)
+                {
+                    text.Append(chunk);
+                }
+                var snapshot = text.ToString();
+                update.Contents.Insert(
+                    firstTextIndex,
+                    new RichTextContent(snapshot, MarkdownRichTextParser.Parse(snapshot)));
+            }
+
+            yield return update;
+        }
+    }
+}

--- a/src/Components/AI/testassets/DojoClient/Formatting/MarkdownRichTextParser.cs
+++ b/src/Components/AI/testassets/DojoClient/Formatting/MarkdownRichTextParser.cs
@@ -1,0 +1,370 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI;
+
+namespace DojoClient.Formatting;
+
+internal static class MarkdownRichTextParser
+{
+    internal static IReadOnlyList<RichTextNode> Parse(string markdown)
+    {
+        ArgumentNullException.ThrowIfNull(markdown);
+
+        var lines = markdown.ReplaceLineEndings("\n").Split('\n');
+        var nodes = new List<RichTextNode>();
+        var lineIndex = 0;
+        while (lineIndex < lines.Length)
+        {
+            if (string.IsNullOrWhiteSpace(lines[lineIndex]))
+            {
+                lineIndex++;
+                continue;
+            }
+
+            if (TryParseCodeBlock(lines, ref lineIndex, out var block))
+            {
+                nodes.Add(block);
+                continue;
+            }
+            if (TryParseHeading(lines[lineIndex], out block) ||
+                TryParseThematicBreak(lines[lineIndex], out block))
+            {
+                nodes.Add(block);
+                lineIndex++;
+                continue;
+            }
+            if (TryParseBlockQuote(lines, ref lineIndex, out block) ||
+                TryParseList(lines, ref lineIndex, out block))
+            {
+                nodes.Add(block);
+                continue;
+            }
+
+            var paragraphLines = new List<string>();
+            while (lineIndex < lines.Length &&
+                !string.IsNullOrWhiteSpace(lines[lineIndex]) &&
+                !StartsBlock(lines, lineIndex))
+            {
+                paragraphLines.Add(lines[lineIndex]);
+                lineIndex++;
+            }
+
+            if (paragraphLines.Count == 0)
+            {
+                paragraphLines.Add(lines[lineIndex]);
+                lineIndex++;
+            }
+
+            var paragraph = new ParagraphNode();
+            for (var i = 0; i < paragraphLines.Count; i++)
+            {
+                AddInlineNodes(paragraph, paragraphLines[i]);
+                if (i < paragraphLines.Count - 1)
+                {
+                    paragraph.AddChild(new LineBreakNode());
+                }
+            }
+            nodes.Add(paragraph);
+        }
+
+        return nodes;
+    }
+
+    private static bool TryParseCodeBlock(
+        string[] lines,
+        ref int lineIndex,
+        out RichTextNode node)
+    {
+        var line = lines[lineIndex];
+        if (!line.StartsWith("```", StringComparison.Ordinal))
+        {
+            node = null!;
+            return false;
+        }
+
+        var language = line[3..].Trim();
+        var codeLines = new List<string>();
+        lineIndex++;
+        while (lineIndex < lines.Length &&
+            !lines[lineIndex].StartsWith("```", StringComparison.Ordinal))
+        {
+            codeLines.Add(lines[lineIndex]);
+            lineIndex++;
+        }
+        if (lineIndex < lines.Length)
+        {
+            lineIndex++;
+        }
+
+        node = new CodeBlockNode(
+            string.Join('\n', codeLines),
+            language.Length == 0 ? null : language);
+        return true;
+    }
+
+    private static bool TryParseHeading(string line, out RichTextNode node)
+    {
+        var level = 0;
+        while (level < line.Length && level < 6 && line[level] == '#')
+        {
+            level++;
+        }
+
+        if (level == 0 || level >= line.Length || line[level] != ' ')
+        {
+            node = null!;
+            return false;
+        }
+
+        var heading = new HeadingNode(level);
+        AddInlineNodes(heading, line[(level + 1)..]);
+        node = heading;
+        return true;
+    }
+
+    private static bool TryParseThematicBreak(string line, out RichTextNode node)
+    {
+        var value = line.Trim();
+        if (value is "---" or "***" or "___")
+        {
+            node = new ThematicBreakNode();
+            return true;
+        }
+
+        node = null!;
+        return false;
+    }
+
+    private static bool TryParseBlockQuote(
+        string[] lines,
+        ref int lineIndex,
+        out RichTextNode node)
+    {
+        if (!lines[lineIndex].StartsWith('>'))
+        {
+            node = null!;
+            return false;
+        }
+
+        var quotedLines = new List<string>();
+        while (lineIndex < lines.Length && lines[lineIndex].StartsWith('>'))
+        {
+            var line = lines[lineIndex][1..];
+            quotedLines.Add(line.StartsWith(' ') ? line[1..] : line);
+            lineIndex++;
+        }
+
+        var quote = new BlockQuoteNode();
+        foreach (var child in Parse(string.Join('\n', quotedLines)))
+        {
+            quote.AddChild(child);
+        }
+        node = quote;
+        return true;
+    }
+
+    private static bool TryParseList(
+        string[] lines,
+        ref int lineIndex,
+        out RichTextNode node)
+    {
+        if (!TryGetListItem(lines[lineIndex], out var ordered, out var start, out _))
+        {
+            node = null!;
+            return false;
+        }
+
+        var list = new ListNode(ordered, start);
+        while (lineIndex < lines.Length &&
+            TryGetListItem(lines[lineIndex], out var itemOrdered, out _, out var itemText) &&
+            itemOrdered == ordered)
+        {
+            var item = new ListItemNode();
+            if (itemText.StartsWith("[ ] ", StringComparison.Ordinal))
+            {
+                item.Checked = false;
+                itemText = itemText[4..];
+            }
+            else if (itemText.StartsWith("[x] ", StringComparison.OrdinalIgnoreCase))
+            {
+                item.Checked = true;
+                itemText = itemText[4..];
+            }
+
+            var paragraph = new ParagraphNode();
+            AddInlineNodes(paragraph, itemText);
+            item.AddChild(paragraph);
+            list.AddChild(item);
+            lineIndex++;
+        }
+
+        node = list;
+        return true;
+    }
+
+    private static bool TryGetListItem(
+        string line,
+        out bool ordered,
+        out int? start,
+        out string item)
+    {
+        if (line.StartsWith("- ", StringComparison.Ordinal) ||
+            line.StartsWith("* ", StringComparison.Ordinal))
+        {
+            ordered = false;
+            start = null;
+            item = line[2..];
+            return true;
+        }
+
+        var markerEnd = line.IndexOf(". ", StringComparison.Ordinal);
+        if (markerEnd > 0 && int.TryParse(line.AsSpan(0, markerEnd), out var number))
+        {
+            ordered = true;
+            start = number;
+            item = line[(markerEnd + 2)..];
+            return true;
+        }
+
+        ordered = false;
+        start = null;
+        item = string.Empty;
+        return false;
+    }
+
+    private static bool StartsBlock(string[] lines, int lineIndex)
+    {
+        var line = lines[lineIndex];
+        return line.StartsWith("```", StringComparison.Ordinal) ||
+            line.StartsWith('>') ||
+            TryParseHeading(line, out _) ||
+            TryParseThematicBreak(line, out _) ||
+            TryGetListItem(line, out _, out _, out _);
+    }
+
+    private static void AddInlineNodes(RichTextNode parent, string text)
+    {
+        var position = 0;
+        while (position < text.Length)
+        {
+            if (TryAddImage(parent, text, ref position) ||
+                TryAddLink(parent, text, ref position) ||
+                TryAddDelimited(parent, text, ref position, "**", static () => new StrongNode()) ||
+                TryAddDelimited(parent, text, ref position, "~~", static () => new StrikethroughNode()) ||
+                TryAddDelimited(parent, text, ref position, "*", static () => new EmphasisNode()) ||
+                TryAddInlineCode(parent, text, ref position))
+            {
+                continue;
+            }
+
+            var nextMarker = FindNextMarker(text, position + 1);
+            var length = nextMarker < 0 ? text.Length - position : nextMarker - position;
+            parent.AddChild(new TextNode(text.Substring(position, length)));
+            position += length;
+        }
+    }
+
+    private static bool TryAddImage(RichTextNode parent, string text, ref int position)
+    {
+        if (!text.AsSpan(position).StartsWith("![", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var labelEnd = text.IndexOf("](", position + 2, StringComparison.Ordinal);
+        var targetEnd = labelEnd < 0 ? -1 : text.IndexOf(')', labelEnd + 2);
+        if (labelEnd < 0 || targetEnd < 0)
+        {
+            return false;
+        }
+
+        parent.AddChild(new ImageNode(
+            text[(labelEnd + 2)..targetEnd],
+            text[(position + 2)..labelEnd]));
+        position = targetEnd + 1;
+        return true;
+    }
+
+    private static bool TryAddLink(RichTextNode parent, string text, ref int position)
+    {
+        if (text[position] != '[')
+        {
+            return false;
+        }
+
+        var labelEnd = text.IndexOf("](", position + 1, StringComparison.Ordinal);
+        var targetEnd = labelEnd < 0 ? -1 : text.IndexOf(')', labelEnd + 2);
+        if (labelEnd < 0 || targetEnd < 0)
+        {
+            return false;
+        }
+
+        var link = new LinkNode(text[(labelEnd + 2)..targetEnd]);
+        AddInlineNodes(link, text[(position + 1)..labelEnd]);
+        parent.AddChild(link);
+        position = targetEnd + 1;
+        return true;
+    }
+
+    private static bool TryAddDelimited(
+        RichTextNode parent,
+        string text,
+        ref int position,
+        string delimiter,
+        Func<RichTextNode> createNode)
+    {
+        if (!text.AsSpan(position).StartsWith(delimiter, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var contentStart = position + delimiter.Length;
+        var contentEnd = text.IndexOf(delimiter, contentStart, StringComparison.Ordinal);
+        if (contentEnd < 0)
+        {
+            return false;
+        }
+
+        var node = createNode();
+        AddInlineNodes(node, text[contentStart..contentEnd]);
+        parent.AddChild(node);
+        position = contentEnd + delimiter.Length;
+        return true;
+    }
+
+    private static bool TryAddInlineCode(
+        RichTextNode parent,
+        string text,
+        ref int position)
+    {
+        if (text[position] != '`')
+        {
+            return false;
+        }
+
+        var contentEnd = text.IndexOf('`', position + 1);
+        if (contentEnd < 0)
+        {
+            return false;
+        }
+
+        parent.AddChild(new InlineCodeNode(text[(position + 1)..contentEnd]));
+        position = contentEnd + 1;
+        return true;
+    }
+
+    private static int FindNextMarker(string text, int start)
+    {
+        var result = -1;
+        foreach (var marker in new[] { "![", "[", "**", "~~", "*", "`" })
+        {
+            var index = text.IndexOf(marker, start, StringComparison.Ordinal);
+            if (index >= 0 && (result < 0 || index < result))
+            {
+                result = index;
+            }
+        }
+        return result;
+    }
+}

--- a/src/Components/AI/testassets/DojoClient/Program.cs
+++ b/src/Components/AI/testassets/DojoClient/Program.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using AGUI.Client;
 using DojoClient;
 using DojoClient.Components;
+using DojoClient.Formatting;
 using Microsoft.Extensions.AI;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -26,7 +27,9 @@ builder.Services.AddScoped<IChatClient>(sp =>
 {
     var httpClient = sp.GetRequiredService<IHttpClientFactory>()
         .CreateClient(DojoScenarios.ApiHttpClientName);
-    return new AGUIChatClient(new AGUIChatClientOptions(httpClient, DojoScenarios.AgenticChatEndpoint));
+    var aguiClient = new AGUIChatClient(
+        new AGUIChatClientOptions(httpClient, DojoScenarios.AgenticChatEndpoint));
+    return new FormattedChatClient(aguiClient);
 });
 
 var app = builder.Build();

--- a/src/Components/Components.slnf
+++ b/src/Components/Components.slnf
@@ -10,6 +10,8 @@
       "src\\Components\\AI\\src\\Microsoft.AspNetCore.Components.AI.csproj",
       "src\\Components\\AI\\test\\Microsoft.AspNetCore.Components.AI.Tests.csproj",
       "src\\Components\\AI\\testassets\\AGUIDojoApi\\AGUIDojoApi.csproj",
+      "src\\Components\\AI\\testassets\\AIApp\\AIApp.csproj",
+      "src\\Components\\AI\\testassets\\AIApp.E2E.Tests\\AIApp.E2E.Tests.csproj",
       "src\\Components\\AI\\testassets\\DojoClient\\DojoClient.csproj",
       "src\\Components\\AI\\testassets\\DojoClient.E2E.Tests\\DojoClient.E2E.Tests.csproj",
       "src\\Components\\Authorization\\src\\Microsoft.AspNetCore.Components.Authorization.csproj",


### PR DESCRIPTION
## Overview

This is position 2 in the native Components.AI stack tracked by #68340 and depends on #68323. It adds protocol-neutral structured rich text to the streaming chat layer, then proves the same formatted response in the broad `AIApp` product surface and in Agentic Chat across the separate DojoClient → AGUI.Client 0.0.5 → HTTP/SSE → AGUI.Server 0.0.5 → AGUIDojoApi boundary. The cross-cutting constraint is that Markdown, Markdig, AG-UI, and every other parser/provider remain outside `Microsoft.AspNetCore.Components.AI`; applications map their source format into presentation nodes.

## Design

```csharp
// src/Components/AI/src/Blocks/RichText/RichTextContent.cs
// A provider supplies a complete text/tree snapshot. Copying the top-level list prevents the
// caller from changing membership after publication; the pipeline can replace one snapshot atomically.
public class RichTextContent : AIContent
{
    public RichTextContent(string text, IReadOnlyList<RichTextNode> nodes)
    {
        ArgumentNullException.ThrowIfNull(text);
        ArgumentNullException.ThrowIfNull(nodes);

        Text = text;
        Nodes = [.. nodes];
    }

    public string Text { get; }
    public IReadOnlyList<RichTextNode> Nodes { get; }
}
```

```csharp
// src/Components/AI/src/Blocks/RichText/RichTextNode.cs
// One recursive presentation contract covers block and inline structure without prescribing
// a source format. Applications can map Markdig or any other parser/provider into this tree.
public abstract class RichTextNode
{
    private List<RichTextNode>? _children;

    public IReadOnlyList<RichTextNode> Children =>
        _children ?? (IReadOnlyList<RichTextNode>)Array.Empty<RichTextNode>();

    public void AddChild(RichTextNode child)
    {
        ArgumentNullException.ThrowIfNull(child);
        _children ??= new();
        _children.Add(child);
    }
}
```

The node hierarchy is compressed into four behavioral equivalence classes rather than separate rendering APIs: **text/inline** (`Text`, emphasis, strong, strikethrough, inline code, links/images and references), **block flow** (paragraph, heading, quote, code block, lists, breaks), **tabular** (table/row/cell plus per-column alignment), and **metadata/fallback** (definitions, footnotes, encoded HTML source). These are presentation concepts, not a Markdown grammar. For example, a Markdig adapter can map `Footnote`, `FootnoteLink`, and `FootnoteGroup` into the footnote presentation nodes, while another parser can map differently or omit that feature entirely.

Two design decisions keep the layer sound and scoped. First, streamed structure is a complete snapshot, not a partially mutated shared tree; renderers never observe half-applied updates. Second, parsing and source interpretation remain application responsibilities. `LineBreakNode` therefore means a forced visual break; a mapper decides whether its source format's soft or hard line ending becomes whitespace, text, or that node.

## Implementation

```csharp
// src/Components/AI/src/Pipeline/RichTextContentHandler.cs
// The first snapshot emits one RichContentBlock; later snapshots replace its text and tree in place.
// Example: heading-only snapshot → heading + paragraph + list snapshot, still one streaming message block.
public override BlockMappingResult<RichContentBlock> Handle(
    BlockMappingContext context, RichContentBlock state)
{
    RichTextContent? snapshot = null;
    foreach (var content in context.UnhandledContents)
    {
        if (content is RichTextContent richText)
        {
            snapshot = richText;
            context.MarkHandled(content);
        }
    }

    if (snapshot is null)
    {
        return state.Id.Length > 0
            ? BlockMappingResult<RichContentBlock>.Complete()
            : BlockMappingResult<RichContentBlock>.Pass();
    }

    state.ReplaceContent(snapshot.Text, snapshot.Nodes);
    if (state.Id.Length == 0)
    {
        state.Id = context.Update.MessageId ?? Guid.NewGuid().ToString("N");
        return BlockMappingResult<RichContentBlock>.Emit(state, state);
    }

    return BlockMappingResult<RichContentBlock>.Update(state);
}
```

The plain-text fallback maps paragraphs into `ParagraphNode` + `TextNode`, so old `TextContent` behavior and app-supplied structured snapshots converge on one renderer. `MessageListContext` recursively renders the four node classes above and gives every recursively rendered sibling its own render-tree region. Ordinary semantic elements share one switch, list/table branches add their metadata, and `HtmlNode` uses `AddContent` so source such as `<mark>…</mark>` is displayed encoded rather than executed. The final browser link/HTML safety policy remains tracked separately by #68427.

```csharp
// src/Components/AI/testassets/DojoClient/Formatting/FormattedChatClient.cs
// The real AGUIChatClient remains the inner client. Text fragments coalesce only when they
// share a MessageId; unidentified and non-text-only updates pass through unchanged.
var textByMessageId = new Dictionary<string, StringBuilder>(StringComparer.Ordinal);

await foreach (var update in base.GetStreamingResponseAsync(
    messages,
    options,
    cancellationToken).ConfigureAwait(false))
{
    if (string.IsNullOrEmpty(update.MessageId))
    {
        yield return update;
        continue;
    }

    // (collect this update's text chunks — omitted)
    if (firstTextIndex >= 0)
    {
        if (!textByMessageId.TryGetValue(update.MessageId, out var text))
        {
            text = new StringBuilder();
            textByMessageId.Add(update.MessageId, text);
        }

        foreach (var chunk in chunks)
        {
            text.Append(chunk);
        }

        var snapshot = text.ToString();
        update.Contents.Insert(
            firstTextIndex,
            new RichTextContent(snapshot, MarkdownRichTextParser.Parse(snapshot)));
    }

    yield return update;
}
```

`MarkdownRichTextParser` is a Dojo test-asset adapter, not product policy. It covers the fixture's block and inline formatting so the browser test can exercise a complete external-mapper → `RichTextNode` → renderer path. Applications can instead use Markdig or any other parser. A workflow remains responsible for dispatching tool calls, activities, and subsequent assistant messages as semantically ordered updates; formatting only coalesces text fragments belonging to the same message.

```csharp
// src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/AgenticChatRichTextScenarioTests.cs
// Acceptance proof: launch two processes, override only the API's model, and route the browser to DojoClient.
var api = await StartServerAsync<AGUIDojoApiAssembly>(TestRoot.Servers, options =>
{
    options.ConfigureServices<DojoModelOverrides>(
        nameof(DojoModelOverrides.AgenticChatRichText));
});
var ui = await StartServerAsync<global::DojoClient.Components.App>(
    TestRoot.Servers,
    options => options.EnvironmentVariables["AGUI_DOJO_API_URL"] = api.AppUrl);

// The first checkpoint proves partial structured rendering; release then proves the completed list/link.
await Expect(assistant.Locator("h2")).ToHaveTextAsync("Blazor components");
await Expect(assistant.Locator("li")).ToHaveCountAsync(0);
await checkpoints.ReleaseAsync(prompt, "structure");
await Expect(assistant.Locator("li")).ToHaveCountAsync(2);
```

**Review guidance:** read the snapshot contract/handler, recursive render regions, and `FormattedChatClient` message-boundary behavior closely. Spot-check one leaf from each node equivalence class, the parser-independent XML documentation, the focused AIApp matrix, and the generated two-checkpoint recording. **Acceptance criteria:** the same response renders headings, inline formatting, links, and lists in AIApp and DojoClient; chunks with the same `MessageId` coalesce while different or missing IDs do not; and DojoClient still performs a real POST/SSE exchange with AGUIDojoApi.

## Outcome

| Validation class | Result |
|---|---|
| Dependency-aware builds (`Microsoft.AspNetCore.Components.AI.Tests`, `AIApp.E2E.Tests`, `DojoClient.E2E.Tests`) | Passed, 0 warnings / 0 errors |
| Product unit tests | 74/74 passed |
| `FormattedChatClientTests` | 4/4 passed |
| AIApp `RichTextTests` | 1/1 passed |
| DojoClient `AgenticChatRichTextScenarioTests` | 1/1 passed over the real dual-host HTTP/SSE path |

The resulting layer preserves plain-text chat, adds atomic structured streaming and default presentation rendering, and establishes formatted Agentic Chat without introducing a core parser dependency or later stack concerns such as client tools, server tools, approval flow, or shared/predictive state.