### PR TITLE
Harden ASP.NET Core PR review validation

### DIFF
--- a/.github/skills/aspnetcore-pr-review/SKILL.md
+++ b/.github/skills/aspnetcore-pr-review/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   worktree before recommending it. Produces one local-only recommendation.
   Do not use in dotnet/maui or any repository other than dotnet/aspnetcore.
   Never posts or pushes.
-compatibility: Requires a dotnet/aspnetcore checkout and the sibling aspnetcore-try-fix project skill
+compatibility: Requires a dotnet/aspnetcore checkout and the sibling aspnetcore-try-fix skill
 ---
 
 # ASP.NET Core Multi-Model Review
@@ -33,11 +33,13 @@ This skill is intentionally repository-specific. Before using it:
 ## Inputs
 
 - Issue/PR number or problem description.
-- Current diff or current fix summary.
-- Target files.
-- Validation evidence and known blockers.
+- Current diff/fix summary, target files, validation evidence, and blockers.
 - An artifact root outside the repository. Prefer the current session's artifact
   directory. If none is available, create a temporary directory and report it.
+
+Resolve `<skill-root>` from the active `SKILL.md` and the candidate only from
+`<skill-root>/../aspnetcore-try-fix/SKILL.md`. Record both paths and hashes;
+stop rather than mix installed and project copies.
 
 ## Model panel
 
@@ -47,9 +49,8 @@ verify the current session model. If it is an Anthropic or other non-GPT model,
 stop and report that the review must be restarted with a GPT orchestrator
 instead of silently continuing.
 
-The orchestrator remains separate from the candidate panel. This prevents the
-two Claude candidates from also controlling evidence selection and final
-synthesis.
+Keep the orchestrator separate so candidate models do not also control evidence
+selection and final synthesis.
 
 Use four different model families/configurations:
 
@@ -60,10 +61,9 @@ Use four different model families/configurations:
 | C | `gpt-5.3-codex` | Repository-pattern alternative |
 | D | `gpt-5.5` | Test falsification and unnecessary-surface removal |
 
-If a model is unavailable, substitute a different available family and record
-the substitution. Preserve four distinct models when possible. If a candidate
-times out or cannot use required tools, record the failure instead of silently
-replacing its result.
+If a model is unavailable, record its substitute and preserve four distinct
+models when possible. Record candidate timeouts/tool failures instead of
+silently replacing their results.
 
 ## Phase 1: Freeze shared evidence
 
@@ -93,6 +93,7 @@ Save the bundle outside the repository using these names:
   empirical/before.diff
   empirical/diagnostic.diff
   empirical/implementation.diff
+  empirical/head.log
   empirical/red.log
   empirical/candidate.diff
   empirical/green.log
@@ -142,8 +143,8 @@ and cannot by itself justify a high-confidence implementation blocker.
 
 ## Phase 3: Independent candidates
 
-Launch all four models with
-`.github/skills/aspnetcore-try-fix/SKILL.md` in `candidate-review` mode.
+Launch all four models with the resolved sibling
+`<skill-root>/../aspnetcore-try-fix/SKILL.md` in `candidate-review` mode.
 
 These invocations are read-only, so run them in parallel. Each prompt must:
 
@@ -245,20 +246,21 @@ merge-readiness verdict.
    A lower rung does not prove a higher-rung scenario. For example, directly
    invoking a callback does not prove which callback a browser interaction
    produces.
-5. Require strict red/green evidence for the review finding:
+5. Run the approved assertion against untouched frozen head first and save the
+   complete result in `empirical/head.log`:
    - add or tighten one assertion that distinguishes the predicted defect;
-   - run it against the frozen PR head and preserve the failing output in
-     `empirical/red.log`;
-   - apply the smallest candidate correction;
-   - run the identical assertion and preserve the passing output in
+   - if head fails behaviorally, copy that result to `empirical/red.log`, apply
+     the smallest correction, and save the identical passing assertion in
      `empirical/green.log`;
-   - save assertion-only changes as both `empirical/before.diff` and
-     `empirical/diagnostic.diff`, production-intended changes as
-     `empirical/implementation.diff`, the combined state as
-     `empirical/candidate.diff`, and the structured result as
-     `empirical/result.md`;
-   - record whether the assertion is `merge-candidate`, `diagnostic-only`, or
-     `rejected`.
+   - if head passes, reject or narrow the blocker. Mark red/green not applicable
+     rather than manufacturing a mutation; any useful mutation is diagnostic
+     only and cannot represent a frozen-head defect;
+   - save assertion changes as `before.diff` and `diagnostic.diff`, production
+     changes as `implementation.diff`, the combined state as `candidate.diff`,
+     and the structured result as `result.md` under `empirical/`;
+   - classify the regression assertion as required, optional, or rejected, and
+     any mutation separately as diagnostic-only, rejected, or not applicable.
+     Required means accepted criteria or a proven defect needs exact coverage.
 6. A valid red must fail at the predicted behavioral assertion. A stale browser
    element, harness timeout before the trigger, build failure, missing asset,
    infrastructure error, unrelated assertion, or different assertion is not
@@ -305,6 +307,8 @@ in the same isolated worktree and save a lifecycle-derived matrix in
 
 - Vary the dimensions that could falsify the mechanism. Repeating one identical
   deterministic scenario demonstrates repeatability, not a complete matrix.
+- Scale the matrix to claim severity and statefulness. Do not add lifecycle
+  scaffolding solely to earn `production-proven`; a lower proof cap is valid.
 - Exercise the real producer/runtime boundary and the narrow neighboring suite.
 - When recommending an observer-only timeout, inspect the inner task states
   after timeout, release or cancel them deterministically, observe exceptions,
@@ -314,7 +318,8 @@ in the same isolated worktree and save a lifecycle-derived matrix in
 - In `empirical/stress-matrix.md`, mark the real producer/runtime boundary,
   varied falsification dimensions, applicable configurations/platforms,
   neighboring suite, and cleanup/interruption paths as `passed` or
-  `not applicable - <specific reason>`.
+  `not applicable - <specific reason>`; list distinct variants under
+  `## Executed cases`.
 - Classify the candidate as `production-proven`, `targeted-proven`,
   `diagnostic-only`, `rejected`, or `blocked`.
 
@@ -442,10 +447,11 @@ Save the synthesized output below to `final/review.md`.
 - <claim and why>
 
 ## Test assessment
-<whether strict red/green and relevant paths are covered; include empirical
-command, red result, green result, and artifact paths, or the exact blocker>
+<frozen-head result and relevant paths; include strict red/green only for a
+proven defect, otherwise state that head passed and no blocker was manufactured>
 
 ## Proof status
+**Frozen-head result:** behavioral-fail / structural-defect / pass / blocked / not-applicable
 **Finding proof:** empirical / structural / missing
 **Scenario proof:** empirical / structural / missing
 **Candidate proof:** production-proven / targeted-proven / diagnostic-only / rejected / blocked / none
@@ -453,7 +459,8 @@ command, red result, green result, and artifact paths, or the exact blocker>
 **Oracle fidelity:** authoritative / corroborated / hypothesis / unknown
 **Mechanism fidelity:** reproduced / structural / inferred / unknown
 **Scenario fidelity:** exact / proxy / synthetic / missing
-**Assertion disposition:** merge-candidate / diagnostic-only / rejected
+**Regression assertion disposition:** required-regression / optional-regression / rejected
+**Diagnostic mutation disposition:** diagnostic-only / rejected / not-applicable
 
 ## Final recommendation
 **Implementation verdict:** KEEP CURRENT FIX / REVISE / REPLACE
@@ -484,10 +491,10 @@ command, red result, green result, and artifact paths, or the exact blocker>
 - Do not let implementation state, model consensus, or a green test substitute
   for an authoritative product oracle.
 - Do not treat infrastructure or harness failure as a behavioral red.
+- Do not manufacture a red after frozen head passes the approved assertion.
 - Do not treat one green run as proof that a production implementation is safe.
 - Do not infer producer behavior from a consumer-only test.
 - Do not collapse disagreement into consensus; preserve unresolved disputes.
 - Never infer the complete change set from `git diff` alone.
 - Never promote an unsupported factual claim into a required change.
-- Never publish internal proof jargon without translating it into concrete
-  maintainer language.
+- Translate internal proof jargon into concrete maintainer language.

--- a/.github/skills/aspnetcore-pr-review/SKILL.md
+++ b/.github/skills/aspnetcore-pr-review/SKILL.md
@@ -1,0 +1,468 @@
+---
+name: aspnetcore-pr-review
+description: >-
+  Multi-model adversarial review specifically for a dotnet/aspnetcore PR, issue
+  fix, or local diff. Use whenever work in the ASP.NET Core repository needs a
+  deep review, competing fixes, multi-model validation, adversarial consensus,
+  or a decision about whether a local fix is the best approach. Runs four
+  independent aspnetcore-try-fix candidates, cross-examines them, empirically
+  adjudicates the strongest surviving finding with a lifecycle-aware proof
+  ladder, then falsifies any proposed production fix in an isolated child
+  worktree before recommending it. Produces one local-only recommendation.
+  Do not use in dotnet/maui or any repository other than dotnet/aspnetcore.
+  Never posts or pushes.
+compatibility: Requires a dotnet/aspnetcore checkout and the sibling aspnetcore-try-fix project skill
+---
+
+# ASP.NET Core Multi-Model Review
+
+Review a PR or local issue fix using independent model diversity followed by an
+adversarial consensus round. Keep the workflow local: no comments, approvals,
+commits, pushes, PR creation, or branch changes.
+
+## Repository scope
+
+This skill is intentionally repository-specific. Before using it:
+
+1. Verify the current Git checkout is `dotnet/aspnetcore` from its configured
+   remote URL or trusted session metadata.
+2. If the repository cannot be verified, stop and report that this skill only
+   supports `dotnet/aspnetcore`.
+3. Do not reinterpret these instructions for .NET MAUI or another repository.
+
+## Inputs
+
+- Issue/PR number or problem description.
+- Current diff or current fix summary.
+- Target files.
+- Validation evidence and known blockers.
+- An artifact root outside the repository. Prefer the current session's artifact
+  directory. If none is available, create a temporary directory and report it.
+
+## Model panel
+
+Use four different model families/configurations:
+
+| Candidate | Model | Primary challenge |
+|---|---|---|
+| A | `claude-opus-4.6` | Minimal root-cause and API-contract repair |
+| B | `claude-opus-4.7` | Compatibility skeptic and failure modes |
+| C | `gpt-5.3-codex` | Repository-pattern alternative |
+| D | `gpt-5.5` | Test falsification and unnecessary-surface removal |
+
+If a model is unavailable, substitute a different available family and record
+the substitution. Preserve four distinct models when possible. If a candidate
+times out or cannot use required tools, record the failure instead of silently
+replacing its result.
+
+## Phase 1: Freeze shared evidence
+
+Create one provenance-backed evidence bundle before launching candidates. `git
+diff` is not a complete dirty-tree inventory because it omits untracked files.
+The authoritative local change set must combine tracked changes and in-scope
+untracked files.
+
+Save the bundle outside the repository using these names:
+
+```text
+<artifact-root>/aspnetcore-pr-review/
+  evidence/manifest.md
+  evidence/product-oracle.md
+  evidence/head-drift.md
+  evidence/tracked.diff
+  evidence/files/
+  candidates/candidate-a.md
+  candidates/candidate-b.md
+  candidates/candidate-c.md
+  candidates/candidate-d.md
+  cross-examination/candidate-a.md
+  cross-examination/candidate-b.md
+  cross-examination/candidate-c.md
+  cross-examination/candidate-d.md
+  empirical/manifest.md
+  empirical/before.diff
+  empirical/red.log
+  empirical/candidate.diff
+  empirical/green.log
+  empirical/claim-matrix.md
+  empirical/stress-matrix.md
+  empirical/result.md
+  final/repository-oracle.md
+  final/review.md
+```
+
+The manifest must record:
+
+1. Repository remote, HEAD SHA, branch, and working directory.
+2. `git status --porcelain=v1 -uall`, including every untracked path.
+3. The complete tracked diff.
+4. The content and SHA-256 hash of every relevant untracked or full source file.
+5. Applicable `AGENTS.md` and instruction files with their hashes.
+6. Issue/PR text and comments, with source URL.
+7. Exact validation commands and complete logs when available.
+8. Known environment failures, explicitly separated from product failures.
+9. Which changed paths are in scope and why unrelated dirty paths were excluded.
+
+Give every model the same manifest, tracked diff, and captured files. Permit a
+narrow source lookup outside the bundle only when the candidate records the
+path and the claim it is verifying.
+
+Do not include the parent's conclusion that the fix is correct. The goal is to
+avoid anchoring.
+
+## Phase 2: Establish the product oracle
+
+Before asking models to diagnose the implementation, separate intended
+behavior from implementation state. Otherwise independent models can converge
+on the same plausible but incorrect lifecycle and then prove it consistently.
+
+Write `evidence/product-oracle.md` with:
+
+1. The user-observable behavior being protected.
+2. The source and confidence for each behavioral claim:
+   - `documented`: public API docs or an accepted specification;
+   - `author-confirmed`: issue author, reporter, or maintainer clarification;
+   - `test-encoded`: an existing test whose intent is supported by another
+     authoritative source;
+   - `inferred`: derived only from implementation, naming, or model reasoning;
+   - `unknown`: competing interpretations remain.
+3. For stateful behavior, the current owner of the user-visible state, events
+   that retain ownership, events that transfer ownership, and what the user
+   should observe after each transition.
+4. Any ambiguity that requires human clarification.
+
+Implementation and existing tests are evidence of current behavior, not
+automatic proof of intended behavior. Multi-model agreement cannot promote an
+`inferred` claim to product intent. If a required behavioral claim remains
+`unknown`, continue investigating testable implementation defects but report
+the lifecycle recommendation as `blocked on product oracle`.
+
+When a human later corrects the oracle, preserve the correction and update all
+downstream hypotheses. Do not defend a prior consensus against authoritative
+product context.
+
+## Phase 3: Independent candidates
+
+Launch all four models with
+`.github/skills/aspnetcore-try-fix/SKILL.md` in `candidate-review` mode.
+
+These invocations are read-only, so run them in parallel. Each prompt must:
+
+- Require one root-cause hypothesis and one candidate only.
+- For stateful, concurrent, lifecycle, interop, or browser-driven behavior,
+  require a transition table containing: state/invariant, entry path, ordinary
+  successful exit, cancellation/interruption exit, owner, and the observable
+  consequence if the state is stranded or consumed twice.
+- Require an approach materially different from the current fix when viable.
+- Allow `NO VIABLE ALTERNATIVE` only after the candidate names and rejects at
+  least one mechanism-level alternative.
+- Require a direct assessment of whether the current test can false-pass.
+- Require citations for compatibility, browser-support, API-breaking,
+  test-execution, and repository-pattern claims. A citation must be an exact
+  source path and line, observed output, or primary-source URL.
+- Require every expected-behavior claim to cite the shared product oracle and
+  preserve its confidence. Candidates may challenge the oracle with evidence,
+  but cannot silently replace it with implementation-derived intent.
+- Label unverifiable claims `UNSUPPORTED`; unsupported claims cannot become
+  required follow-ups or consensus findings.
+- Prohibit edits, commits, pushes, comments, and external posting.
+- Withhold all other models' outputs.
+
+Save each raw response unchanged at its configured candidate path. Do not
+replace raw output with an orchestrator summary.
+
+## Phase 4: Adversarial cross-examination
+
+After all independent candidates complete, send every model an anonymized
+summary of all candidates and the current fix. Use IDs `P1` through `P4`, not
+model names, and preserve this schema for each proposal:
+
+```text
+ID:
+Root-cause hypothesis:
+Mechanism-level change:
+Files/surfaces:
+Evidence and citations:
+Known risks:
+Recommendation:
+```
+
+Each model must:
+
+1. Identify the strongest candidate and why.
+2. Attack every candidate with one concrete failure scenario.
+3. Mark each candidate `support`, `dispute`, or `discard`.
+4. State whether the current fix is complete.
+5. Offer a genuinely new idea or `NO NEW IDEA`.
+6. Mark factual claims `VERIFIED`, `CONTRADICTED`, or `UNSUPPORTED` with evidence.
+7. Rank surviving behavioral claims by falsifiability: concrete trigger,
+   observable failure, and faithful test boundary. Prefer a bounded claim over a
+   broad concern that cannot be distinguished.
+
+One cross-examination round is sufficient for this minimal reviewer. If two or
+more models produce the same new idea, the orchestrator must verify it against
+source or observed output before including it in synthesis. Save each raw
+cross-examination response at its configured path.
+
+## Phase 5: Empirical adjudication
+
+Multi-model agreement is corroboration, not runtime proof. After
+cross-examination, empirically adjudicate the highest-severity surviving
+finding whose consequence can be tested. Do this before assigning the final
+merge-readiness verdict.
+
+1. Select one finding that:
+   - has support from at least two independent candidates, or is a
+     high-severity minority finding;
+   - has no surviving source-level contradiction;
+   - predicts a concrete observable failure;
+   - can be distinguished at the smallest test surface that still exercises the
+     information producer relevant to the claim. Do not choose an easier
+     consumer-only unit test when the finding depends on browser, transport,
+     process, or scheduler behavior.
+2. Create an isolated child session or disposable detached worktree at the
+   frozen PR head. Never edit the parent review worktree. Record its exact path,
+   SHA, and clean status in `empirical/manifest.md`.
+3. Invoke `aspnetcore-try-fix` in `empirical` mode sequentially, using the
+   strongest consensus hypothesis, the exact claim to prove or reject, the
+   relevant product-oracle entries, an exact assertion contract, its allowed
+   perturbations, and the smallest targeted validation command. The empirical
+   agent may edit only its isolated worktree.
+4. Build a proof ladder in `empirical/claim-matrix.md` and record the highest
+   completed rung for each blocker-caliber claim:
+   - source invariant or contradictory contract;
+   - direct consumer behavior;
+   - producer classification or dispatch;
+   - real integration/runtime interaction;
+   - production-candidate regression coverage.
+   A lower rung does not prove a higher-rung scenario. For example, directly
+   invoking a callback does not prove which callback a browser interaction
+   produces.
+5. Require strict red/green evidence for the review finding:
+   - add or tighten one assertion that distinguishes the predicted defect;
+   - run it against the frozen PR head and preserve the failing output in
+     `empirical/red.log`;
+   - apply the smallest candidate correction;
+   - run the identical assertion and preserve the passing output in
+     `empirical/green.log`;
+   - save the assertion-only diff as `empirical/before.diff`, the complete
+     candidate diff as `empirical/candidate.diff`, and the structured result as
+     `empirical/result.md`.
+6. A valid red must fail at the predicted behavioral assertion. A stale browser
+   element, harness timeout before the trigger, build failure, missing asset,
+   infrastructure error, unrelated assertion, or different assertion is not
+   behavioral red evidence. Fix the harness or classify the run as `Blocked`.
+7. A pre-existing failing test is acceptable only when the same assertion
+   passes after the candidate correction. A build-only failure, unrelated test
+   failure, different assertion, or source-only prediction is not green
+   evidence.
+8. Treat the first green as causal evidence for the finding, not proof that the
+   candidate is production-ready. Preserve these as separate conclusions:
+   - **Finding proof:** does frozen head exhibit the predicted defect?
+   - **Scenario proof:** did the real producer/runtime path exhibit it?
+   - **Candidate proof:** did the proposed fix survive relevant counterexamples?
+9. Run at most three iterations for the same hypothesis. If the environment,
+   browser harness, or target test cannot run, preserve the failure and classify
+   adjudication as `Blocked`; do not substitute aggregate CI or model agreement.
+10. For every other blocker-caliber behavioral claim, execute a narrow
+    differentiating test when practical. If frozen head passes, explicitly
+    discard or narrow the claim. If frozen head fails at the predicted
+    assertion, promote it to a required follow-up using the highest proof rung
+    reached. If it is not run, downgrade it rather than carrying it as an
+    implementation blocker.
+11. Do not require empirical validation for a claim fully established without
+   runtime execution, such as a compiler error or a directly contradictory API
+   contract. Record why execution adds no information.
+12. Preserve all empirical artifacts before removing a disposable worktree. If
+   safe cleanup is unavailable, leave the isolated worktree in place and report
+   it rather than using destructive cleanup.
+
+If no surviving finding can be empirically adjudicated, the final verdict must
+say `blocked on evidence` for behavioral claims. It must not say `blocked on
+implementation` with high confidence solely from multi-model source reasoning.
+
+## Phase 6: Production-candidate falsification
+
+Only recommend a specific production implementation after it survives a stress
+matrix derived from the affected lifecycle and producer boundary. Save the
+matrix and results in `empirical/stress-matrix.md`.
+
+Continue in the same isolated Phase 5 worktree. Re-invoke
+`aspnetcore-try-fix` in `empirical` mode sequentially with the diagnostic
+candidate, proof status, and lifecycle-derived stress matrix. A Phase 5
+red/green result reported as `Blocked` solely because stress or producer
+validation remains pending is the expected handoff into this phase, not a
+failed finding adjudication.
+
+1. Start from the transition table, not a generic checklist. Exercise every
+   ordinary exit and applicable interruption path.
+2. For stateful or timing-sensitive behavior, cover applicable cases such as:
+   equal and changed measurements, delayed/out-of-order delivery, no-op
+   operations, repeated or rapid operations, cancellation, disposal, opposite
+   transitions, missing/partial observer batches, and multiple generations.
+3. When browser or JavaScript behavior is part of the claim, run a real
+   interaction using the repository's canonical sample/E2E workflow. Confirm
+   interactivity and inspect relevant console/network failures.
+4. Re-run timing-sensitive tests enough times to expose instability. A single
+   pass followed by a failure means the candidate is not proven; investigate
+   the divergence rather than selecting the passing log.
+5. Run the narrow neighboring existing suite after the candidate.
+6. Distinguish candidate outcomes:
+   - `Production-proven`: behavioral red/green plus applicable stress matrix and
+     real producer path pass consistently.
+   - `Diagnostic-only`: turns the targeted assertion green but has not survived
+     the full relevant matrix.
+   - `Rejected`: introduces a regression, flakes, or contradicts an invariant.
+   - `Blocked`: required execution cannot be completed for a recorded reason.
+
+If no candidate is production-proven, the review may still request changes for
+a proven defect. Describe the required invariant and evidence, but do not
+prescribe an exact implementation.
+
+## Phase 7: Recheck live head and synthesize
+
+Before final synthesis for a pull request, fetch the live PR head again and
+compare it with the frozen evidence SHA. Save the comparison in
+`evidence/head-drift.md`.
+
+- If the head is unchanged, proceed.
+- If only unrelated paths changed, record why the evidence remains applicable.
+- If a relevant source, test, contract, or instruction changed, refresh the
+  evidence bundle and rerun the affected proof before presenting the finding
+  as current.
+- Never silently describe frozen-head evidence as current-head validation.
+
+The orchestrator, not any candidate model, synthesizes the result.
+
+For each claim:
+
+- **Agree:** at least two models independently support it and no concrete
+  counterexample survives, with factual support verified by the orchestrator.
+- **Dispute:** models disagree or evidence is incomplete.
+- **Discard:** the claim conflicts with source code, repository conventions, or
+  observed test evidence.
+- **Unsupported:** the claim lacks repository evidence, observed output, or a
+  primary source. Exclude it from required follow-ups and verdict severity.
+- **Oracle-blocked:** the implementation concern is testable, but the intended
+  behavior still depends on unresolved product context.
+
+For the empirically adjudicated finding:
+
+- Promote a finding to a required implementation follow-up when frozen head
+  fails at the predicted behavioral assertion and the causal mechanism is
+  supported. A diagnostic correction turning the same assertion green
+  strengthens causality but does not make that correction production-ready.
+- If adjudication is blocked, preserve the structural concern under `Dispute`
+  or as a required evidence follow-up, calibrated to the strongest evidence
+  actually obtained.
+- If the test contradicts the prediction, discard or narrow the finding before
+  synthesis.
+
+Select the recommended fix in this order:
+
+1. Must satisfy strict behavioral red/green evidence.
+2. Must survive the lifecycle-derived stress matrix and real producer boundary.
+3. Must cover all producer/consumer paths involved in the bug.
+4. Must preserve compatibility and public API requirements.
+5. Prefer fewer concepts and files when correctness is equal.
+6. Prefer established ASP.NET Core patterns over novel machinery.
+
+## Phase 8: Preserve repository knowledge and draft readable comments
+
+Write `final/repository-oracle.md` for product knowledge that was missing,
+corrected, or difficult to discover during the review. Recommend only durable
+surfaces appropriate to the information:
+
+- Public observable behavior belongs in API documentation.
+- Internal lifecycle and ownership invariants belong next to the state machine.
+- Retention and takeover behavior belongs in paired behavioral tests.
+- Cross-cutting review guidance belongs in repository agent instructions.
+
+Do not leak review-session mechanics, model identities, local paths, or private
+conversation into repository guidance.
+
+When drafting a review comment, translate the internal proof into maintainer
+language:
+
+1. Start with the concrete action and visible failure.
+2. Explain the causal code path using only the minimum necessary terminology.
+3. State the requested change.
+4. Include one concrete example when it makes the behavior easier to see.
+
+Avoid compressed phrases such as "pair the takeover check with a focused
+retention assertion" when plain language can say "change one item above the
+initial target, verify the target stays in place, then press End and verify the
+last item loads." Internal terms such as product oracle, ownership, proof
+ladder, and producer boundary may remain in artifacts, but define or translate
+them before using them in a GitHub comment.
+
+Save the synthesized output below to `final/review.md`.
+
+## Output
+
+```markdown
+# Multi-Model Review
+
+## Current fix
+<summary>
+
+## Independent candidates
+| ID | Model | Root cause | Approach | Assessment |
+|---|---|---|---|---|
+
+## Adversarial consensus
+### Agree
+- <claim and evidence>
+
+### Dispute
+- <claim and unresolved evidence>
+
+### Discard
+- <claim and why>
+
+## Test assessment
+<whether strict red/green and relevant paths are covered; include empirical
+command, red result, green result, and artifact paths, or the exact blocker>
+
+## Proof status
+**Finding proof:** empirical / structural / missing
+**Scenario proof:** empirical / structural / missing
+**Candidate proof:** production-proven / diagnostic-only / rejected / blocked / none
+**Product oracle:** documented / author-confirmed / test-encoded / inferred / unknown
+
+## Final recommendation
+**Implementation verdict:** KEEP CURRENT FIX / REVISE / REPLACE
+**Behavioral evidence:** empirical / structural / missing
+**Merge readiness:** ready / blocked on evidence / blocked on product oracle / blocked on implementation
+**Implementation confidence:** high / medium / low
+**Reason:** <concise evidence>
+
+## Required follow-ups
+- <only concrete remaining work, or "None">
+
+## Repository oracle gaps
+- <durable documentation, invariant, test, or agent-guidance follow-up, or "None">
+
+## Suggested review comments
+- <plain-language comment with the concrete behavior and ask, or "None">
+```
+
+## Guardrails
+
+- Never post review comments or submit GitHub review events.
+- Never approve or request changes on GitHub.
+- Never push, commit, create a PR, change branches, stash, reset, or clean.
+- Never allow candidate agents to edit the shared worktree.
+- Never allow the empirical agent to edit the parent review worktree; it must
+  use an isolated child session or disposable detached worktree.
+- Do not let test/build output substitute for behavioral evidence.
+- Do not let implementation state, model consensus, or a green test substitute
+  for an authoritative product oracle.
+- Do not treat infrastructure or harness failure as a behavioral red.
+- Do not treat one green run as proof that a production implementation is safe.
+- Do not infer producer behavior from a consumer-only test.
+- Do not collapse disagreement into consensus; preserve unresolved disputes.
+- Never infer the complete change set from `git diff` alone.
+- Never promote an unsupported factual claim into a required change.
+- Never publish internal proof jargon without translating it into concrete
+  maintainer language.

--- a/.github/skills/aspnetcore-pr-review/SKILL.md
+++ b/.github/skills/aspnetcore-pr-review/SKILL.md
@@ -91,6 +91,8 @@ Save the bundle outside the repository using these names:
   cross-examination/candidate-d.md
   empirical/manifest.md
   empirical/before.diff
+  empirical/diagnostic.diff
+  empirical/implementation.diff
   empirical/red.log
   empirical/candidate.diff
   empirical/green.log
@@ -122,34 +124,21 @@ avoid anchoring.
 
 ## Phase 2: Establish the product oracle
 
-Before asking models to diagnose the implementation, separate intended
-behavior from implementation state. Otherwise independent models can converge
-on the same plausible but incorrect lifecycle and then prove it consistently.
+Read `references/proof-calibration.md` before writing
+`evidence/product-oracle.md`. Separate four things that are easy to conflate:
+the observed symptom, the intended behavior, the patch author's objective, and
+the proposed historical cause.
 
-Write `evidence/product-oracle.md` with:
+Classify each expected-behavior claim using the authority ladder in that
+reference. A PR description can establish what its author is trying to change,
+but cannot by itself establish accepted product intent or prove why an earlier
+failure occurred. Implementation, existing tests, and model agreement remain
+evidence of current behavior rather than automatic product intent.
 
-1. The user-observable behavior being protected.
-2. The source and confidence for each behavioral claim:
-   - `documented`: public API docs or an accepted specification;
-   - `author-confirmed`: issue author, reporter, or maintainer clarification;
-   - `test-encoded`: an existing test whose intent is supported by another
-     authoritative source;
-   - `inferred`: derived only from implementation, naming, or model reasoning;
-   - `unknown`: competing interpretations remain.
-3. For stateful behavior, the current owner of the user-visible state, events
-   that retain ownership, events that transfer ownership, and what the user
-   should observe after each transition.
-4. Any ambiguity that requires human clarification.
-
-Implementation and existing tests are evidence of current behavior, not
-automatic proof of intended behavior. Multi-model agreement cannot promote an
-`inferred` claim to product intent. If a required behavioral claim remains
-`unknown`, continue investigating testable implementation defects but report
-the lifecycle recommendation as `blocked on product oracle`.
-
-When a human later corrects the oracle, preserve the correction and update all
-downstream hypotheses. Do not defend a prior consensus against authoritative
-product context.
+Freeze the expected assertion and its independent authority before selecting a
+candidate correction. If the scenario is justified only by a candidate or
+patch-author hypothesis, it may be explored, but it starts as diagnostic-only
+and cannot by itself justify a high-confidence implementation blocker.
 
 ## Phase 3: Independent candidates
 
@@ -173,6 +162,8 @@ These invocations are read-only, so run them in parallel. Each prompt must:
 - Require every expected-behavior claim to cite the shared product oracle and
   preserve its confidence. Candidates may challenge the oracle with evidence,
   but cannot silently replace it with implementation-derived intent.
