### PR TITLE
[Blazor] Add Components.AI client tool rendering

### DIFF
--- a/src/Components/AI/src/Blocks/UIActionBlock.cs
+++ b/src/Components/AI/src/Blocks/UIActionBlock.cs
@@ -57,7 +57,10 @@ public class UIActionBlock : ContentBlock
     /// <summary>
     /// Executes the registered function once using the arguments supplied by the model.
     /// </summary>
-    /// <param name="cancellationToken">A token that cancels the action.</param>
+    /// <param name="cancellationToken">
+    /// A token that cancels the action when this call starts it. Subsequent calls return the
+    /// existing invocation task and do not replace its cancellation token.
+    /// </param>
     /// <returns>A task that completes when the action has finished.</returns>
     public Task InvokeAsync(CancellationToken cancellationToken = default)
     {

--- a/src/Components/AI/src/Blocks/UIActionBlock.cs
+++ b/src/Components/AI/src/Blocks/UIActionBlock.cs
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a function call that must execute in the UI before the conversation can continue.
+/// </summary>
+/// <remarks>
+/// Register the corresponding function with
+/// <see cref="UIAgentOptions.RegisterUIAction(AIFunction)"/>. Renderers can call
+/// <see cref="InvokeAsync(CancellationToken)"/> to execute it in the current UI circuit.
+/// </remarks>
+/// <example>
+/// <code>
+/// &lt;BlockRenderer TBlock="UIActionBlock" Context="action"&gt;
+///     &lt;button @onclick="() =&gt; action.InvokeAsync()"&gt;Run&lt;/button&gt;
+/// &lt;/BlockRenderer&gt;
+/// </code>
+/// </example>
+public class UIActionBlock : ContentBlock
+{
+    private readonly AIFunction _function;
+    private readonly TaskCompletionSource<AIContent> _resultSource =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly object _invocationLock = new();
+    private Task? _invocation;
+
+    internal UIActionBlock(AIFunction function, FunctionCallContent call)
+    {
+        _function = function;
+        Call = call;
+    }
+
+    /// <summary>
+    /// Gets the function call requested by the model.
+    /// </summary>
+    public FunctionCallContent Call { get; }
+
+    /// <summary>
+    /// Gets the registered UI action name.
+    /// </summary>
+    public string ToolName => Call.Name;
+
+    /// <summary>
+    /// Gets the function result after the action completes.
+    /// </summary>
+    public FunctionResultContent? Result { get; private set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the action completed successfully.
+    /// </summary>
+    public bool IsComplete => Result is not null;
+
+    /// <summary>
+    /// Executes the registered function once using the arguments supplied by the model.
+    /// </summary>
+    /// <param name="cancellationToken">A token that cancels the action.</param>
+    /// <returns>A task that completes when the action has finished.</returns>
+    public Task InvokeAsync(CancellationToken cancellationToken = default)
+    {
+        lock (_invocationLock)
+        {
+            _invocation ??= InvokeCoreAsync(cancellationToken);
+            return _invocation;
+        }
+    }
+
+    internal Task<AIContent> GetResultAsync(CancellationToken cancellationToken)
+        => _resultSource.Task.WaitAsync(cancellationToken);
+
+    private async Task InvokeCoreAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var arguments = Call.Arguments is not null
+                ? new AIFunctionArguments(Call.Arguments)
+                : null;
+            var result = await _function.InvokeAsync(arguments, cancellationToken);
+            Result = new FunctionResultContent(Call.CallId ?? Id, result);
+            NotifyChanged();
+            _resultSource.TrySetResult(Result);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            _resultSource.TrySetCanceled(cancellationToken);
+            throw;
+        }
+        catch (Exception exception)
+        {
+            _resultSource.TrySetException(exception);
+            throw;
+        }
+    }
+}

--- a/src/Components/AI/src/Engine/AgentContext.cs
+++ b/src/Components/AI/src/Engine/AgentContext.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using Microsoft.Extensions.AI;
 
 namespace Microsoft.AspNetCore.Components.AI;
@@ -195,19 +196,46 @@ public class AgentContext : IDisposable
 
         try
         {
-            await foreach (var block in _agent.SendMessageAsync(message, cancellationToken)
-                .WithCancellation(cancellationToken))
+            ChatMessage? currentMessage = message;
+            while (currentMessage is not null)
             {
-                if (block.Role == message.Role)
+                var actions = new List<UIActionBlock>();
+
+                await foreach (var block in _agent.SendMessageAsync(currentMessage, cancellationToken)
+                    .WithCancellation(cancellationToken))
                 {
-                    turn.AddRequestBlock(block);
-                }
-                else
-                {
-                    turn.AddResponseBlock(block);
+                    if (block.Role == message.Role)
+                    {
+                        turn.AddRequestBlock(block);
+                    }
+                    else
+                    {
+                        turn.AddResponseBlock(block);
+                    }
+
+                    if (block is UIActionBlock action)
+                    {
+                        actions.Add(action);
+                    }
+
+                    NotifyBlockAdded(turn, block);
                 }
 
-                NotifyBlockAdded(turn, block);
+                if (actions.Count == 0)
+                {
+                    currentMessage = null;
+                    continue;
+                }
+
+                Status = ConversationStatus.AwaitingInput;
+                NotifyStatusChanged();
+
+                var results = await Task.WhenAll(
+                    actions.Select(action => action.GetResultAsync(cancellationToken)));
+
+                currentMessage = new ChatMessage(ChatRole.Tool, [.. results]);
+                Status = ConversationStatus.Streaming;
+                NotifyStatusChanged();
             }
 
             Status = ConversationStatus.Idle;

--- a/src/Components/AI/src/Engine/AgentContext.cs
+++ b/src/Components/AI/src/Engine/AgentContext.cs
@@ -75,7 +75,7 @@ public class AgentContext : IDisposable
     {
         ArgumentNullException.ThrowIfNull(message);
 
-        if (Status == ConversationStatus.Streaming)
+        if (Status is ConversationStatus.Streaming or ConversationStatus.AwaitingInput)
         {
             throw new InvalidOperationException("A message is already being processed.");
         }

--- a/src/Components/AI/src/Engine/UIAgent.cs
+++ b/src/Components/AI/src/Engine/UIAgent.cs
@@ -128,9 +128,10 @@ public class UIAgent : IDisposable
         UIAgentLog.StreamingAssistantResponse(_logger);
         var assistantUpdates = new List<ChatResponseUpdate>();
         var updateIndex = 0;
+        var chatOptions = BuildChatOptions();
 
         await foreach (var update in _chatClient.GetStreamingResponseAsync(
-            _history, _options.ChatOptions, cancellationToken).ConfigureAwait(false))
+            _history, chatOptions, cancellationToken).ConfigureAwait(false))
         {
             var contentTypes = string.Join(", ", update.Contents.Select(c => c.GetType().Name));
             UIAgentLog.ReceivedUpdate(_logger, updateIndex++, update.Role?.Value, contentTypes);
@@ -158,6 +159,27 @@ public class UIAgent : IDisposable
         }
 
         UIAgentLog.AddedToHistory(_logger, response.Messages.Count);