+- Require every proposed discriminating assertion to state why the expected
+  result is required independently of that candidate.
 - Label unverifiable claims `UNSUPPORTED`; unsupported claims cannot become
   required follow-ups or consensus findings.
 - Prohibit edits, commits, pushes, comments, and external posting.
@@ -196,6 +187,12 @@ Evidence and citations:
 Known risks:
 Recommendation:
 ```
+
+Before cross-examination, validate each response against the sibling
+`aspnetcore-try-fix` output schema. Allow one correction turn for missing
+required fields or an oversized full-file restatement. Record how many distinct
+root-cause mechanisms survived; four models selecting a helper shown in their
+shared evidence is correlated convergence, not four independent runtime proofs.
 
 Each model must:
 
@@ -235,9 +232,9 @@ merge-readiness verdict.
    SHA, and clean status in `empirical/manifest.md`.
 3. Invoke `aspnetcore-try-fix` in `empirical` mode sequentially, using the
    strongest consensus hypothesis, the exact claim to prove or reject, the
-   relevant product-oracle entries, an exact assertion contract, its allowed
-   perturbations, and the smallest targeted validation command. The empirical
-   agent may edit only its isolated worktree.
+   relevant product-oracle entries, the already-approved candidate-independent
+   assertion contract, its allowed perturbations, and the smallest targeted
+   validation command. The empirical agent may edit only its isolated worktree.
 4. Build a proof ladder in `empirical/claim-matrix.md` and record the highest
    completed rung for each blocker-caliber claim:
    - source invariant or contradictory contract;
@@ -255,9 +252,13 @@ merge-readiness verdict.
    - apply the smallest candidate correction;
    - run the identical assertion and preserve the passing output in
      `empirical/green.log`;
-   - save the assertion-only diff as `empirical/before.diff`, the complete
-     candidate diff as `empirical/candidate.diff`, and the structured result as
-     `empirical/result.md`.
+   - save assertion-only changes as both `empirical/before.diff` and
+     `empirical/diagnostic.diff`, production-intended changes as
+     `empirical/implementation.diff`, the combined state as
+     `empirical/candidate.diff`, and the structured result as
+     `empirical/result.md`;
+   - record whether the assertion is `merge-candidate`, `diagnostic-only`, or
+     `rejected`.
 6. A valid red must fail at the predicted behavioral assertion. A stale browser
    element, harness timeout before the trigger, build failure, missing asset,
    infrastructure error, unrelated assertion, or different assertion is not
@@ -274,6 +275,11 @@ merge-readiness verdict.
 9. Run at most three iterations for the same hypothesis. If the environment,
    browser harness, or target test cannot run, preserve the failure and classify
    adjudication as `Blocked`; do not substitute aggregate CI or model agreement.
+   If a generated asset or unrelated build target blocks the focused command,
+   record the baseline failure before applying a documented property override.
+   Verify the bypassed target cannot affect the exercised behavior and cap the
+   candidate at `targeted-proven` unless the standard build or exact CI path
+   later validates it.
 10. For every other blocker-caliber behavioral claim, execute a narrow
     differentiating test when practical. If frozen head passes, explicitly
     discard or narrow the claim. If frozen head fails at the predicted
@@ -293,37 +299,24 @@ implementation` with high confidence solely from multi-model source reasoning.
 
 ## Phase 6: Production-candidate falsification
 
-Only recommend a specific production implementation after it survives a stress
-matrix derived from the affected lifecycle and producer boundary. Save the
-matrix and results in `empirical/stress-matrix.md`.
+Apply the production-proof rules in `references/proof-calibration.md`. Continue
+in the same isolated worktree and save a lifecycle-derived matrix in
+`empirical/stress-matrix.md`.
 
-Continue in the same isolated Phase 5 worktree. Re-invoke
-`aspnetcore-try-fix` in `empirical` mode sequentially with the diagnostic
-candidate, proof status, and lifecycle-derived stress matrix. A Phase 5
-red/green result reported as `Blocked` solely because stress or producer
-validation remains pending is the expected handoff into this phase, not a
-failed finding adjudication.
-
-1. Start from the transition table, not a generic checklist. Exercise every
-   ordinary exit and applicable interruption path.
-2. For stateful or timing-sensitive behavior, cover applicable cases such as:
-   equal and changed measurements, delayed/out-of-order delivery, no-op
-   operations, repeated or rapid operations, cancellation, disposal, opposite
-   transitions, missing/partial observer batches, and multiple generations.
-3. When browser or JavaScript behavior is part of the claim, run a real
-   interaction using the repository's canonical sample/E2E workflow. Confirm
-   interactivity and inspect relevant console/network failures.
-4. Re-run timing-sensitive tests enough times to expose instability. A single
-   pass followed by a failure means the candidate is not proven; investigate
-   the divergence rather than selecting the passing log.
-5. Run the narrow neighboring existing suite after the candidate.
-6. Distinguish candidate outcomes:
-   - `Production-proven`: behavioral red/green plus applicable stress matrix and
-     real producer path pass consistently.
-   - `Diagnostic-only`: turns the targeted assertion green but has not survived
-     the full relevant matrix.
-   - `Rejected`: introduces a regression, flakes, or contradicts an invariant.
-   - `Blocked`: required execution cannot be completed for a recorded reason.
+- Vary the dimensions that could falsify the mechanism. Repeating one identical
+  deterministic scenario demonstrates repeatability, not a complete matrix.
+- Exercise the real producer/runtime boundary and the narrow neighboring suite.
+- When recommending an observer-only timeout, inspect the inner task states
+  after timeout, release or cancel them deterministically, observe exceptions,
+  and verify cleanup cannot leak into later tests.
+- Preserve configuration and platform limits. A targeted run using a build
+  bypass cannot become cross-platform `production-proven`.
+- In `empirical/stress-matrix.md`, mark the real producer/runtime boundary,
+  varied falsification dimensions, applicable configurations/platforms,
+  neighboring suite, and cleanup/interruption paths as `passed` or
+  `not applicable - <specific reason>`.
+- Classify the candidate as `production-proven`, `targeted-proven`,
+  `diagnostic-only`, `rejected`, or `blocked`.
 
 If no candidate is production-proven, the review may still request changes for
 a proven defect. Describe the required invariant and evidence, but do not
@@ -344,6 +337,19 @@ compare it with the frozen evidence SHA. Save the comparison in
 
 The orchestrator, not any candidate model, synthesizes the result.
 
+Before writing the final report, resolve `<skill-root>` to the directory that
+contains this `SKILL.md` and run:
+
+```bash
+python3 <skill-root>/scripts/validate_artifacts.py \
+  <artifact-root>/aspnetcore-pr-review
+```
+
+Fix missing files or sections before synthesis. If an artifact is legitimately
+not applicable, create it with the reason instead of omitting it. Do not
+override proof-calibration failures merely because the final narrative explains
+them elsewhere.
+
 For each claim:
 
 - **Agree:** at least two models independently support it and no concrete
@@ -359,9 +365,10 @@ For each claim:
 For the empirically adjudicated finding:
 
 - Promote a finding to a required implementation follow-up when frozen head
-  fails at the predicted behavioral assertion and the causal mechanism is
-  supported. A diagnostic correction turning the same assertion green
-  strengthens causality but does not make that correction production-ready.
+  fails at an independently justified behavioral assertion, the relevant oracle
+  is authoritative enough for the requested severity, and the causal mechanism
+  is supported. A candidate-shaped diagnostic turning green proves only its
+  scoped experiment.
 - If adjudication is blocked, preserve the structural concern under `Dispute`
   or as a required evidence follow-up, calibrated to the strongest evidence
   actually obtained.
@@ -398,6 +405,8 @@ language:
 2. Explain the causal code path using only the minimum necessary terminology.
 3. State the requested change.
 4. Include one concrete example when it makes the behavior easier to see.
+5. State what the experiment does not prove whenever scenario, mechanism,
+   configuration, or oracle fidelity is weaker than exact.
 
 Avoid compressed phrases such as "pair the takeover check with a focused
 retention assertion" when plain language can say "change one item above the
@@ -439,13 +448,17 @@ command, red result, green result, and artifact paths, or the exact blocker>
 ## Proof status
 **Finding proof:** empirical / structural / missing
 **Scenario proof:** empirical / structural / missing
-**Candidate proof:** production-proven / diagnostic-only / rejected / blocked / none
+**Candidate proof:** production-proven / targeted-proven / diagnostic-only / rejected / blocked / none
 **Product oracle:** documented / author-confirmed / test-encoded / inferred / unknown
+**Oracle fidelity:** authoritative / corroborated / hypothesis / unknown
+**Mechanism fidelity:** reproduced / structural / inferred / unknown
+**Scenario fidelity:** exact / proxy / synthetic / missing
+**Assertion disposition:** merge-candidate / diagnostic-only / rejected
 
 ## Final recommendation
 **Implementation verdict:** KEEP CURRENT FIX / REVISE / REPLACE
 **Behavioral evidence:** empirical / structural / missing
-**Merge readiness:** ready / blocked on evidence / blocked on product oracle / blocked on implementation
+**Merge readiness:** ready / recommendation only / blocked on evidence / blocked on product oracle / blocked on implementation
 **Implementation confidence:** high / medium / low
 **Reason:** <concise evidence>
 

--- a/.github/skills/aspnetcore-pr-review/SKILL.md
+++ b/.github/skills/aspnetcore-pr-review/SKILL.md
@@ -41,6 +41,16 @@ This skill is intentionally repository-specific. Before using it:
 
 ## Model panel
 
+Run orchestration and final synthesis in a GPT-family session. Prefer
+`gpt-5.6-sol` or the strongest newer GPT model available. Before Phase 1,
+verify the current session model. If it is an Anthropic or other non-GPT model,
+stop and report that the review must be restarted with a GPT orchestrator
+instead of silently continuing.
+
+The orchestrator remains separate from the candidate panel. This prevents the
+two Claude candidates from also controlling evidence selection and final
+synthesis.
+
 Use four different model families/configurations:
 
 | Candidate | Model | Primary challenge |
@@ -402,6 +412,8 @@ Save the synthesized output below to `final/review.md`.
 
 ```markdown
 # Multi-Model Review
+
+**Orchestrator:** <GPT model>
 
 ## Current fix
 <summary>

--- a/.github/skills/aspnetcore-pr-review/SKILL.md
+++ b/.github/skills/aspnetcore-pr-review/SKILL.md
@@ -79,6 +79,7 @@ Save the bundle outside the repository using these names:
   evidence/manifest.md
   evidence/product-oracle.md
   evidence/head-drift.md
+  evidence/impact-map.md
   evidence/tracked.diff
   evidence/files/
   candidates/candidate-a.md
@@ -115,10 +116,20 @@ The manifest must record:
 7. Exact validation commands and complete logs when available.
 8. Known environment failures, explicitly separated from product failures.
 9. Which changed paths are in scope and why unrelated dirty paths were excluded.
+10. An impact map from every changed producer, dispatcher, callback filter, or
+    state transition to the consumers and unchanged tests that exercise each
+    affected branch. Record the exact command selected for each test, or a
+    source-backed reason why no existing test is impacted.
 
 Give every model the same manifest, tracked diff, and captured files. Permit a
 narrow source lookup outside the bundle only when the candidate records the
 path and the claim it is verifying.
+
+Changed paths are not a sufficient impact analysis. A narrow producer edit can
+break an unchanged consumer test in another directory. Build
+`evidence/impact-map.md` from symbols, callbacks, event branches, and callers
+before selecting new assertions. Prefer running directly impacted existing
+tests over inventing candidate-specific tests.
 
 Do not include the parent's conclusion that the fix is correct. The goal is to
 avoid anchoring.
@@ -153,6 +164,11 @@ These invocations are read-only, so run them in parallel. Each prompt must:
   require a transition table containing: state/invariant, entry path, ordinary
   successful exit, cancellation/interruption exit, owner, and the observable
   consequence if the state is stranded or consumed twice.
+- When callbacks, observers, measurements, or notifications are suppressed,
+  disabled, discarded, or deferred, extend the table with: what stops
+  updating, the first event after recovery, any ownership transfer, the
+  generation/provenance of every value consumed after recovery, stale values
+  that survive, and the opposite edge or boundary.
 - Require an approach materially different from the current fix when viable.
 - Allow `NO VIABLE ALTERNATIVE` only after the candidate names and rejects at
   least one mechanism-level alternative.
@@ -165,6 +181,8 @@ These invocations are read-only, so run them in parallel. Each prompt must:
   but cannot silently replace it with implementation-derived intent.
 - Require every proposed discriminating assertion to state why the expected
   result is required independently of that candidate.
+- Pass `evidence/impact-map.md` explicitly and require the candidate to assess
+  its mapped unchanged tests and uncovered producer branches.
 - Label unverifiable claims `UNSUPPORTED`; unsupported claims cannot become
   required follow-ups or consensus findings.
 - Prohibit edits, commits, pushes, comments, and external posting.
@@ -206,6 +224,10 @@ Each model must:
 7. Rank surviving behavioral claims by falsifiability: concrete trigger,
    observable failure, and faithful test boundary. Prefer a bounded claim over a
    broad concern that cannot be distinguished.
+8. Challenge whether the current tests cover the first event after a suppressed
+   interval, every changed producer branch, and the opposite boundary. Propose
+   one bounded state-derived adjacent scenario when they do not; do not expand
+   into an unrelated Cartesian test matrix.
 
 One cross-examination round is sufficient for this minimal reviewer. If two or
 more models produce the same new idea, the orchestrator must verify it against
@@ -228,14 +250,17 @@ merge-readiness verdict.
      information producer relevant to the claim. Do not choose an easier
      consumer-only unit test when the finding depends on browser, transport,
      process, or scheduler behavior.
+     - is informed by the impact map and by directly impacted unchanged tests,
+       not only the tests added or edited by the pull request.
 2. Create an isolated child session or disposable detached worktree at the
    frozen PR head. Never edit the parent review worktree. Record its exact path,
    SHA, and clean status in `empirical/manifest.md`.
 3. Invoke `aspnetcore-try-fix` in `empirical` mode sequentially, using the
    strongest consensus hypothesis, the exact claim to prove or reject, the
    relevant product-oracle entries, the already-approved candidate-independent
-   assertion contract, its allowed perturbations, and the smallest targeted
-   validation command. The empirical agent may edit only its isolated worktree.
+   assertion contract, its allowed perturbations, `evidence/impact-map.md`, and
+   the smallest targeted validation command. The empirical agent may edit only
+   its isolated worktree.
 4. Build a proof ladder in `empirical/claim-matrix.md` and record the highest
    completed rung for each blocker-caliber claim:
    - source invariant or contradictory contract;
@@ -246,7 +271,12 @@ merge-readiness verdict.
    A lower rung does not prove a higher-rung scenario. For example, directly
    invoking a callback does not prove which callback a browser interaction
    produces.
-5. Run the approved assertion against untouched frozen head first and save the
+5. Run directly impacted existing tests from `evidence/impact-map.md` against
+   untouched frozen head before adding a new assertion. Preserve their commands
+   and complete output. If an unchanged test already distinguishes the defect,
+   use it as the primary assertion rather than replacing it with a narrower
+   candidate-specific test.
+6. Run the approved assertion against untouched frozen head first and save the
    complete result in `empirical/head.log`:
    - add or tighten one assertion that distinguishes the predicted defect;
    - if head fails behaviorally, copy that result to `empirical/red.log`, apply
@@ -261,20 +291,20 @@ merge-readiness verdict.
    - classify the regression assertion as required, optional, or rejected, and
      any mutation separately as diagnostic-only, rejected, or not applicable.
      Required means accepted criteria or a proven defect needs exact coverage.
-6. A valid red must fail at the predicted behavioral assertion. A stale browser
+7. A valid red must fail at the predicted behavioral assertion. A stale browser
    element, harness timeout before the trigger, build failure, missing asset,
    infrastructure error, unrelated assertion, or different assertion is not
    behavioral red evidence. Fix the harness or classify the run as `Blocked`.
-7. A pre-existing failing test is acceptable only when the same assertion
+8. A pre-existing failing test is acceptable only when the same assertion
    passes after the candidate correction. A build-only failure, unrelated test
    failure, different assertion, or source-only prediction is not green
    evidence.
-8. Treat the first green as causal evidence for the finding, not proof that the
+9. Treat the first green as causal evidence for the finding, not proof that the
    candidate is production-ready. Preserve these as separate conclusions:
    - **Finding proof:** does frozen head exhibit the predicted defect?
    - **Scenario proof:** did the real producer/runtime path exhibit it?
    - **Candidate proof:** did the proposed fix survive relevant counterexamples?
-9. Run at most three iterations for the same hypothesis. If the environment,
+10. Run at most three iterations for the same hypothesis. If the environment,
    browser harness, or target test cannot run, preserve the failure and classify
    adjudication as `Blocked`; do not substitute aggregate CI or model agreement.
    If a generated asset or unrelated build target blocks the focused command,
@@ -282,16 +312,16 @@ merge-readiness verdict.
    Verify the bypassed target cannot affect the exercised behavior and cap the
    candidate at `targeted-proven` unless the standard build or exact CI path
    later validates it.
-10. For every other blocker-caliber behavioral claim, execute a narrow
+11. For every other blocker-caliber behavioral claim, execute a narrow
     differentiating test when practical. If frozen head passes, explicitly
     discard or narrow the claim. If frozen head fails at the predicted
     assertion, promote it to a required follow-up using the highest proof rung
     reached. If it is not run, downgrade it rather than carrying it as an
     implementation blocker.
-11. Do not require empirical validation for a claim fully established without
+12. Do not require empirical validation for a claim fully established without
    runtime execution, such as a compiler error or a directly contradictory API
    contract. Record why execution adds no information.
-12. Preserve all empirical artifacts before removing a disposable worktree. If
+13. Preserve all empirical artifacts before removing a disposable worktree. If
    safe cleanup is unavailable, leave the isolated worktree in place and report
    it rather than using destructive cleanup.
 
@@ -310,6 +340,14 @@ in the same isolated worktree and save a lifecycle-derived matrix in
 - Scale the matrix to claim severity and statefulness. Do not add lifecycle
   scaffolding solely to earn `production-proven`; a lower proof cap is valid.
 - Exercise the real producer/runtime boundary and the narrow neighboring suite.
+- For a suppressed callback, observer, or measurement interval, exercise the
+  first resumed event and the opposite edge or boundary. When geometry or
+  measurement provenance is on the changed path, include one fixed-size control
+  and one realistic variable-size or layout perturbation. Expand further only
+  after a behavioral divergence or when the claim is platform-specific.
+- For asymmetric before/after handling or batch filtering, cover before-only,
+  after-only, and both-in-one-batch cases so suppressing a duplicate does not
+  discard the callback required by another consumer.
 - When recommending an observer-only timeout, inspect the inner task states
   after timeout, release or cancel them deterministically, observe exceptions,
   and verify cleanup cannot leak into later tests.
@@ -336,8 +374,9 @@ compare it with the frozen evidence SHA. Save the comparison in
 - If the head is unchanged, proceed.
 - If only unrelated paths changed, record why the evidence remains applicable.
 - If a relevant source, test, contract, or instruction changed, refresh the
-  evidence bundle and rerun the affected proof before presenting the finding
-  as current.
+  evidence bundle, regenerate `evidence/impact-map.md`, and rerun both the
+  affected proof and mapped unchanged tests before presenting the finding as
+  current.
 - Never silently describe frozen-head evidence as current-head validation.
 
 The orchestrator, not any candidate model, synthesizes the result.

--- a/.github/skills/aspnetcore-pr-review/evals/eval-policy.md
+++ b/.github/skills/aspnetcore-pr-review/evals/eval-policy.md
@@ -1,0 +1,105 @@
+# Evaluation anti-overfit policy
+
+This policy applies to both `aspnetcore-pr-review` and `aspnetcore-try-fix`. It
+protects their evaluation sets from optimizing for a small, recognizable
+collection of prompts.
+
+## Retention and scoring
+
+Retain a regression once it is discovered. A lower score weight is not a reason
+to delete, weaken, or stop running a regression. Score changes only affect
+aggregation; they do not change the required behavioral evidence.
+
+Aggregate scores by taking the mean within each `(tier, score_family)` and then
+macro-average families in that tier. Consequently, every eval has normalized
+family weight `1 / (number of families in its tier * number of evals in its
+tier and family)`; adding near-duplicates cannot increase that family's
+influence.
+
+Designate held-out cases before changing the skill, and do not tune prompts,
+examples, instructions, or scoring against them. A held-out failure may motivate
+a new, separately provenanced train regression, but the original held-out case
+remains unchanged.
+
+## Instruction promotion
+
+A regression does not automatically justify another global instruction. Promote
+a rule into the always-loaded skill only when:
+
+1. A retained before-change result fails for the reason the rule addresses.
+2. The same mechanism transfers to an independently provenanced case outside
+   the source PR or subsystem.
+3. Held-out no-defect and bounded-stateless canaries do not acquire extra
+   blockers or unnecessary lifecycle work.
+4. The rule can be stated without source-PR nouns. Otherwise keep it in a
+   conditional domain reference.
+5. The addition consolidates or replaces narrower guidance when possible,
+   rather than growing the skill indefinitely.
+
+Passing only the regression that motivated a rule shows memorization, not
+generalization.
+
+## Metadata and controls
+
+Every eval has `eval_metadata`. `mechanism` and `score_family` are lower
+kebab-case labels; provenance identifies a PR, historical case, or synthetic
+source. `controls.positive` and `controls.negative` are disjoint, nonempty,
+zero-based indexes into `expectations`. Positive controls identify evidence that
+must be present; negative controls identify an overclaim, unrelated scaffold,
+mutation, or side effect the evaluator must reject or avoid. These are
+expectation-level grading controls, not substitutes for matched scenario
+controls.
+
+Every new defect regression also needs a matched no-defect, alternate-cause, or
+scope-control scenario in the same score family before its lesson becomes a
+global instruction. The held-out no-defect and bounded-stateless cases are
+permanent complexity-inflation canaries.
+
+Discovery prompts must list nonempty `forbidden_prompt_terms`. Those terms must
+not occur in the prompt, case-insensitively. Verification prompts may use an
+empty list, but every term listed is still forbidden. Keep issue numbers,
+implementation names, answer phrases, and other answer-revealing vocabulary out
+of discovery prompts. Discovery evals receive frozen evidence through `files`;
+removing facts from a prompt without supplying a fixture makes the eval
+ungradeable rather than de-leaked.
+
+Held-out evals carry a `frozen_hash`. The validator recomputes it from the full
+eval, excluding the hash field itself, so changes to a held-out fixture contract
+are explicit. Train and held-out provenance must remain disjoint within a suite.
+
+## Maintenance
+
+Use ablations before accepting a new mechanism or scoring rule: remove the
+claimed signal and confirm that the score changes for the intended reason. Prune
+only a duplicate or disproven eval, recording the replacement or rationale;
+never prune a regression merely because it is inconvenient.
+
+Each expectation must reject a crafted bad result and accept a correct
+paraphrase. An expectation that rejects neither is non-discriminating; one that
+rejects the paraphrase is a wording matcher. Keep discovery prompts limited to
+the evidence a reviewer would receive. Put the mechanism to discover in the
+expected result, not in the prompt.
+
+The validator reports family, tier, provenance, and prompt/expectation-overlap
+concentration as warnings. These are investigation signals, not arbitrary
+acceptance quotas: unusual distributions can be legitimate and must be judged
+with provenance and transfer evidence.
+
+Report family-macro and provenance-macro results separately. A source PR can
+teach several real mechanisms; one scalar must not let its spread across
+families hide poor transfer to other provenance.
+
+Before accepting eval changes, run:
+
+```bash
+python3 .github/skills/aspnetcore-pr-review/scripts/validate_evals.py \
+  .github/skills/aspnetcore-pr-review/evals/evals.json \
+  .github/skills/aspnetcore-try-fix/evals/evals.json
+```
+
+Other repository eval harnesses use different schemas. This suite therefore
+uses a small explicit score contract rather than guessing how to consume their
+results: a JSON object keyed by `skill_name`, then eval ID, with numeric scores
+from zero to one. Run `scripts/aggregate_eval_scores.py` with both eval files
+and `--scores <path>` to report raw, family-macro, provenance-macro, and
+train-to-held-out transfer results separately.

--- a/.github/skills/aspnetcore-pr-review/evals/evals.json
+++ b/.github/skills/aspnetcore-pr-review/evals/evals.json
@@ -109,7 +109,7 @@
       "expectations": [
         "The review distinguishes structural support for accepting the old payload from authority that the old payload remains supported.",
         "The PR author's compatibility claim is not promoted into accepted product intent.",
-        "The old-payload test is not automatically treated as a merge-candidate assertion merely because the alias makes it green.",
+        "The old-payload test is not automatically treated as required regression coverage merely because the alias makes it green.",
         "The result is blocked on product oracle or presented as a recommendation rather than a high-confidence implementation blocker.",
         "Four candidates choosing the pre-supplied alias helper is not counted as four independent mechanism discoveries.",
         "The final output identifies what maintainer or contract evidence would change the verdict."
@@ -154,6 +154,33 @@
         "The candidate is allowed to become production-proven after the varied lifecycle matrix and exact CI configurations pass.",
         "The final review uses blocked on implementation and high confidence because the current PR still omits the proven producer-fault correction and no weak fidelity dimension remains.",
         "The public comment requests the missing producer-fault correction without adding uncertainty that the evidence has already resolved or claiming the separate candidate is already in the PR."
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "Review a small ASP.NET Core registration fix. A documented contract says a preconfigured compatible handler instance takes precedence over type fallback. The PR removes the line that discarded that instance and already includes a weaker regression test. A stronger unique-result assertion passes on untouched frozen head through Options, dependency injection, and the real consumer, but no concrete false-pass exists for the checked-in test. Reintroducing the removed line makes the stronger assertion fail. A narrow fallback matrix passes, but the local test needed an unrelated frontend-build bypass. Keep the review local.",
+      "expected_output": "A no-blocker review that keeps the current fix, distinguishes frozen-head success from a diagnostic historical mutation, treats stronger test coverage as optional, and caps candidate proof at targeted-proven.",
+      "files": [],
+      "expectations": [
+        "The untouched frozen-head result is recorded before any mutation or candidate.",
+        "Frozen-head success rejects an implementation blocker even though a historical mutation can produce red.",
+        "The historical mutation is diagnostic-only and is not described as a current-head defect.",
+        "The stronger assertion is optional-regression rather than a required merge change.",
+        "The build bypass caps candidate proof at targeted-proven.",
+        "The final verdict keeps the current fix and reports ready or recommendation-only rather than blocked on implementation."
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "Review a one-line stateless ASP.NET Core lookup correction with an authoritative contract. The exact real path fails on frozen head and passes after the correction, and the two nearest key-shape counterexamples pass. No ownership, cancellation, concurrency, interop, or background work is involved. Decide how much falsification is required and classify the candidate.",
+      "expected_output": "A proportionate review that accepts a bounded real-path and nearest-counterexample matrix without inventing lifecycle scaffolding, while preserving explicit configuration limits.",
+      "files": [],
+      "expectations": [
+        "The review requires strict frozen-head red and candidate green for the claimed defect.",
+        "The falsification matrix is limited to dimensions that can affect the stateless lookup mechanism.",
+        "The review does not add cancellation, disposal, concurrency, or observer-timeout scaffolding solely to satisfy a template.",
+        "The candidate proof label preserves any untested configuration or platform limits.",
+        "The assertion is required-regression because it proves the authoritative defect and correction."
       ]
     }
   ]

--- a/.github/skills/aspnetcore-pr-review/evals/evals.json
+++ b/.github/skills/aspnetcore-pr-review/evals/evals.json
@@ -8,6 +8,7 @@
       "files": [],
       "expectations": [
         "The review verifies that the checkout is dotnet/aspnetcore before proceeding.",
+        "The review records a GPT-family orchestrator model and does not run orchestration or final synthesis under an Anthropic model.",
         "The evidence manifest includes repository provenance, status with untracked files, the tracked diff, relevant file hashes, issue text, and validation logs or an explicit statement that logs are unavailable.",
         "The review includes four independent candidates from the configured model panel.",
         "Each candidate states a root-cause hypothesis and assesses whether an alternative is materially better than the current fix.",
@@ -69,6 +70,19 @@
         "The suggested comment includes a concrete example instead of relying on phrases such as product oracle, takeover assertion, or producer boundary.",
         "Internal technical terminology remains available in artifacts but is translated or defined in the GitHub-facing draft.",
         "No GitHub review is posted by the skill."
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "The current session is running Claude Sonnet. Use aspnetcore-pr-review to review an open dotnet/aspnetcore pull request.",
+      "expected_output": "The skill stops before evidence collection and clearly requests that the review be restarted in a GPT-family orchestrator session while preserving the configured diverse candidate panel.",
+      "files": [],
+      "expectations": [
+        "The response identifies that the current orchestrator is not a GPT-family model.",
+        "The review does not begin Phase 1 or launch candidate agents.",
+        "The response requests a restart using gpt-5.6-sol or a stronger available GPT model.",
+        "The response does not replace the configured candidate panel with copies of the orchestrator model.",
+        "No repository or GitHub state is modified."
       ]
     }
   ]

--- a/.github/skills/aspnetcore-pr-review/evals/evals.json
+++ b/.github/skills/aspnetcore-pr-review/evals/evals.json
@@ -182,6 +182,38 @@
         "The candidate proof label preserves any untested configuration or platform limits.",
         "The assertion is required-regression because it proves the authoritative defect and correction."
       ]
+    },
+    {
+      "id": 12,
+      "prompt": "Review a dotnet/aspnetcore Virtualize pull request that opens a variable-height list at InitialItemIndex 500. The implementation suppresses observer callbacks while pinning the initial target. Existing tests cover initial placement and Home/End ownership transfer but do not scroll far enough to expose the opposite spacer after recovery. Maintainer-confirmed behavior requires the target to remain stable through unrelated layout activity and ordinary scrolling must not jump the visible range backward. Keep the review local and bounded.",
+      "expected_output": "A lifecycle-aware review that looks beyond the edited tests, models the suppressed interval and first resumed observer callback, identifies mixed measurement generations as a concrete risk, and selects a bounded real-browser scenario with a fixed-size control and variable-height perturbation.",
+      "files": [],
+      "expectations": [
+        "The transition analysis records what measurements stop updating while callbacks are suppressed.",
+        "The review analyzes the first observer callback after suppression rather than stopping at callback re-enablement.",
+        "The review tracks the generation or provenance of spacer pixels, rendered-row separation, item count, and the item-size divisor consumed by redistribution.",
+        "The review identifies that combining stale spacer geometry with a newly measured variable-row average can move the logical window backward.",
+        "The bounded adjacent scenario opens near item 500, verifies initial placement, scrolls ordinarily until the opposite or bottom spacer is exposed, and asserts that the visible range does not jump backward.",
+        "The empirical plan uses one fixed-size control and one realistic variable-height perturbation instead of an unrelated global stress matrix.",
+        "The scenario exercises the real browser observer and DOM measurement producer rather than injecting only a downstream C# callback.",
+        "The existing Home/End ownership assertion remains a separate oracle and is not rewritten to stand in for stale-measurement recovery."
+      ]
+    },
+    {
+      "id": 13,
+      "prompt": "A dotnet/aspnetcore Virtualize review completed at frozen head A. A later pull request commit changes the shared IntersectionObserver producer so that when before and after spacers appear in one batch it always drops the after-spacer entry. The tests edited by the new commit pass, but an unchanged ProgrammaticScrollToBottom_ReachesLastItems E2E test depends on the after-spacer callback to fetch the tail. Reassess the live head locally without posting.",
+      "expected_output": "A head-drift reassessment that regenerates a changed-producer impact map, discovers and runs the unchanged bottom-scroll test, and scopes the newly observed regression to the later commit instead of attributing it to the earlier frozen review.",
+      "files": [],
+      "expectations": [
+        "The review states that evidence from frozen head A cannot predict or validate a later producer change.",
+        "Relevant head drift causes the evidence bundle and impact map to be regenerated.",
+        "The impact map connects the changed both-spacers filter to before-only, after-only, and both-in-one-batch consumers.",
+        "The review discovers ProgrammaticScrollToBottom_ReachesLastItems even though the test file was unchanged.",
+        "The unchanged impacted E2E test is run before inventing a candidate-specific assertion.",
+        "The causal explanation states that dropping the after-spacer entry prevents the tail distribution or fetch required by programmatic bottom scrolling.",
+        "A prior-head pass and current-head behavioral failure are preserved separately from infrastructure or aggregate CI status.",
+        "The final report attributes the regression to the post-review commit and does not misrepresent earlier reviewed-head evidence as current."
+      ]
     }
   ]
 }

--- a/.github/skills/aspnetcore-pr-review/evals/evals.json
+++ b/.github/skills/aspnetcore-pr-review/evals/evals.json
@@ -1,0 +1,75 @@
+{
+  "skill_name": "aspnetcore-pr-review",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "In a dotnet/aspnetcore checkout, run the ASP.NET Core multi-model adversarial review against issue #66479 and the current local ToggleEventArgs implementation. Do not modify the parent checkout or post anything. An isolated disposable child worktree may be used for empirical validation. Determine whether the current fix and strict red/green E2E test are complete and whether any independent alternative is better.",
+      "expected_output": "Four independent model candidates, an adversarial cross-examination, isolated empirical adjudication of the strongest surviving behavioral finding, and a final keep/revise/replace recommendation grounded in strict red/green evidence or explicitly downgraded when execution is blocked.",
+      "files": [],
+      "expectations": [
+        "The review verifies that the checkout is dotnet/aspnetcore before proceeding.",
+        "The evidence manifest includes repository provenance, status with untracked files, the tracked diff, relevant file hashes, issue text, and validation logs or an explicit statement that logs are unavailable.",
+        "The review includes four independent candidates from the configured model panel.",
+        "Each candidate states a root-cause hypothesis and assesses whether an alternative is materially better than the current fix.",
+        "For stateful or lifecycle-sensitive code, candidates trace state entry, ordinary successful exit, interruption exit, ownership, and the observable consequence of stranded state.",
+        "Raw candidate and cross-examination outputs are preserved under deterministic names outside the repository.",
+        "Compatibility, browser-support, API-breaking, and test-execution claims have exact citations or are labeled unsupported.",
+        "The adversarial round explicitly classifies claims or candidates as supported, disputed, or discarded.",
+        "A high-severity falsifiable minority finding can enter empirical adjudication without requiring a second model to agree first.",
+        "The synthesis evaluates the strict red/green evidence and identifies any test coverage gaps.",
+        "After consensus, the strongest testable behavioral finding is adjudicated in empirical mode in an isolated child session or disposable worktree.",
+        "The empirical report records a proof ladder that distinguishes source invariant, consumer behavior, producer/runtime behavior, and production-candidate coverage.",
+        "Empirical adjudication preserves the same discriminating assertion failing at the frozen reviewed state and passing after the candidate correction, with commands, diffs, and complete logs.",
+        "The frozen red fails at the predicted behavioral assertion rather than an infrastructure, build, setup, stale-element, or unrelated harness failure.",
+        "The first green is treated as causal evidence rather than sufficient proof of production readiness.",
+        "Any recommended implementation is challenged with a lifecycle-derived stress matrix and the real producer/runtime path when applicable.",
+        "Timing-sensitive candidates are rerun to detect instability, and inconsistent outcomes prevent a production-proven recommendation.",
+        "Other blocker-caliber behavioral claims are empirically falsified when practical or explicitly downgraded rather than carried forward untested.",
+        "A secondary claim that fails at its predicted frozen-head assertion is promoted using its achieved proof level rather than falling through synthesis.",
+        "Production-candidate stress testing explicitly continues in the same isolated worktree through a sequential empirical try-fix handoff.",
+        "If empirical adjudication cannot run, behavioral findings are reported as blocked on evidence rather than high-confidence implementation blockers.",
+        "The parent checkout remains unchanged throughout empirical validation.",
+        "The final output separately reports finding proof, scenario proof, candidate proof, implementation verdict, merge readiness, and calibrated confidence."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "In a dotnet/aspnetcore checkout, review a local patch for a stateful browser component that opens a long list at an initial anchor. The implementation appears to finish the initial state after pixel alignment, but an authoritative maintainer note says the anchor must remain pinned through unrelated content growth and transfer control only after explicit user navigation. Do not post or push. Prove or reject a separate report that boundary keys cannot take over while the initial anchor is active.",
+      "expected_output": "A lifecycle-aware review that treats the maintainer clarification as the product oracle, rejects alignment completion as inferred intent, and proves the separate boundary-key defect with a focused real-browser red/green assertion while preserving retention through one adjacent content change.",
+      "files": [],
+      "expectations": [
+        "The review records a product oracle that distinguishes authoritative maintainer context from behavior inferred from implementation or tests.",
+        "The lifecycle analysis states which events retain the initial anchor and which explicit events transfer control.",
+        "The review does not recommend ending ownership merely because pixel alignment or measurement completed.",
+        "The browser assertion changes only one item immediately above the initial anchor and verifies that the anchor remains pinned before user navigation.",
+        "A real browser or repository E2E test drives the initial anchor followed by a boundary key and obtains a behavioral failure that the final range did not load.",
+        "A stale-element exception, setup failure, build failure, or unrelated timeout is explicitly rejected as behavioral red evidence.",
+        "The report distinguishes unit-level callback proof from proof of the actual browser producer sequence.",
+        "The first candidate green is treated as diagnostic rather than production-ready.",
+        "The identical focused assertion is repeated against frozen head and the candidate in every required execution mode.",
+        "The empirical agent does not replace the focused one-item change with a global layout-mode change.",
+        "A human product clarification overrides earlier model consensus and is reflected in all downstream recommendations.",
+        "Before synthesis, the review compares the live PR head with the frozen evidence head and reruns or narrows evidence if relevant paths changed.",
+        "The final report recommends durable public documentation, internal invariants, paired behavioral tests, or agent guidance for product knowledge that was previously missing.",
+        "Suggested review comments lead with the concrete user action and visible failure instead of unexplained proof terminology.",
+        "The final report separately states finding proof, scenario proof, candidate proof, and whether an exact implementation can safely be recommended.",
+        "No GitHub state or parent worktree is modified."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Review a dotnet/aspnetcore pull request with a well-supported browser defect and produce the local-only final review. The internal evidence uses lifecycle and producer-classification terminology, but the target maintainer asked for plain language. While validation is running, the pull request receives a new commit that changes a relevant test.",
+      "expected_output": "The review checks whether the new head invalidates or supersedes the frozen evidence, refreshes affected proof when needed, and drafts a concise maintainer-facing comment that explains the concrete action, visible failure, causal path, and requested change without unexplained internal jargon.",
+      "files": [],
+      "expectations": [
+        "The review records the frozen head and checks the live pull request head again before final synthesis.",
+        "Relevant head drift causes the affected evidence to be rerun or explicitly narrowed rather than presented as current-head proof.",
+        "The suggested comment begins with the concrete action and visible failure.",
+        "The suggested comment explains only the minimum causal code path needed to justify the request.",
+        "The suggested comment includes a concrete example instead of relying on phrases such as product oracle, takeover assertion, or producer boundary.",
+        "Internal technical terminology remains available in artifacts but is translated or defined in the GitHub-facing draft.",
+        "No GitHub review is posted by the skill."
+      ]
+    }
+  ]
+}

--- a/.github/skills/aspnetcore-pr-review/evals/evals.json
+++ b/.github/skills/aspnetcore-pr-review/evals/evals.json
@@ -6,6 +6,22 @@
       "prompt": "In a dotnet/aspnetcore checkout, run the ASP.NET Core multi-model adversarial review against issue #66479 and the current local ToggleEventArgs implementation. Do not modify the parent checkout or post anything. An isolated disposable child worktree may be used for empirical validation. Determine whether the current fix and strict red/green E2E test are complete and whether any independent alternative is better.",
       "expected_output": "Four independent model candidates, an adversarial cross-examination, isolated empirical adjudication of the strongest surviving behavioral finding, and a final keep/revise/replace recommendation grounded in strict red/green evidence or explicitly downgraded when execution is blocked.",
       "files": [],
+      "eval_metadata": {
+        "mechanism": "multi-model-empirical-adjudication",
+        "provenance": {
+          "kind": "pr",
+          "source": "dotnet/aspnetcore#66479"
+        },
+        "area": "Components",
+        "score_family": "orchestration-artifact-integrity",
+        "tier": "train",
+        "discovery_mode": "verification",
+        "controls": {
+          "positive": [0, 3, 8, 11, 12, 13, 16, 20],
+          "negative": [1, 7, 14, 15, 17, 21, 22]
+        },
+        "forbidden_prompt_terms": []
+      },
       "expectations": [
         "The review verifies that the checkout is dotnet/aspnetcore before proceeding.",
         "The review records a GPT-family orchestrator model and does not run orchestration or final synthesis under an Anthropic model.",
@@ -38,6 +54,22 @@
       "prompt": "In a dotnet/aspnetcore checkout, review a local patch for a stateful browser component that opens a long list at an initial anchor. The implementation appears to finish the initial state after pixel alignment, but an authoritative maintainer note says the anchor must remain pinned through unrelated content growth and transfer control only after explicit user navigation. Do not post or push. Prove or reject a separate report that boundary keys cannot take over while the initial anchor is active.",
       "expected_output": "A lifecycle-aware review that treats the maintainer clarification as the product oracle, rejects alignment completion as inferred intent, and proves the separate boundary-key defect with a focused real-browser red/green assertion while preserving retention through one adjacent content change.",
       "files": [],
+      "eval_metadata": {
+        "mechanism": "lifecycle-product-oracle",
+        "provenance": {
+          "kind": "historical",
+          "source": "dotnet/aspnetcore#68114"
+        },
+        "area": "Components/Virtualization",
+        "score_family": "lifecycle-ownership",
+        "tier": "train",
+        "discovery_mode": "verification",
+        "controls": {
+          "positive": [0, 1, 3, 4, 7],
+          "negative": [2, 5, 9, 15]
+        },
+        "forbidden_prompt_terms": []
+      },
       "expectations": [
         "The review records a product oracle that distinguishes authoritative maintainer context from behavior inferred from implementation or tests.",
         "The lifecycle analysis states which events retain the initial anchor and which explicit events transfer control.",
@@ -62,6 +94,22 @@
       "prompt": "Review a dotnet/aspnetcore pull request with a well-supported browser defect and produce the local-only final review. The internal evidence uses lifecycle and producer-classification terminology, but the target maintainer asked for plain language. While validation is running, the pull request receives a new commit that changes a relevant test.",
       "expected_output": "The review checks whether the new head invalidates or supersedes the frozen evidence, refreshes affected proof when needed, and drafts a concise maintainer-facing comment that explains the concrete action, visible failure, causal path, and requested change without unexplained internal jargon.",
       "files": [],
+      "eval_metadata": {
+        "mechanism": "relevant-head-drift",
+        "provenance": {
+          "kind": "historical",
+          "source": "dotnet/aspnetcore#68114"
+        },
+        "area": "Components",
+        "score_family": "head-drift-impact",
+        "tier": "train",
+        "discovery_mode": "verification",
+        "controls": {
+          "positive": [0, 1, 2, 3, 4],
+          "negative": [6]
+        },
+        "forbidden_prompt_terms": []
+      },
       "expectations": [
         "The review records the frozen head and checks the live pull request head again before final synthesis.",
         "Relevant head drift causes the affected evidence to be rerun or explicitly narrowed rather than presented as current-head proof.",
@@ -77,6 +125,22 @@
       "prompt": "The current session is running Claude Sonnet. Use aspnetcore-pr-review to review an open dotnet/aspnetcore pull request.",
       "expected_output": "The skill stops before evidence collection and clearly requests that the review be restarted in a GPT-family orchestrator session while preserving the configured diverse candidate panel.",
       "files": [],
+      "eval_metadata": {
+        "mechanism": "orchestrator-model-guardrail",
+        "provenance": {
+          "kind": "synthetic",
+          "source": "orchestrator model mismatch"
+        },
+        "area": "Cross-cutting",
+        "score_family": "orchestration-artifact-integrity",
+        "tier": "train",
+        "discovery_mode": "verification",
+        "controls": {
+          "positive": [0, 2],
+          "negative": [1, 3, 4]
+        },
+        "forbidden_prompt_terms": []
+      },
       "expectations": [
         "The response identifies that the current orchestrator is not a GPT-family model.",
         "The review does not begin Phase 1 or launch candidate agents.",
@@ -90,6 +154,22 @@
       "prompt": "Review a one-file dotnet/aspnetcore test-only PR for an asynchronous cache refresh. The issue records an OperationCanceledException after the test's two-second cancellation token fires, but the original CI logs are unavailable. The PR author says healthy work can remain queued longer than two seconds and replaces the token with an external two-second WaitAsync. All four candidates receive evidence containing an existing repository helper with a fifteen-second Release timeout and recommend it. A new test gates the worker for three seconds, fails at the PR head, and passes with the helper. Keep the review local.",
       "expected_output": "A calibrated review that recognizes the strict red/green timeout-policy result without treating the synthetic candidate-shaped probe as exact proof of the historical CI mechanism or an independently established correctness blocker.",
       "files": [],
+      "eval_metadata": {
+        "mechanism": "timeout-policy-proof-boundary",
+        "provenance": {
+          "kind": "historical",
+          "source": "timeout-policy calibration"
+        },
+        "area": "Testing/Infrastructure",
+        "score_family": "proof-calibration",
+        "tier": "train",
+        "discovery_mode": "verification",
+        "controls": {
+          "positive": [0, 1, 2, 3],
+          "negative": [4, 5, 6, 7]
+        },
+        "forbidden_prompt_terms": []
+      },
       "expectations": [
         "The product oracle separates the observed cancellation symptom, the patch author's objective, accepted behavior, and the proposed historical cause.",
         "The PR-author scheduling explanation is classified as a hypothesis unless corroborated by stronger authority.",
@@ -106,6 +186,22 @@
       "prompt": "Review a dotnet/aspnetcore serializer PR that removes a legacy payload alias. The PR author says no supported clients send the old property, but there is no compatibility document, accepted issue criterion, telemetry, or maintainer clarification. Four candidates are shown the same alias helper and propose restoring it. A new old-payload test fails without the alias and passes when it is restored. Do not modify GitHub.",
       "expected_output": "A review that does not let a clean candidate-shaped red/green test establish an unsupported compatibility contract, preserves the structural evidence, and asks for authoritative product context before declaring a blocker.",
       "files": [],
+      "eval_metadata": {
+        "mechanism": "compatibility-oracle",
+        "provenance": {
+          "kind": "synthetic",
+          "source": "legacy serializer alias scenario"
+        },
+        "area": "MVC/Serialization",
+        "score_family": "oracle-authority",
+        "tier": "train",
+        "discovery_mode": "verification",
+        "controls": {
+          "positive": [0, 4, 5],
+          "negative": [1, 2, 3]
+        },
+        "forbidden_prompt_terms": []
+      },
       "expectations": [
         "The review distinguishes structural support for accepting the old payload from authority that the old payload remains supported.",
         "The PR author's compatibility claim is not promoted into accepted product intent.",
@@ -120,6 +216,22 @@
       "prompt": "Complete an ASP.NET Core multi-model review whose narrative looks finished, but the artifact root lacks product-oracle.md, head-drift.md, claim-matrix.md, stress-matrix.md, and repository-oracle.md. The final report also omits the orchestrator and suggested review comment, while claiming production-proven and high confidence. Do not recreate evidence from memory.",
       "expected_output": "The reviewer runs the artifact validator, rejects incomplete synthesis, creates explicit not-applicable artifacts only when justified, and refuses impossible proof labels until the missing evidence is repaired.",
       "files": [],
+      "eval_metadata": {
+        "mechanism": "artifact-validator-integrity",
+        "provenance": {
+          "kind": "synthetic",
+          "source": "incomplete artifact bundle"
+        },
+        "area": "Cross-cutting",
+        "score_family": "orchestration-artifact-integrity",
+        "tier": "train",
+        "discovery_mode": "verification",
+        "controls": {
+          "positive": [0, 1],
+          "negative": [2, 3, 4]
+        },
+        "forbidden_prompt_terms": []
+      },
       "expectations": [
         "The deterministic artifact validator is run before final synthesis.",
         "Missing required files are reported rather than assumed to exist because equivalent prose appears elsewhere.",
@@ -133,6 +245,22 @@
       "prompt": "Empirically review an ASP.NET Core background-worker test change that replaces cooperative cancellation with an observer-only timeout. The focused C# test can run only after disabling an unrelated web-asset build target in the fresh worktree. The candidate turns the focused assertion green, and the same deterministic assertion passes twenty times. Determine the proof level and any remaining lifecycle validation.",
       "expected_output": "A scoped result that records the build bypass, avoids cross-platform production claims, distinguishes repetition from a stress matrix, and verifies what happens to inner worker tasks after the observer times out.",
       "files": [],
+      "eval_metadata": {
+        "mechanism": "observer-timeout-cleanup",
+        "provenance": {
+          "kind": "historical",
+          "source": "background-worker timeout calibration"
+        },
+        "area": "Testing/Infrastructure",
+        "score_family": "cleanup-proof-boundary",
+        "tier": "train",
+        "discovery_mode": "verification",
+        "controls": {
+          "positive": [0, 2, 3],
+          "negative": [1, 4, 5]
+        },
+        "forbidden_prompt_terms": []
+      },
       "expectations": [
         "The unrelated build failure and property override are recorded separately from behavioral red evidence.",
         "The candidate is capped at targeted-proven until the standard build or exact CI path validates it.",
@@ -147,6 +275,22 @@
       "prompt": "Review an ASP.NET Core pooled-resource fix. Accepted issue criteria and a maintainer clarification require every lease to be returned exactly once on normal completion, cancellation, and producer fault. Retained traces show a double return on cancellation. The current PR fixes cancellation but still leaks the lease on producer fault. A separate candidate not present in the PR centralizes release in one ownership exit. The identical real-path assertions fail at the frozen PR head for cancellation and fault, pass with the candidate, and a varied normal/cancel/fault/dispose matrix plus neighboring tests pass on the exact CI configurations. Keep the review local.",
       "expected_output": "A high-confidence review that blocks the still-incomplete PR implementation while allowing the separate candidate to become production-proven because authoritative intent, reproduced mechanism, exact scenarios, real producer paths, varied stress, and exact CI configurations all align.",
       "files": [],
+      "eval_metadata": {
+        "mechanism": "pooled-resource-ownership",
+        "provenance": {
+          "kind": "synthetic",
+          "source": "pooled lease ownership scenario"
+        },
+        "area": "Servers",
+        "score_family": "lifecycle-ownership",
+        "tier": "train",
+        "discovery_mode": "verification",
+        "controls": {
+          "positive": [0, 1, 2, 3, 4],
+          "negative": [5]
+        },
+        "forbidden_prompt_terms": []
+      },
       "expectations": [
         "The accepted criteria and maintainer clarification produce authoritative oracle fidelity.",
         "Retained traces and exact frozen-head failures produce reproduced mechanism fidelity.",
@@ -158,9 +302,36 @@
     },
     {
       "id": 10,
-      "prompt": "Review a small ASP.NET Core registration fix. A documented contract says a preconfigured compatible handler instance takes precedence over type fallback. The PR removes the line that discarded that instance and already includes a weaker regression test. A stronger unique-result assertion passes on untouched frozen head through Options, dependency injection, and the real consumer, but no concrete false-pass exists for the checked-in test. Reintroducing the removed line makes the stronger assertion fail. A narrow fallback matrix passes, but the local test needed an unrelated frontend-build bypass. Keep the review local.",
+      "prompt": "Review the supplied ASP.NET Core registration-fix fixture. Determine whether the current implementation has a merge-blocking defect, what the retained evidence proves, and how much additional validation is proportionate. Keep the review local.",
       "expected_output": "A no-blocker review that keeps the current fix, distinguishes frozen-head success from a diagnostic historical mutation, treats stronger test coverage as optional, and caps candidate proof at targeted-proven.",
-      "files": [],
+      "files": [
+        ".github/skills/aspnetcore-pr-review/evals/fixtures/registration-instance-precedence.md"
+      ],
+      "eval_metadata": {
+        "mechanism": "no-defect-registration",
+        "provenance": {
+          "kind": "historical",
+          "source": "dotnet/aspnetcore#68081"
+        },
+        "area": "Hosting/DependencyInjection",
+        "score_family": "no-defect-calibration",
+        "tier": "held_out",
+        "frozen_hash": "51d98d5357f75180018320f7c4699584cb6a02af4094006f1aa10a2820d01e88",
+        "fixture_hashes": {
+          ".github/skills/aspnetcore-pr-review/evals/fixtures/registration-instance-precedence.md": "df21462ee1948f8974614ed8a24016de01ebf18ebe8d4a745a02be32ec92e074"
+        },
+        "discovery_mode": "discovery",
+        "controls": {
+          "positive": [0, 2, 3, 4, 5],
+          "negative": [1]
+        },
+        "forbidden_prompt_terms": [
+          "passes on untouched frozen head",
+          "diagnostic-only",
+          "optional-regression",
+          "frontend-build bypass"
+        ]
+      },
       "expectations": [
         "The untouched frozen-head result is recorded before any mutation or candidate.",
         "Frozen-head success rejects an implementation blocker even though a historical mutation can produce red.",
@@ -172,9 +343,36 @@
     },
     {
       "id": 11,
-      "prompt": "Review a one-line stateless ASP.NET Core lookup correction with an authoritative contract. The exact real path fails on frozen head and passes after the correction, and the two nearest key-shape counterexamples pass. No ownership, cancellation, concurrency, interop, or background work is involved. Decide how much falsification is required and classify the candidate.",
+      "prompt": "Review the supplied ASP.NET Core lookup-correction fixture. Determine the required falsification scope and candidate classification without importing unrelated review machinery.",
       "expected_output": "A proportionate review that accepts a bounded real-path and nearest-counterexample matrix without inventing lifecycle scaffolding, while preserving explicit configuration limits.",
-      "files": [],
+      "files": [
+        ".github/skills/aspnetcore-pr-review/evals/fixtures/stateless-lookup.md"
+      ],
+      "eval_metadata": {
+        "mechanism": "proportionate-stateless-validation",
+        "provenance": {
+          "kind": "synthetic",
+          "source": "one-line stateless lookup scenario"
+        },
+        "area": "Http",
+        "score_family": "proportionate-validation",
+        "tier": "held_out",
+        "frozen_hash": "15fd59f94b4174779ba309965a78eb82ec300faca1e0a764ace0a3130ae3eb82",
+        "fixture_hashes": {
+          ".github/skills/aspnetcore-pr-review/evals/fixtures/stateless-lookup.md": "c395cbcdb376549ba18d00a53e780b04e99ff59e739107a6d69a167f2309ed3a"
+        },
+        "discovery_mode": "discovery",
+        "controls": {
+          "positive": [0, 1, 3, 4],
+          "negative": [2]
+        },
+        "forbidden_prompt_terms": [
+          "cancellation",
+          "disposal",
+          "observer-timeout",
+          "stateless"
+        ]
+      },
       "expectations": [
         "The review requires strict frozen-head red and candidate green for the claimed defect.",
         "The falsification matrix is limited to dimensions that can affect the stateless lookup mechanism.",
@@ -185,9 +383,32 @@
     },
     {
       "id": 12,
-      "prompt": "Review a dotnet/aspnetcore Virtualize pull request that opens a variable-height list at InitialItemIndex 500. The implementation suppresses observer callbacks while pinning the initial target. Existing tests cover initial placement and Home/End ownership transfer but do not scroll far enough to expose the opposite spacer after recovery. Maintainer-confirmed behavior requires the target to remain stable through unrelated layout activity and ordinary scrolling must not jump the visible range backward. Keep the review local and bounded.",
+      "prompt": "Review a dotnet/aspnetcore pull request that changes how a browser-backed variable-height list handles InitialItemIndex. The patch changes when IntersectionObserver callbacks are ignored during initial positioning. The edited tests cover initial placement and keyboard ownership transfer. Maintainer-confirmed behavior requires the target to remain stable through unrelated layout activity, and ordinary scrolling must preserve a monotonic visible range. Inspect adjacent states and impacted existing behavior; keep the review local and bounded.",
       "expected_output": "A lifecycle-aware review that looks beyond the edited tests, models the suppressed interval and first resumed observer callback, identifies mixed measurement generations as a concrete risk, and selects a bounded real-browser scenario with a fixed-size control and variable-height perturbation.",
-      "files": [],
+      "files": [
+        ".github/skills/aspnetcore-pr-review/evals/fixtures/virtualization-recovery.md"
+      ],
+      "eval_metadata": {
+        "mechanism": "observer-recovery-measurement-generation",
+        "provenance": {
+          "kind": "historical",
+          "source": "dotnet/aspnetcore#68114"
+        },
+        "area": "Components/Virtualization",
+        "score_family": "recovery-measurement-generation",
+        "tier": "train",
+        "discovery_mode": "discovery",
+        "controls": {
+          "positive": [0, 1, 2, 3, 4, 6],
+          "negative": [5, 7]
+        },
+        "forbidden_prompt_terms": [
+          "first resumed",
+          "opposite spacer",
+          "mixed measurement generations",
+          "item 500"
+        ]
+      },
       "expectations": [
         "The transition analysis records what measurements stop updating while callbacks are suppressed.",
         "The review analyzes the first observer callback after suppression rather than stopping at callback re-enablement.",
@@ -201,9 +422,32 @@
     },
     {
       "id": 13,
-      "prompt": "A dotnet/aspnetcore Virtualize review completed at frozen head A. A later pull request commit changes the shared IntersectionObserver producer so that when before and after spacers appear in one batch it always drops the after-spacer entry. The tests edited by the new commit pass, but an unchanged ProgrammaticScrollToBottom_ReachesLastItems E2E test depends on the after-spacer callback to fetch the tail. Reassess the live head locally without posting.",
+      "prompt": "An earlier local review of a dotnet/aspnetcore browser virtualization pull request completed at frozen head A. A later commit modifies filtering in the shared IntersectionObserver callback producer, and the edited tests pass. Reassess the live head locally, including unchanged behavior that shares the producer, without posting.",
       "expected_output": "A head-drift reassessment that regenerates a changed-producer impact map, discovers and runs the unchanged bottom-scroll test, and scopes the newly observed regression to the later commit instead of attributing it to the earlier frozen review.",
-      "files": [],
+      "files": [
+        ".github/skills/aspnetcore-pr-review/evals/fixtures/virtualization-producer-drift.md"
+      ],
+      "eval_metadata": {
+        "mechanism": "producer-impact-head-drift",
+        "provenance": {
+          "kind": "historical",
+          "source": "dotnet/aspnetcore#68114"
+        },
+        "area": "Components/Virtualization",
+        "score_family": "head-drift-impact",
+        "tier": "train",
+        "discovery_mode": "discovery",
+        "controls": {
+          "positive": [1, 2, 3, 4, 5, 6],
+          "negative": [0, 7]
+        },
+        "forbidden_prompt_terms": [
+          "ProgrammaticScrollToBottom_ReachesLastItems",
+          "drops the after-spacer",
+          "both spacers",
+          "tail distribution"
+        ]
+      },
       "expectations": [
         "The review states that evidence from frozen head A cannot predict or validate a later producer change.",
         "Relevant head drift causes the evidence bundle and impact map to be regenerated.",
@@ -213,6 +457,121 @@
         "The causal explanation states that dropping the after-spacer entry prevents the tail distribution or fetch required by programmatic bottom scrolling.",
         "A prior-head pass and current-head behavioral failure are preserved separately from infrastructure or aggregate CI status.",
         "The final report attributes the regression to the post-review commit and does not misrepresent earlier reviewed-head evidence as current."
+      ]
+    },
+    {
+      "id": 14,
+      "prompt": "Review the supplied ASP.NET Core deferred connection-abort fixture. Determine whether the current fix requires changes and what evidence is necessary for the verdict. Keep all work local.",
+      "expected_output": "A calibrated no-blocker review that traces the abort/dispose ownership race, validates the untouched focused test before any diagnostic mutation, distinguishes the disposed-source exception from cancellation callback failures, and rejects broader coordination requirements that lack contract authority.",
+      "files": [
+        ".github/skills/aspnetcore-pr-review/evals/fixtures/connection-abort-dispose.md"
+      ],
+      "eval_metadata": {
+        "mechanism": "deferred-cancel-dispose-race",
+        "provenance": {
+          "kind": "pr",
+          "source": "dotnet/aspnetcore#68146"
+        },
+        "area": "Servers/Connections",
+        "score_family": "lifecycle-ownership",
+        "tier": "held_out",
+        "frozen_hash": "5ad5ef70c86f5a04dc36fd2fb452ea6b42ee6d4b43a13c6e5f77e859cad589da",
+        "fixture_hashes": {
+          ".github/skills/aspnetcore-pr-review/evals/fixtures/connection-abort-dispose.md": "20b6ac1f855ecc47ab2b3c8bc7d319f3043d4c4c40e3eeaa2b1c21779cb312a4"
+        },
+        "discovery_mode": "discovery",
+        "controls": {
+          "positive": [0, 1, 2, 3, 4, 7],
+          "negative": [5, 6]
+        },
+        "forbidden_prompt_terms": [
+          "first-chance exception",
+          "deadlock",
+          "KestrelConnection"
+        ]
+      },
+      "expectations": [
+        "The product oracle uses the accepted issue discussion to establish that queued work must tolerate state changes between scheduling and execution.",
+        "The review traces ownership from deferred cancellation through immediate disposal and identifies the narrow disposed-source race.",
+        "The untouched isolated-process regression is run or exact current CI evidence is preserved before any diagnostic mutation.",
+        "The review distinguishes CancellationTokenSource disposal from exceptions thrown by cancellation callbacks.",
+        "Any first-chance exception marker is classified as diagnostic-only rather than required regression coverage.",
+        "The review does not require ConnectionClosed cancellation after disposal without an authoritative contract.",
+        "Wait-for-worker or deferred-disposal alternatives are rejected when they can deadlock the exact worker-starvation ordering or strand cleanup.",
+        "The final verdict keeps the current fix and reports no implementation blocker."
+      ]
+    },
+    {
+      "id": 15,
+      "prompt": "Review dotnet/aspnetcore PR #68037 at head 2df89bef7b6001fb64b5e8bef3dda447f1e4967b. The pull request changes how Components render-batch frames are passed to a writer, adds a benchmark, and adds a mutation-safety test. Inspect the exact diff, linked issue, review discussion, benchmark shape, generated call shape, tests, and current status. Determine whether the implementation and performance claim are ready. Keep all work local.",
+      "expected_output": "A performance-evidence review that separates correct wire behavior from an unproven optimization claim, detects when the mutation test observes the source array rather than the actual by-reference argument, and requests comparative benchmark and generated-code evidence without claiming a production correctness defect that was not shown.",
+      "files": [],
+      "eval_metadata": {
+        "mechanism": "performance-call-shape-proof",
+        "provenance": {
+          "kind": "pr",
+          "source": "dotnet/aspnetcore#68037"
+        },
+        "area": "Components/RenderTree",
+        "score_family": "performance-proof",
+        "tier": "train",
+        "discovery_mode": "verification",
+        "controls": {
+          "positive": [0, 1, 2, 3, 4, 6],
+          "negative": [5]
+        },
+        "forbidden_prompt_terms": []
+      },
+      "expectations": [
+        "The review freezes and records the exact reviewed head before evaluating generated code or benchmarks.",
+        "The review distinguishes protocol correctness from evidence that the new call shape materially improves performance.",
+        "A benchmark with no same-run comparator or generated-code evidence is insufficient to establish the optimization claim.",
+        "The mutation-safety test is rejected if the writer receives a copied local while the assertion inspects the original array.",
+        "A direct array-by-reference alternative may prove mutation reachability structurally but is not preferred without safety and performance evidence.",
+        "The final verdict is revise or blocked on evidence rather than blocked on a demonstrated wire-correctness defect.",
+        "The requested follow-up compares the original, one-copy, and direct-array call shapes using identical workload and generated-code evidence."
+      ]
+    },
+    {
+      "id": 16,
+      "prompt": "Reassess the later head represented by the supplied ASP.NET Core SignalR reconnect fixture. Determine whether the changed shared producer affects unchanged consumers and whether earlier-head evidence remains current. Keep the review local.",
+      "expected_output": "A head-drift review that re-establishes the nullable retry-policy contract, maps the changed result normalization to unchanged stop-reconnecting behavior, runs or selects the unchanged impacted test, and scopes any regression to the later head.",
+      "files": [
+        ".github/skills/aspnetcore-pr-review/evals/fixtures/signalr-reconnect-drift.md"
+      ],
+      "eval_metadata": {
+        "mechanism": "signalr-retry-policy-head-drift",
+        "provenance": {
+          "kind": "synthetic",
+          "source": "signalr retry-policy drift fixture"
+        },
+        "area": "SignalR/Client",
+        "score_family": "head-drift-impact",
+        "tier": "held_out",
+        "frozen_hash": "04431ffc03bd56b468b684e4be823f2f11f67fbe03783932ef851cb9e7a10674",
+        "fixture_hashes": {
+          ".github/skills/aspnetcore-pr-review/evals/fixtures/signalr-reconnect-drift.md": "111a0a8934b6d50941094bbe48c3202c1b295c91fc3a9cc3ad98fb611a8bb73d"
+        },
+        "discovery_mode": "discovery",
+        "controls": {
+          "positive": [0, 1, 2, 3, 5],
+          "negative": [4, 6]
+        },
+        "forbidden_prompt_terms": [
+          "NextRetryDelay",
+          "TimeSpan.Zero",
+          "StopsIfTheReconnectPolicyReturnsNull",
+          "Disconnected"
+        ]
+      },
+      "expectations": [
+        "The review re-establishes from the fixture that a null retry delay stops automatic reconnect.",
+        "The changed null-to-zero normalization is mapped to the shared reconnect scheduler.",
+        "The impact analysis selects the unchanged null-after-failed-retry test from the supplied reconnect-suite inventory.",
+        "The unchanged impacted test is selected before inventing a candidate-specific assertion.",
+        "Earlier-head success is not presented as proof for the later shared-producer change.",
+        "The final report attributes any immediate-retry regression to the later head.",
+        "The review does not generalize the result beyond retry policies returning null."
       ]
     }
   ]

--- a/.github/skills/aspnetcore-pr-review/evals/evals.json
+++ b/.github/skills/aspnetcore-pr-review/evals/evals.json
@@ -84,6 +84,77 @@
         "The response does not replace the configured candidate panel with copies of the orchestrator model.",
         "No repository or GitHub state is modified."
       ]
+    },
+    {
+      "id": 5,
+      "prompt": "Review a one-file dotnet/aspnetcore test-only PR for an asynchronous cache refresh. The issue records an OperationCanceledException after the test's two-second cancellation token fires, but the original CI logs are unavailable. The PR author says healthy work can remain queued longer than two seconds and replaces the token with an external two-second WaitAsync. All four candidates receive evidence containing an existing repository helper with a fifteen-second Release timeout and recommend it. A new test gates the worker for three seconds, fails at the PR head, and passes with the helper. Keep the review local.",
+      "expected_output": "A calibrated review that recognizes the strict red/green timeout-policy result without treating the synthetic candidate-shaped probe as exact proof of the historical CI mechanism or an independently established correctness blocker.",
+      "files": [],
+      "expectations": [
+        "The product oracle separates the observed cancellation symptom, the patch author's objective, accepted behavior, and the proposed historical cause.",
+        "The PR-author scheduling explanation is classified as a hypothesis unless corroborated by stronger authority.",
+        "The three-second gate is classified as a synthetic diagnostic because its expected success is not independently established.",
+        "The report states that the experiment proves a timeout-policy difference but not the unavailable historical scheduling mechanism.",
+        "The candidate is not classified as production-proven solely because the identical diagnostic passes repeatedly.",
+        "Agreement on the helper is treated as correlated convergence because every candidate received the same helper evidence.",
+        "The final confidence is capped by the weak oracle or scenario fidelity.",
+        "The suggested maintainer comment says what the experiment does not prove and frames the helper as a recommendation unless stronger intent is found."
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Review a dotnet/aspnetcore serializer PR that removes a legacy payload alias. The PR author says no supported clients send the old property, but there is no compatibility document, accepted issue criterion, telemetry, or maintainer clarification. Four candidates are shown the same alias helper and propose restoring it. A new old-payload test fails without the alias and passes when it is restored. Do not modify GitHub.",
+      "expected_output": "A review that does not let a clean candidate-shaped red/green test establish an unsupported compatibility contract, preserves the structural evidence, and asks for authoritative product context before declaring a blocker.",
+      "files": [],
+      "expectations": [
+        "The review distinguishes structural support for accepting the old payload from authority that the old payload remains supported.",
+        "The PR author's compatibility claim is not promoted into accepted product intent.",
+        "The old-payload test is not automatically treated as a merge-candidate assertion merely because the alias makes it green.",
+        "The result is blocked on product oracle or presented as a recommendation rather than a high-confidence implementation blocker.",
+        "Four candidates choosing the pre-supplied alias helper is not counted as four independent mechanism discoveries.",
+        "The final output identifies what maintainer or contract evidence would change the verdict."
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Complete an ASP.NET Core multi-model review whose narrative looks finished, but the artifact root lacks product-oracle.md, head-drift.md, claim-matrix.md, stress-matrix.md, and repository-oracle.md. The final report also omits the orchestrator and suggested review comment, while claiming production-proven and high confidence. Do not recreate evidence from memory.",
+      "expected_output": "The reviewer runs the artifact validator, rejects incomplete synthesis, creates explicit not-applicable artifacts only when justified, and refuses impossible proof labels until the missing evidence is repaired.",
+      "files": [],
+      "expectations": [
+        "The deterministic artifact validator is run before final synthesis.",
+        "Missing required files are reported rather than assumed to exist because equivalent prose appears elsewhere.",
+        "The final report is not accepted without the orchestrator, proof status, repository oracle gaps, and suggested review comments sections.",
+        "Production-proven is rejected when the stress matrix is missing, lacks multiple executed cases, or omits explicit producer, variation, configuration/platform, neighboring-suite, and cleanup/interruption coverage.",
+        "The reviewer does not override validator failures with a narrative explanation."
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Empirically review an ASP.NET Core background-worker test change that replaces cooperative cancellation with an observer-only timeout. The focused C# test can run only after disabling an unrelated web-asset build target in the fresh worktree. The candidate turns the focused assertion green, and the same deterministic assertion passes twenty times. Determine the proof level and any remaining lifecycle validation.",
+      "expected_output": "A scoped result that records the build bypass, avoids cross-platform production claims, distinguishes repetition from a stress matrix, and verifies what happens to inner worker tasks after the observer times out.",
+      "files": [],
+      "expectations": [
+        "The unrelated build failure and property override are recorded separately from behavioral red evidence.",
+        "The candidate is capped at targeted-proven until the standard build or exact CI path validates it.",
+        "Twenty identical deterministic passes are described as repetition evidence rather than a complete stress matrix.",
+        "The lifecycle matrix inspects inner task state after timeout and requires deterministic release or cancellation and exception observation.",
+        "The report does not generalize one local configuration to all CI platforms.",
+        "Diagnostic assertion changes and implementation-intended changes are preserved in separate diffs with an assertion disposition."
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "Review an ASP.NET Core pooled-resource fix. Accepted issue criteria and a maintainer clarification require every lease to be returned exactly once on normal completion, cancellation, and producer fault. Retained traces show a double return on cancellation. The current PR fixes cancellation but still leaks the lease on producer fault. A separate candidate not present in the PR centralizes release in one ownership exit. The identical real-path assertions fail at the frozen PR head for cancellation and fault, pass with the candidate, and a varied normal/cancel/fault/dispose matrix plus neighboring tests pass on the exact CI configurations. Keep the review local.",
+      "expected_output": "A high-confidence review that blocks the still-incomplete PR implementation while allowing the separate candidate to become production-proven because authoritative intent, reproduced mechanism, exact scenarios, real producer paths, varied stress, and exact CI configurations all align.",
+      "files": [],
+      "expectations": [
+        "The accepted criteria and maintainer clarification produce authoritative oracle fidelity.",
+        "Retained traces and exact frozen-head failures produce reproduced mechanism fidelity.",
+        "The real normal, cancellation, and producer-fault paths produce exact scenario fidelity.",
+        "The candidate is allowed to become production-proven after the varied lifecycle matrix and exact CI configurations pass.",
+        "The final review uses blocked on implementation and high confidence because the current PR still omits the proven producer-fault correction and no weak fidelity dimension remains.",
+        "The public comment requests the missing producer-fault correction without adding uncertainty that the evidence has already resolved or claiming the separate candidate is already in the PR."
+      ]
     }
   ]
 }

--- a/.github/skills/aspnetcore-pr-review/evals/fixtures/connection-abort-dispose.md
+++ b/.github/skills/aspnetcore-pr-review/evals/fixtures/connection-abort-dispose.md
@@ -1,0 +1,27 @@
+# Deferred connection abort/dispose fixture
+
+## Accepted issue behavior
+
+Queued connection-lifetime work must tolerate state changes between scheduling
+and execution. The issue demonstrates `Abort()` immediately followed by
+`DisposeAsync()` terminating the process from deferred work.
+
+## Frozen implementation
+
+`Abort()` queues a static callback whose state is the connection's
+`CancellationTokenSource`. `DisposeAsync()` disposes that source without
+waiting for the queued callback. The patch catches only
+`ObjectDisposedException` around the deferred `Cancel()` call.
+
+An analogous Kestrel connection-closing path catches the same disposed-source
+race. BCL behavior distinguishes a disposed source from exceptions raised by
+cancellation callbacks.
+
+## Regression evidence
+
+The regression runs in `RemoteExecutor`, constrains the worker pool, blocks the
+only worker, calls `Abort()`, disposes the connection, then releases the worker.
+Untouched patched head and current CI pass. A first-chance exception listener
+can observe the disposed-source exception without changing the product
+assertion.
+

--- a/.github/skills/aspnetcore-pr-review/evals/fixtures/registration-instance-precedence.md
+++ b/.github/skills/aspnetcore-pr-review/evals/fixtures/registration-instance-precedence.md
@@ -1,0 +1,22 @@
+# Registration instance precedence fixture
+
+## Contract
+
+The documented registration contract says that a compatible handler instance
+configured by the caller takes precedence over type-based fallback activation.
+
+## Frozen patch
+
+The patch removes an assignment that replaced the configured instance with a
+type-created handler. A checked-in regression asserts only that resolution
+returns a compatible handler.
+
+## Retained evidence
+
+- The exact configured instance is distinguishable from the fallback instance.
+- An assertion that checks exact instance identity passes on untouched patched
+  head through Options, dependency injection, and the real consumer.
+- Reintroducing the removed assignment makes that assertion fail.
+- A narrow compatible/incompatible/missing registration matrix passes.
+- The local focused test requires an unrelated frontend-build target bypass.
+

--- a/.github/skills/aspnetcore-pr-review/evals/fixtures/signalr-reconnect-drift.md
+++ b/.github/skills/aspnetcore-pr-review/evals/fixtures/signalr-reconnect-drift.md
@@ -1,0 +1,35 @@
+# SignalR reconnect producer-drift fixture
+
+## Contract
+
+`IRetryPolicy.NextRetryDelay` returns a nullable delay. A `null` result stops
+automatic reconnect and transitions the connection to `Disconnected`.
+
+## Review history and later-head diff
+
+An earlier local review completed before this later commit:
+
+```csharp
+var nextDelay = _retryPolicy.NextRetryDelay(retryContext);
+return nextDelay ?? TimeSpan.Zero;
+```
+
+The edited test covers a policy returning `TimeSpan.Zero` followed by a
+successful reconnect.
+
+## Unchanged consumers and tests
+
+The unchanged reconnect suite includes:
+
+- `StopsIfTheReconnectPolicyReturnsNull`: the custom policy returns zero for
+  the first retry and `null` after that retry fails. The test awaits `Closed`,
+  expects an `OperationCanceledException`, records two retry contexts, and
+  expects zero successful reconnections.
+- `CanBeInducedByCloseMessageWithAllowReconnectSet`: the custom policy always
+  returns zero, and the connection successfully reconnects after a server close
+  message allows reconnect.
+- `ContinuesIfConnectionLostDuringReconnectHandshake`: the custom policy always
+  returns zero while the test fails and retries a reconnect handshake.
+
+All three tests passed before the later commit. The edited later-head test
+covers a concrete zero delay followed by a successful reconnect.

--- a/.github/skills/aspnetcore-pr-review/evals/fixtures/stateless-lookup.md
+++ b/.github/skills/aspnetcore-pr-review/evals/fixtures/stateless-lookup.md
@@ -1,0 +1,17 @@
+# Stateless lookup fixture
+
+## Contract
+
+An authoritative contract requires an exact key lookup to select the matching
+registered value and preserve the existing fallback behavior for the two
+nearest key shapes.
+
+## Frozen patch and evidence
+
+- The patch changes one lookup expression.
+- The real consumer has no asynchronous work, retained ownership, callbacks,
+  cancellation, disposal, or background processing on this path.
+- The exact real-path assertion fails on frozen head and passes with the patch.
+- The two nearest key-shape counterexamples pass with the patch.
+- Only one local configuration has been executed.
+

--- a/.github/skills/aspnetcore-pr-review/evals/fixtures/virtualization-producer-drift.md
+++ b/.github/skills/aspnetcore-pr-review/evals/fixtures/virtualization-producer-drift.md
@@ -1,0 +1,27 @@
+# Browser virtualization producer-drift fixture
+
+## Review history
+
+The original local review completed at frozen head A. A later commit changes
+the shared `IntersectionObserver` batch producer.
+
+## Later-head diff
+
+```typescript
+const bothSpacersIntersect = entries.some(isBefore) && entries.some(isAfter);
+const entriesToDispatch = entries.filter(entry =>
+  !(bothSpacersIntersect && entry.target === spacerAfter));
+```
+
+The edited startup test verifies that one callback is dispatched when both
+spacers are visible during initial observation.
+
+## Unchanged consumers and status
+
+- `ProgrammaticScrollToBottom_ReachesLastItems` sets `scrollTop` to
+  `scrollHeight` and waits for a rendered item index above 480.
+- Tail loading is initiated by the after-spacer callback.
+- The test passed at frozen head A.
+- The current Components E2E run fails that unchanged test in CoreCLR and both
+  Mono execution modes.
+

--- a/.github/skills/aspnetcore-pr-review/evals/fixtures/virtualization-recovery.md
+++ b/.github/skills/aspnetcore-pr-review/evals/fixtures/virtualization-recovery.md
@@ -1,0 +1,33 @@
+# Browser virtualization recovery fixture
+
+## Accepted behavior
+
+- A positive initial item remains authoritative through unrelated layout
+  activity until an explicit navigation action transfers ownership.
+- Ordinary scrolling after initial positioning must not move the visible range
+  backward.
+
+## Changed path
+
+The patch changes how `IntersectionObserver` callbacks are classified and
+ignored while JavaScript positions the initial item. Ignored callbacks return
+before the .NET measurement consumer commits the observed spacer and row data.
+
+The next processed callback supplies:
+
+- a spacer pixel size from the DOM;
+- rendered-row separation from the current DOM batch;
+- the current item count; and
+- an average item size recomputed by `ProcessMeasurements`.
+
+`CalculateItemDistribution` then divides spacer pixels by the committed average
+item size to select the next logical window.
+
+## Existing tests
+
+- Initial placement at `InitialItemIndex = 500`.
+- Home/End ownership transfer after initial placement.
+- Fixed-height and variable-height rendering samples.
+- No test performs ordinary scrolling until the opposite spacer becomes
+  visible after the ignored-callback interval.
+

--- a/.github/skills/aspnetcore-pr-review/references/proof-calibration.md
+++ b/.github/skills/aspnetcore-pr-review/references/proof-calibration.md
@@ -55,7 +55,22 @@ Keep diagnostic and implementation changes separate:
   finding.
 - `implementation.diff`: the smallest change intended for the reviewed patch.
 - `candidate.diff`: the combined state used during validation.
-- `assertion_disposition`: `merge-candidate`, `diagnostic-only`, or `rejected`.
+- `regression_assertion_disposition`: `required-regression`,
+  `optional-regression`, or `rejected`.
+- `diagnostic_mutation_disposition`: `diagnostic-only`, `rejected`, or
+  `not-applicable`.
+
+Classify assertions and mutations in separate fields. A merge-suitable
+hardening assertion may be `optional-regression` while a historical mutation
+used to challenge it remains `diagnostic-only`.
+Use `required-regression` only when authoritative acceptance criteria or a
+proven defect makes that exact coverage necessary.
+
+Run the approved assertion on untouched frozen head before applying a candidate.
+If it passes, the blocker is contradicted. Do not mutate working code merely to
+obtain red. A historical regression mutation may be useful diagnostically, but
+it cannot substitute for a frozen-head failure or justify implementation
+severity.
 
 ## Fidelity dimensions
 
@@ -102,11 +117,19 @@ Record each requirement in `empirical/stress-matrix.md` with these exact labels:
 `Applicable configurations/platforms`, `Neighboring suite`, and
 `Cleanup/interruption paths`. Mark each `passed` or
 `not applicable - <specific reason>` before claiming `production-proven`.
+List the distinct varied rows under an `## Executed cases` heading; duplicate
+rows and unrelated tables do not satisfy the matrix.
 
 Repeated runs of one deterministic scenario are repetition evidence, not a
 stress matrix. A supported build-property bypass can produce
 `targeted-proven`, but cannot imply the bypassed targets or other platforms were
 validated.