+    }
+
+    private ChatOptions? BuildChatOptions()
+    {
+        if (_options.UIActions.Count == 0)
+        {
+            return _options.ChatOptions;
+        }
+
+        var chatOptions = _options.ChatOptions?.Clone() ?? new ChatOptions();
+        var tools = chatOptions.Tools is null
+            ? new List<AITool>()
+            : [.. chatOptions.Tools];
+
+        foreach (var action in _options.UIActions.Values)
+        {
+            tools.Add(action.AsDeclarationOnly());
+        }
+
+        chatOptions.Tools = tools;
+        return chatOptions;
     }
 
     /// <summary>

--- a/src/Components/AI/src/Pipeline/BlockMappingPipeline.cs
+++ b/src/Components/AI/src/Pipeline/BlockMappingPipeline.cs
@@ -29,6 +29,12 @@ internal class BlockMappingPipeline
             _handlers.Add(registration.CreateEntry());
         }
 
+        if (options.UIActions.Count > 0)
+        {
+            _handlers.Add(new HandlerEntry<UIActionHandler.State>(
+                new UIActionHandler(options.UIActions)));
+        }
+
         // Structured snapshots take precedence over the plain-text fallback.
         _handlers.Add(new HandlerEntry<RichContentBlock>(new RichTextContentHandler()));
 