+
+Scale falsification to the claim. Stateful lifecycle, concurrency, interop, and
+observer-timeout claims need the dimensions that can strand ownership or leak
+work. A bounded stateless change may need only the real path and its nearest
+counterexamples. Never add unrelated scaffolding solely to upgrade a proof
+label; retain a lower candidate classification instead.
 
 When an observer timeout does not cancel its inner work, the matrix must inspect
 the inner task states after timeout, release or cancel them deterministically,

--- a/.github/skills/aspnetcore-pr-review/references/proof-calibration.md
+++ b/.github/skills/aspnetcore-pr-review/references/proof-calibration.md
@@ -1,0 +1,134 @@
+# Proof calibration
+
+Use these rules before turning a plausible finding into a merge-readiness
+verdict. Strict red/green establishes causality only for the assertion that was
+actually run. It cannot make an unsupported assertion premise authoritative.
+
+## Authority ladder
+
+Classify every expected-behavior claim separately. Prefer the strongest
+applicable source:
+
+1. Accepted issue criteria or explicit maintainer clarification.
+2. Public documentation, specification, or established compatibility contract.
+3. An existing test whose intent is stated by one of the sources above.
+4. Reporter observations and retained logs. These establish symptoms, not
+   product intent unless they include accepted criteria.
+5. A patch author's rationale. This can establish the patch objective, but is a
+   hypothesis for product intent and historical cause until corroborated.
+6. Implementation state, naming, repository pattern, or model inference.
+
+Do not collapse patch intent, accepted product behavior, and historical cause
+into one oracle entry. Record the claim, source, authority level, confidence,
+and scope. A weaker source can motivate investigation, but final severity is
+limited by the authority supporting the expected result.
+
+`Product oracle` records the source category
+(`documented`/`author-confirmed`/`test-encoded`/`inferred`/`unknown`).
+`Oracle fidelity` records the authority result after scope is considered. For
+example, a patch author can confirm patch intent while the corresponding
+product-contract fidelity remains `hypothesis`.
+
+## Candidate-independent assertion approval
+
+Freeze the assertion contract before choosing the correction:
+
+```text
+Setup:
+Control:
+Trigger:
+Expected assertion:
+Independent authority for the expected result:
+Allowed perturbations:
+Runtime variants:
+Repetitions:
+```
+
+Ask whether the same assertion would still be required if the proposed
+candidate were unknown. A probe selected because its input falls between the
+old and proposed thresholds proves a policy difference, but remains
+diagnostic-only unless an independent authority says that input must succeed.
+
+Keep diagnostic and implementation changes separate:
+
+- `diagnostic.diff`: instrumentation or assertions used to understand the
+  finding.
+- `implementation.diff`: the smallest change intended for the reviewed patch.
+- `candidate.diff`: the combined state used during validation.
+- `assertion_disposition`: `merge-candidate`, `diagnostic-only`, or `rejected`.
+
+## Fidelity dimensions
+
+Report each dimension independently:
+
+| Dimension | Values | Meaning |
+|---|---|---|
+| Oracle | authoritative / corroborated / hypothesis / unknown | Why the expected result is required |
+| Mechanism | reproduced / structural / inferred / unknown | Whether the causal path was observed |
+| Scenario | exact / proxy / synthetic / missing | How closely execution matches the reported situation |
+| Candidate | production-proven / targeted-proven / diagnostic-only / rejected / blocked | How broadly the proposed correction was validated |
+
+The final confidence cannot exceed the weakest fidelity relevant to the
+verdict. Describe mixed evidence explicitly, for example: "synthetic timeout
+policy empirical; historical scheduler mechanism missing."
+
+## Verdict gates
+
+Use `blocked on implementation` only when all are true:
+
+1. The expected behavior has sufficient authority for blocker severity.
+2. Frozen head exhibits the predicted failure at a faithful assertion.
+3. The supported mechanism connects that failure to the reviewed change.
+
+Use `recommendation only` when evidence supports a repository-pattern,
+diagnostic, resilience, or simplification improvement but not a correctness
+blocker. Use `blocked on evidence` when the relevance or mechanism of a
+behavioral concern cannot be established. Use `blocked on product oracle` when
+competing intended behaviors require human clarification.
+
+## Production-proof requirements
+
+One green establishes a causal relationship for the scoped assertion. A
+candidate becomes `production-proven` only after:
+
+- the real producer/runtime boundary passes;
+- a matrix varies the dimensions that could falsify the mechanism;
+- applicable configurations and platforms are covered;
+- the neighboring suite passes; and
+- cleanup and interruption paths are exercised.
+
+Record each requirement in `empirical/stress-matrix.md` with these exact labels:
+`Real producer/runtime boundary`, `Varied falsification dimensions`,
+`Applicable configurations/platforms`, `Neighboring suite`, and
+`Cleanup/interruption paths`. Mark each `passed` or
+`not applicable - <specific reason>` before claiming `production-proven`.
+
+Repeated runs of one deterministic scenario are repetition evidence, not a
+stress matrix. A supported build-property bypass can produce
+`targeted-proven`, but cannot imply the bypassed targets or other platforms were
+validated.
+
+When an observer timeout does not cancel its inner work, the matrix must inspect
+the inner task states after timeout, release or cancel them deterministically,
+observe their exceptions, and verify cleanup cannot leak into later tests.
+
+## Correlated convergence
+
+Model diversity is not mechanism diversity. If every candidate receives the
+same suggested helper, oracle framing, or diagnostic design, agreement on that
+surface is correlated. Record distinct root-cause mechanisms and use consensus
+as corroboration only after source or runtime evidence independently supports
+the claim.
+
+## Public comment calibration
+
+Before drafting a comment, answer:
+
+1. What did the experiment prove?
+2. What did it not reproduce or establish?
+3. Is the requested change required for correctness, or recommended for
+   consistency, diagnostics, resilience, or simplicity?
+4. What maintainer context could change the conclusion?
+
+Translate those answers into ordinary maintainer language. Do not expose the
+internal fidelity labels unless they make the request clearer.

--- a/.github/skills/aspnetcore-pr-review/scripts/aggregate_eval_scores.py
+++ b/.github/skills/aspnetcore-pr-review/scripts/aggregate_eval_scores.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+"""Aggregate reviewer eval scores without rewarding correlated duplicates."""
+
+import argparse
+import json
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+
+def mean(values: Iterable[float]) -> float:
+    materialized = list(values)
+    return statistics.fmean(materialized) if materialized else 0.0
+
+
+def macro_average(evals: list[dict[str, Any]], scores: dict[str, float], field: str) -> float:
+    grouped: dict[str, list[float]] = defaultdict(list)
+    for eval_data in evals:
+        metadata = eval_data["eval_metadata"]
+        if field == "provenance":
+            provenance = metadata["provenance"]
+            key = f"{provenance['kind']}:{provenance['source']}"
+        else:
+            key = metadata[field]
+        grouped[key].append(scores[str(eval_data["id"])])
+    return mean(mean(group_scores) for group_scores in grouped.values())
+
+
+def aggregate_document(
+    document: dict[str, Any], score_document: dict[str, Any]
+) -> tuple[dict[str, Any], list[str]]:
+    errors: list[str] = []
+    evals = document.get("evals", [])
+    scores: dict[str, float] = {}
+    expected_ids = {str(eval_data["id"]) for eval_data in evals}
+
+    for identifier, value in score_document.items():
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            errors.append(f"score for eval {identifier} must be numeric")
+        elif not 0 <= value <= 1:
+            errors.append(f"score for eval {identifier} must be between 0 and 1")
+        else:
+            scores[str(identifier)] = float(value)
+
+    missing = sorted(expected_ids - set(scores))
+    extra = sorted(set(scores) - expected_ids)
+    if missing:
+        errors.append(f"missing eval scores: {', '.join(missing)}")
+    if extra:
+        errors.append(f"unknown eval scores: {', '.join(extra)}")
+    if errors:
+        return {}, errors
+
+    tiers: dict[str, Any] = {}
+    for tier in ("train", "held_out"):
+        tier_evals = [
+            eval_data
+            for eval_data in evals
+            if eval_data["eval_metadata"]["tier"] == tier
+        ]
+        if not tier_evals:
+            continue
+        tiers[tier] = {
+            "eval_count": len(tier_evals),
+            "raw_mean": mean(scores[str(eval_data["id"])] for eval_data in tier_evals),
+            "family_macro": macro_average(
+                tier_evals, scores, "score_family"
+            ),
+            "provenance_macro": macro_average(
+                tier_evals, scores, "provenance"
+            ),
+        }
+
+    train = tiers.get("train", {})
+    held_out = tiers.get("held_out", {})
+    return {
+        "raw_mean": mean(scores.values()),
+        "tiers": tiers,
+        "transfer_gap": {
+            "family_macro": (
+                train["family_macro"] - held_out["family_macro"]
+                if train and held_out
+                else None
+            ),
+            "provenance_macro": (
+                train["provenance_macro"] - held_out["provenance_macro"]
+                if train and held_out
+                else None
+            ),
+        },
+    }, []
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Macro-aggregate ASP.NET Core reviewer eval scores."
+    )
+    parser.add_argument("eval_files", nargs="+", type=Path)
+    parser.add_argument(
+        "--scores",
+        required=True,
+        type=Path,
+        help="JSON object keyed by skill_name, then eval id, with scores from 0 to 1",
+    )
+    args = parser.parse_args()
+
+    try:
+        score_data = json.loads(args.scores.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        print(f"ERROR: unable to read scores: {error}", file=sys.stderr)
+        return 1
+
+    result: dict[str, Any] = {}
+    errors: list[str] = []
+    for eval_path in args.eval_files:
+        try:
+            document = json.loads(eval_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            errors.append(f"{eval_path}: unable to read evals: {error}")
+            continue
+        skill_name = document.get("skill_name")
+        if not isinstance(skill_name, str) or not skill_name:
+            errors.append(f"{eval_path}: skill_name must be a nonempty string")
+            continue
+        skill_scores = score_data.get(skill_name)
+        if not isinstance(skill_scores, dict):
+            errors.append(f"{skill_name}: scores must be an object keyed by eval id")
+            continue
+        aggregate, aggregate_errors = aggregate_document(document, skill_scores)
+        errors.extend(f"{skill_name}: {error}" for error in aggregate_errors)
+        if not aggregate_errors:
+            result[skill_name] = aggregate
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/aspnetcore-pr-review/scripts/test_aggregate_eval_scores.py
+++ b/.github/skills/aspnetcore-pr-review/scripts/test_aggregate_eval_scores.py
@@ -1,0 +1,76 @@
+import unittest
+
+from aggregate_eval_scores import aggregate_document
+
+
+class AggregateEvalScoresTests(unittest.TestCase):
+    def test_family_macro_does_not_reward_duplicate_family_cases(self):
+        document = {
+            "evals": [
+                self.eval_data(1, "train", "family-a", "source-a"),
+                self.eval_data(2, "train", "family-a", "source-a"),
+                self.eval_data(3, "train", "family-b", "source-b"),
+                self.eval_data(4, "held_out", "family-c", "source-c"),
+            ]
+        }
+        result, errors = aggregate_document(
+            document,
+            {"1": 1.0, "2": 1.0, "3": 0.0, "4": 0.5},
+        )
+
+        self.assertEqual([], errors)
+        self.assertAlmostEqual(0.5, result["tiers"]["train"]["family_macro"])
+        self.assertAlmostEqual(0.5, result["tiers"]["train"]["provenance_macro"])
+        self.assertAlmostEqual(2 / 3, result["tiers"]["train"]["raw_mean"])
+
+    def test_scores_must_cover_exact_eval_ids(self):
+        document = {
+            "evals": [
+                self.eval_data(1, "train", "family-a", "source-a"),
+            ]
+        }
+
+        result, errors = aggregate_document(
+            document,
+            {"2": 1.0},
+        )
+
+        self.assertEqual({}, result)
+        self.assertIn("missing eval scores: 1", errors)
+        self.assertIn("unknown eval scores: 2", errors)
+
+    def test_transfer_gap_is_null_without_both_tiers(self):
+        document = {
+            "evals": [
+                self.eval_data(1, "train", "family-a", "source-a"),
+            ]
+        }
+
+        result, errors = aggregate_document(document, {"1": 1.0})
+
+        self.assertEqual([], errors)
+        self.assertIsNone(result["transfer_gap"]["family_macro"])
+        self.assertIsNone(result["transfer_gap"]["provenance_macro"])
+
+    @staticmethod
+    def eval_data(
+        identifier: int,
+        tier: str,
+        family: str,
+        provenance: str,
+    ) -> dict:
+        return {
+            "id": identifier,
+            "eval_metadata": {
+                "tier": tier,
+                "score_family": family,
+                "provenance": {
+                    "kind": "synthetic",
+                    "source": provenance,
+                },
+            },
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/skills/aspnetcore-pr-review/scripts/test_validate_artifacts.py
+++ b/.github/skills/aspnetcore-pr-review/scripts/test_validate_artifacts.py
@@ -1,0 +1,243 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from validate_artifacts import REQUIRED_EXISTING, REQUIRED_NONEMPTY, validate
+
+
+VALID_REVIEW = """# Multi-Model Review
+
+**Orchestrator:** gpt-test
+
+## Current fix
+Current behavior.
+
+## Independent candidates
+Candidates.
+
+## Adversarial consensus
+Consensus.
+
+## Test assessment
+Assessment.
+
+## Proof status
+**Finding proof:** empirical
+**Scenario proof:** empirical
+**Candidate proof:** targeted-proven
+**Product oracle:** documented
+**Oracle fidelity:** authoritative
+**Mechanism fidelity:** reproduced
+**Scenario fidelity:** proxy
+**Assertion disposition:** diagnostic-only
+
+## Final recommendation
+**Implementation verdict:** REVISE
+**Behavioral evidence:** empirical
+**Merge readiness:** recommendation only
+**Implementation confidence:** medium
+**Reason:** The evidence supports a scoped recommendation.
+
+## Required follow-ups
+None.
+
+## Repository oracle gaps
+None.
+
+## Suggested review comments
+None.
+"""
+
+
+class ValidateArtifactsTests(unittest.TestCase):
+    def create_root(self) -> Path:
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        root = Path(temp_dir.name)
+
+        for relative_path in REQUIRED_NONEMPTY:
+            path = root / relative_path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("evidence\n", encoding="utf-8")
+
+        for relative_path in REQUIRED_EXISTING:
+            path = root / relative_path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch()
+
+        (root / "final/review.md").write_text(VALID_REVIEW, encoding="utf-8")
+        return root
+
+    def test_valid_artifacts_pass(self):
+        self.assertEqual([], validate(self.create_root()))
+
+    def test_missing_required_artifact_fails(self):
+        root = self.create_root()
+        (root / "evidence/product-oracle.md").unlink()
+
+        errors = validate(root)
+
+        self.assertIn(
+            "missing required artifact: evidence/product-oracle.md",
+            errors,
+        )
+
+    def test_missing_final_recommendation_field_fails(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review_path.write_text(
+            VALID_REVIEW.replace(
+                "**Behavioral evidence:** empirical\n",
+                "",
+            ),
+            encoding="utf-8",
+        )
+
+        errors = validate(root)
+
+        self.assertIn(
+            "final review missing marker: **Behavioral evidence:**",
+            errors,
+        )
+
+    def test_weak_oracle_cannot_block_on_implementation(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review = VALID_REVIEW.replace(
+            "**Oracle fidelity:** authoritative",
+            "**Oracle fidelity:** hypothesis",
+        ).replace(
+            "**Merge readiness:** recommendation only",
+            "**Merge readiness:** blocked on implementation",
+        )
+        review_path.write_text(review, encoding="utf-8")
+
+        errors = validate(root)
+
+        self.assertIn(
+            "blocked on implementation requires stronger oracle, mechanism, and "
+            "scenario fidelity",
+            errors,
+        )
+
+    def test_inferred_mechanism_cannot_block_on_implementation(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review = VALID_REVIEW.replace(
+            "**Mechanism fidelity:** reproduced",
+            "**Mechanism fidelity:** inferred",
+        ).replace(
+            "**Merge readiness:** recommendation only",
+            "**Merge readiness:** blocked on implementation",
+        )
+        review_path.write_text(review, encoding="utf-8")
+
+        errors = validate(root)
+
+        self.assertIn(
+            "blocked on implementation requires stronger oracle, mechanism, and "
+            "scenario fidelity",
+            errors,
+        )
+
+    def test_production_proven_requires_multiple_stress_cases(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review_path.write_text(
+            VALID_REVIEW.replace(
+                "**Candidate proof:** targeted-proven",
+                "**Candidate proof:** production-proven",
+            ),
+            encoding="utf-8",
+        )
+        (root / "empirical/stress-matrix.md").write_text(
+            "| Configuration | Result |\n|---|---|\n| only | pass |\n",
+            encoding="utf-8",
+        )
+
+        errors = validate(root)
+
+        self.assertIn(
+            "production-proven requires a stress matrix with multiple executed cases",
+            errors,
+        )
+
+    def test_production_proven_requires_explicit_coverage_dimensions(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review_path.write_text(
+            VALID_REVIEW.replace(
+                "**Candidate proof:** targeted-proven",
+                "**Candidate proof:** production-proven",
+            ).replace(
+                "**Assertion disposition:** diagnostic-only",
+                "**Assertion disposition:** merge-candidate",
+            ),
+            encoding="utf-8",
+        )
+        (root / "empirical/stress-matrix.md").write_text(
+            "| Configuration | Result |\n"
+            "|---|---|\n"
+            "| Debug | pass |\n"
+            "| Release | pass |\n",
+            encoding="utf-8",
+        )
+
+        errors = validate(root)
+
+        self.assertIn(
+            "production-proven requires an explicit passed or justified "
+            "not-applicable status for: Real producer/runtime boundary",
+            errors,
+        )
+
+    def test_production_proven_accepts_complete_stress_evidence(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review_path.write_text(
+            VALID_REVIEW.replace(
+                "**Candidate proof:** targeted-proven",
+                "**Candidate proof:** production-proven",
+            ).replace(
+                "**Assertion disposition:** diagnostic-only",
+                "**Assertion disposition:** merge-candidate",
+            ),
+            encoding="utf-8",
+        )
+        (root / "empirical/stress-matrix.md").write_text(
+            "**Real producer/runtime boundary:** passed in integration test\n"
+            "**Varied falsification dimensions:** passed across exit paths\n"
+            "**Applicable configurations/platforms:** passed on exact CI matrix\n"
+            "**Neighboring suite:** passed\n"
+            "**Cleanup/interruption paths:** not applicable - synchronous API\n\n"
+            "| Configuration | Result |\n"
+            "|---|---|\n"
+            "| Debug | pass |\n"
+            "| Release | pass |\n",
+            encoding="utf-8",
+        )
+
+        self.assertEqual([], validate(root))
+
+    def test_diagnostic_only_cannot_claim_high_confidence(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review = VALID_REVIEW.replace(
+            "**Candidate proof:** targeted-proven",
+            "**Candidate proof:** diagnostic-only",
+        ).replace(
+            "**Implementation confidence:** medium",
+            "**Implementation confidence:** high",
+        )
+        review_path.write_text(review, encoding="utf-8")
+
+        errors = validate(root)
+
+        self.assertIn(
+            "diagnostic-only candidate proof is incompatible with high confidence",
+            errors,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/skills/aspnetcore-pr-review/scripts/test_validate_artifacts.py
+++ b/.github/skills/aspnetcore-pr-review/scripts/test_validate_artifacts.py
@@ -84,6 +84,17 @@ class ValidateArtifactsTests(unittest.TestCase):
             errors,
         )
 
+    def test_missing_impact_map_fails(self):
+        root = self.create_root()
+        (root / "evidence/impact-map.md").unlink()
+
+        errors = validate(root)
+
+        self.assertIn(
+            "missing required artifact: evidence/impact-map.md",
+            errors,
+        )
+
     def test_missing_final_recommendation_field_fails(self):
         root = self.create_root()
         review_path = root / "final/review.md"

--- a/.github/skills/aspnetcore-pr-review/scripts/test_validate_artifacts.py
+++ b/.github/skills/aspnetcore-pr-review/scripts/test_validate_artifacts.py
@@ -22,6 +22,7 @@ Consensus.
 Assessment.
 
 ## Proof status
+**Frozen-head result:** behavioral-fail
 **Finding proof:** empirical
 **Scenario proof:** empirical
 **Candidate proof:** targeted-proven
@@ -29,7 +30,8 @@ Assessment.
 **Oracle fidelity:** authoritative
 **Mechanism fidelity:** reproduced
 **Scenario fidelity:** proxy
-**Assertion disposition:** diagnostic-only
+**Regression assertion disposition:** optional-regression
+**Diagnostic mutation disposition:** not-applicable
 
 ## Final recommendation
 **Implementation verdict:** REVISE
@@ -100,6 +102,35 @@ class ValidateArtifactsTests(unittest.TestCase):
             errors,
         )
 
+    def test_placeholder_proof_value_fails(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review_path.write_text(
+            VALID_REVIEW.replace(
+                "**Frozen-head result:** behavioral-fail",
+                "**Frozen-head result:** behavioral-fail / pass",
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertIn(
+            "invalid calibrated value for Frozen-head result: behavioral-fail / pass",
+            validate(root),
+        )
+
+    def test_duplicate_calibration_marker_fails(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review_path.write_text(
+            VALID_REVIEW + "\n**Frozen-head result:** pass\n",
+            encoding="utf-8",
+        )
+
+        self.assertIn(
+            "final review contains duplicate marker: **Frozen-head result:**",
+            validate(root),
+        )
+
     def test_weak_oracle_cannot_block_on_implementation(self):
         root = self.create_root()
         review_path = root / "final/review.md"
@@ -115,8 +146,8 @@ class ValidateArtifactsTests(unittest.TestCase):
         errors = validate(root)
 
         self.assertIn(
-            "blocked on implementation requires stronger oracle, mechanism, and "
-            "scenario fidelity",
+            "blocked on implementation requires a proven frozen-head defect and "
+            "stronger oracle, mechanism, scenario, and finding proof",
             errors,
         )
 
@@ -135,9 +166,71 @@ class ValidateArtifactsTests(unittest.TestCase):
         errors = validate(root)
 
         self.assertIn(
-            "blocked on implementation requires stronger oracle, mechanism, and "
-            "scenario fidelity",
+            "blocked on implementation requires a proven frozen-head defect and "
+            "stronger oracle, mechanism, scenario, and finding proof",
             errors,
+        )
+
+    def test_passing_head_cannot_block_on_implementation(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review_path.write_text(
+            VALID_REVIEW.replace(
+                "**Frozen-head result:** behavioral-fail",
+                "**Frozen-head result:** pass",
+            ).replace(
+                "**Merge readiness:** recommendation only",
+                "**Merge readiness:** blocked on implementation",
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertIn(
+            "blocked on implementation requires a proven frozen-head defect and "
+            "stronger oracle, mechanism, scenario, and finding proof",
+            validate(root),
+        )
+
+    def test_structural_head_defect_can_block_on_implementation(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review_path.write_text(
+            VALID_REVIEW.replace(
+                "**Frozen-head result:** behavioral-fail",
+                "**Frozen-head result:** structural-defect",
+            ).replace(
+                "**Finding proof:** empirical",
+                "**Finding proof:** structural",
+            ).replace(
+                "**Scenario proof:** empirical",
+                "**Scenario proof:** structural",
+            ).replace(
+                "**Merge readiness:** recommendation only",
+                "**Merge readiness:** blocked on implementation",
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertEqual([], validate(root))
+
+    def test_behavioral_blocker_requires_empirical_proof(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review_path.write_text(
+            VALID_REVIEW.replace(
+                "**Finding proof:** empirical",
+                "**Finding proof:** structural",
+            ).replace(
+                "**Merge readiness:** recommendation only",
+                "**Merge readiness:** blocked on implementation",
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertIn(
+            "blocked on implementation requires a proven frozen-head defect and "
+            "stronger oracle, mechanism, scenario, and finding proof",
+            validate(root),
         )
 
     def test_production_proven_requires_multiple_stress_cases(self):
@@ -151,6 +244,7 @@ class ValidateArtifactsTests(unittest.TestCase):
             encoding="utf-8",
         )
         (root / "empirical/stress-matrix.md").write_text(
+            "## Executed cases\n"
             "| Configuration | Result |\n|---|---|\n| only | pass |\n",
             encoding="utf-8",
         )
@@ -158,7 +252,7 @@ class ValidateArtifactsTests(unittest.TestCase):
         errors = validate(root)
 
         self.assertIn(
-            "production-proven requires a stress matrix with multiple executed cases",
+            "production-proven requires multiple distinct executed cases",
             errors,
         )
 
@@ -170,12 +264,13 @@ class ValidateArtifactsTests(unittest.TestCase):
                 "**Candidate proof:** targeted-proven",
                 "**Candidate proof:** production-proven",
             ).replace(
-                "**Assertion disposition:** diagnostic-only",
-                "**Assertion disposition:** merge-candidate",
+                "**Regression assertion disposition:** optional-regression",
+                "**Regression assertion disposition:** required-regression",
             ),
             encoding="utf-8",
         )
         (root / "empirical/stress-matrix.md").write_text(
+            "## Executed cases\n"
             "| Configuration | Result |\n"
             "|---|---|\n"
             "| Debug | pass |\n"
@@ -199,8 +294,8 @@ class ValidateArtifactsTests(unittest.TestCase):
                 "**Candidate proof:** targeted-proven",
                 "**Candidate proof:** production-proven",
             ).replace(
-                "**Assertion disposition:** diagnostic-only",
-                "**Assertion disposition:** merge-candidate",
+                "**Regression assertion disposition:** optional-regression",
+                "**Regression assertion disposition:** required-regression",
             ),
             encoding="utf-8",
         )
@@ -210,6 +305,7 @@ class ValidateArtifactsTests(unittest.TestCase):
             "**Applicable configurations/platforms:** passed on exact CI matrix\n"
             "**Neighboring suite:** passed\n"
             "**Cleanup/interruption paths:** not applicable - synchronous API\n\n"
+            "## Executed cases\n"
             "| Configuration | Result |\n"
             "|---|---|\n"
             "| Debug | pass |\n"
@@ -218,6 +314,148 @@ class ValidateArtifactsTests(unittest.TestCase):
         )
 
         self.assertEqual([], validate(root))
+
+    def test_structural_defect_cannot_claim_production_proven(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review_path.write_text(
+            VALID_REVIEW.replace(
+                "**Candidate proof:** targeted-proven",
+                "**Candidate proof:** production-proven",
+            ).replace(
+                "**Frozen-head result:** behavioral-fail",
+                "**Frozen-head result:** structural-defect",
+            ).replace(
+                "**Finding proof:** empirical",
+                "**Finding proof:** structural",
+            ).replace(
+                "**Regression assertion disposition:** optional-regression",
+                "**Regression assertion disposition:** required-regression",
+            ),
+            encoding="utf-8",
+        )
+        (root / "empirical/stress-matrix.md").write_text(
+            "**Real producer/runtime boundary:** passed\n"
+            "**Varied falsification dimensions:** passed\n"
+            "**Applicable configurations/platforms:** passed\n"
+            "**Neighboring suite:** passed\n"
+            "**Cleanup/interruption paths:** not applicable - synchronous API\n\n"
+            "## Executed cases\n"
+            "| Configuration | Result |\n"
+            "|---|---|\n"
+            "| Debug | pass |\n"
+            "| Release | pass |\n",
+            encoding="utf-8",
+        )
+
+        self.assertIn(
+            "production-proven requires empirical finding and scenario proof",
+            validate(root),
+        )
+
+    def test_production_proven_rejects_weak_oracle_fidelity(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review_path.write_text(
+            VALID_REVIEW.replace(
+                "**Candidate proof:** targeted-proven",
+                "**Candidate proof:** production-proven",
+            ).replace(
+                "**Oracle fidelity:** authoritative",
+                "**Oracle fidelity:** hypothesis",
+            ).replace(
+                "**Regression assertion disposition:** optional-regression",
+                "**Regression assertion disposition:** required-regression",
+            ),
+            encoding="utf-8",
+        )
+        (root / "empirical/stress-matrix.md").write_text(
+            "**Real producer/runtime boundary:** passed\n"
+            "**Varied falsification dimensions:** passed\n"
+            "**Applicable configurations/platforms:** passed\n"
+            "**Neighboring suite:** passed\n"
+            "**Cleanup/interruption paths:** not applicable - synchronous API\n\n"
+            "## Executed cases\n"
+            "| Configuration | Result |\n"
+            "|---|---|\n"
+            "| Debug | pass |\n"
+            "| Release | pass |\n",
+            encoding="utf-8",
+        )
+
+        self.assertIn(
+            "production-proven is incompatible with weak oracle, mechanism, or "
+            "scenario fidelity",
+            validate(root),
+        )
+
+    def test_production_proven_rejects_duplicate_executed_cases(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review_path.write_text(
+            VALID_REVIEW.replace(
+                "**Candidate proof:** targeted-proven",
+                "**Candidate proof:** production-proven",
+            ).replace(
+                "**Regression assertion disposition:** optional-regression",
+                "**Regression assertion disposition:** required-regression",
+            ),
+            encoding="utf-8",
+        )
+        (root / "empirical/stress-matrix.md").write_text(
+            "**Real producer/runtime boundary:** passed\n"
+            "**Varied falsification dimensions:** passed\n"
+            "**Applicable configurations/platforms:** passed\n"
+            "**Neighboring suite:** passed\n"
+            "**Cleanup/interruption paths:** not applicable - synchronous API\n\n"
+            "## Executed cases\n"
+            "| Configuration | Result |\n"
+            "|---|---|\n"
+            "| Debug | pass |\n"
+            "| Debug | pass |\n",
+            encoding="utf-8",
+        )
+
+        self.assertIn(
+            "production-proven requires multiple distinct executed cases",
+            validate(root),
+        )
+
+    def test_production_proven_rejects_duplicate_executed_sections(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review_path.write_text(
+            VALID_REVIEW.replace(
+                "**Candidate proof:** targeted-proven",
+                "**Candidate proof:** production-proven",
+            ).replace(
+                "**Regression assertion disposition:** optional-regression",
+                "**Regression assertion disposition:** required-regression",
+            ),
+            encoding="utf-8",
+        )
+        (root / "empirical/stress-matrix.md").write_text(
+            "**Real producer/runtime boundary:** passed\n"
+            "**Varied falsification dimensions:** passed\n"
+            "**Applicable configurations/platforms:** passed\n"
+            "**Neighboring suite:** passed\n"
+            "**Cleanup/interruption paths:** not applicable - synchronous API\n\n"
+            "## Executed cases\n"
+            "| Configuration | Result |\n"
+            "|---|---|\n"
+            "| Debug | pass |\n"
+            "| Release | pass |\n\n"
+            "## Executed cases\n"
+            "| Configuration | Result |\n"
+            "|---|---|\n"
+            "| Other | pass |\n",
+            encoding="utf-8",
+        )
+
+        self.assertIn(
+            "production-proven requires exactly one Executed cases section",
+            validate(root),
+        )
 
     def test_diagnostic_only_cannot_claim_high_confidence(self):
         root = self.create_root()
@@ -236,6 +474,54 @@ class ValidateArtifactsTests(unittest.TestCase):
         self.assertIn(
             "diagnostic-only candidate proof is incompatible with high confidence",
             errors,
+        )
+
+    def test_legacy_merge_candidate_disposition_fails(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review_path.write_text(
+            VALID_REVIEW.replace(
+                "**Regression assertion disposition:** optional-regression",
+                "**Regression assertion disposition:** merge-candidate",
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertIn(
+            "regression assertion disposition must use a calibrated severity value",
+            validate(root),
+        )
+
+    def test_negated_assertion_disposition_fails(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review_path.write_text(
+            VALID_REVIEW.replace(
+                "**Regression assertion disposition:** optional-regression",
+                "**Regression assertion disposition:** not required-regression",
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertIn(
+            "regression assertion disposition must use a calibrated severity value",
+            validate(root),
+        )
+
+    def test_invalid_diagnostic_mutation_disposition_fails(self):
+        root = self.create_root()
+        review_path = root / "final/review.md"
+        review_path.write_text(
+            VALID_REVIEW.replace(
+                "**Diagnostic mutation disposition:** not-applicable",
+                "**Diagnostic mutation disposition:** required-regression",
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertIn(
+            "diagnostic mutation disposition must use a calibrated severity value",
+            validate(root),
         )
 
 

--- a/.github/skills/aspnetcore-pr-review/scripts/test_validate_evals.py
+++ b/.github/skills/aspnetcore-pr-review/scripts/test_validate_evals.py
@@ -1,0 +1,234 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from validate_evals import (
+    file_sha256,
+    held_out_hash,
+    read_documents,
+    summary,
+    validate_documents,
+)
+
+
+def valid_eval() -> dict:
+    return {
+        "id": 1,
+        "prompt": "Review a component behavior without using its internal name.",
+        "files": ["fixture.md"],
+        "expectations": [
+            "The review establishes the observable behavior.",
+            "The review rejects a stale-element failure as evidence.",
+        ],
+        "eval_metadata": {
+            "mechanism": "lifecycle-retention",
+            "provenance": {"kind": "historical", "source": "issue-123"},
+            "area": "Components",
+            "score_family": "lifecycle",
+            "tier": "train",
+            "discovery_mode": "discovery",
+            "controls": {"positive": [0], "negative": [1]},
+            "forbidden_prompt_terms": ["stale-element"],
+        },
+    }
+
+
+class ValidateEvalsTests(unittest.TestCase):
+    def test_valid_metadata_passes_and_reports_family_weight(self):
+        result = validate_documents([("valid.json", {"evals": [valid_eval()]})])
+
+        self.assertEqual([], result.errors)
+        self.assertEqual(1, summary(result)["raw_count"])
+        self.assertEqual(1.0, summary(result)["family_weights"][0]["weight"])
+
+    def test_missing_metadata_fields_fail(self):
+        eval_data = valid_eval()
+        del eval_data["eval_metadata"]["area"]
+        del eval_data["eval_metadata"]["provenance"]["source"]
+
+        result = validate_documents([("invalid.json", {"evals": [eval_data]})])
+
+        self.assertIn(
+            "invalid.json: evals[0].eval_metadata.area must be a nonempty string",
+            result.errors,
+        )
+        self.assertIn(
+            "invalid.json: evals[0].eval_metadata.provenance.source must be a nonempty string",
+            result.errors,
+        )
+
+    def test_missing_id_fails(self):
+        eval_data = valid_eval()
+        del eval_data["id"]
+
+        result = validate_documents([("invalid.json", {"evals": [eval_data]})])
+
+        self.assertIn(
+            "invalid.json: evals[0].id must be a positive integer",
+            result.errors,
+        )
+
+    def test_invalid_controls_fail(self):
+        eval_data = valid_eval()
+        eval_data["eval_metadata"]["controls"] = {
+            "positive": [0, 3],
+            "negative": [0],
+        }
+
+        result = validate_documents([("invalid.json", {"evals": [eval_data]})])
+
+        self.assertIn(
+            "invalid.json: evals[0].eval_metadata.controls.positive index 3 must reference expectations",
+            result.errors,
+        )
+        self.assertIn(
+            "invalid.json: evals[0].eval_metadata.controls positive and negative must be disjoint",
+            result.errors,
+        )
+
+    def test_forbidden_prompt_term_fails_case_insensitively(self):
+        eval_data = valid_eval()
+        eval_data["eval_metadata"]["forbidden_prompt_terms"] = ["COMPONENT"]
+
+        result = validate_documents([("leaked.json", {"evals": [eval_data]})])
+
+        self.assertIn(
+            "leaked.json: evals[0].eval_metadata.forbidden_prompt_terms contains prompt term: 'COMPONENT'",
+            result.errors,
+        )
+
+    def test_discovery_prompt_rejects_pull_request_identity(self):
+        prompts = [
+            "Review PR #123.",
+            "Review issue #68114.",
+            "Review #68037.",
+            "Review head 2df89be.",
+        ]
+        for prompt in prompts:
+            with self.subTest(prompt=prompt):
+                eval_data = valid_eval()
+                eval_data["prompt"] = prompt
+
+                result = validate_documents(
+                    [("leaked.json", {"evals": [eval_data]})]
+                )
+
+                self.assertIn(
+                    "leaked.json: evals[0].prompt must not expose issue, "
+                    "pull request, or commit identities in discovery mode",
+                    result.errors,
+                )
+
+    def test_concentration_is_warning_only(self):
+        first = valid_eval()
+        second = valid_eval()
+        second["id"] = 2
+
+        result = validate_documents([("concentrated.json", {"evals": [first, second]})])
+
+        self.assertEqual([], result.errors)
+        self.assertTrue(
+            any("family concentration" in warning for warning in result.warnings)
+        )
+        self.assertTrue(
+            any("provenance concentration" in warning for warning in result.warnings)
+        )
+
+    def test_family_weights_are_scoped_to_each_eval_file(self):
+        first = valid_eval()
+        second = valid_eval()
+        second["id"] = 2
+
+        result = validate_documents(
+            [
+                ("review-evals.json", {"evals": [first]}),
+                ("try-fix-evals.json", {"evals": [second]}),
+            ]
+        )
+        weights = summary(result)["family_weights"]
+
+        self.assertEqual([1.0, 1.0], [weight["weight"] for weight in weights])
+
+    def test_family_weights_are_normalized_within_each_tier(self):
+        first = valid_eval()
+        second = valid_eval()
+        second["id"] = 2
+        second["eval_metadata"]["score_family"] = "oracle"
+
+        result = validate_documents([("evals.json", {"evals": [first, second]})])
+        weights = summary(result)["family_weights"]
+
+        self.assertEqual(1.0, sum(weight["weight"] for weight in weights))
+        self.assertEqual([0.5, 0.5], [weight["weight"] for weight in weights])
+
+    def test_held_out_hash_rejects_mutation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory) / "fixture.md"
+            fixture.write_text("fixture", encoding="utf-8")
+            eval_data = valid_eval()
+            eval_data["files"] = [str(fixture)]
+            eval_data["eval_metadata"]["tier"] = "held_out"
+            eval_data["eval_metadata"]["fixture_hashes"] = {
+                str(fixture): file_sha256(fixture)
+            }
+            eval_data["eval_metadata"]["frozen_hash"] = held_out_hash(eval_data)
+            eval_data["prompt"] = "Mutated after freezing."
+
+            result = validate_documents(
+                [(str(Path(directory) / "evals.json"), {"evals": [eval_data]})]
+            )
+
+        self.assertIn(
+            f"{Path(directory) / 'evals.json'}: "
+            "evals[0].eval_metadata.frozen_hash does not match the held-out eval",
+            result.errors,
+        )
+
+    def test_held_out_fixture_hash_rejects_mutation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            fixture = Path(directory) / "fixture.md"
+            fixture.write_text("fixture", encoding="utf-8")
+            eval_data = valid_eval()
+            eval_data["files"] = [str(fixture)]
+            eval_data["eval_metadata"]["tier"] = "held_out"
+            eval_data["eval_metadata"]["fixture_hashes"] = {
+                str(fixture): file_sha256(fixture)
+            }
+            eval_data["eval_metadata"]["frozen_hash"] = held_out_hash(eval_data)
+            fixture.write_text("mutated fixture", encoding="utf-8")
+
+            result = validate_documents(
+                [(str(Path(directory) / "evals.json"), {"evals": [eval_data]})]
+            )
+
+        self.assertTrue(
+            any("does not match the fixture" in error for error in result.errors)
+        )
+
+    def test_duplicate_eval_ids_fail(self):
+        first = valid_eval()
+        second = valid_eval()
+
+        result = validate_documents(
+            [("duplicates.json", {"evals": [first, second]})]
+        )
+
+        self.assertIn(
+            "duplicates.json.evals contains duplicate ids: 1",
+            result.errors,
+        )
+
+    def test_checked_in_eval_suites_pass(self):
+        skill_root = Path(__file__).resolve().parents[1]
+        eval_paths = [
+            skill_root / "evals" / "evals.json",
+            skill_root.parent / "aspnetcore-try-fix" / "evals" / "evals.json",
+        ]
+        documents, read_errors = read_documents(eval_paths)
+
+        self.assertEqual([], read_errors)
+        self.assertEqual([], validate_documents(documents).errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/skills/aspnetcore-pr-review/scripts/validate_artifacts.py
+++ b/.github/skills/aspnetcore-pr-review/scripts/validate_artifacts.py
@@ -10,6 +10,7 @@ REQUIRED_NONEMPTY = (
     "evidence/manifest.md",
     "evidence/product-oracle.md",
     "evidence/head-drift.md",
+    "evidence/impact-map.md",
     "candidates/candidate-a.md",
     "candidates/candidate-b.md",
     "candidates/candidate-c.md",

--- a/.github/skills/aspnetcore-pr-review/scripts/validate_artifacts.py
+++ b/.github/skills/aspnetcore-pr-review/scripts/validate_artifacts.py
@@ -19,6 +19,7 @@ REQUIRED_NONEMPTY = (
     "cross-examination/candidate-c.md",
     "cross-examination/candidate-d.md",
     "empirical/manifest.md",
+    "empirical/head.log",
     "empirical/claim-matrix.md",
     "empirical/stress-matrix.md",
     "empirical/result.md",
@@ -44,6 +45,7 @@ REQUIRED_FINAL_MARKERS = (
     "## Adversarial consensus",
     "## Test assessment",
     "## Proof status",
+    "**Frozen-head result:**",
     "**Finding proof:**",
     "**Scenario proof:**",
     "**Candidate proof:**",
@@ -51,7 +53,8 @@ REQUIRED_FINAL_MARKERS = (
     "**Oracle fidelity:**",
     "**Mechanism fidelity:**",
     "**Scenario fidelity:**",
-    "**Assertion disposition:**",
+    "**Regression assertion disposition:**",
+    "**Diagnostic mutation disposition:**",
     "## Final recommendation",
     "**Implementation verdict:**",
     "**Behavioral evidence:**",
@@ -77,6 +80,14 @@ def extract_label(content: str, label: str) -> str | None:
     return match.group(1).strip().lower() if match else None
 
 
+def count_marker(content: str, marker: str) -> int:
+    if marker.startswith("#"):
+        pattern = rf"^{re.escape(marker)}\s*$"
+    else:
+        pattern = rf"^{re.escape(marker)}.*$"
+    return len(re.findall(pattern, content, re.MULTILINE))
+
+
 def validate(root: Path) -> list[str]:
     errors: list[str] = []
 
@@ -97,26 +108,105 @@ def validate(root: Path) -> list[str]:
 
     content = final_path.read_text(encoding="utf-8", errors="replace")
     for marker in REQUIRED_FINAL_MARKERS:
-        if marker not in content:
+        occurrences = count_marker(content, marker)
+        if occurrences == 0:
             errors.append(f"final review missing marker: {marker}")
+        elif occurrences > 1:
+            errors.append(f"final review contains duplicate marker: {marker}")
 
+    head_result = extract_label(content, "Frozen-head result")
+    finding_proof = extract_label(content, "Finding proof")
+    scenario_proof = extract_label(content, "Scenario proof")
+    product_oracle = extract_label(content, "Product oracle")
     oracle = extract_label(content, "Oracle fidelity")
     mechanism = extract_label(content, "Mechanism fidelity")
     scenario = extract_label(content, "Scenario fidelity")
     candidate = extract_label(content, "Candidate proof")
-    assertion = extract_label(content, "Assertion disposition")
+    regression_assertion = extract_label(content, "Regression assertion disposition")
+    diagnostic_mutation = extract_label(content, "Diagnostic mutation disposition")
     readiness = extract_label(content, "Merge readiness")
     confidence = extract_label(content, "Implementation confidence")
+    implementation_verdict = extract_label(content, "Implementation verdict")
+    behavioral_evidence = extract_label(content, "Behavioral evidence")
+
+    allowed_labels = {
+        "Frozen-head result": (
+            head_result,
+            {"behavioral-fail", "structural-defect", "pass", "blocked", "not-applicable"},
+        ),
+        "Finding proof": (finding_proof, {"empirical", "structural", "missing"}),
+        "Scenario proof": (scenario_proof, {"empirical", "structural", "missing"}),
+        "Candidate proof": (
+            candidate,
+            {
+                "production-proven",
+                "targeted-proven",
+                "diagnostic-only",
+                "rejected",
+                "blocked",
+                "none",
+            },
+        ),
+        "Product oracle": (
+            product_oracle,
+            {"documented", "author-confirmed", "test-encoded", "inferred", "unknown"},
+        ),
+        "Oracle fidelity": (
+            oracle,
+            {"authoritative", "corroborated", "hypothesis", "unknown"},
+        ),
+        "Mechanism fidelity": (
+            mechanism,
+            {"reproduced", "structural", "inferred", "unknown"},
+        ),
+        "Scenario fidelity": (scenario, {"exact", "proxy", "synthetic", "missing"}),
+        "Implementation verdict": (
+            implementation_verdict,
+            {"keep current fix", "revise", "replace"},
+        ),
+        "Behavioral evidence": (
+            behavioral_evidence,
+            {"empirical", "structural", "missing"},
+        ),
+        "Merge readiness": (
+            readiness,
+            {
+                "ready",
+                "recommendation only",
+                "blocked on evidence",
+                "blocked on product oracle",
+                "blocked on implementation",
+            },
+        ),
+        "Implementation confidence": (confidence, {"high", "medium", "low"}),
+    }
+    for label, (value, allowed) in allowed_labels.items():
+        if value not in allowed:
+            errors.append(f"invalid calibrated value for {label}: {value or 'missing'}")
 
     weak_oracle = oracle in {"hypothesis", "unknown"}
     weak_mechanism = mechanism in {"inferred", "unknown"}
     weak_scenario = scenario in {"synthetic", "missing"}
+    proven_head_defect = head_result in {"behavioral-fail", "structural-defect"}
+    proof_matches_head = (
+        head_result == "behavioral-fail"
+        and finding_proof == "empirical"
+        and scenario_proof == "empirical"
+    ) or (
+        head_result == "structural-defect"
+        and finding_proof in {"empirical", "structural"}
+        and scenario_proof in {"empirical", "structural"}
+    )
     if readiness == "blocked on implementation" and (
-        weak_oracle or weak_mechanism or weak_scenario
+        weak_oracle
+        or weak_mechanism
+        or weak_scenario
+        or not proven_head_defect
+        or not proof_matches_head
     ):
         errors.append(
-            "blocked on implementation requires stronger oracle, mechanism, and "
-            "scenario fidelity"
+            "blocked on implementation requires a proven frozen-head defect and "
+            "stronger oracle, mechanism, scenario, and finding proof"
         )
 
     if confidence == "high" and (weak_oracle or weak_mechanism or weak_scenario):
@@ -145,20 +235,79 @@ def validate(root: Path) -> list[str]:
                     f"not-applicable status for: {dimension}"
                 )
 
-        table_rows = [
-            line
-            for line in stress.splitlines()
-            if line.strip().startswith("|")
-            and "---" not in line
-        ]
-        data_rows = table_rows[1:] if table_rows else []
-        if len(data_rows) < 2:
+        executed_headings = list(
+            re.finditer(r"^## Executed cases\s*$", stress, re.MULTILINE)
+        )
+        if not executed_headings:
             errors.append(
-                "production-proven requires a stress matrix with multiple executed cases"
+                "production-proven requires an explicit Executed cases section"
             )
+        elif len(executed_headings) > 1:
+            errors.append(
+                "production-proven requires exactly one Executed cases section"
+            )
+        else:
+            section_start = executed_headings[0].end()
+            next_heading = re.search(
+                r"^## ",
+                stress[section_start:],
+                re.MULTILINE,
+            )
+            section_end = (
+                section_start + next_heading.start()
+                if next_heading is not None
+                else len(stress)
+            )
+            table_rows = [
+                line.strip()
+                for line in stress[section_start:section_end].splitlines()
+                if line.strip().startswith("|") and "---" not in line
+            ]
+            data_rows = table_rows[1:] if table_rows else []
+            distinct_rows = set(data_rows)
+            if len(distinct_rows) < 2:
+                errors.append(
+                    "production-proven requires multiple distinct executed cases"
+                )
 
-    if candidate == "production-proven" and assertion != "merge-candidate":
-        errors.append("production-proven requires a merge-candidate assertion disposition")
+    if regression_assertion not in {
+        "required-regression",
+        "optional-regression",
+        "rejected",
+    }:
+        errors.append(
+            "regression assertion disposition must use a calibrated severity value"
+        )
+
+    if diagnostic_mutation not in {"diagnostic-only", "rejected", "not-applicable"}:
+        errors.append(
+            "diagnostic mutation disposition must use a calibrated severity value"
+        )
+
+    if candidate == "production-proven" and not proven_head_defect:
+        errors.append("production-proven requires a proven frozen-head defect")
+
+    if candidate == "production-proven" and (
+        weak_oracle or weak_mechanism or weak_scenario
+    ):
+        errors.append(
+            "production-proven is incompatible with weak oracle, mechanism, or "
+            "scenario fidelity"
+        )
+
+    if candidate == "production-proven" and (
+        finding_proof != "empirical" or scenario_proof != "empirical"
+    ):
+        errors.append(
+            "production-proven requires empirical finding and scenario proof"
+        )
+
+    if candidate == "production-proven" and (
+        regression_assertion != "required-regression"
+    ):
+        errors.append(
+            "production-proven requires a required-regression assertion disposition"
+        )
 
     return errors
 

--- a/.github/skills/aspnetcore-pr-review/scripts/validate_artifacts.py
+++ b/.github/skills/aspnetcore-pr-review/scripts/validate_artifacts.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+REQUIRED_NONEMPTY = (
+    "evidence/manifest.md",
+    "evidence/product-oracle.md",
+    "evidence/head-drift.md",
+    "candidates/candidate-a.md",
+    "candidates/candidate-b.md",
+    "candidates/candidate-c.md",
+    "candidates/candidate-d.md",
+    "cross-examination/candidate-a.md",
+    "cross-examination/candidate-b.md",
+    "cross-examination/candidate-c.md",
+    "cross-examination/candidate-d.md",
+    "empirical/manifest.md",
+    "empirical/claim-matrix.md",
+    "empirical/stress-matrix.md",
+    "empirical/result.md",
+    "final/repository-oracle.md",
+    "final/review.md",
+)
+
+REQUIRED_EXISTING = (
+    "evidence/tracked.diff",
+    "empirical/before.diff",
+    "empirical/diagnostic.diff",
+    "empirical/implementation.diff",
+    "empirical/red.log",
+    "empirical/candidate.diff",
+    "empirical/green.log",
+)
+
+REQUIRED_FINAL_MARKERS = (
+    "# Multi-Model Review",
+    "**Orchestrator:**",
+    "## Current fix",
+    "## Independent candidates",
+    "## Adversarial consensus",
+    "## Test assessment",
+    "## Proof status",
+    "**Finding proof:**",
+    "**Scenario proof:**",
+    "**Candidate proof:**",
+    "**Product oracle:**",
+    "**Oracle fidelity:**",
+    "**Mechanism fidelity:**",
+    "**Scenario fidelity:**",
+    "**Assertion disposition:**",
+    "## Final recommendation",
+    "**Implementation verdict:**",
+    "**Behavioral evidence:**",
+    "**Merge readiness:**",
+    "**Implementation confidence:**",
+    "**Reason:**",
+    "## Required follow-ups",
+    "## Repository oracle gaps",
+    "## Suggested review comments",
+)
+
+PRODUCTION_STRESS_DIMENSIONS = (
+    "Real producer/runtime boundary",
+    "Varied falsification dimensions",
+    "Applicable configurations/platforms",
+    "Neighboring suite",
+    "Cleanup/interruption paths",
+)
+
+
+def extract_label(content: str, label: str) -> str | None:
+    match = re.search(rf"^\*\*{re.escape(label)}:\*\*\s*(.+?)\s*$", content, re.MULTILINE)
+    return match.group(1).strip().lower() if match else None
+
+
+def validate(root: Path) -> list[str]:
+    errors: list[str] = []
+
+    for relative_path in REQUIRED_NONEMPTY:
+        path = root / relative_path
+        if not path.is_file():
+            errors.append(f"missing required artifact: {relative_path}")
+        elif not path.read_text(encoding="utf-8", errors="replace").strip():
+            errors.append(f"required artifact is empty: {relative_path}")
+
+    for relative_path in REQUIRED_EXISTING:
+        if not (root / relative_path).is_file():
+            errors.append(f"missing required artifact: {relative_path}")
+
+    final_path = root / "final/review.md"
+    if not final_path.is_file():
+        return errors
+
+    content = final_path.read_text(encoding="utf-8", errors="replace")
+    for marker in REQUIRED_FINAL_MARKERS:
+        if marker not in content:
+            errors.append(f"final review missing marker: {marker}")
+
+    oracle = extract_label(content, "Oracle fidelity")
+    mechanism = extract_label(content, "Mechanism fidelity")
+    scenario = extract_label(content, "Scenario fidelity")
+    candidate = extract_label(content, "Candidate proof")
+    assertion = extract_label(content, "Assertion disposition")
+    readiness = extract_label(content, "Merge readiness")
+    confidence = extract_label(content, "Implementation confidence")
+
+    weak_oracle = oracle in {"hypothesis", "unknown"}
+    weak_mechanism = mechanism in {"inferred", "unknown"}
+    weak_scenario = scenario in {"synthetic", "missing"}
+    if readiness == "blocked on implementation" and (
+        weak_oracle or weak_mechanism or weak_scenario
+    ):
+        errors.append(
+            "blocked on implementation requires stronger oracle, mechanism, and "
+            "scenario fidelity"
+        )
+
+    if confidence == "high" and (weak_oracle or weak_mechanism or weak_scenario):
+        errors.append(
+            "high confidence is incompatible with weak oracle, mechanism, or "
+            "scenario fidelity"
+        )
+
+    if candidate == "diagnostic-only" and confidence == "high":
+        errors.append("diagnostic-only candidate proof is incompatible with high confidence")
+
+    if candidate == "diagnostic-only" and readiness == "ready":
+        errors.append("diagnostic-only candidate proof is incompatible with ready")
+
+    stress_path = root / "empirical/stress-matrix.md"
+    if candidate == "production-proven" and stress_path.is_file():
+        stress = stress_path.read_text(encoding="utf-8", errors="replace")
+        for dimension in PRODUCTION_STRESS_DIMENSIONS:
+            status = extract_label(stress, dimension)
+            if status is None or not (
+                status.startswith("passed")
+                or re.match(r"^not applicable\s*[-:]\s*\S", status)
+            ):
+                errors.append(
+                    "production-proven requires an explicit passed or justified "
+                    f"not-applicable status for: {dimension}"
+                )
+
+        table_rows = [
+            line
+            for line in stress.splitlines()
+            if line.strip().startswith("|")
+            and "---" not in line
+        ]
+        data_rows = table_rows[1:] if table_rows else []
+        if len(data_rows) < 2:
+            errors.append(
+                "production-proven requires a stress matrix with multiple executed cases"
+            )
+
+    if candidate == "production-proven" and assertion != "merge-candidate":
+        errors.append("production-proven requires a merge-candidate assertion disposition")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate ASP.NET Core review artifacts and proof calibration."
+    )
+    parser.add_argument("artifact_root", type=Path)
+    args = parser.parse_args()
+
+    errors = validate(args.artifact_root)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print("ASP.NET Core review artifacts are complete and calibrated.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/aspnetcore-pr-review/scripts/validate_evals.py
+++ b/.github/skills/aspnetcore-pr-review/scripts/validate_evals.py
@@ -1,0 +1,588 @@
+#!/usr/bin/env python3
+
+"""Validate anti-overfit metadata on ASP.NET Core review skill evals."""
+
+import argparse
+import copy
+import hashlib
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+KEBAB_CASE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+PROVENANCE_KINDS = {"pr", "historical", "synthetic"}
+TIERS = {"train", "held_out"}
+DISCOVERY_MODES = {"discovery", "verification"}
+HIGH_OVERLAP_THRESHOLD = 0.60
+MEANINGFUL_TOKEN = re.compile(r"[a-z0-9][a-z0-9_-]{3,}")
+ISSUE_OR_PULL_REQUEST = re.compile(
+    r"(?:\b(?:pull request|pr|issue)\s*#?\d+|#\d{3,})",
+    re.IGNORECASE,
+)
+COMMIT_SHA = re.compile(
+    r"\b(?=[0-9a-f]{7,40}\b)(?=[0-9a-f]*\d)[0-9a-f]{7,40}\b",
+    re.IGNORECASE,
+)
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True)
+class EvalRecord:
+    source: str
+    index: int
+    identifier: str
+    tier: str
+    family: str
+    provenance: str
+    area: str
+    prompt_overlap: float
+
+
+@dataclass
+class ValidationResult:
+    errors: list[str]
+    warnings: list[str]
+    records: list[EvalRecord]
+
+
+def is_nonempty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def indexed_name(source: str, index: int) -> str:
+    return f"{source}: evals[{index}]"
+
+
+def meaningful_tokens(value: str) -> set[str]:
+    return set(MEANINGFUL_TOKEN.findall(value.casefold()))
+
+
+def prompt_expectation_overlap(prompt: str, expectations: list[str]) -> float:
+    prompt_tokens = meaningful_tokens(prompt)
+    expectation_tokens = meaningful_tokens(" ".join(expectations))
+    if not prompt_tokens or not expectation_tokens:
+        return 0.0
+    return len(prompt_tokens & expectation_tokens) / len(expectation_tokens)
+
+
+def held_out_hash(eval_data: dict[str, Any]) -> str:
+    normalized = copy.deepcopy(eval_data)
+    metadata = normalized.get("eval_metadata")
+    if isinstance(metadata, dict):
+        metadata.pop("frozen_hash", None)
+    encoded = json.dumps(
+        normalized,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def resolve_fixture_path(source: str, fixture: str) -> Path | None:
+    fixture_path = Path(fixture)
+    if fixture_path.is_absolute() and fixture_path.is_file():
+        return fixture_path
+
+    source_path = Path(source).resolve()
+    for parent in (source_path.parent, *source_path.parents):
+        candidate = parent / fixture_path
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def validate_eval(eval_data: Any, source: str, index: int) -> tuple[list[str], EvalRecord | None]:
+    errors: list[str] = []
+    name = indexed_name(source, index)
+    if not isinstance(eval_data, dict):
+        return [f"{name} must be an object"], None
+
+    identifier_value = eval_data.get("id")
+    if not (
+        isinstance(identifier_value, int)
+        and not isinstance(identifier_value, bool)
+        and identifier_value > 0
+    ):
+        errors.append(f"{name}.id must be a positive integer")
+
+    prompt = eval_data.get("prompt")
+    if not is_nonempty_string(prompt):
+        errors.append(f"{name}.prompt must be a nonempty string")
+        prompt = ""
+
+    expectations_data = eval_data.get("expectations")
+    if not isinstance(expectations_data, list) or not expectations_data:
+        errors.append(f"{name}.expectations must be a nonempty array")
+        expectations: list[str] = []
+    elif not all(is_nonempty_string(item) for item in expectations_data):
+        errors.append(f"{name}.expectations must contain only nonempty strings")
+        expectations = []
+    else:
+        expectations = expectations_data
+
+    files = eval_data.get("files")
+    if not isinstance(files, list) or not all(is_nonempty_string(item) for item in files):
+        errors.append(f"{name}.files must be an array of nonempty strings")
+        files = []
+    elif Path(source).is_file():
+        for fixture in files:
+            if resolve_fixture_path(source, fixture) is None:
+                errors.append(f"{name}.files fixture does not exist: {fixture}")
+
+    metadata = eval_data.get("eval_metadata")
+    if not isinstance(metadata, dict):
+        return errors + [f"{name}.eval_metadata must be an object"], None
+
+    mechanism = metadata.get("mechanism")
+    if not is_nonempty_string(mechanism) or not KEBAB_CASE.fullmatch(mechanism):
+        errors.append(f"{name}.eval_metadata.mechanism must be nonempty kebab-case")
+
+    area = metadata.get("area")
+    if not is_nonempty_string(area):
+        errors.append(f"{name}.eval_metadata.area must be a nonempty string")
+
+    family = metadata.get("score_family")
+    if not is_nonempty_string(family) or not KEBAB_CASE.fullmatch(family):
+        errors.append(f"{name}.eval_metadata.score_family must be nonempty kebab-case")
+
+    tier = metadata.get("tier")
+    if tier not in TIERS:
+        errors.append(f"{name}.eval_metadata.tier must be train or held_out")
+
+    discovery_mode = metadata.get("discovery_mode")
+    if discovery_mode not in DISCOVERY_MODES:
+        errors.append(
+            f"{name}.eval_metadata.discovery_mode must be discovery or verification"
+        )
+
+    provenance = metadata.get("provenance")
+    provenance_label = ""
+    if not isinstance(provenance, dict):
+        errors.append(f"{name}.eval_metadata.provenance must be an object")
+    else:
+        kind = provenance.get("kind")
+        source_value = provenance.get("source")
+        if kind not in PROVENANCE_KINDS:
+            errors.append(
+                f"{name}.eval_metadata.provenance.kind must be pr, historical, or synthetic"
+            )
+        if not is_nonempty_string(source_value):
+            errors.append(f"{name}.eval_metadata.provenance.source must be a nonempty string")
+        if kind in PROVENANCE_KINDS and is_nonempty_string(source_value):
+            provenance_label = f"{kind}:{source_value.strip()}"
+
+    controls = metadata.get("controls")
+    if not isinstance(controls, dict):
+        errors.append(f"{name}.eval_metadata.controls must be an object")
+    else:
+        control_sets: dict[str, set[int]] = {}
+        for control_name in ("positive", "negative"):
+            values = controls.get(control_name)
+            if (
+                not isinstance(values, list)
+                or not values
+                or not all(isinstance(item, int) and not isinstance(item, bool) for item in values)
+            ):
+                errors.append(
+                    f"{name}.eval_metadata.controls.{control_name} must be a nonempty integer array"
+                )
+                continue
+            if len(values) != len(set(values)):
+                errors.append(
+                    f"{name}.eval_metadata.controls.{control_name} must not repeat indexes"
+                )
+            control_sets[control_name] = set(values)
+            for value in values:
+                if value < 0 or value >= len(expectations):
+                    errors.append(
+                        f"{name}.eval_metadata.controls.{control_name} index {value} "
+                        "must reference expectations"
+                    )
+        if (
+            "positive" in control_sets
+            and "negative" in control_sets
+            and control_sets["positive"] & control_sets["negative"]
+        ):
+            errors.append(f"{name}.eval_metadata.controls positive and negative must be disjoint")
+
+    forbidden_terms = metadata.get("forbidden_prompt_terms")
+    if not isinstance(forbidden_terms, list) or not all(
+        is_nonempty_string(term) for term in forbidden_terms
+    ):
+        errors.append(
+            f"{name}.eval_metadata.forbidden_prompt_terms must be an array of nonempty strings"
+        )
+        forbidden_terms = []
+    elif discovery_mode == "discovery" and not forbidden_terms:
+        errors.append(
+            f"{name}.eval_metadata.forbidden_prompt_terms must be nonempty for discovery"
+        )
+
+    if discovery_mode == "discovery":
+        if not files:
+            errors.append(f"{name}.files must provide a discovery fixture")
+        if ISSUE_OR_PULL_REQUEST.search(prompt) or COMMIT_SHA.search(prompt):
+            errors.append(
+                f"{name}.prompt must not expose issue, pull request, or commit "
+                "identities in discovery mode"
+            )
+
+    frozen_hash = metadata.get("frozen_hash")
+    if tier == "held_out":
+        fixture_hashes = metadata.get("fixture_hashes")
+        if not isinstance(fixture_hashes, dict) or set(fixture_hashes) != set(files):
+            errors.append(
+                f"{name}.eval_metadata.fixture_hashes must map every held-out fixture"
+            )
+        else:
+            for fixture, expected_hash in fixture_hashes.items():
+                if not is_nonempty_string(expected_hash) or not SHA256.fullmatch(
+                    expected_hash
+                ):
+                    errors.append(
+                        f"{name}.eval_metadata.fixture_hashes[{fixture!r}] "
+                        "must be a lowercase SHA-256"
+                    )
+                    continue
+                fixture_path = resolve_fixture_path(source, fixture)
+                if fixture_path is None:
+                    errors.append(f"{name}.files fixture does not exist: {fixture}")
+                elif file_sha256(fixture_path) != expected_hash:
+                    errors.append(
+                        f"{name}.eval_metadata.fixture_hashes[{fixture!r}] "
+                        "does not match the fixture"
+                    )
+
+        if not is_nonempty_string(frozen_hash) or not SHA256.fullmatch(frozen_hash):
+            errors.append(
+                f"{name}.eval_metadata.frozen_hash must be a lowercase SHA-256 for held_out evals"
+            )
+        elif frozen_hash != held_out_hash(eval_data):
+            errors.append(f"{name}.eval_metadata.frozen_hash does not match the held-out eval")
+
+    prompt_folded = prompt.casefold()
+    for term in forbidden_terms:
+        if term.casefold() in prompt_folded:
+            errors.append(
+                f"{name}.eval_metadata.forbidden_prompt_terms contains prompt term: {term!r}"
+            )
+
+    if errors:
+        return errors, None
+
+    identifier = str(identifier_value)
+    return [], EvalRecord(
+        source=source,
+        index=index,
+        identifier=identifier,
+        tier=tier,
+        family=family,
+        provenance=provenance_label,
+        area=area,
+        prompt_overlap=prompt_expectation_overlap(prompt, expectations),
+    )
+
+
+def validate_documents(documents: Iterable[tuple[str, Any]]) -> ValidationResult:
+    errors: list[str] = []
+    records: list[EvalRecord] = []
+
+    for source, document in documents:
+        if not isinstance(document, dict):
+            errors.append(f"{source} must contain a JSON object")
+            continue
+        evals = document.get("evals")
+        if not isinstance(evals, list) or not evals:
+            errors.append(f"{source}.evals must be a nonempty array")
+            continue
+        identifiers = [
+            eval_data.get("id")
+            for eval_data in evals
+            if isinstance(eval_data, dict)
+        ]
+        duplicates = sorted(
+            {
+                str(identifier)
+                for identifier, count in Counter(identifiers).items()
+                if identifier is not None and count > 1
+            }
+        )
+        if duplicates:
+            errors.append(f"{source}.evals contains duplicate ids: {', '.join(duplicates)}")
+        for index, eval_data in enumerate(evals):
+            eval_errors, record = validate_eval(eval_data, source, index)
+            errors.extend(eval_errors)
+            if record is not None:
+                records.append(record)
+
+    records_by_source: dict[str, list[EvalRecord]] = defaultdict(list)
+    for record in records:
+        records_by_source[record.source].append(record)
+    for source, source_records in records_by_source.items():
+        train_provenance = {
+            record.provenance for record in source_records if record.tier == "train"
+        }
+        held_out_provenance = {
+            record.provenance for record in source_records if record.tier == "held_out"
+        }
+        overlap = sorted(train_provenance & held_out_provenance)
+        if overlap:
+            errors.append(
+                f"{source}: train and held_out provenance must be disjoint: "
+                f"{', '.join(overlap)}"
+            )
+
+    warnings = collect_warnings(records)
+    return ValidationResult(errors=errors, warnings=warnings, records=records)
+
+
+def collect_warnings(records: list[EvalRecord]) -> list[str]:
+    if not records:
+        return []
+
+    warnings: list[str] = []
+    by_source: dict[str, list[EvalRecord]] = defaultdict(list)
+    for record in records:
+        by_source[record.source].append(record)
+
+    for source, source_records in sorted(by_source.items()):
+        total = len(source_records)
+        held_out = sum(record.tier == "held_out" for record in source_records)
+        held_out_share = held_out / total
+        if held_out_share < 0.20 or held_out_share > 0.50:
+            warnings.append(
+                f"{source}: held-out share is {held_out}/{total} "
+                f"({held_out_share:.1%}); review tier balance"
+            )
+
+        by_tier_family: dict[str, Counter[str]] = defaultdict(Counter)
+        for record in source_records:
+            by_tier_family[record.tier][record.family] += 1
+        for tier, families in sorted(by_tier_family.items()):
+            tier_total = sum(families.values())
+            family, count = families.most_common(1)[0]
+            if count / tier_total > 0.50:
+                warnings.append(
+                    f"{source}: {tier} family concentration is {family} "
+                    f"({count}/{tier_total}); review diversity"
+                )
+
+        provenance_counts = Counter(record.provenance for record in source_records)
+        provenance, count = provenance_counts.most_common(1)[0]
+        if count / total > 0.50:
+            warnings.append(
+                f"{source}: provenance concentration is {provenance} "
+                f"({count}/{total}); review independence"
+            )
+
+        for tier in TIERS:
+            tier_records = [
+                record for record in source_records if record.tier == tier
+            ]
+            tier_families = {record.family for record in tier_records}
+            provenance_families: dict[str, set[str]] = defaultdict(set)
+            for record in tier_records:
+                provenance_families[record.provenance].add(record.family)
+            for provenance, families in sorted(provenance_families.items()):
+                if len(tier_families) >= 3 and len(families) / len(tier_families) > 1 / 3:
+                    warnings.append(
+                        f"{source}: {tier} provenance {provenance} spans "
+                        f"{len(families)}/{len(tier_families)} score families; "
+                        "compare provenance-macro transfer"
+                    )
+
+        train_areas = {
+            record.area for record in source_records if record.tier == "train"
+        }
+        held_out_areas = {
+            record.area for record in source_records if record.tier == "held_out"
+        }
+        if held_out_areas and held_out_areas <= train_areas:
+            warnings.append(
+                f"{source}: held-out areas do not add transfer coverage beyond train"
+            )
+
+        train_families = {
+            record.family for record in source_records if record.tier == "train"
+        }
+        held_out_families = {
+            record.family for record in source_records if record.tier == "held_out"
+        }
+        uncovered_families = sorted(train_families - held_out_families)
+        if uncovered_families:
+            warnings.append(
+                f"{source}: train families without held-out transfer cases: "
+                f"{', '.join(uncovered_families)}"
+            )
+
+        for record in source_records:
+            if record.prompt_overlap >= HIGH_OVERLAP_THRESHOLD:
+                warnings.append(
+                    f"{record.source}: evals[{record.index}] prompt/expectation term overlap "
+                    f"is {record.prompt_overlap:.1%}; review for answer leakage"
+                )
+    return warnings
+
+
+def summary(result: ValidationResult) -> dict[str, Any]:
+    records = result.records
+    tier_family_counts: dict[tuple[str, str], Counter[str]] = defaultdict(Counter)
+    tier_provenance_counts: dict[tuple[str, str], Counter[str]] = defaultdict(Counter)
+    source_counts = Counter(record.source for record in records)
+    source_held_out = Counter(
+        record.source for record in records if record.tier == "held_out"
+    )
+    for record in records:
+        tier_family_counts[(record.source, record.tier)][record.family] += 1
+        tier_provenance_counts[(record.source, record.tier)][record.provenance] += 1
+
+    total = len(records)
+    held_out = sum(record.tier == "held_out" for record in records)
+    return {
+        "raw_count": total,
+        "family_counts": {
+            source: {
+                tier: dict(sorted(tier_family_counts[(source, tier)].items()))
+                for tier in sorted(
+                    {
+                        record.tier
+                        for record in records
+                        if record.source == source
+                    }
+                )
+            }
+            for source in sorted(source_counts)
+        },
+        "held_out": {
+            "count": held_out,
+            "share": held_out / total if total else 0.0,
+            "by_source": {
+                source: {
+                    "count": source_held_out[source],
+                    "total": source_counts[source],
+                    "share": source_held_out[source] / source_counts[source],
+                }
+                for source in sorted(source_counts)
+            },
+        },
+        "provenance_concentration": dict(
+            sorted(Counter(record.provenance for record in records).items())
+        ),
+        "family_weights": [
+            {
+                "source": record.source,
+                "eval_index": record.index,
+                "eval_id": record.identifier,
+                "tier": record.tier,
+                "score_family": record.family,
+                "weight": 1
+                / (
+                    len(tier_family_counts[(record.source, record.tier)])
+                    * tier_family_counts[(record.source, record.tier)][record.family]
+                ),
+            }
+            for record in records
+        ],
+        "provenance_weights": [
+            {
+                "source": record.source,
+                "eval_index": record.index,
+                "eval_id": record.identifier,
+                "tier": record.tier,
+                "provenance": record.provenance,
+                "weight": 1
+                / (
+                    len(tier_provenance_counts[(record.source, record.tier)])
+                    * tier_provenance_counts[
+                        (record.source, record.tier)
+                    ][record.provenance]
+                ),
+            }
+            for record in records
+        ],
+    }
+
+
+def read_documents(paths: Iterable[Path]) -> tuple[list[tuple[str, Any]], list[str]]:
+    documents: list[tuple[str, Any]] = []
+    errors: list[str] = []
+    for path in paths:
+        try:
+            documents.append((str(path), json.loads(path.read_text(encoding="utf-8"))))
+        except OSError as error:
+            errors.append(f"{path}: unable to read JSON: {error}")
+        except json.JSONDecodeError as error:
+            errors.append(f"{path}: invalid JSON: {error.msg} at line {error.lineno}")
+    return documents, errors
+
+
+def print_text(result: ValidationResult) -> None:
+    report = summary(result)
+    print(f"Eval count: {report['raw_count']}")
+    print("Family counts:")
+    for source, tiers in report["family_counts"].items():
+        print(f"  {source}:")
+        for tier, families in tiers.items():
+            print(
+                f"    {tier}: "
+                f"{', '.join(f'{family}={count}' for family, count in families.items())}"
+            )
+    held_out = report["held_out"]
+    print(f"Held-out share: {held_out['count']}/{report['raw_count']} ({held_out['share']:.1%})")
+    for source, source_held_out in held_out["by_source"].items():
+        print(
+            f"  {source}: {source_held_out['count']}/{source_held_out['total']} "
+            f"({source_held_out['share']:.1%})"
+        )
+    print("Provenance concentration:")
+    for provenance, count in report["provenance_concentration"].items():
+        print(f"  {provenance}: {count}")
+    print("Per-eval family weights:")
+    for weight in report["family_weights"]:
+        print(
+            f"  {weight['source']}: eval {weight['eval_id']} "
+            f"({weight['tier']}/{weight['score_family']}) = {weight['weight']:.6g}"
+        )
+    print("Per-eval provenance weights:")
+    for weight in report["provenance_weights"]:
+        print(
+            f"  {weight['source']}: eval {weight['eval_id']} "
+            f"({weight['tier']}/{weight['provenance']}) = {weight['weight']:.6g}"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate ASP.NET Core review eval anti-overfit metadata."
+    )
+    parser.add_argument("eval_files", nargs="+", type=Path)
+    parser.add_argument("--json", action="store_true", help="emit a JSON report")
+    args = parser.parse_args()
+
+    documents, read_errors = read_documents(args.eval_files)
+    result = validate_documents(documents)
+    result.errors[:0] = read_errors
+    report = summary(result)
+    if args.json:
+        print(json.dumps({**asdict(result), "summary": report}, indent=2))
+    else:
+        for error in result.errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        for warning in result.warnings:
+            print(f"WARNING: {warning}", file=sys.stderr)
+        print_text(result)
+    return 1 if result.errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/aspnetcore-try-fix/SKILL.md
+++ b/.github/skills/aspnetcore-try-fix/SKILL.md
@@ -14,9 +14,9 @@ compatibility: Requires a dotnet/aspnetcore checkout, git, and its local .NET/No
 
 Generate one independent fix candidate, test it when isolation permits, and
 return evidence that another reviewer can compare with other candidates.
-When the sibling reviewer skill is available, use
-`../aspnetcore-pr-review/references/proof-calibration.md` as the canonical
-calibration contract; the rules below are the standalone minimum.
+Resolve sibling references from this active `SKILL.md` root. When available,
+use `../aspnetcore-pr-review/references/proof-calibration.md` as the canonical
+contract; never silently mix user-installed and project-installed copies.
 
 ## Repository scope
 
@@ -99,8 +99,9 @@ mechanism is available, return `Blocked` instead of modifying it.
 3. Select the smallest existing build/test command that covers the behavior.
    For Components issues, follow `src/Components/AGENTS.md`, including browser
    reproduction and a permanent E2E test when behavior is browser-observable.
-4. When a test is added for a bug, require strict red/green evidence:
-   the same assertion must fail for the missing behavior and pass with the fix.
+4. Require strict red/green only to prove a defect and correction. Run untouched
+   frozen head first; if it passes, reject the blocker rather than manufacturing
+   a failing mutation.
 5. Treat pre-existing or infrastructure failures separately. Demonstrate them
    with an unchanged baseline test before calling them unrelated.
 6. A documented build-property bypass is allowed only after showing the
@@ -170,7 +171,8 @@ Independent authority for the expected result:
 Allowed perturbations:
 Runtime variants:
 Repetitions:
-Assertion disposition: merge-candidate / diagnostic-only / rejected
+Regression assertion disposition: required-regression / optional-regression / rejected
+Diagnostic mutation disposition: diagnostic-only / rejected / not-applicable
 ```
 
 Preserve the caller's assertion contract. Do not replace a focused stimulus
@@ -182,11 +184,13 @@ Before editing, ask whether this assertion would still be required if the
 candidate were unknown. A synthetic input chosen because it falls between the
 old and proposed thresholds demonstrates the policy difference, but remains
 diagnostic-only unless independent authority says that input must succeed.
+Use `required-regression` only when accepted criteria or a proven defect makes
+that exact coverage necessary; otherwise merge-suitable hardening is optional.
 
 Keep diagnostic assertions and the proposed implementation separable. Capture
 the diagnostic-only diff, implementation-only diff, and combined candidate
 diff. Do not recommend committing a slow, configuration-specific, or synthetic
-assertion without explicitly classifying it as merge-candidate.
+assertion without classifying it as required or optional regression coverage.
 
 If no alternative is viable, return `NO VIABLE ALTERNATIVE` only after naming
 and rejecting at least one mechanism-level alternative with evidence.
@@ -216,13 +220,15 @@ Record only concrete concerns with a failing scenario.
 In `candidate-review`, evaluate whether the supplied validation is sufficient
 and predict the differentiating result. Do not claim `Pass`.
 
-In `empirical`, first require frozen-head failure at the predicted behavioral
-assertion. Infrastructure, build, stale-element, setup, or unrelated assertion
-failures are `Blocked`, not behavioral red. Then run the supplied command with
-the candidate and classify:
+In `empirical`, run the predicted behavioral assertion on untouched frozen head
+first. Infrastructure, build, stale-element, setup, or unrelated assertion
+failures are `Blocked`, not behavioral red. If head passes, report no defect and
+do not create a mutation merely to obtain red. If head fails, run the supplied
+command with the candidate and classify:
 
 | Evidence | Result |
 |---|---|
+| Frozen head passes the approved assertion | `Pass` with no defect; no production correction |
 | Behavioral red/green, stress matrix, and required producer path pass consistently | `Pass` |
 | Targeted assertion turns green but stress/producer validation is incomplete | `Blocked` |
 | Test ran and failed | `Fail` |
@@ -241,8 +247,9 @@ runtime variants, and repetition count match the assertion plan. Report a
 per-execution matrix rather than only an aggregate pass/fail result.
 
 Repeating one deterministic case establishes repeatability, not a complete
-stress matrix. Vary the dimensions that could falsify the mechanism. Preserve
-configuration, platform, and build-bypass limits when classifying proof.
+stress matrix. Vary only dimensions that could falsify the claimed mechanism,
+proportional to severity and statefulness. Do not add scaffolding solely to
+upgrade the proof label; preserve configuration, platform, and bypass limits.
 
 If repeated timing-sensitive runs disagree, return `Fail` until the divergence
 is explained and corrected. Never select only the passing run.
@@ -264,7 +271,8 @@ Use this exact shape:
 **Oracle fidelity:** authoritative / corroborated / hypothesis / unknown
 **Mechanism fidelity:** reproduced / structural / inferred / unknown
 **Scenario fidelity:** exact / proxy / synthetic / missing
-**Assertion disposition:** merge-candidate / diagnostic-only / rejected
+**Regression assertion disposition:** required-regression / optional-regression / rejected
+**Diagnostic mutation disposition:** diagnostic-only / rejected / not-applicable
 
 ### Proposed change
 <specific implementation>

--- a/.github/skills/aspnetcore-try-fix/SKILL.md
+++ b/.github/skills/aspnetcore-try-fix/SKILL.md
@@ -86,6 +86,7 @@ mechanism is available, return `Blocked` instead of modifying it.
 | `allowed_perturbations` | `empirical` | What the empirical test may vary without changing the scenario |
 | `mode` | Yes | `candidate-review` or `empirical` |
 | `evidence_manifest` | Yes | Frozen evidence bundle from the orchestrator |
+| `impact_map` | Yes | Changed producers/branches, consumers, and directly impacted unchanged tests |
 | `artifact_path` | Yes | Exact path for the raw candidate response |
 | `prior_attempts` | No | Approaches already tried and why they failed |
 | `hints` | No | Advisory review findings or constraints |
@@ -136,6 +137,14 @@ State:
 - For stateful behavior, a transition table with the state/invariant, entry,
   ordinary successful exit, interruption exit, owner, and stranded-state
   consequence.
+- For callbacks, observers, measurements, or notifications that are suppressed,
+  disabled, discarded, or deferred: what data stops updating, the first event
+  after recovery, any ownership transfer, the generation/provenance of values
+  consumed after recovery, stale values that survive, and the opposite edge or
+  boundary.
+- The unchanged tests in the impact map that exercise each changed producer
+  branch. Changed-file tests alone are not sufficient when another consumer
+  shares the producer.
 
 Implementation and tests show current behavior, but do not establish product
 intent by themselves. If the expected behavior is only inferred, label it
@@ -169,6 +178,11 @@ Trigger:
 Expected assertion:
 Independent authority for the expected result:
 Allowed perturbations:
+Impacted existing tests:
+Suppressed interval:
+Resume trigger:
+Pre/post measurement generation:
+Control/perturbation:
 Runtime variants:
 Repetitions:
 Regression assertion disposition: required-regression / optional-regression / rejected
@@ -207,6 +221,14 @@ Before declaring the candidate viable, attack it:
 - Is the assertion independently justified, or shaped to favor this candidate?
 - What happens for null/default values, repeated events, and opposite state
   transitions?
+- Which callbacks or events are ignored, what data stops refreshing, what stale
+  state survives, and can the first resumed event combine old state or geometry
+  with new measurements?
+- Which render, commit, observer, or measurement generation owns each input to
+  the first post-recovery calculation?
+- Does every changed producer/filter branch have an unchanged impacted test?
+  If before/after events are filtered asymmetrically, what happens for
+  before-only, after-only, and both in one batch?
 - For timing-sensitive state, what happens with equal/changed inputs,
   delayed/out-of-order delivery, no-op operations, rapid generations,
   cancellation, disposal, and partial observer/event batches?
@@ -220,11 +242,13 @@ Record only concrete concerns with a failing scenario.
 In `candidate-review`, evaluate whether the supplied validation is sufficient
 and predict the differentiating result. Do not claim `Pass`.
 
-In `empirical`, run the predicted behavioral assertion on untouched frozen head
-first. Infrastructure, build, stale-element, setup, or unrelated assertion
-failures are `Blocked`, not behavioral red. If head passes, report no defect and
-do not create a mutation merely to obtain red. If head fails, run the supplied
-command with the candidate and classify:
+In `empirical`, run the directly impacted unchanged tests from the impact map,
+then the predicted behavioral assertion, on untouched frozen head first.
+Prefer an unchanged test that already distinguishes the defect over a
+candidate-specific assertion. Infrastructure, build, stale-element, setup, or
+unrelated assertion failures are `Blocked`, not behavioral red. If head passes,
+report no defect and do not create a mutation merely to obtain red. If head
+fails, run the supplied command with the candidate and classify:
 
 | Evidence | Result |
 |---|---|
@@ -250,6 +274,14 @@ Repeating one deterministic case establishes repeatability, not a complete
 stress matrix. Vary only dimensions that could falsify the claimed mechanism,
 proportional to severity and statefulness. Do not add scaffolding solely to
 upgrade the proof label; preserve configuration, platform, and bypass limits.
+For suppressed callbacks or measurements, include the first resumed event and
+the opposite boundary. When geometry is involved, use one fixed-size control
+and one bounded realistic variable-size perturbation. For asymmetric event
+filtering, cover before-only, after-only, and both-in-one-batch behavior.
+
+Do not classify a candidate as `production-proven` until every directly
+impacted unchanged test in the supplied impact map passes, or the caller records
+a source-backed reason that a mapped test is not applicable.
 
 If repeated timing-sensitive runs disagree, return `Fail` until the divergence
 is explained and corrected. Never select only the passing run.
@@ -282,6 +314,12 @@ Use this exact shape:
 
 ### Execution matrix
 <one row per requested runtime variant and repetition>
+
+### Impacted existing tests
+<mapped unchanged tests run, results, and any justified exclusions>
+
+### Recovery and provenance
+<suppressed interval, first resumed event, state/measurement generations, stale values, and opposite boundary, or "Not applicable">
 
 ### Proof status
 - Finding: empirical / structural / missing

--- a/.github/skills/aspnetcore-try-fix/SKILL.md
+++ b/.github/skills/aspnetcore-try-fix/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: aspnetcore-try-fix
+description: >-
+  Produce and evaluate one independent fix candidate specifically for the
+  dotnet/aspnetcore repository. Use whenever an ASP.NET Core issue, PR, or local
+  patch needs an alternative root-cause hypothesis, a competing implementation,
+  or empirical validation. Each invocation owns one candidate only and must
+  differ materially from the current fix or prior attempts. Do not use this
+  skill in dotnet/maui or any repository other than dotnet/aspnetcore.
+compatibility: Requires a dotnet/aspnetcore checkout, git, and its local .NET/Node toolchain
+---
+
+# ASP.NET Core Try-Fix
+
+Generate one independent fix candidate, test it when isolation permits, and
+return evidence that another reviewer can compare with other candidates.
+
+## Repository scope
+
+This skill is intentionally repository-specific. Before using it:
+
+1. Verify the current Git checkout is `dotnet/aspnetcore` from its configured
+   remote URL or trusted session metadata.
+2. If the repository cannot be verified, stop and report that this skill only
+   supports `dotnet/aspnetcore`.
+3. Do not reinterpret these instructions for .NET MAUI or another repository.
+
+## Activation guard
+
+Use this skill only when all of these are available:
+
+- A concrete bug or behavior to fix.
+- The current fix or a description of prior attempts.
+- Target files or an area to investigate.
+- A relevant validation command or an explicit reason testing is blocked.
+
+Do not use it for summaries, general architecture questions, CI-only triage, or
+ordinary code review with no request for an alternative.
+
+## Modes
+
+### `candidate-review`
+
+Use this mode when reviewing an existing PR or dirty local diff. It is strictly
+read-only and safe to run concurrently across models.
+
+- Form a root-cause hypothesis independently from the current fix.
+- Propose one concrete alternative.
+- Compare it with the current fix only after the proposal is formed.
+- Inspect existing validation and identify gaps.
+- Do not edit files, run destructive git commands, commit, push, or post.
+
+### `empirical`
+
+Use this mode only in an isolated child session/worktree or when the caller has
+explicitly provided a safe restoration mechanism.
+
+- Implement one candidate.
+- Run the supplied targeted validation.
+- Allow at most three implementation iterations for that same hypothesis.
+- Capture the diff and test output before restoring.
+- Run attempts sequentially if they share a workspace or server.
+- Treat the first green as provisional. Before returning `Pass`, execute the
+  caller's lifecycle-derived stress matrix and the real producer/runtime path
+  when the claim depends on browser, interop, transport, process, or scheduler
+  behavior.
+
+If the parent worktree contains user changes and no isolation/restoration
+mechanism is available, return `Blocked` instead of modifying it.
+
+## Inputs
+
+| Input | Required | Description |
+|---|---|---|
+| `problem` | Yes | Observable behavior and expected behavior |
+| `current_fix` | Yes | Current local/PR approach or `none` |
+| `target_files` | Yes | Relevant files or repository area |
+| `validation` | Yes | Targeted command(s) or known blocker |
+| `product_oracle` | Yes | Expected user-visible behavior, source, and confidence |
+| `proof_target` | `empirical` | The exact behavioral claim this candidate must prove or reject |
+| `assertion_contract` | `empirical` | Required setup, control, trigger, and assertion |
+| `allowed_perturbations` | `empirical` | What the empirical test may vary without changing the scenario |
+| `mode` | Yes | `candidate-review` or `empirical` |
+| `evidence_manifest` | Yes | Frozen evidence bundle from the orchestrator |
+| `artifact_path` | Yes | Exact path for the raw candidate response |
+| `prior_attempts` | No | Approaches already tried and why they failed |
+| `hints` | No | Advisory review findings or constraints |
+
+## Repository rules
+
+1. Read applicable `AGENTS.md` and `.github/instructions/*.instructions.md`
+   files before analysis or edits.
+2. Activate the local SDK before any `dotnet` command:
+   `source activate.sh` on macOS/Linux or `. ./activate.ps1` on Windows.
+3. Select the smallest existing build/test command that covers the behavior.
+   For Components issues, follow `src/Components/AGENTS.md`, including browser
+   reproduction and a permanent E2E test when behavior is browser-observable.
+4. When a test is added for a bug, require strict red/green evidence:
+   the same assertion must fail for the missing behavior and pass with the fix.
+5. Treat pre-existing or infrastructure failures separately. Demonstrate them
+   with an unchanged baseline test before calling them unrelated.
+6. Never change `global.json`, package manifests, lock files, or NuGet
+   configuration unless the caller explicitly requests it.
+7. Never commit, push, create a PR, post comments, or change branches.
+8. Cite exact repository paths and lines, observed output, or primary sources
+   for compatibility, browser-support, API-breaking, test-execution, and
+   repository-pattern claims. Label claims `UNSUPPORTED` when they cannot be
+   verified; unsupported claims cannot justify a required change.
+
+## Workflow
+
+### 1. Inspect independently
+
+Start from the frozen evidence manifest. Read the target code, full surrounding
+files, call sites, tests, and relevant history before reading the current fix
+in detail. Record any narrow lookup outside the bundle and the claim it verifies.
+State:
+
+- The product oracle and whether each expected behavior is documented,
+  author-confirmed, test-encoded, inferred, or unknown.
+- The observable failure.
+- The likely root cause.
+- The code path that produces the behavior.
+- The smallest test that can distinguish broken from fixed.
+- For stateful behavior, a transition table with the state/invariant, entry,
+  ordinary successful exit, interruption exit, owner, and stranded-state
+  consequence.
+
+Implementation and tests show current behavior, but do not establish product
+intent by themselves. If the expected behavior is only inferred, label it
+`UNSUPPORTED` and do not recommend a lifecycle change as though it were
+authoritative. If the caller provides an authoritative clarification, update
+the hypothesis instead of defending a prior inference.
+
+### 2. Review current and prior approaches
+
+Read the current diff and prior attempts. Explain why the new candidate is
+different at the root-cause level, not merely a different edit location.
+
+### 3. Design one candidate
+
+Choose exactly one approach. Prefer:
+
+- Correcting the producer/consumer contract where information is lost.
+- Reusing established repository patterns.
+- Minimal API and compatibility surface.
+- Tests that exercise the real dispatch/runtime path.
+
+Reject candidates that only suppress symptoms, duplicate an existing failed
+hypothesis, or require unrelated refactoring.
+
+In `empirical` mode, write the exact assertion plan before editing:
+
+```text
+Setup:
+Control:
+Trigger:
+Expected assertion:
+Allowed perturbations:
+Runtime variants:
+Repetitions:
+```
+
+Preserve the caller's assertion contract. Do not replace a focused stimulus
+with a broader one merely because an existing control is convenient. For
+example, changing one adjacent item's size is not equivalent to switching the
+layout model for every item.
+
+If no alternative is viable, return `NO VIABLE ALTERNATIVE` only after naming
+and rejecting at least one mechanism-level alternative with evidence.
+
+### 4. Adversarial self-review
+
+Before declaring the candidate viable, attack it:
+
+- What call path or target framework bypasses it?
+- Does it preserve existing handlers and compatibility behavior?
+- Does a new public API require API baseline or documentation updates?
+- Does serialization/deserialization stay in sync across JS and .NET?
+- Can the test pass without exercising the reported bug?
+- What happens for null/default values, repeated events, and opposite state
+  transitions?
+- For timing-sensitive state, what happens with equal/changed inputs,
+  delayed/out-of-order delivery, no-op operations, rapid generations,
+  cancellation, disposal, and partial observer/event batches?
+
+Record only concrete concerns with a failing scenario.
+
+### 5. Validate
+
+In `candidate-review`, evaluate whether the supplied validation is sufficient
+and predict the differentiating result. Do not claim `Pass`.
+
+In `empirical`, first require frozen-head failure at the predicted behavioral
+assertion. Infrastructure, build, stale-element, setup, or unrelated assertion
+failures are `Blocked`, not behavioral red. Then run the supplied command with
+the candidate and classify:
+
+| Evidence | Result |
+|---|---|
+| Behavioral red/green, stress matrix, and required producer path pass consistently | `Pass` |
+| Targeted assertion turns green but stress/producer validation is incomplete | `Blocked` |
+| Test ran and failed | `Fail` |
+| Code did not compile | `Fail` |
+| Required environment unavailable | `Blocked` |
+| Only review/build succeeded, behavior test did not run | `Blocked` |
+
+If the test fails before reaching the requested trigger, classify it as
+`Scenario mismatch` under `Blocked` or preserve it as a separate finding. Do
+not claim it proves or disproves the requested behavior, and do not stop the
+requested proof when a narrower stimulus can faithfully exercise the supplied
+assertion contract.
+
+After each run, verify that the executed setup, control, trigger, assertion,
+runtime variants, and repetition count match the assertion plan. Report a
+per-execution matrix rather than only an aggregate pass/fail result.
+
+If repeated timing-sensitive runs disagree, return `Fail` until the divergence
+is explained and corrected. Never select only the passing run.
+
+### 6. Return a structured candidate
+
+Use this exact shape:
+
+```markdown
+## Try-Fix Candidate
+
+**Mode:** candidate-review / empirical
+**Approach:** <short name>
+**Root-cause hypothesis:** <mechanism>
+**Different from current fix:** <mechanism-level difference>
+**Files:** <paths>
+**Result:** Pass / Fail / Blocked / Proposed
+**Product oracle:** documented / author-confirmed / test-encoded / inferred / unknown
+
+### Proposed change
+<specific implementation>
+
+### Evidence
+<tests run or evidence still required, with exact citations>
+
+### Execution matrix
+<one row per requested runtime variant and repetition>
+
+### Proof status
+- Finding: empirical / structural / missing
+- Scenario: empirical / structural / missing
+- Candidate: production-proven / diagnostic-only / rejected / blocked
+- Assertion fidelity: exact / scenario mismatch / incomplete
+
+### Claim verification
+- VERIFIED: <claim and source/output>
+- CONTRADICTED: <claim and source/output>
+- UNSUPPORTED: <claim lacking evidence, or "None">
+
+### Adversarial findings
+- <concrete issue, or "None">
+
+### Tradeoffs
+<complexity, compatibility, and coverage>
+
+### Recommendation
+Keep current fix / prefer this candidate / combine specific parts
+```
+
+Write the complete response to `artifact_path` and return that path to the
+orchestrator. Do not overwrite another candidate's artifact.

--- a/.github/skills/aspnetcore-try-fix/SKILL.md
+++ b/.github/skills/aspnetcore-try-fix/SKILL.md
@@ -14,6 +14,9 @@ compatibility: Requires a dotnet/aspnetcore checkout, git, and its local .NET/No
 
 Generate one independent fix candidate, test it when isolation permits, and
 return evidence that another reviewer can compare with other candidates.
+When the sibling reviewer skill is available, use
+`../aspnetcore-pr-review/references/proof-calibration.md` as the canonical
+calibration contract; the rules below are the standalone minimum.
 
 ## Repository scope
 
@@ -77,6 +80,7 @@ mechanism is available, return `Blocked` instead of modifying it.
 | `target_files` | Yes | Relevant files or repository area |
 | `validation` | Yes | Targeted command(s) or known blocker |
 | `product_oracle` | Yes | Expected user-visible behavior, source, and confidence |
+| `oracle_authority` | Yes | Why the expected result is required independently of a candidate |
 | `proof_target` | `empirical` | The exact behavioral claim this candidate must prove or reject |
 | `assertion_contract` | `empirical` | Required setup, control, trigger, and assertion |
 | `allowed_perturbations` | `empirical` | What the empirical test may vary without changing the scenario |
@@ -99,10 +103,13 @@ mechanism is available, return `Blocked` instead of modifying it.
    the same assertion must fail for the missing behavior and pass with the fix.
 5. Treat pre-existing or infrastructure failures separately. Demonstrate them
    with an unchanged baseline test before calling them unrelated.
-6. Never change `global.json`, package manifests, lock files, or NuGet
+6. A documented build-property bypass is allowed only after showing the
+   bypassed target cannot affect the focused behavior. Record it and cap proof
+   at `targeted-proven` until the standard build or exact CI path passes.
+7. Never change `global.json`, package manifests, lock files, or NuGet
    configuration unless the caller explicitly requests it.
-7. Never commit, push, create a PR, post comments, or change branches.
-8. Cite exact repository paths and lines, observed output, or primary sources
+8. Never commit, push, create a PR, post comments, or change branches.
+9. Cite exact repository paths and lines, observed output, or primary sources
    for compatibility, browser-support, API-breaking, test-execution, and
    repository-pattern claims. Label claims `UNSUPPORTED` when they cannot be
    verified; unsupported claims cannot justify a required change.
@@ -118,6 +125,9 @@ State:
 
 - The product oracle and whether each expected behavior is documented,
   author-confirmed, test-encoded, inferred, or unknown.
+- Whether the source establishes accepted behavior, patch intent, an observed
+  symptom, or only a proposed historical cause. A PR-author rationale can state
+  patch intent but is not automatically an accepted contract or causal proof.
 - The observable failure.
 - The likely root cause.
 - The code path that produces the behavior.
@@ -156,15 +166,27 @@ Setup:
 Control:
 Trigger:
 Expected assertion:
+Independent authority for the expected result:
 Allowed perturbations:
 Runtime variants:
 Repetitions:
+Assertion disposition: merge-candidate / diagnostic-only / rejected
 ```
 
 Preserve the caller's assertion contract. Do not replace a focused stimulus
 with a broader one merely because an existing control is convenient. For
 example, changing one adjacent item's size is not equivalent to switching the
 layout model for every item.
+
+Before editing, ask whether this assertion would still be required if the
+candidate were unknown. A synthetic input chosen because it falls between the
+old and proposed thresholds demonstrates the policy difference, but remains
+diagnostic-only unless independent authority says that input must succeed.
+
+Keep diagnostic assertions and the proposed implementation separable. Capture
+the diagnostic-only diff, implementation-only diff, and combined candidate
+diff. Do not recommend committing a slow, configuration-specific, or synthetic
+assertion without explicitly classifying it as merge-candidate.
 
 If no alternative is viable, return `NO VIABLE ALTERNATIVE` only after naming
 and rejecting at least one mechanism-level alternative with evidence.
@@ -178,11 +200,14 @@ Before declaring the candidate viable, attack it:
 - Does a new public API require API baseline or documentation updates?
 - Does serialization/deserialization stay in sync across JS and .NET?
 - Can the test pass without exercising the reported bug?
+- Is the assertion independently justified, or shaped to favor this candidate?
 - What happens for null/default values, repeated events, and opposite state
   transitions?
 - For timing-sensitive state, what happens with equal/changed inputs,
   delayed/out-of-order delivery, no-op operations, rapid generations,
   cancellation, disposal, and partial observer/event batches?
+- If an observer times out without canceling inner work, what state are those
+  tasks in, how are they released, and can they leak into later tests?
 
 Record only concrete concerns with a failing scenario.
 
@@ -215,6 +240,10 @@ After each run, verify that the executed setup, control, trigger, assertion,
 runtime variants, and repetition count match the assertion plan. Report a
 per-execution matrix rather than only an aggregate pass/fail result.
 
+Repeating one deterministic case establishes repeatability, not a complete
+stress matrix. Vary the dimensions that could falsify the mechanism. Preserve
+configuration, platform, and build-bypass limits when classifying proof.
+
 If repeated timing-sensitive runs disagree, return `Fail` until the divergence
 is explained and corrected. Never select only the passing run.
 
@@ -232,6 +261,10 @@ Use this exact shape:
 **Files:** <paths>
 **Result:** Pass / Fail / Blocked / Proposed
 **Product oracle:** documented / author-confirmed / test-encoded / inferred / unknown
+**Oracle fidelity:** authoritative / corroborated / hypothesis / unknown
+**Mechanism fidelity:** reproduced / structural / inferred / unknown
+**Scenario fidelity:** exact / proxy / synthetic / missing
+**Assertion disposition:** merge-candidate / diagnostic-only / rejected
 
 ### Proposed change
 <specific implementation>
@@ -245,7 +278,7 @@ Use this exact shape:
 ### Proof status
 - Finding: empirical / structural / missing
 - Scenario: empirical / structural / missing
-- Candidate: production-proven / diagnostic-only / rejected / blocked
+- Candidate: production-proven / targeted-proven / diagnostic-only / rejected / blocked
 - Assertion fidelity: exact / scenario mismatch / incomplete
 
 ### Claim verification

--- a/.github/skills/aspnetcore-try-fix/evals/eval-policy.md
+++ b/.github/skills/aspnetcore-try-fix/evals/eval-policy.md
@@ -1,0 +1,4 @@
+# Evaluation policy
+
+This suite follows the shared
+[`aspnetcore-pr-review` evaluation anti-overfit policy](../../aspnetcore-pr-review/evals/eval-policy.md).

--- a/.github/skills/aspnetcore-try-fix/evals/evals.json
+++ b/.github/skills/aspnetcore-try-fix/evals/evals.json
@@ -100,6 +100,36 @@
         "The assertion disposition is required-regression.",
         "Candidate fidelity remains limited by the configurations and platforms actually executed."
       ]
+    },
+    {
+      "id": 8,
+      "prompt": "In an isolated dotnet/aspnetcore worktree, evaluate a Virtualize candidate where observer callbacks are suppressed while InitialItemIndex pins a variable-height list. The first resumed bottom-spacer callback may combine old spacer pixels with a new measured item-size average. Existing tests cover initial placement and boundary-key takeover but not this recovery edge. Keep the experiment bounded and local.",
+      "expected_output": "A structured empirical candidate that models measurement provenance across suppression, runs impacted existing tests first, and tests the first resumed real-browser callback with one fixed-size control and one variable-height perturbation.",
+      "files": [],
+      "expectations": [
+        "The assertion plan records the suppressed interval, resume trigger, pre/post measurement generations, and impacted existing tests.",
+        "The candidate explains which geometry remains stale and which measurement becomes current before redistribution.",
+        "The real observer and DOM measurement producer are exercised rather than only directly invoking a C# consumer callback.",
+        "The bounded matrix contains a fixed-size control and one realistic variable-height perturbation.",
+        "The trigger scrolls to expose the opposite or bottom spacer after initial positioning and asserts no backward visible-range jump.",
+        "Existing initial-placement and boundary-key tests are run but are not treated as substitutes for the recovery scenario.",
+        "The candidate cannot become production-proven until mapped unchanged tests and the recovery matrix pass."
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "In candidate-review mode, assess a Virtualize change that filters an IntersectionObserver batch containing both before and after spacers by unconditionally deleting the after-spacer entry. The edited startup test expects duplicate suppression. An unchanged programmatic-scroll-to-bottom E2E test relies on the after callback. Do not edit the checkout.",
+      "expected_output": "A read-only candidate that uses the impact map to preserve both consumers, analyzes before-only, after-only, and both-in-one-batch behavior, and predicts the unchanged bottom-scroll regression without proposing an unbounded test matrix.",
+      "files": [],
+      "expectations": [
+        "The candidate maps the changed filter to both startup alignment and bottom-scroll consumers.",
+        "The self-review covers before-only, after-only, and both-in-one-batch cases.",
+        "The candidate identifies that unconditional after-entry removal can prevent loading the tail.",
+        "ProgrammaticScrollToBottom_ReachesLastItems is selected as an impacted unchanged test.",
+        "The edited narrow startup test is not treated as complete coverage of the shared observer producer.",
+        "The recommendation preserves the callback required by bottom scrolling while addressing duplicate startup handling.",
+        "The proposed validation remains bounded to producer branches and directly impacted consumers."
+      ]
     }
   ]
 }

--- a/.github/skills/aspnetcore-try-fix/evals/evals.json
+++ b/.github/skills/aspnetcore-try-fix/evals/evals.json
@@ -6,6 +6,22 @@
       "prompt": "In an isolated dotnet/aspnetcore worktree, empirically validate a browser list bug. The supplied assertion contract opens at item 400, increases only item 399's height, confirms item 400 stays pinned, then presses End and expects the last item. Run the identical assertion against frozen head and one candidate in both requested runtime variants for three repetitions. Do not post or push.",
       "expected_output": "A structured empirical candidate that preserves the exact focused stimulus, reaches the End assertion, reports every execution, and does not substitute a global variable-height or all-items layout change.",
       "files": [],
+      "eval_metadata": {
+        "mechanism": "browser-lifecycle-assertion-fidelity",
+        "provenance": {
+          "kind": "historical",
+          "source": "dotnet/aspnetcore#68114"
+        },
+        "area": "Components/Virtualization",
+        "score_family": "assertion-fidelity",
+        "tier": "train",
+        "discovery_mode": "verification",
+        "controls": {
+          "positive": [0, 1, 2, 5, 6, 7],
+          "negative": [3, 4, 8]
+        },
+        "forbidden_prompt_terms": []
+      },
       "expectations": [
         "The candidate states the product oracle and its source confidence before proposing a fix.",
         "The assertion plan lists setup, control, trigger, expected assertion, allowed perturbations, runtime variants, and repetitions.",
@@ -23,6 +39,22 @@
       "prompt": "In empirical mode, evaluate an ASP.NET Core worker-test candidate that changes an observer timeout from two seconds to ten seconds. The only support for allowing longer work is the patch author's hypothesis. A proposed diagnostic gates healthy work for three seconds, so it fails under the old timeout and passes under the candidate. Use an isolated worktree and keep all changes local.",
       "expected_output": "A structured candidate that can run the synthetic diagnostic while refusing to turn a candidate-shaped threshold probe into authoritative scenario proof or a production-proven implementation.",
       "files": [],
+      "eval_metadata": {
+        "mechanism": "timeout-policy-oracle",
+        "provenance": {
+          "kind": "historical",
+          "source": "timeout-policy calibration"
+        },
+        "area": "Testing/Infrastructure",
+        "score_family": "proof-calibration",
+        "tier": "train",
+        "discovery_mode": "verification",
+        "controls": {
+          "positive": [0, 1, 2, 3, 4],
+          "negative": [5, 6]
+        },
+        "forbidden_prompt_terms": []
+      },
       "expectations": [
         "The output distinguishes accepted behavior from patch intent and the proposed historical cause.",
         "Oracle fidelity is hypothesis unless stronger independent authority is found.",
@@ -38,6 +70,22 @@
       "prompt": "In candidate-review mode, assess restoring a removed legacy serializer alias. The only claim that old payloads are unsupported comes from the current patch description. A proposed regression test sends the old property and passes only with the alias restored. Do not edit the checkout.",
       "expected_output": "A read-only candidate that explains the structural compatibility effect but does not treat its own old-payload test as an authoritative compatibility contract.",
       "files": [],
+      "eval_metadata": {
+        "mechanism": "compatibility-oracle",
+        "provenance": {
+          "kind": "synthetic",
+          "source": "legacy serializer alias scenario"
+        },
+        "area": "MVC/Serialization",
+        "score_family": "oracle-authority",
+        "tier": "train",
+        "discovery_mode": "verification",
+        "controls": {
+          "positive": [0, 1, 4],
+          "negative": [2, 3]
+        },
+        "forbidden_prompt_terms": []
+      },
       "expectations": [
         "The candidate identifies whether the old-payload expectation has documentation, accepted criteria, maintainer context, or only patch-author rationale.",
         "The proposed test states why its expected result is required independently of restoring the alias.",
@@ -51,6 +99,22 @@
       "prompt": "In an isolated worktree, empirically assess a test harness that waits on two inner tasks with an observer-only timeout. A focused test runs only with an unrelated frontend build disabled. Preserve a diagnostic assertion, apply one implementation candidate, and determine whether the result is production-ready.",
       "expected_output": "A scoped empirical result with separate diagnostic and implementation diffs, build-bypass proof limits, a varied stress matrix, and deterministic cleanup of inner tasks after observer timeout.",
       "files": [],
+      "eval_metadata": {
+        "mechanism": "timeout-cleanup-build-bypass",
+        "provenance": {
+          "kind": "historical",
+          "source": "background-worker timeout calibration"
+        },
+        "area": "Testing/Infrastructure",
+        "score_family": "cleanup-proof-boundary",
+        "tier": "train",
+        "discovery_mode": "verification",
+        "controls": {
+          "positive": [0, 1, 3, 4, 5, 6],
+          "negative": [2]
+        },
+        "forbidden_prompt_terms": []
+      },
       "expectations": [
         "The diagnostic assertion and implementation candidate are captured separately and given an assertion disposition.",
         "The build-property override is recorded and shown irrelevant to the focused behavior before use.",
@@ -66,6 +130,22 @@
       "prompt": "In an isolated ASP.NET Core worktree, evaluate one pooled-resource candidate. Accepted criteria require exactly one lease return on normal completion, cancellation, producer fault, and disposal. Frozen-head assertions reproduce a cancellation double-return and a producer-fault leak through the real owner path. The candidate unifies ownership exit, and the identical assertions plus a varied lifecycle matrix pass on every required configuration.",
       "expected_output": "A structured empirical candidate that can reach production-proven because the oracle, mechanism, scenario, real producer path, stress matrix, and configurations are all strong.",
       "files": [],
+      "eval_metadata": {
+        "mechanism": "pooled-resource-strong-proof",
+        "provenance": {
+          "kind": "synthetic",
+          "source": "pooled lease ownership scenario"
+        },
+        "area": "Servers",
+        "score_family": "proof-promotion",
+        "tier": "train",
+        "discovery_mode": "verification",
+        "controls": {
+          "positive": [0, 1, 2, 3, 4],
+          "negative": [5]
+        },
+        "forbidden_prompt_terms": []
+      },
       "expectations": [
         "Oracle fidelity is authoritative and cites the accepted criteria.",
         "Mechanism fidelity is reproduced using the retained failures and frozen-head assertions.",
@@ -77,9 +157,36 @@
     },
     {
       "id": 6,
-      "prompt": "In an isolated ASP.NET Core worktree, assess a registration PR where an independently justified exact-instance assertion passes on untouched frozen head through the real consumer. Reintroducing the removed historical assignment makes it fail. Validate the current fix without inventing a production change.",
+      "prompt": "In an isolated ASP.NET Core worktree, assess the supplied registration-fix fixture. Determine whether the current implementation needs a production change and what regression evidence is justified.",
       "expected_output": "A structured no-defect result that records the head pass, labels the historical mutation diagnostic-only, and treats any stronger regression assertion as optional coverage.",
-      "files": [],
+      "files": [
+        ".github/skills/aspnetcore-pr-review/evals/fixtures/registration-instance-precedence.md"
+      ],
+      "eval_metadata": {
+        "mechanism": "no-defect-registration",
+        "provenance": {
+          "kind": "historical",
+          "source": "dotnet/aspnetcore#68081"
+        },
+        "area": "Hosting/DependencyInjection",
+        "score_family": "no-defect-calibration",
+        "tier": "held_out",
+        "frozen_hash": "198f97d59b484286fc82214dcfe73e2dda2eaeecbafd19f0f82b358fa155dc7a",
+        "fixture_hashes": {
+          ".github/skills/aspnetcore-pr-review/evals/fixtures/registration-instance-precedence.md": "df21462ee1948f8974614ed8a24016de01ebf18ebe8d4a745a02be32ec92e074"
+        },
+        "discovery_mode": "discovery",
+        "controls": {
+          "positive": [0, 2, 3, 4],
+          "negative": [1]
+        },
+        "forbidden_prompt_terms": [
+          "passes on untouched frozen head",
+          "diagnostic-only",
+          "optional-regression",
+          "manufacture"
+        ]
+      },
       "expectations": [
         "Untouched frozen head is executed first and its passing result is preserved.",
         "The agent does not manufacture a frozen-head red or propose a production correction after head passes.",
@@ -90,9 +197,36 @@
     },
     {
       "id": 7,
-      "prompt": "In an isolated ASP.NET Core worktree, validate a one-line stateless lookup fix against an authoritative contract. Frozen head fails the real-path assertion, the candidate passes it, and two nearest key-shape counterexamples pass. No lifecycle or asynchronous state exists.",
+      "prompt": "In an isolated ASP.NET Core worktree, validate the supplied lookup-correction fixture. Determine the proportionate assertion matrix and candidate proof level.",
       "expected_output": "A proportionate empirical candidate that uses the real path and relevant key-shape variants without unrelated lifecycle scaffolding.",
-      "files": [],
+      "files": [
+        ".github/skills/aspnetcore-pr-review/evals/fixtures/stateless-lookup.md"
+      ],
+      "eval_metadata": {
+        "mechanism": "proportionate-stateless-validation",
+        "provenance": {
+          "kind": "synthetic",
+          "source": "one-line stateless lookup scenario"
+        },
+        "area": "Http",
+        "score_family": "proportionate-validation",
+        "tier": "held_out",
+        "frozen_hash": "423bc1166ad2bd7b64819e3161e3272029ca6a533007f6727f7bc99595085831",
+        "fixture_hashes": {
+          ".github/skills/aspnetcore-pr-review/evals/fixtures/stateless-lookup.md": "c395cbcdb376549ba18d00a53e780b04e99ff59e739107a6d69a167f2309ed3a"
+        },
+        "discovery_mode": "discovery",
+        "controls": {
+          "positive": [0, 1, 3, 4],
+          "negative": [2]
+        },
+        "forbidden_prompt_terms": [
+          "cancellation",
+          "disposal",
+          "timing tests",
+          "stateless"
+        ]
+      },
       "expectations": [
         "The identical assertion provides strict frozen-head red and candidate green.",
         "The matrix varies relevant lookup inputs rather than unrelated lifecycle dimensions.",
@@ -103,9 +237,32 @@
     },
     {
       "id": 8,
-      "prompt": "In an isolated dotnet/aspnetcore worktree, evaluate a Virtualize candidate where observer callbacks are suppressed while InitialItemIndex pins a variable-height list. The first resumed bottom-spacer callback may combine old spacer pixels with a new measured item-size average. Existing tests cover initial placement and boundary-key takeover but not this recovery edge. Keep the experiment bounded and local.",
+      "prompt": "In an isolated dotnet/aspnetcore worktree, evaluate a candidate that changes callback handling while InitialItemIndex positions a browser-backed variable-height list. The edited tests cover initial placement and keyboard takeover. Determine which adjacent recovery behavior and impacted existing tests are needed to validate the candidate. Keep the experiment bounded and local.",
       "expected_output": "A structured empirical candidate that models measurement provenance across suppression, runs impacted existing tests first, and tests the first resumed real-browser callback with one fixed-size control and one variable-height perturbation.",
-      "files": [],
+      "files": [
+        ".github/skills/aspnetcore-pr-review/evals/fixtures/virtualization-recovery.md"
+      ],
+      "eval_metadata": {
+        "mechanism": "measurement-generation-recovery",
+        "provenance": {
+          "kind": "historical",
+          "source": "dotnet/aspnetcore#68114"
+        },
+        "area": "Components/Virtualization",
+        "score_family": "recovery-measurement-generation",
+        "tier": "train",
+        "discovery_mode": "discovery",
+        "controls": {
+          "positive": [0, 1, 2, 3, 4, 6],
+          "negative": [5]
+        },
+        "forbidden_prompt_terms": [
+          "first resumed",
+          "bottom spacer",
+          "old spacer pixels",
+          "measured item-size average"
+        ]
+      },
       "expectations": [
         "The assertion plan records the suppressed interval, resume trigger, pre/post measurement generations, and impacted existing tests.",
         "The candidate explains which geometry remains stale and which measurement becomes current before redistribution.",
@@ -118,9 +275,32 @@
     },
     {
       "id": 9,
-      "prompt": "In candidate-review mode, assess a Virtualize change that filters an IntersectionObserver batch containing both before and after spacers by unconditionally deleting the after-spacer entry. The edited startup test expects duplicate suppression. An unchanged programmatic-scroll-to-bottom E2E test relies on the after callback. Do not edit the checkout.",
+      "prompt": "In candidate-review mode, assess a browser virtualization change that filters entries from a shared IntersectionObserver callback batch. The edited startup test expects duplicate suppression. Determine all directly impacted producer branches and unchanged consumers before recommending the change. Do not edit the checkout.",
       "expected_output": "A read-only candidate that uses the impact map to preserve both consumers, analyzes before-only, after-only, and both-in-one-batch behavior, and predicts the unchanged bottom-scroll regression without proposing an unbounded test matrix.",
-      "files": [],
+      "files": [
+        ".github/skills/aspnetcore-pr-review/evals/fixtures/virtualization-producer-drift.md"
+      ],
+      "eval_metadata": {
+        "mechanism": "shared-producer-impact",
+        "provenance": {
+          "kind": "historical",
+          "source": "dotnet/aspnetcore#68114"
+        },
+        "area": "Components/Virtualization",
+        "score_family": "producer-impact",
+        "tier": "train",
+        "discovery_mode": "discovery",
+        "controls": {
+          "positive": [0, 1, 2, 3, 5],
+          "negative": [4, 6]
+        },
+        "forbidden_prompt_terms": [
+          "before-only",
+          "after-only",
+          "ProgrammaticScrollToBottom_ReachesLastItems",
+          "loading the tail"
+        ]
+      },
       "expectations": [
         "The candidate maps the changed filter to both startup alignment and bottom-scroll consumers.",
         "The self-review covers before-only, after-only, and both-in-one-batch cases.",
@@ -129,6 +309,120 @@
         "The edited narrow startup test is not treated as complete coverage of the shared observer producer.",
         "The recommendation preserves the callback required by bottom scrolling while addressing duplicate startup handling.",
         "The proposed validation remains bounded to producer branches and directly impacted consumers."
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "In an isolated dotnet/aspnetcore worktree, assess the supplied deferred connection-abort fixture. Determine whether the current implementation needs a production change and what evidence supports that decision.",
+      "expected_output": "A no-defect empirical result that runs the untouched focused test first, traces the deferred-cancel/dispose race, uses any exception instrumentation only diagnostically, and keeps the narrow current fix when broader coordination alternatives introduce liveness or cleanup risks.",
+      "files": [
+        ".github/skills/aspnetcore-pr-review/evals/fixtures/connection-abort-dispose.md"
+      ],
+      "eval_metadata": {
+        "mechanism": "deferred-cancel-dispose-race",
+        "provenance": {
+          "kind": "pr",
+          "source": "dotnet/aspnetcore#68146"
+        },
+        "area": "Servers/Connections",
+        "score_family": "lifecycle-ownership",
+        "tier": "held_out",
+        "frozen_hash": "36ec49c9f26acc5c2fe372fc0c317b3c6b421e22d163eb67454ae378278505aa",
+        "fixture_hashes": {
+          ".github/skills/aspnetcore-pr-review/evals/fixtures/connection-abort-dispose.md": "20b6ac1f855ecc47ab2b3c8bc7d319f3043d4c4c40e3eeaa2b1c21779cb312a4"
+        },
+        "discovery_mode": "discovery",
+        "controls": {
+          "positive": [0, 1, 2, 3, 6],
+          "negative": [4, 5]
+        },
+        "forbidden_prompt_terms": [
+          "first-chance exception",
+          "deadlock",
+          "ConnectionClosed"
+        ]
+      },
+      "expectations": [
+        "The untouched focused regression is executed or exact current CI evidence is preserved before applying diagnostic instrumentation.",
+        "The candidate traces the deferred cancellation and immediate disposal ownership race.",
+        "The narrow ObjectDisposedException catch is distinguished from cancellation callback exceptions.",
+        "Any first-chance exception marker is diagnostic-only and does not become required regression coverage.",
+        "The candidate does not invent a requirement that ConnectionClosed callbacks complete after disposal.",
+        "Alternatives that wait for the queued worker or transfer disposal ownership are rejected when they can deadlock or strand cleanup.",
+        "The result keeps the current fix and does not manufacture a production correction."
+      ]
+    },
+    {
+      "id": 11,
+      "prompt": "In an isolated dotnet/aspnetcore worktree, evaluate PR #68037 at head 2df89bef7b6001fb64b5e8bef3dda447f1e4967b. It changes the Components render-batch writer call shape and includes one benchmark plus a mutation-safety test. Determine what can be proven about correctness, mutation reachability, and performance before recommending an implementation.",
+      "expected_output": "A scoped performance candidate that validates unchanged wire behavior, falsifies a mutation test that passes a copied local by reference while checking the source array, and requires comparative benchmark and generated-code evidence before preferring one-copy or direct-array call shapes.",
+      "files": [],
+      "eval_metadata": {
+        "mechanism": "performance-call-shape-proof",
+        "provenance": {
+          "kind": "pr",
+          "source": "dotnet/aspnetcore#68037"
+        },
+        "area": "Components/RenderTree",
+        "score_family": "performance-proof",
+        "tier": "train",
+        "discovery_mode": "verification",
+        "controls": {
+          "positive": [0, 1, 2, 3, 4],
+          "negative": [5, 6]
+        },
+        "forbidden_prompt_terms": []
+      },
+      "expectations": [
+        "The candidate preserves and runs the relevant protocol serialization tests before changing the call shape.",
+        "The candidate separates wire correctness, mutation reachability, generated call shape, and material performance as distinct claims.",
+        "A mutation assertion is rejected when Write receives a copied local but the test compares the original array.",
+        "The empirical plan compares the original in-parameter, one-copy by-value or local-ref, and direct-array-ref shapes under the same workload.",
+        "Generated IL or disassembly is required to establish the intended call-shape difference.",
+        "A direct-array-ref candidate is not production-proven without falsifying writable-alias safety and demonstrating material benefit.",
+        "The final result remains blocked on evidence rather than claiming an unproven performance winner."
+      ]
+    },
+    {
+      "id": 12,
+      "prompt": "In candidate-review mode, assess the later head represented by the supplied ASP.NET Core SignalR reconnect fixture. Determine the changed producer branches, impacted unchanged consumers, and the bounded validation needed before recommending the change.",
+      "expected_output": "A read-only producer-impact candidate that re-establishes null retry-delay semantics, maps the later normalization to the reconnect scheduler, and selects the impacted unchanged test from the frozen reconnect-suite inventory without being told which entry is affected in the prompt.",
+      "files": [
+        ".github/skills/aspnetcore-pr-review/evals/fixtures/signalr-reconnect-drift.md"
+      ],
+      "eval_metadata": {
+        "mechanism": "signalr-retry-policy-producer-impact",
+        "provenance": {
+          "kind": "synthetic",
+          "source": "signalr retry-policy drift fixture"
+        },
+        "area": "SignalR/Client",
+        "score_family": "producer-impact",
+        "tier": "held_out",
+        "frozen_hash": "7c74f2766fd17cac927644199a50dd3a16150e45e10450ad09ca00798467c39d",
+        "fixture_hashes": {
+          ".github/skills/aspnetcore-pr-review/evals/fixtures/signalr-reconnect-drift.md": "111a0a8934b6d50941094bbe48c3202c1b295c91fc3a9cc3ad98fb611a8bb73d"
+        },
+        "discovery_mode": "discovery",
+        "controls": {
+          "positive": [0, 1, 2, 3, 5],
+          "negative": [4, 6]
+        },
+        "forbidden_prompt_terms": [
+          "NextRetryDelay",
+          "TimeSpan.Zero",
+          "StopsIfTheReconnectPolicyReturnsNull",
+          "Disconnected"
+        ]
+      },
+      "expectations": [
+        "The candidate establishes from the fixture that a null retry delay stops automatic reconnect.",
+        "The changed null-to-zero normalization is mapped to the shared reconnect scheduler.",
+        "The impact map selects the unchanged null-after-failed-retry test from the supplied reconnect-suite inventory.",
+        "The unchanged impacted test is selected before a candidate-specific assertion.",
+        "Earlier-head success is not treated as validation of the later producer change.",
+        "The candidate predicts that normalizing null to zero schedules an unintended immediate retry.",
+        "The proposed validation remains bounded to retry-result branches and directly impacted consumers."
       ]
     }
   ]

--- a/.github/skills/aspnetcore-try-fix/evals/evals.json
+++ b/.github/skills/aspnetcore-try-fix/evals/evals.json
@@ -17,6 +17,63 @@
         "The response distinguishes finding proof, scenario proof, candidate proof, and assertion fidelity.",
         "No GitHub state or parent worktree is modified."
       ]
+    },
+    {
+      "id": 2,
+      "prompt": "In empirical mode, evaluate an ASP.NET Core worker-test candidate that changes an observer timeout from two seconds to ten seconds. The only support for allowing longer work is the patch author's hypothesis. A proposed diagnostic gates healthy work for three seconds, so it fails under the old timeout and passes under the candidate. Use an isolated worktree and keep all changes local.",
+      "expected_output": "A structured candidate that can run the synthetic diagnostic while refusing to turn a candidate-shaped threshold probe into authoritative scenario proof or a production-proven implementation.",
+      "files": [],
+      "expectations": [
+        "The output distinguishes accepted behavior from patch intent and the proposed historical cause.",
+        "Oracle fidelity is hypothesis unless stronger independent authority is found.",
+        "The assertion plan states the independent authority for expecting three-second work to succeed.",
+        "If no independent authority exists, the assertion disposition is diagnostic-only.",
+        "Scenario fidelity is synthetic rather than exact.",
+        "A green candidate is not production-proven without a varied stress matrix and real producer validation.",
+        "The response says the experiment proves the timeout-policy difference but not the original failure mechanism."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "In candidate-review mode, assess restoring a removed legacy serializer alias. The only claim that old payloads are unsupported comes from the current patch description. A proposed regression test sends the old property and passes only with the alias restored. Do not edit the checkout.",
+      "expected_output": "A read-only candidate that explains the structural compatibility effect but does not treat its own old-payload test as an authoritative compatibility contract.",
+      "files": [],
+      "expectations": [
+        "The candidate identifies whether the old-payload expectation has documentation, accepted criteria, maintainer context, or only patch-author rationale.",
+        "The proposed test states why its expected result is required independently of restoring the alias.",
+        "Without stronger authority, the candidate labels the compatibility requirement unsupported or oracle-blocked.",
+        "The candidate does not claim Pass in candidate-review mode.",
+        "The recommendation is calibrated as a compatibility question or defensive option rather than a proven required change."
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "In an isolated worktree, empirically assess a test harness that waits on two inner tasks with an observer-only timeout. A focused test runs only with an unrelated frontend build disabled. Preserve a diagnostic assertion, apply one implementation candidate, and determine whether the result is production-ready.",
+      "expected_output": "A scoped empirical result with separate diagnostic and implementation diffs, build-bypass proof limits, a varied stress matrix, and deterministic cleanup of inner tasks after observer timeout.",
+      "files": [],
+      "expectations": [
+        "The diagnostic assertion and implementation candidate are captured separately and given an assertion disposition.",
+        "The build-property override is recorded and shown irrelevant to the focused behavior before use.",
+        "The proof is capped at targeted-proven while the standard build or exact CI path remains unvalidated.",
+        "Repeated identical passes are not substituted for a varied stress matrix.",
+        "The test inspects inner task state after timeout and deterministically releases or cancels outstanding work.",
+        "Exceptions from timed-out inner work are observed so they cannot leak into later tests.",
+        "The final fidelity fields preserve configuration and scenario limits."
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "In an isolated ASP.NET Core worktree, evaluate one pooled-resource candidate. Accepted criteria require exactly one lease return on normal completion, cancellation, producer fault, and disposal. Frozen-head assertions reproduce a cancellation double-return and a producer-fault leak through the real owner path. The candidate unifies ownership exit, and the identical assertions plus a varied lifecycle matrix pass on every required configuration.",
+      "expected_output": "A structured empirical candidate that can reach production-proven because the oracle, mechanism, scenario, real producer path, stress matrix, and configurations are all strong.",
+      "files": [],
+      "expectations": [
+        "Oracle fidelity is authoritative and cites the accepted criteria.",
+        "Mechanism fidelity is reproduced using the retained failures and frozen-head assertions.",
+        "Scenario fidelity is exact across normal, cancellation, producer-fault, and disposal paths.",
+        "The stress matrix varies lifecycle exits rather than merely repeating one deterministic assertion.",
+        "The candidate may be classified production-proven after all required configurations and neighboring tests pass.",
+        "The recommendation is not artificially downgraded when every relevant proof dimension is strong."
+      ]
     }
   ]
 }

--- a/.github/skills/aspnetcore-try-fix/evals/evals.json
+++ b/.github/skills/aspnetcore-try-fix/evals/evals.json
@@ -1,0 +1,22 @@
+{
+  "skill_name": "aspnetcore-try-fix",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "In an isolated dotnet/aspnetcore worktree, empirically validate a browser list bug. The supplied assertion contract opens at item 400, increases only item 399's height, confirms item 400 stays pinned, then presses End and expects the last item. Run the identical assertion against frozen head and one candidate in both requested runtime variants for three repetitions. Do not post or push.",
+      "expected_output": "A structured empirical candidate that preserves the exact focused stimulus, reaches the End assertion, reports every execution, and does not substitute a global variable-height or all-items layout change.",
+      "files": [],
+      "expectations": [
+        "The candidate states the product oracle and its source confidence before proposing a fix.",
+        "The assertion plan lists setup, control, trigger, expected assertion, allowed perturbations, runtime variants, and repetitions.",
+        "Only the specified adjacent item is resized before the boundary-key trigger.",
+        "The test does not substitute a global layout-mode or all-items height change.",
+        "A failure before the End trigger is classified as a scenario mismatch or separate finding rather than proof of the requested claim.",
+        "Frozen-head and candidate runs use the identical behavioral assertion.",
+        "The execution matrix contains one result for every requested runtime variant and repetition.",
+        "The response distinguishes finding proof, scenario proof, candidate proof, and assertion fidelity.",
+        "No GitHub state or parent worktree is modified."
+      ]
+    }
+  ]
+}

--- a/.github/skills/aspnetcore-try-fix/evals/evals.json
+++ b/.github/skills/aspnetcore-try-fix/evals/evals.json
@@ -74,6 +74,32 @@
         "The candidate may be classified production-proven after all required configurations and neighboring tests pass.",
         "The recommendation is not artificially downgraded when every relevant proof dimension is strong."
       ]
+    },
+    {
+      "id": 6,
+      "prompt": "In an isolated ASP.NET Core worktree, assess a registration PR where an independently justified exact-instance assertion passes on untouched frozen head through the real consumer. Reintroducing the removed historical assignment makes it fail. Validate the current fix without inventing a production change.",
+      "expected_output": "A structured no-defect result that records the head pass, labels the historical mutation diagnostic-only, and treats any stronger regression assertion as optional coverage.",
+      "files": [],
+      "expectations": [
+        "Untouched frozen head is executed first and its passing result is preserved.",
+        "The agent does not manufacture a frozen-head red or propose a production correction after head passes.",
+        "The historical mutation is explicitly diagnostic-only.",
+        "The stronger test assertion is optional-regression rather than required-regression.",
+        "The result states that no current-head production defect was proven."
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "In an isolated ASP.NET Core worktree, validate a one-line stateless lookup fix against an authoritative contract. Frozen head fails the real-path assertion, the candidate passes it, and two nearest key-shape counterexamples pass. No lifecycle or asynchronous state exists.",
+      "expected_output": "A proportionate empirical candidate that uses the real path and relevant key-shape variants without unrelated lifecycle scaffolding.",
+      "files": [],
+      "expectations": [
+        "The identical assertion provides strict frozen-head red and candidate green.",
+        "The matrix varies relevant lookup inputs rather than unrelated lifecycle dimensions.",
+        "The response does not add cancellation, disposal, concurrency, or timing tests solely to upgrade proof.",
+        "The assertion disposition is required-regression.",
+        "Candidate fidelity remains limited by the configurations and platforms actually executed."
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

- require a GPT orchestrator, independent product-oracle evidence, impact mapping, and lifecycle-aware empirical adjudication for ASP.NET Core PR reviews
- distinguish proven frozen-head defects from diagnostic mutations and calibrate merge-readiness to the strongest completed proof rung
- add anti-overfit eval policy, fixture-backed discovery cases, held-out cross-area transfer coverage, family/provenance macro scoring, and deterministic validation for both reviewer skills

## Validation

- `python3 -m pytest -q .github/skills/aspnetcore-pr-review/scripts/test_validate_evals.py .github/skills/aspnetcore-pr-review/scripts/test_aggregate_eval_scores.py .github/skills/aspnetcore-pr-review/scripts/test_validate_artifacts.py`
- `python3 .github/skills/aspnetcore-pr-review/scripts/validate_evals.py .github/skills/aspnetcore-pr-review/evals/evals.json .github/skills/aspnetcore-try-fix/evals/evals.json`
- independent final review by Claude Opus 5, Claude Sonnet 5, and GPT-5.6 Terra; all agreed with no required changes