--- a/src/Components/AI/src/Pipeline/UIActionHandler.cs
+++ b/src/Components/AI/src/Pipeline/UIActionHandler.cs
@@ -16,6 +16,11 @@ internal sealed class UIActionHandler : ContentBlockHandler<UIActionHandler.Stat
 
     public override BlockMappingResult<State> Handle(BlockMappingContext context, State state)
     {
+        if (state.HasEmitted)
+        {
+            return BlockMappingResult<State>.Pass();
+        }
+
         foreach (var content in context.UnhandledContents)
         {
             if (content is FunctionCallContent call &&
@@ -23,6 +28,7 @@ internal sealed class UIActionHandler : ContentBlockHandler<UIActionHandler.Stat
                 _actions.TryGetValue(call.Name, out var function))
             {
                 context.MarkHandled(call);
+                state.HasEmitted = true;
                 return BlockMappingResult<State>.Emit(
                     new UIActionBlock(function, call)
                     {
@@ -37,5 +43,6 @@ internal sealed class UIActionHandler : ContentBlockHandler<UIActionHandler.Stat
 
     internal sealed class State
     {
+        public bool HasEmitted { get; set; }
     }
 }

--- a/src/Components/AI/src/Pipeline/UIActionHandler.cs
+++ b/src/Components/AI/src/Pipeline/UIActionHandler.cs
@@ -19,6 +19,7 @@ internal sealed class UIActionHandler : ContentBlockHandler<UIActionHandler.Stat
         foreach (var content in context.UnhandledContents)
         {
             if (content is FunctionCallContent call &&
+                !call.InformationalOnly &&
                 _actions.TryGetValue(call.Name, out var function))
             {
                 context.MarkHandled(call);

--- a/src/Components/AI/src/Pipeline/UIActionHandler.cs
+++ b/src/Components/AI/src/Pipeline/UIActionHandler.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+internal sealed class UIActionHandler : ContentBlockHandler<UIActionHandler.State>
+{
+    private readonly IReadOnlyDictionary<string, AIFunction> _actions;
+
+    internal UIActionHandler(IReadOnlyDictionary<string, AIFunction> actions)
+    {
+        _actions = actions;
+    }
+
+    public override BlockMappingResult<State> Handle(BlockMappingContext context, State state)
+    {
+        foreach (var content in context.UnhandledContents)
+        {
+            if (content is FunctionCallContent call &&
+                _actions.TryGetValue(call.Name, out var function))
+            {
+                context.MarkHandled(call);
+                return BlockMappingResult<State>.Emit(
+                    new UIActionBlock(function, call)
+                    {
+                        Id = call.CallId ?? Guid.NewGuid().ToString("N")
+                    },
+                    state);
+            }
+        }
+
+        return BlockMappingResult<State>.Pass();
+    }
+
+    internal sealed class State
+    {
+    }
+}

--- a/src/Components/AI/src/Pipeline/UIAgentOptions.cs
+++ b/src/Components/AI/src/Pipeline/UIAgentOptions.cs
@@ -46,7 +46,12 @@ public class UIAgentOptions
     /// Registers a function that a matching model tool call executes in the UI.
     /// The function is sent to the chat client as a declaration, not as an executable server tool.
     /// </summary>
-    /// <param name="function">The function to execute in the UI.</param>
+    /// <param name="function">
+    /// The function to execute in the UI. Its name must be unique among the registered UI actions.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// An action with the same name is already registered.
+    /// </exception>
     public void RegisterUIAction(AIFunction function)
     {
         ArgumentNullException.ThrowIfNull(function);

--- a/src/Components/AI/src/Pipeline/UIAgentOptions.cs
+++ b/src/Components/AI/src/Pipeline/UIAgentOptions.cs
@@ -25,6 +25,9 @@ public class UIAgentOptions
 
     internal List<IHandlerRegistration> HandlerRegistrations { get; } = new();
 
+    internal Dictionary<string, AIFunction> UIActions { get; } =
+        new(StringComparer.Ordinal);
+
     /// <summary>
     /// Registers a handler that maps model updates into content blocks. Registered handlers
     /// run before the built-in ones, so they can claim content the built-in handlers would
@@ -37,6 +40,17 @@ public class UIAgentOptions
     {
         ArgumentNullException.ThrowIfNull(handler);
         HandlerRegistrations.Add(new HandlerRegistration<TState>(handler));
+    }
+
+    /// <summary>
+    /// Registers a function that a matching model tool call executes in the UI.
+    /// The function is sent to the chat client as a declaration, not as an executable server tool.
+    /// </summary>
+    /// <param name="function">The function to execute in the UI.</param>
+    public void RegisterUIAction(AIFunction function)
+    {
+        ArgumentNullException.ThrowIfNull(function);
+        UIActions.Add(function.Name, function);
     }
 
     internal interface IHandlerRegistration

--- a/src/Components/AI/src/PublicAPI.Unshipped.txt
+++ b/src/Components/AI/src/PublicAPI.Unshipped.txt
@@ -255,7 +255,14 @@ Microsoft.AspNetCore.Components.AI.UIAgentOptions
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.AddBlockHandler<TState>(Microsoft.AspNetCore.Components.AI.ContentBlockHandler<TState>! handler) -> void
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.ChatOptions.get -> Microsoft.Extensions.AI.ChatOptions?
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.ChatOptions.set -> void
+Microsoft.AspNetCore.Components.AI.UIAgentOptions.RegisterUIAction(Microsoft.Extensions.AI.AIFunction! function) -> void
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.UIAgentOptions() -> void
+Microsoft.AspNetCore.Components.AI.UIActionBlock
+Microsoft.AspNetCore.Components.AI.UIActionBlock.Call.get -> Microsoft.Extensions.AI.FunctionCallContent!
+Microsoft.AspNetCore.Components.AI.UIActionBlock.InvokeAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.AI.UIActionBlock.IsComplete.get -> bool
+Microsoft.AspNetCore.Components.AI.UIActionBlock.Result.get -> Microsoft.Extensions.AI.FunctionResultContent?
+Microsoft.AspNetCore.Components.AI.UIActionBlock.ToolName.get -> string!
 abstract Microsoft.AspNetCore.Components.AI.ContentBlockHandler<TState>.Handle(Microsoft.AspNetCore.Components.AI.BlockMappingContext! context, TState state) -> Microsoft.AspNetCore.Components.AI.BlockMappingResult<TState>
 override Microsoft.AspNetCore.Components.AI.AgentBoundary.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
 override Microsoft.AspNetCore.Components.AI.AgentBoundary.OnInitialized() -> void

--- a/src/Components/AI/test/Engine/AgentContextUIActionTests.cs
+++ b/src/Components/AI/test/Engine/AgentContextUIActionTests.cs
@@ -141,6 +141,32 @@ public class AgentContextUIActionTests
     }
 
     [Fact]
+    public async Task UIAction_InformationalCallIsIgnored()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((messages, options, cancellationToken) =>
+            EmitUIActionCall(
+                new FunctionCallContent("call-1", "change_background")
+                {
+                    InformationalOnly = true
+                },
+                cancellationToken));
+
+        using var agent = new UIAgent(client, options =>
+        {
+            options.RegisterUIAction(AIFunctionFactory.Create(
+                () => "changed",
+                "change_background",
+                "Changes the background."));
+        });
+        using var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Change it");
+
+        Assert.Empty(Assert.Single(context.Turns).ResponseBlocks.OfType<UIActionBlock>());
+    }
+
+    [Fact]
     public async Task UIAction_InvokeAsyncExecutesOnlyOnce()
     {
         var invocationCount = 0;
@@ -172,9 +198,14 @@ public class AgentContextUIActionTests
         Assert.Equal("call-1", block.Result?.CallId);
     }
 
-    private static async IAsyncEnumerable<ChatResponseUpdate> EmitUIActionCall(
+    private static IAsyncEnumerable<ChatResponseUpdate> EmitUIActionCall(
         string callId,
         string name,
+        CancellationToken cancellationToken)
+        => EmitUIActionCall(new FunctionCallContent(callId, name), cancellationToken);
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitUIActionCall(
+        FunctionCallContent call,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -182,7 +213,7 @@ public class AgentContextUIActionTests
         {
             Role = ChatRole.Assistant,
             MessageId = Guid.NewGuid().ToString("N"),
-            Contents = [new FunctionCallContent(callId, name)],
+            Contents = [call],
             FinishReason = ChatFinishReason.ToolCalls,
         };
         await Task.CompletedTask;

--- a/src/Components/AI/test/Engine/AgentContextUIActionTests.cs
+++ b/src/Components/AI/test/Engine/AgentContextUIActionTests.cs
@@ -1,0 +1,190 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class AgentContextUIActionTests
+{
+    [Fact]
+    public async Task UIAction_ContinuesWithOneToolResult()
+    {
+        var invocationCount = 0;
+        var clientCallCount = 0;
+        List<ChatMessage>? continuationMessages = null;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((messages, options, cancellationToken) =>
+        {
+            clientCallCount++;
+            if (clientCallCount == 1)
+            {
+                return EmitUIActionCall("call-1", "get_client_value", cancellationToken);
+            }
+
+            continuationMessages = messages.ToList();
+            return ResponseEmitters.EmitTextResponse("Client value received.", cancellationToken);
+        });
+
+        using var agent = new UIAgent(client, options =>
+        {
+            options.RegisterUIAction(AIFunctionFactory.Create(
+                () =>
+                {
+                    invocationCount++;
+                    return "client-value";
+                },
+                "get_client_value",
+                "Gets a value from the client."));
+        });
+        using var context = new AgentContext(agent);
+        var statuses = new List<ConversationStatus>();
+        using var subscription = context.RegisterOnStatusChanged(status =>
+        {
+            statuses.Add(status);
+            if (status == ConversationStatus.AwaitingInput)
+            {
+                _ = context.Turns[^1].ResponseBlocks
+                    .OfType<UIActionBlock>()
+                    .Single()
+                    .InvokeAsync();
+            }
+        });
+
+        await context.SendMessageAsync("Get the value");
+
+        Assert.Equal(1, invocationCount);
+        Assert.Equal(2, clientCallCount);
+        Assert.Equal(
+            [
+                ConversationStatus.Streaming,
+                ConversationStatus.AwaitingInput,
+                ConversationStatus.Streaming,
+                ConversationStatus.Idle
+            ],
+            statuses);
+
+        var toolMessage = Assert.IsType<ChatMessage>(
+            continuationMessages?.LastOrDefault(message => message.Role == ChatRole.Tool));
+        var result = Assert.IsType<FunctionResultContent>(Assert.Single(toolMessage.Contents));
+        Assert.Equal("call-1", result.CallId);
+        Assert.Equal("client-value", result.Result?.ToString());
+
+        var turn = Assert.Single(context.Turns);
+        Assert.Single(turn.ResponseBlocks.OfType<UIActionBlock>());
+        Assert.Equal(
+            "Client value received.",
+            Assert.Single(turn.ResponseBlocks.OfType<RichContentBlock>()).RawText);
+    }
+
+    [Fact]
+    public async Task UIAction_IsAdvertisedAsDeclarationOnlyAndPreservesConfiguredTools()
+    {
+        ChatOptions? capturedOptions = null;
+        var serverTool = AIFunctionFactory.Create(() => "server", "server_tool", "Server tool.");
+        var clientTool = AIFunctionFactory.Create(() => "client", "client_tool", "Client tool.");
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((messages, options, cancellationToken) =>
+        {
+            capturedOptions = options;
+            return ResponseEmitters.EmitTextResponse("Done", cancellationToken);
+        });
+
+        using var agent = new UIAgent(client, options =>
+        {
+            options.ChatOptions = new ChatOptions { Tools = [serverTool] };
+            options.RegisterUIAction(clientTool);
+        });
+        using var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Go");
+
+        Assert.NotNull(capturedOptions);
+        Assert.Collection(
+            capturedOptions.Tools!,
+            tool => Assert.Same(serverTool, tool),
+            tool =>
+            {
+                Assert.IsAssignableFrom<AIFunctionDeclaration>(tool);
+                Assert.IsNotAssignableFrom<AIFunction>(tool);
+                Assert.Equal("client_tool", ((AIFunctionDeclaration)tool).Name);
+            });
+    }
+
+    [Fact]
+    public async Task UIAction_NameMatchingIsOrdinal()
+    {
+        var invoked = false;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((messages, options, cancellationToken) =>
+            EmitUIActionCall("call-1", "CHANGE_BACKGROUND", cancellationToken));
+
+        using var agent = new UIAgent(client, options =>
+        {
+            options.RegisterUIAction(AIFunctionFactory.Create(
+                () =>
+                {
+                    invoked = true;
+                    return "changed";
+                },
+                "change_background",
+                "Changes the background."));
+        });
+        using var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Change it");
+
+        Assert.False(invoked);
+        Assert.Empty(Assert.Single(context.Turns).ResponseBlocks.OfType<UIActionBlock>());
+    }
+
+    [Fact]
+    public async Task UIAction_InvokeAsyncExecutesOnlyOnce()
+    {
+        var invocationCount = 0;
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var function = AIFunctionFactory.Create(
+            async () =>
+            {
+                invocationCount++;
+                await gate.Task;
+                return "done";
+            },
+            "run_once",
+            "Runs once.");
+        var block = new UIActionBlock(
+            function,
+            new FunctionCallContent("call-1", "run_once"))
+        {
+            Id = "call-1"
+        };
+
+        var first = block.InvokeAsync();
+        var second = block.InvokeAsync();
+        gate.SetResult();
+        await Task.WhenAll(first, second);
+
+        Assert.Same(first, second);
+        Assert.Equal(1, invocationCount);
+        Assert.True(block.IsComplete);
+        Assert.Equal("call-1", block.Result?.CallId);
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitUIActionCall(
+        string callId,
+        string name,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = Guid.NewGuid().ToString("N"),
+            Contents = [new FunctionCallContent(callId, name)],
+            FinishReason = ChatFinishReason.ToolCalls,
+        };
+        await Task.CompletedTask;
+    }
+}

--- a/src/Components/AI/test/Engine/AgentContextUIActionTests.cs
+++ b/src/Components/AI/test/Engine/AgentContextUIActionTests.cs
@@ -9,6 +9,91 @@ namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
 
 public class AgentContextUIActionTests
 {
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task UIAction_MultipleCallsContinueAcrossUpdateBoundaries(bool splitAcrossUpdates)
+    {
+        var firstActionInvocations = 0;
+        var secondActionInvocations = 0;
+        var clientCallCount = 0;
+        List<ChatMessage>? continuationMessages = null;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((messages, options, cancellationToken) =>
+        {
+            clientCallCount++;
+            if (clientCallCount == 1)
+            {
+                return EmitTwoUIActionCalls(splitAcrossUpdates, cancellationToken);
+            }
+
+            continuationMessages = messages.ToList();
+            return ResponseEmitters.EmitTextResponse("Both values received.", cancellationToken);
+        });
+
+        using var agent = new UIAgent(client, options =>
+        {
+            options.RegisterUIAction(AIFunctionFactory.Create(
+                () =>
+                {
+                    firstActionInvocations++;
+                    return "client-value-1";
+                },
+                "get_client_value_1",
+                "Gets the first value from the client."));
+            options.RegisterUIAction(AIFunctionFactory.Create(
+                () =>
+                {
+                    secondActionInvocations++;
+                    return "client-value-2";
+                },
+                "get_client_value_2",
+                "Gets the second value from the client."));
+        });
+        using var context = new AgentContext(agent);
+        using var subscription = context.RegisterOnStatusChanged(status =>
+        {
+            if (status == ConversationStatus.AwaitingInput)
+            {
+                foreach (var action in context.Turns[^1].ResponseBlocks.OfType<UIActionBlock>())
+                {
+                    _ = action.InvokeAsync();
+                }
+            }
+        });
+
+        await context.SendMessageAsync("Get both values");
+
+        Assert.Equal(1, firstActionInvocations);
+        Assert.Equal(1, secondActionInvocations);
+        Assert.Equal(2, clientCallCount);
+
+        var toolMessage = Assert.IsType<ChatMessage>(
+            continuationMessages?.LastOrDefault(message => message.Role == ChatRole.Tool));
+        var results = toolMessage.Contents.OfType<FunctionResultContent>().ToArray();
+        Assert.Collection(
+            results,
+            result =>
+            {
+                Assert.Equal("call-1", result.CallId);
+                Assert.Equal("client-value-1", result.Result?.ToString());
+            },
+            result =>
+            {
+                Assert.Equal("call-2", result.CallId);
+                Assert.Equal("client-value-2", result.Result?.ToString());
+            });
+
+        var turn = Assert.Single(context.Turns);
+        Assert.Collection(
+            turn.ResponseBlocks.OfType<UIActionBlock>(),
+            block => Assert.Equal("call-1", block.Call.CallId),
+            block => Assert.Equal("call-2", block.Call.CallId));
+        Assert.Equal(
+            "Both values received.",
+            Assert.Single(turn.ResponseBlocks.OfType<RichContentBlock>()).RawText);
+    }
+
     [Fact]
     public async Task UIAction_ContinuesWithOneToolResult()
     {
@@ -214,6 +299,48 @@ public class AgentContextUIActionTests
             Role = ChatRole.Assistant,
             MessageId = Guid.NewGuid().ToString("N"),
             Contents = [call],
+            FinishReason = ChatFinishReason.ToolCalls,
+        };
+        await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitTwoUIActionCalls(
+        bool splitAcrossUpdates,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        var messageId = Guid.NewGuid().ToString("N");
+        if (splitAcrossUpdates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = messageId,
+                Contents = [new FunctionCallContent("call-1", "get_client_value_1")],
+            };
+
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = messageId,
+                Contents = [new FunctionCallContent("call-2", "get_client_value_2")],
+                FinishReason = ChatFinishReason.ToolCalls,
+            };
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = messageId,
+            Contents =
+            [
+                new FunctionCallContent("call-1", "get_client_value_1"),
+                new FunctionCallContent("call-2", "get_client_value_2"),
+            ],
             FinishReason = ChatFinishReason.ToolCalls,
         };
         await Task.CompletedTask;

--- a/src/Components/AI/test/Engine/AgentContextUIActionTests.cs
+++ b/src/Components/AI/test/Engine/AgentContextUIActionTests.cs
@@ -165,6 +165,50 @@ public class AgentContextUIActionTests
     }
 
     [Fact]
+    public async Task UIAction_SendMessageAsyncWhileAwaitingInputThrows()
+    {
+        var clientCallCount = 0;
+        var awaitingInputReached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        UIActionBlock? pendingAction = null;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((messages, options, cancellationToken) =>
+        {
+            clientCallCount++;
+            return clientCallCount == 1
+                ? EmitUIActionCall("call-1", "get_client_value", cancellationToken)
+                : ResponseEmitters.EmitTextResponse("Done", cancellationToken);
+        });
+
+        using var agent = new UIAgent(client, options =>
+        {
+            options.RegisterUIAction(AIFunctionFactory.Create(
+                () => "client-value",
+                "get_client_value",
+                "Gets a value from the client."));
+        });
+        using var context = new AgentContext(agent);
+        using var subscription = context.RegisterOnStatusChanged(status =>
+        {
+            if (status == ConversationStatus.AwaitingInput)
+            {
+                pendingAction = context.Turns[^1].ResponseBlocks.OfType<UIActionBlock>().Single();
+                awaitingInputReached.TrySetResult();
+            }
+        });
+
+        var firstSendTask = context.SendMessageAsync("First");
+        await awaitingInputReached.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => context.SendMessageAsync("Second"));
+
+        await pendingAction!.InvokeAsync();
+        await firstSendTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(2, clientCallCount);
+        Assert.Single(context.Turns);
+    }
+
+    [Fact]
     public async Task UIAction_IsAdvertisedAsDeclarationOnlyAndPreservesConfiguredTools()
     {
         ChatOptions? capturedOptions = null;

--- a/src/Components/AI/testassets/AGUIDojoApi/ScriptedChatClient.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/ScriptedChatClient.cs
@@ -20,8 +20,21 @@ internal sealed class ScriptedChatClient : IChatClient
     {
         ArgumentNullException.ThrowIfNull(messages);
 
+        var messageList = messages.ToList();
+        if (messageList.LastOrDefault()?.Role == ChatRole.Tool)
+        {
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = Guid.NewGuid().ToString("N"),
+                Contents = [new TextContent("Background changed to a sunset gradient.")],
+                FinishReason = ChatFinishReason.Stop,
+            };
+            yield break;
+        }
+
         var prompt = string.Empty;
-        foreach (var message in messages)
+        foreach (var message in messageList)
         {
             if (message.Role == ChatRole.User)
             {
@@ -30,6 +43,29 @@ internal sealed class ScriptedChatClient : IChatClient
         }
 
         var messageId = Guid.NewGuid().ToString("N");
+        if (prompt.Contains("background", StringComparison.OrdinalIgnoreCase) &&
+            options?.Tools?.OfType<AIFunctionDeclaration>()
+                .Any(tool => tool.Name == "change_background") == true)
+        {
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = messageId,
+                Contents =
+                [
+                    new FunctionCallContent(
+                        "agentic-chat-background-1",
+                        "change_background",
+                        new Dictionary<string, object?>
+                        {
+                            ["background"] = "linear-gradient(135deg, #ff9a9e, #fad0c4)"
+                        })
+                ],
+                FinishReason = ChatFinishReason.ToolCalls,
+            };
+            yield break;
+        }
+
         var answer = $"""
             ## Agentic response
 

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Baselines/AgenticChatClientTool.recording.json
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Baselines/AgenticChatClientTool.recording.json
@@ -1,0 +1,42 @@
+{
+  "calls": [
+    {
+      "prompt": "Change the background to something new",
+      "messageCount": 1,
+      "toolNames": [
+        "change_background"
+      ],
+      "frames": [
+        {
+          "name": "background-action",
+          "functionCall": {
+            "callId": "agentic-chat-background-1",
+            "name": "change_background",
+            "arguments": {
+              "background": "linear-gradient(135deg, #ff9a9e, #fad0c4)"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "prompt": "Change the background to something new",
+      "messageCount": 3,
+      "toolNames": [
+        "change_background"
+      ],
+      "toolResultCallIds": [
+        "agentic-chat-background-1"
+      ],
+      "frames": [
+        {
+          "name": "confirmation",
+          "chunks": [
+            "Background changed",
+            " to a sunset gradient."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/DojoModelOverrides.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/DojoModelOverrides.cs
@@ -17,6 +17,9 @@ internal class DojoModelOverrides
     public static void AgenticChatRichText(IServiceCollection services)
         => AddRecordedModel(services, "AgenticChatRichText.recording.json");
 
+    public static void AgenticChatClientTool(IServiceCollection services)
+        => AddRecordedModel(services, "AgenticChatClientTool.recording.json");
+
     private static void AddRecordedModel(IServiceCollection services, string recordingFileName)
     {
         services.AddSingleton(_ => RecordedScript.Load(recordingFileName));

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/RecordedChatClient.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/RecordedChatClient.cs
@@ -33,13 +33,33 @@ internal sealed class RecordedChatClient : IChatClient
     {
         ArgumentNullException.ThrowIfNull(messages);
 
-        var lastUserMessage = messages.LastOrDefault(message => message.Role == ChatRole.User)?.Text ?? "";
-        var call = _script.GetCall(lastUserMessage);
+        var messageList = messages.ToList();
+        var lastUserMessage =
+            messageList.LastOrDefault(message => message.Role == ChatRole.User)?.Text ?? "";
+        var call = _script.GetCall(lastUserMessage, messageList.Count);
+        AssertRequest(call, messageList, options);
         var messageId = Guid.NewGuid().ToString("N");
 
         for (var frameIndex = 0; frameIndex < call.Frames.Count; frameIndex++)
         {
             var frame = call.Frames[frameIndex];
+            if (frame.FunctionCall is not null)
+            {
+                yield return new ChatResponseUpdate
+                {
+                    Role = ChatRole.Assistant,
+                    MessageId = messageId,
+                    Contents =
+                    [
+                        new FunctionCallContent(
+                            frame.FunctionCall.CallId,
+                            frame.FunctionCall.Name,
+                            frame.FunctionCall.Arguments)
+                    ],
+                    FinishReason = ChatFinishReason.ToolCalls,
+                };
+            }
+
             foreach (var chunk in frame.Chunks)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -60,6 +80,42 @@ internal sealed class RecordedChatClient : IChatClient
 
     internal static string GetLockKey(string lastUserMessage, string frameName)
         => $"replay:{lastUserMessage}:{frameName}";
+
+    private static void AssertRequest(
+        RecordedCall call,
+        IReadOnlyList<ChatMessage> messages,
+        ChatOptions? options)
+    {
+        if (call.ToolNames is not null)
+        {
+            var actualToolNames = options?.Tools?
+                .OfType<AIFunctionDeclaration>()
+                .Select(tool => tool.Name)
+                .ToList() ?? [];
+            if (!actualToolNames.SequenceEqual(call.ToolNames))
+            {
+                throw new InvalidOperationException(
+                    $"Expected tools [{string.Join(", ", call.ToolNames)}], " +
+                    $"received [{string.Join(", ", actualToolNames)}].");
+            }
+        }
+
+        if (call.ToolResultCallIds is not null)
+        {
+            var actualCallIds = messages
+                .Where(message => message.Role == ChatRole.Tool)
+                .SelectMany(message => message.Contents)
+                .OfType<FunctionResultContent>()
+                .Select(result => result.CallId)
+                .ToList();
+            if (!actualCallIds.SequenceEqual(call.ToolResultCallIds))
+            {
+                throw new InvalidOperationException(
+                    $"Expected tool results [{string.Join(", ", call.ToolResultCallIds)}], " +
+                    $"received [{string.Join(", ", actualCallIds)}].");
+            }
+        }
+    }
 
     public Task<ChatResponse> GetResponseAsync(
         IEnumerable<ChatMessage> messages,

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/RecordedScript.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/RecordedScript.cs
@@ -31,18 +31,20 @@ internal sealed class RecordedScript
             ?? throw new InvalidOperationException($"Recording decoded to null: {recordingFileName}");
     }
 
-    public RecordedCall GetCall(string lastUserMessage)
+    public RecordedCall GetCall(string lastUserMessage, int messageCount)
     {
         foreach (var call in Calls)
         {
-            if (lastUserMessage.StartsWith(call.Prompt, StringComparison.Ordinal))
+            if (lastUserMessage.StartsWith(call.Prompt, StringComparison.Ordinal) &&
+                (call.MessageCount is null || call.MessageCount == messageCount))
             {
                 return call;
             }
         }
 
         throw new InvalidOperationException(
-            $"No recorded call matches the last user message '{lastUserMessage}'. " +
+            $"No recorded call matches the last user message '{lastUserMessage}' " +
+            $"with {messageCount} messages. " +
             $"Recorded prompts: {string.Join(", ", Calls.Select(call => call.Prompt))}.");
     }
 }
@@ -51,6 +53,15 @@ internal sealed class RecordedCall
 {
     /// <summary>The prefix of the last user message this call answers.</summary>
     public required string Prompt { get; init; }
+
+    /// <summary>The message count that distinguishes continuations of the same prompt.</summary>
+    public int? MessageCount { get; init; }
+
+    /// <summary>The tool declarations expected on this model request.</summary>
+    public List<string>? ToolNames { get; init; }
+
+    /// <summary>The function result call IDs expected on this model request.</summary>
+    public List<string>? ToolResultCallIds { get; init; }
 
     /// <summary>The response, split into the checkpoints a test can stop at.</summary>
     public required List<RecordedFrame> Frames { get; init; }
@@ -62,5 +73,17 @@ internal sealed class RecordedFrame
     public required string Name { get; init; }
 
     /// <summary>The text chunks streamed for this checkpoint.</summary>
-    public required List<string> Chunks { get; init; }
+    public List<string> Chunks { get; init; } = [];
+
+    /// <summary>A function call emitted at this checkpoint.</summary>
+    public RecordedFunctionCall? FunctionCall { get; init; }
+}
+
+internal sealed class RecordedFunctionCall
+{
+    public required string CallId { get; init; }
+
+    public required string Name { get; init; }
+
+    public Dictionary<string, object?> Arguments { get; init; } = [];
 }

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/AgenticChatScenarioTests.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/AgenticChatScenarioTests.cs
@@ -19,6 +19,9 @@ public partial class AgenticChatScenarioTests : BrowserTest
 {
     private const string FirstPrompt = "Tell me about Blazor";
     private const string SecondPrompt = "And what about streaming";
+    private const string BackgroundPrompt = "Change the background to something new";
+    private const string Background =
+        "linear-gradient(135deg, #ff9a9e, #fad0c4)";
 
     private ServerInstance _api = null!;
     private ServerInstance _ui = null!;
@@ -36,7 +39,19 @@ public partial class AgenticChatScenarioTests : BrowserTest
 
         _api = await StartServerAsync<AGUIDojoApiAssembly>(TestRoot.Servers, options =>
         {
-            options.ConfigureServices<DojoModelOverrides>(nameof(DojoModelOverrides.AgenticChat));
+            var usesClientToolRecording = TestContext.TestName?.Contains(
+                "ClientTool",
+                StringComparison.Ordinal) == true;
+            if (usesClientToolRecording)
+            {
+                options.ConfigureServices<DojoModelOverrides>(
+                    nameof(DojoModelOverrides.AgenticChatClientTool));
+            }
+            else
+            {
+                options.ConfigureServices<DojoModelOverrides>(
+                    nameof(DojoModelOverrides.AgenticChat));
+            }
         });
 
         _ui = await StartServerAsync<global::DojoClient.Components.App>(TestRoot.Servers, options =>
@@ -102,6 +117,41 @@ public partial class AgenticChatScenarioTests : BrowserTest
         await Expect(AssistantMessage.Nth(0)).ToContainTextAsync("Blazor renders");
     }
 
+    [TestMethod]
+    public async Task AgenticChat_ClientToolExecutesAndContinuesWithOneResult()
+    {
+        await GoToScenarioAsync();
+        var prompt = Prompt(BackgroundPrompt);
+
+        await SendAsync(prompt);
+
+        var scenario = _page.Locator(".agentic-chat");
+        await Expect(scenario).ToHaveAttributeAsync("data-background", Background);
+        await Expect(_page.Locator(".agentic-chat__action-status"))
+            .ToContainTextAsync("Background updated");
+        await Expect(AssistantMessage)
+            .ToContainTextAsync("Background changed to a sunset gradient.");
+    }
+
+    [TestMethod]
+    public async Task AgenticChat_ClientToolStateIsIsolatedPerCircuit()
+    {
+        await GoToScenarioAsync();
+
+        var secondContext = await NewContext(
+            new BrowserNewContextOptions().WithServerRouting(_ui));
+        var secondPage = await secondContext.NewPageAsync();
+        await secondPage.GotoAsync($"{_ui.TestUrl}/agentic_chat");
+        await secondPage.WaitForInteractiveAsync("textarea.sc-ai-input__textarea");
+
+        await SendAsync(Prompt(BackgroundPrompt));
+
+        await Expect(_page.Locator(".agentic-chat"))
+            .ToHaveAttributeAsync("data-background", Background);
+        Assert.IsNull(await secondPage.Locator(".agentic-chat")
+            .GetAttributeAsync("data-background"));
+    }
+
     private ILocator UserMessage => _page.Locator(".sc-ai-message--user .sc-ai-message__content");
 
     private ILocator AssistantMessage => _page.Locator(".sc-ai-message--assistant .sc-ai-message__content");
@@ -121,4 +171,5 @@ public partial class AgenticChatScenarioTests : BrowserTest
         await _page.FillAsync("textarea.sc-ai-input__textarea", prompt);
         await _page.ClickAsync("button.sc-ai-input__send");
     }
+
 }

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticChat/AgenticChatScenario.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticChat/AgenticChatScenario.razor
@@ -6,26 +6,52 @@
 
 <PageTitle>Agentic Chat</PageTitle>
 
-<ChatPage Agent="_agent"
-          Placeholder="Type a message..."
-          data-scenario="agentic_chat">
-    <Header>
-        <h1 class="dojo-scenario__title">Agentic Chat</h1>
-    </Header>
-    <WelcomeContent>
-        <p class="dojo-scenario__welcome">Ask the agent something to start the conversation.</p>
-    </WelcomeContent>
-</ChatPage>
+<div class="agentic-chat" data-background="@_background" style="@BackgroundStyle">
+    <ChatPage Agent="_agent"
+              Placeholder="Type a message..."
+              data-scenario="agentic_chat">
+        <Header>
+            <h1 class="dojo-scenario__title">Agentic Chat</h1>
+        </Header>
+        <WelcomeContent>
+            <p class="dojo-scenario__welcome">Ask the agent something to start the conversation.</p>
+        </WelcomeContent>
+        <MessageListContent>
+            <BlockRenderer TBlock="UIActionBlock"
+                           Context="action"
+                           When="@(action => action.ToolName == "change_background")">
+                <AutoInvokeAction Block="action" />
+            </BlockRenderer>
+        </MessageListContent>
+    </ChatPage>
+</div>
 
 @code {
     private UIAgent _agent = default!;
+    private string? _background;
 
     protected override void OnInitialized()
     {
         // The injected IChatClient is an AGUIChatClient pointed at AGUIDojoApi, so every
         // message crosses the real AG-UI HTTP + SSE boundary.
-        _agent = new UIAgent(ChatClient, configure: null, LoggerFactory);
+        _agent = new UIAgent(ChatClient, options =>
+        {
+            options.RegisterUIAction(AIFunctionFactory.Create(
+                ChangeBackground,
+                name: "change_background",
+                description: "Change the chat background using a CSS color or gradient."));
+        }, LoggerFactory);
     }
+
+    private async Task<string> ChangeBackground(string background)
+    {
+        _background = background;
+        await InvokeAsync(StateHasChanged);
+        return "Background changed successfully.";
+    }
+
+    private string? BackgroundStyle =>
+        _background is null ? null : $"background: {_background};";
 
     public void Dispose() => _agent?.Dispose();
 }

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticChat/AutoInvokeAction.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticChat/AutoInvokeAction.razor
@@ -1,0 +1,25 @@
+@using Microsoft.AspNetCore.Components.AI
+
+<span class="agentic-chat__action-status" role="status">
+    @if (Block.IsComplete)
+    {
+        <text>Background updated</text>
+    }
+    else
+    {
+        <text>Updating background...</text>
+    }
+</span>
+
+@code {
+    [Parameter, EditorRequired]
+    public UIActionBlock Block { get; set; } = default!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (!Block.IsComplete)
+        {
+            await Block.InvokeAsync();
+        }
+    }
+}

--- a/src/Components/AI/testassets/DojoClient/wwwroot/app.css
+++ b/src/Components/AI/testassets/DojoClient/wwwroot/app.css
@@ -22,3 +22,15 @@ html, body {
 .dojo-scenario__welcome {
     color: #6c757d;
 }
+
+.agentic-chat {
+    min-height: 100vh;
+    transition: background 200ms ease;
+}
+
+.agentic-chat__action-status {
+    display: block;
+    margin: 0.5rem 1rem;
+    color: #495057;
+    font-size: 0.875rem;
+}


### PR DESCRIPTION
## Overview

Position 3 in native stack #68340, this layer depends on #68324 and adds browser-owned tool execution to the chat/rich-text foundation. Across four commits and 17 files, it introduces a provider-neutral client-action contract, continues the same conversation after the browser returns a tool result, and lights up the canonical Agentic Chat `change_background` action. The cross-cutting constraint is that executable client functions stay inside the Blazor circuit: the model receives declarations only, while DojoClient still reaches AGUIDojoApi through AGUI.Client 0.0.5, HTTP/SSE, and AGUI.Server 0.0.5.

## Design

```csharp
// src/Components/AI/src/Pipeline/UIAgentOptions.cs
// Public registration associates an exact tool name with code owned by this UIAgent instance.
// The implementation stores the function for browser invocation; it is not handed to the server as executable code.
public void RegisterUIAction(AIFunction function)
{
    ArgumentNullException.ThrowIfNull(function);
    UIActions.Add(function.Name, function);
}
```

```csharp
// src/Components/AI/src/Blocks/UIActionBlock.cs
// Public render contract: consumers can inspect the model call, render by ToolName, invoke once,
// and observe the correlated FunctionResultContent that resumes the conversation.
public class UIActionBlock : ContentBlock
{
    public FunctionCallContent Call { get; }
    public string ToolName => Call.Name;
    public FunctionResultContent? Result { get; private set; }
    public bool IsComplete => Result is not null;

    public Task InvokeAsync(CancellationToken cancellationToken = default)
    {
        lock (_invocationLock)
        {
            // Two renderer callbacks receive the same Task; the browser action executes once.
            _invocation ??= InvokeCoreAsync(cancellationToken);
            return _invocation;
        }
    }
}
```

The action name dictionary uses ordinal matching, so `change_background` is claimed while `CHANGE_BACKGROUND` remains unhandled; this avoids accidentally dispatching a different tool. Registered actions are added to cloned `ChatOptions` with `AsDeclarationOnly()`, preserving any existing server tools without exposing browser closures to the API. All client actions share this one contract and handler pattern; `change_background` is the representative canonical use rather than a special-purpose product API.

## Implementation

```csharp
// src/Components/AI/src/Pipeline/UIActionHandler.cs
// The pipeline claims only FunctionCallContent whose exact name was registered on this agent.
// Every registered action follows this path; unmatched calls pass to later handlers unchanged.
if (content is FunctionCallContent call &&
    _actions.TryGetValue(call.Name, out var function))
{
    context.MarkHandled(call);
    return BlockMappingResult<State>.Emit(
        new UIActionBlock(function, call)
        {
            // Preserve the model call ID so the continuation result correlates over AG-UI.
            Id = call.CallId ?? Guid.NewGuid().ToString("N")
        },
        state);
}
```

```csharp
// src/Components/AI/src/Engine/AgentContext.cs
// A turn streams normally until one or more UIActionBlocks appear, then pauses for browser results.
ChatMessage? currentMessage = message;
while (currentMessage is not null)
{
    var actions = new List<UIActionBlock>();

    await foreach (var block in _agent.SendMessageAsync(currentMessage, cancellationToken)
        .WithCancellation(cancellationToken))
    {
        // Existing request/response block routing is unchanged (omitted).
        if (block is UIActionBlock action)
        {
            actions.Add(action);
        }
    }

    if (actions.Count == 0)
    {
        currentMessage = null;
        continue;
    }

    Status = ConversationStatus.AwaitingInput;
    NotifyStatusChanged();

    // One action or many parallel actions are the same equivalence class: wait for all,
    // then send one tool-role message containing exactly one result per action.
    var results = await Task.WhenAll(
        actions.Select(action => action.GetResultAsync(cancellationToken)));
    currentMessage = new ChatMessage(ChatRole.Tool, [.. results]);

    Status = ConversationStatus.Streaming;
    NotifyStatusChanged();
}
```

```razor
@* src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticChat/AgenticChatScenario.razor *@
@* The renderer auto-invokes only the canonical action, and ChangeBackground mutates component-local state,
   which makes the effect circuit-local rather than server-global. *@
<BlockRenderer TBlock="UIActionBlock"
               Context="action"
               When="@(action => action.ToolName == "change_background")">
    <AutoInvokeAction Block="action" />
</BlockRenderer>

@code {
    private async Task<string> ChangeBackground(string background)
    {
        _background = background;
        await InvokeAsync(StateHasChanged);
        return "Background changed successfully.";
    }
}
```

The deterministic browser fixture replaces only the API's underlying model client. Its recording asserts the `change_background` declaration on the first request and exactly one matching tool-result call ID on the continuation; AGUI.Server serialization, HTTP/SSE transport, AGUI.Client parsing, product mapping, and Blazor invocation remain real. Test cases are compressed into two equivalence classes: product tests cover registration/matching/single execution/continuation, while browser tests cover visible completion and isolation between two circuits.

## Outcome

| Equivalence class | Proven behavior |
|---|---|
| Product contract | Declaration-only client tools preserve configured server tools, match names ordinally, invoke once, transition `Streaming → AwaitingInput → Streaming → Idle`, and resume with one correlated result. |
| Canonical Agentic Chat | `change_background` updates the owning circuit, streams confirmation text after the continuation, and leaves a second circuit unchanged. |
| Transport/replay | Only the API model is recorded; the separate DojoClient/AGUIDojoApi AG-UI HTTP/SSE boundary is exercised end to end. |

**Review guidance:** read the declaration-only option construction, exact-name handler, `UIActionBlock` single-invocation gate, and `AgentContext` continuation loop closely. The action styling and generated recording need only a spot-check for scenario identity and sensitive-data absence.

**Acceptance criteria:** one circuit changes only its own background; the model receives the declared `change_background` tool and exactly one result with the original call ID; confirmation text arrives after that continuation.

Validation: dependency-aware build **0 warnings / 0 errors**; `AgentContextUIActionTests` **4/4 passed**; `AgenticChatScenarioTests` **5/5 passed**.