### PR TITLE
[Blazor] Add tool-based generative UI dojo scenario

### DIFF
--- a/src/Components/AI/testassets/AGUIDojoApi/ChatClientAgentFactory.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/ChatClientAgentFactory.cs
@@ -28,6 +28,13 @@ internal static class ChatClientAgentFactory
         If the user rejected every step, acknowledge that no steps will be performed.
         """;
 
+    internal const string ToolBasedGenerativeUISystemPrompt = """
+        You are a Japanese haiku assistant.
+        For every haiku request, call generate_haiku with exactly three Japanese lines, exactly
+        three English translation lines, a relevant image_name, and an attractive CSS gradient.
+        Do not print the haiku as ordinary chat text before calling the tool.
+        """;
+
     internal static IChatClient CreateAgenticChat(IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);

--- a/src/Components/AI/testassets/AGUIDojoApi/ChatClientAgentFactory.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/ChatClientAgentFactory.cs
@@ -31,7 +31,8 @@ internal static class ChatClientAgentFactory
     internal const string ToolBasedGenerativeUISystemPrompt = """
         You are a Japanese haiku assistant.
         For every haiku request, call generate_haiku with exactly three Japanese lines, exactly
-        three English translation lines, a relevant image_name, and an attractive CSS gradient.
+        three English translation lines, image_name set to ancient-pond.svg, and a two-color CSS
+        linear-gradient written as linear-gradient(<angle>deg, <hex color>, <hex color>).
         Do not print the haiku as ordinary chat text before calling the tool.
         """;
 

--- a/src/Components/AI/testassets/AGUIDojoApi/Program.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/Program.cs
@@ -38,6 +38,9 @@ app.MapDojoEndpoint(
 app.MapDojoEndpoint(
     "/human_in_the_loop",
     systemPrompt: ChatClientAgentFactory.HumanInTheLoopSystemPrompt);
+app.MapDojoEndpoint(
+    "/tool_based_generative_ui",
+    systemPrompt: ChatClientAgentFactory.ToolBasedGenerativeUISystemPrompt);
 
 await app.RunAsync();
 

--- a/src/Components/AI/testassets/AGUIDojoApi/ScriptedChatClient.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/ScriptedChatClient.cs
@@ -33,6 +33,8 @@ internal sealed class ScriptedChatClient : IChatClient
                     "The weather in San Francisco is sunny with a temperature of 20\u00b0C.",
                 { CallId: "human-in-the-loop-steps-1" } result =>
                     CreateTaskStepsSummary(result.Result),
+                { CallId: "tool-generative-ui-haiku-1" } =>
+                    "Your nature haiku is ready\u2014a quiet pond awakened by a frog.",
                 _ => "Background changed to a sunset gradient.",
             };
             yield return new ChatResponseUpdate
@@ -124,6 +126,32 @@ internal sealed class ScriptedChatClient : IChatClient
                                 new { description = "Plan launch and Mars surface operations", status = "enabled" },
                                 new { description = "Prepare communications and contingency plans", status = "enabled" },
                             },
+                        })
+                ],
+                FinishReason = ChatFinishReason.ToolCalls,
+            };
+            yield break;
+        }
+
+        if (prompt.Contains("haiku", StringComparison.OrdinalIgnoreCase) &&
+            options?.Tools?.OfType<AIFunctionDeclaration>()
+                .Any(tool => tool.Name == "generate_haiku") == true)
+        {
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = messageId,
+                Contents =
+                [
+                    new FunctionCallContent(
+                        "tool-generative-ui-haiku-1",
+                        "generate_haiku",
+                        new Dictionary<string, object?>
+                        {
+                            ["japanese"] = new[] { "\u53e4\u6c60\u3084", "\u86d9\u98db\u3073\u3053\u3080", "\u6c34\u306e\u97f3" },
+                            ["english"] = new[] { "An ancient pond\u2014", "A frog leaps in,", "The sound of water." },
+                            ["image_name"] = "ancient-pond",
+                            ["gradient"] = "linear-gradient(135deg, #134e5e, #71b280)",
                         })
                 ],
                 FinishReason = ChatFinishReason.ToolCalls,

--- a/src/Components/AI/testassets/AGUIDojoApi/ScriptedChatClient.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/ScriptedChatClient.cs
@@ -33,7 +33,10 @@ internal sealed class ScriptedChatClient : IChatClient
                     "The weather in San Francisco is sunny with a temperature of 20\u00b0C.",
                 { CallId: "human-in-the-loop-steps-1" } result =>
                     CreateTaskStepsSummary(result.Result),
-                { CallId: "tool-generative-ui-haiku-1" } =>
+                { CallId: var callId }
+                    when callId.StartsWith(
+                        "tool-generative-ui-haiku-",
+                        StringComparison.Ordinal) =>
                     "Your nature haiku is ready\u2014a quiet pond awakened by a frog.",
                 _ => "Background changed to a sunset gradient.",
             };
@@ -137,6 +140,7 @@ internal sealed class ScriptedChatClient : IChatClient
             options?.Tools?.OfType<AIFunctionDeclaration>()
                 .Any(tool => tool.Name == "generate_haiku") == true)
         {
+            var callId = $"tool-generative-ui-haiku-{Guid.NewGuid():N}";
             yield return new ChatResponseUpdate
             {
                 Role = ChatRole.Assistant,
@@ -144,13 +148,13 @@ internal sealed class ScriptedChatClient : IChatClient
                 Contents =
                 [
                     new FunctionCallContent(
-                        "tool-generative-ui-haiku-1",
+                        callId,
                         "generate_haiku",
                         new Dictionary<string, object?>
                         {
                             ["japanese"] = new[] { "\u53e4\u6c60\u3084", "\u86d9\u98db\u3073\u3053\u3080", "\u6c34\u306e\u97f3" },
                             ["english"] = new[] { "An ancient pond\u2014", "A frog leaps in,", "The sound of water." },
-                            ["image_name"] = "ancient-pond",
+                            ["image_name"] = "ancient-pond.svg",
                             ["gradient"] = "linear-gradient(135deg, #134e5e, #71b280)",
                         })
                 ],

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Baselines/ToolBasedGenerativeUI.recording.json
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Baselines/ToolBasedGenerativeUI.recording.json
@@ -1,0 +1,64 @@
+{
+  "calls": [
+    {
+      "prompt": "Write me a haiku about nature",
+      "messageCount": 2,
+      "toolNames": [
+        "generate_haiku"
+      ],
+      "frames": [
+        {
+          "name": "haiku-action",
+          "functionCall": {
+            "callId": "tool-generative-ui-haiku-1",
+            "name": "generate_haiku",
+            "arguments": {
+              "japanese": [
+                "\u53e4\u6c60\u3084",
+                "\u86d9\u98db\u3073\u3053\u3080",
+                "\u6c34\u306e\u97f3"
+              ],
+              "english": [
+                "An ancient pond\u2014",
+                "A frog leaps in,",
+                "The sound of water."
+              ],
+              "image_name": "ancient-pond",
+              "gradient": "linear-gradient(135deg, #134e5e, #71b280)"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "prompt": "Write me a haiku about nature",
+      "messageCount": 4,
+      "toolNames": [
+        "generate_haiku"
+      ],
+      "toolResultCallIds": [
+        "tool-generative-ui-haiku-1"
+      ],
+      "toolResults": [
+        {
+          "callId": "tool-generative-ui-haiku-1",
+          "result": "\"Haiku displayed to user.\""
+        }
+      ],
+      "frames": [
+        {
+          "name": "haiku-summary-start",
+          "chunks": [
+            "Your nature haiku is ready"
+          ]
+        },
+        {
+          "name": "haiku-summary-final",
+          "chunks": [
+            "\u2014a quiet pond awakened by a frog."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Baselines/ToolBasedGenerativeUI.recording.json
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Baselines/ToolBasedGenerativeUI.recording.json
@@ -23,7 +23,7 @@
                 "A frog leaps in,",
                 "The sound of water."
               ],
-              "image_name": "ancient-pond",
+              "image_name": "ancient-pond.svg",
               "gradient": "linear-gradient(135deg, #134e5e, #71b280)"
             }
           }

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/DojoModelOverrides.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/DojoModelOverrides.cs
@@ -31,6 +31,9 @@ internal class DojoModelOverrides
     public static void HumanInTheLoop(IServiceCollection services)
         => AddRecordedModel(services, "HumanInTheLoop.recording.json");
 
+    public static void ToolBasedGenerativeUI(IServiceCollection services)
+        => AddRecordedModel(services, "ToolBasedGenerativeUI.recording.json");
+
     private static void AddRecordedModel(IServiceCollection services, string recordingFileName)
     {
         services.AddSingleton(_ => RecordedScript.Load(recordingFileName));

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/ToolBasedGenerativeUIScenarioTests.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/ToolBasedGenerativeUIScenarioTests.cs
@@ -52,21 +52,24 @@ public partial class ToolBasedGenerativeUIScenarioTests : BrowserTest
         Assert.AreEqual(
             "linear-gradient(135deg, #667eea, #764ba2)",
             global::DojoClient.Components.Scenarios.ToolBasedGenerativeUI
-                .ToolBasedGenerativeUIScenario.GetSafeGradient(
+                .HaikuData.NormalizeGradient(
                     "linear-gradient(135deg, #134e5e, #71b280); background: url(https://example.com)"));
 
         var prompt = $"{HaikuPrompt} ({_runId})";
-        var carousel = _page.Locator(".haiku-carousel");
+        var carousel = _page.Locator(".tool-generative-ui__display .haiku-carousel");
 
-        await AssertPlaceholderHaikuAsync(carousel);
+        await AssertPlaceholderHaikuAsync(carousel.Locator(".haiku-card"));
         await Expect(carousel.Locator(".haiku-carousel__nav")).ToHaveCountAsync(0);
 
-        await _page.FillAsync("textarea.sc-ai-input__textarea", prompt);
-        await _page.ClickAsync("button.sc-ai-input__send");
+        await SendAsync(prompt);
 
-        await AssertGeneratedHaikuAsync(carousel);
-        await AssertGeneratedCarouselControlsAsync(carousel);
+        await AssertNatureHaikuAsync(carousel.Locator(".haiku-card"));
+        await Expect(carousel.Locator(".haiku-carousel__nav")).ToHaveCountAsync(0);
+        await Expect(carousel).Not.ToContainTextAsync("A placeholder verse");
         await Expect(_page.Locator(".haiku-action-status")).ToHaveTextAsync("Haiku ready");
+        var transcriptCards = _page.Locator(".tool-generative-ui__chat .haiku-card");
+        await Expect(transcriptCards).ToHaveCountAsync(1);
+        await AssertNatureHaikuAsync(transcriptCards.First);
 
         var assistant = _page.Locator(
             ".sc-ai-message--assistant .sc-ai-message__content");
@@ -74,23 +77,6 @@ public partial class ToolBasedGenerativeUIScenarioTests : BrowserTest
         await Expect(assistant).ToHaveClassAsync(
             "sc-ai-message__content sc-ai-message__content--streaming");
         await Expect(_page.Locator("button.sc-ai-input__send")).ToBeDisabledAsync();
-
-        var previous = carousel.GetByRole(
-            AriaRole.Button,
-            new() { Name = "Previous haiku", Exact = true });
-        var next = carousel.GetByRole(
-            AriaRole.Button,
-            new() { Name = "Next haiku", Exact = true });
-
-        await previous.ClickAsync();
-        await AssertPlaceholderHaikuAsync(carousel);
-        await Expect(carousel.Locator(".haiku-carousel__counter")).ToHaveTextAsync("1 / 2");
-        await Expect(previous).ToBeDisabledAsync();
-        await Expect(next).ToBeEnabledAsync();
-
-        await next.ClickAsync();
-        await AssertGeneratedHaikuAsync(carousel);
-        await AssertGeneratedCarouselControlsAsync(carousel);
 
         await _checkpoints.ReleaseAsync(prompt, "haiku-summary-start");
 
@@ -101,39 +87,33 @@ public partial class ToolBasedGenerativeUIScenarioTests : BrowserTest
         await Expect(_page.Locator(".sc-ai-typing")).ToHaveCountAsync(0);
     }
 
-    private static async Task AssertPlaceholderHaikuAsync(ILocator carousel)
+    private static async Task AssertPlaceholderHaikuAsync(ILocator card)
     {
-        var card = carousel.Locator(".haiku-card");
         await Expect(card).ToHaveAttributeAsync(
             "style",
             "background: linear-gradient(135deg, #667eea, #764ba2);");
-        await Expect(card.Locator(".haiku-card__japanese p"))
+        await Expect(card.Locator(".haiku-card__japanese"))
             .ToHaveTextAsync(["\u3053\u3053\u306b\u4e00\u53e5", "\u4eee\u306e\u3046\u305f\u7f6e\u304f", "\u6625\u3092\u5f85\u3064"]);
-        await Expect(card.Locator(".haiku-card__english p"))
+        await Expect(card.Locator(".haiku-card__english"))
             .ToHaveTextAsync(["A placeholder verse\u2014", "Resting here for now,", "Awaiting your words."]);
     }
 
-    private static async Task AssertGeneratedHaikuAsync(ILocator carousel)
+    private static async Task AssertNatureHaikuAsync(ILocator card)
     {
-        var card = carousel.Locator(".haiku-card");
         await Expect(card).ToHaveAttributeAsync(
             "style",
             "background: linear-gradient(135deg, #134e5e, #71b280);");
-        await Expect(card.Locator(".haiku-card__japanese p"))
+        await Expect(card.Locator(".haiku-card__japanese"))
             .ToHaveTextAsync(["\u53e4\u6c60\u3084", "\u86d9\u98db\u3073\u3053\u3080", "\u6c34\u306e\u97f3"]);
-        await Expect(card.Locator(".haiku-card__english p"))
+        await Expect(card.Locator(".haiku-card__english"))
             .ToHaveTextAsync(["An ancient pond\u2014", "A frog leaps in,", "The sound of water."]);
+        await Expect(card.Locator(".haiku-card__image"))
+            .ToHaveAttributeAsync("src", "/images/ancient-pond.svg");
     }
 
-    private static async Task AssertGeneratedCarouselControlsAsync(ILocator carousel)
+    private async Task SendAsync(string prompt)
     {
-        await Expect(carousel.Locator(".haiku-carousel__nav")).ToHaveCountAsync(1);
-        await Expect(carousel.Locator(".haiku-carousel__counter")).ToHaveTextAsync("2 / 2");
-        await Expect(carousel.GetByRole(
-            AriaRole.Button,
-            new() { Name = "Previous haiku", Exact = true })).ToBeEnabledAsync();
-        await Expect(carousel.GetByRole(
-            AriaRole.Button,
-            new() { Name = "Next haiku", Exact = true })).ToBeDisabledAsync();
+        await _page.FillAsync("textarea.sc-ai-input__textarea", prompt);
+        await _page.ClickAsync("button.sc-ai-input__send");
     }
 }

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/ToolBasedGenerativeUIScenarioTests.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/ToolBasedGenerativeUIScenarioTests.cs
@@ -49,6 +49,12 @@ public partial class ToolBasedGenerativeUIScenarioTests : BrowserTest
     [TestMethod]
     public async Task GenerateHaiku_RendersWhileStreamingAndNavigatesCarousel()
     {
+        Assert.AreEqual(
+            "linear-gradient(135deg, #667eea, #764ba2)",
+            global::DojoClient.Components.Scenarios.ToolBasedGenerativeUI
+                .ToolBasedGenerativeUIScenario.GetSafeGradient(
+                    "linear-gradient(135deg, #134e5e, #71b280); background: url(https://example.com)"));
+
         var prompt = $"{HaikuPrompt} ({_runId})";
         var carousel = _page.Locator(".haiku-carousel");
 

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/ToolBasedGenerativeUIScenarioTests.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/ToolBasedGenerativeUIScenarioTests.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using AGUIDojoApi;
+using DojoClient.E2E.Tests.Fixtures;
+using DojoClient.E2E.Tests.ServiceOverrides;
+using Microsoft.AspNetCore.Components.Testing.Infrastructure;
+using Microsoft.AspNetCore.Components.Testing.Playwright;
+using Microsoft.Playwright;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DojoClient.E2E.Tests.Tests;
+
+// The browser reaches AGUIDojoApi through DojoClient's real AGUIChatClient. Only the API model
+// is recorded, so tool declaration, streamed SSE events, invocation, and continuation stay real.
+[UITest]
+public partial class ToolBasedGenerativeUIScenarioTests : BrowserTest
+{
+    private const string HaikuPrompt = "Write me a haiku about nature";
+
+    private ServerInstance _api = null!;
+    private ServerInstance _ui = null!;
+    private ApiCheckpointClient _checkpoints = null!;
+    private IPage _page = null!;
+    private string _runId = null!;
+
+    protected override async Task InitializeCoreAsync()
+    {
+        await base.InitializeCoreAsync();
+
+        _runId = Guid.NewGuid().ToString("N")[..8];
+        _api = await StartServerAsync<AGUIDojoApiAssembly>(TestRoot.Servers, options =>
+        {
+            options.ConfigureServices<DojoModelOverrides>(
+                nameof(DojoModelOverrides.ToolBasedGenerativeUI));
+        });
+        _ui = await StartServerAsync<global::DojoClient.Components.App>(TestRoot.Servers, options =>
+        {
+            options.EnvironmentVariables["AGUI_DOJO_API_URL"] = _api.AppUrl;
+        });
+        _checkpoints = new ApiCheckpointClient(_api);
+
+        var context = await NewContext(new BrowserNewContextOptions().WithServerRouting(_ui));
+        _page = await context.NewPageAsync();
+        await _page.GotoAsync($"{_ui.TestUrl}/tool_based_generative_ui");
+        await _page.WaitForInteractiveAsync("textarea.sc-ai-input__textarea");
+    }
+
+    [TestMethod]
+    public async Task GenerateHaiku_RendersWhileStreamingAndNavigatesCarousel()
+    {
+        var prompt = $"{HaikuPrompt} ({_runId})";
+        var carousel = _page.Locator(".haiku-carousel");
+
+        await AssertPlaceholderHaikuAsync(carousel);
+        await Expect(carousel.Locator(".haiku-carousel__nav")).ToHaveCountAsync(0);
+
+        await _page.FillAsync("textarea.sc-ai-input__textarea", prompt);
+        await _page.ClickAsync("button.sc-ai-input__send");
+
+        await AssertGeneratedHaikuAsync(carousel);
+        await AssertGeneratedCarouselControlsAsync(carousel);
+        await Expect(_page.Locator(".haiku-action-status")).ToHaveTextAsync("Haiku ready");
+
+        var assistant = _page.Locator(
+            ".sc-ai-message--assistant .sc-ai-message__content");
+        await Expect(assistant).ToHaveTextAsync("Your nature haiku is ready");
+        await Expect(assistant).ToHaveClassAsync(
+            "sc-ai-message__content sc-ai-message__content--streaming");
+        await Expect(_page.Locator("button.sc-ai-input__send")).ToBeDisabledAsync();
+
+        var previous = carousel.GetByRole(
+            AriaRole.Button,
+            new() { Name = "Previous haiku", Exact = true });
+        var next = carousel.GetByRole(
+            AriaRole.Button,
+            new() { Name = "Next haiku", Exact = true });
+
+        await previous.ClickAsync();
+        await AssertPlaceholderHaikuAsync(carousel);
+        await Expect(carousel.Locator(".haiku-carousel__counter")).ToHaveTextAsync("1 / 2");
+        await Expect(previous).ToBeDisabledAsync();
+        await Expect(next).ToBeEnabledAsync();
+
+        await next.ClickAsync();
+        await AssertGeneratedHaikuAsync(carousel);
+        await AssertGeneratedCarouselControlsAsync(carousel);
+
+        await _checkpoints.ReleaseAsync(prompt, "haiku-summary-start");
+
+        await Expect(assistant).ToHaveTextAsync(
+            "Your nature haiku is ready\u2014a quiet pond awakened by a frog.");
+        await Expect(assistant).ToHaveClassAsync("sc-ai-message__content");
+        await Expect(_page.Locator("button.sc-ai-input__send")).ToBeEnabledAsync();
+        await Expect(_page.Locator(".sc-ai-typing")).ToHaveCountAsync(0);
+    }
+
+    private static async Task AssertPlaceholderHaikuAsync(ILocator carousel)
+    {
+        var card = carousel.Locator(".haiku-card");
+        await Expect(card).ToHaveAttributeAsync(
+            "style",
+            "background: linear-gradient(135deg, #667eea, #764ba2);");
+        await Expect(card.Locator(".haiku-card__japanese p"))
+            .ToHaveTextAsync(["\u3053\u3053\u306b\u4e00\u53e5", "\u4eee\u306e\u3046\u305f\u7f6e\u304f", "\u6625\u3092\u5f85\u3064"]);
+        await Expect(card.Locator(".haiku-card__english p"))
+            .ToHaveTextAsync(["A placeholder verse\u2014", "Resting here for now,", "Awaiting your words."]);
+    }
+
+    private static async Task AssertGeneratedHaikuAsync(ILocator carousel)
+    {
+        var card = carousel.Locator(".haiku-card");
+        await Expect(card).ToHaveAttributeAsync(
+            "style",
+            "background: linear-gradient(135deg, #134e5e, #71b280);");
+        await Expect(card.Locator(".haiku-card__japanese p"))
+            .ToHaveTextAsync(["\u53e4\u6c60\u3084", "\u86d9\u98db\u3073\u3053\u3080", "\u6c34\u306e\u97f3"]);
+        await Expect(card.Locator(".haiku-card__english p"))
+            .ToHaveTextAsync(["An ancient pond\u2014", "A frog leaps in,", "The sound of water."]);
+    }
+
+    private static async Task AssertGeneratedCarouselControlsAsync(ILocator carousel)
+    {
+        await Expect(carousel.Locator(".haiku-carousel__nav")).ToHaveCountAsync(1);
+        await Expect(carousel.Locator(".haiku-carousel__counter")).ToHaveTextAsync("2 / 2");
+        await Expect(carousel.GetByRole(
+            AriaRole.Button,
+            new() { Name = "Previous haiku", Exact = true })).ToBeEnabledAsync();
+        await Expect(carousel.GetByRole(
+            AriaRole.Button,
+            new() { Name = "Next haiku", Exact = true })).ToBeDisabledAsync();
+    }
+}

--- a/src/Components/AI/testassets/DojoClient/Components/App.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/App.razor
@@ -7,6 +7,7 @@
     <base href="/" />
     <link rel="stylesheet" href="@Assets["_content/Microsoft.AspNetCore.Components.AI/ai-chat.css"]" />
     <link rel="stylesheet" href="@Assets["app.css"]" />
+    <link rel="stylesheet" href="@Assets["DojoClient.styles.css"]" />
     <ImportMap />
     <HeadOutlet />
 </head>

--- a/src/Components/AI/testassets/DojoClient/Components/Pages/Home.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Pages/Home.razor
@@ -10,4 +10,5 @@
     <li><a href="/agentic_chat" data-scenario="agentic_chat">Agentic Chat</a></li>
     <li><a href="/backend_tool_rendering" data-scenario="backend_tool_rendering">Backend Tool Rendering</a></li>
     <li><a href="/human_in_the_loop" data-scenario="human_in_the_loop">Human in the Loop</a></li>
+    <li><a href="/tool_based_generative_ui" data-scenario="tool_based_generative_ui">Tool-Based Generative UI</a></li>
 </ul>

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/GenerateHaikuAction.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/GenerateHaikuAction.razor
@@ -1,0 +1,16 @@
+<span class="haiku-action-status" role="status">
+    @(Block.IsComplete ? "Haiku ready" : "Generating haiku...")
+</span>
+
+@code {
+    [Parameter, EditorRequired]
+    public UIActionBlock Block { get; set; } = default!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (!Block.IsComplete)
+        {
+            await Block.InvokeAsync();
+        }
+    }
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/GenerateHaikuAction.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/GenerateHaikuAction.razor
@@ -11,19 +11,12 @@
 
 @code {
     private HaikuData? _haiku;
-    private UIActionBlock? _initializedBlock;
 
     [Parameter, EditorRequired]
     public UIActionBlock Block { get; set; } = default!;
 
-    protected override async Task OnParametersSetAsync()
+    protected override async Task OnInitializedAsync()
     {
-        if (ReferenceEquals(_initializedBlock, Block))
-        {
-            return;
-        }
-
-        _initializedBlock = Block;
         _haiku = HaikuData.FromCall(Block.Call);
 
         if (!Block.IsComplete)

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/GenerateHaikuAction.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/GenerateHaikuAction.razor
@@ -1,13 +1,31 @@
-<span class="haiku-action-status" role="status">
-    @(Block.IsComplete ? "Haiku ready" : "Generating haiku...")
-</span>
+<div class="haiku-action">
+    @if (_haiku is not null)
+    {
+        <HaikuCard Haiku="_haiku" />
+    }
+
+    <span class="haiku-action-status" role="status">
+        @(Block.IsComplete ? "Haiku ready" : "Generating haiku...")
+    </span>
+</div>
 
 @code {
+    private HaikuData? _haiku;
+    private UIActionBlock? _initializedBlock;
+
     [Parameter, EditorRequired]
     public UIActionBlock Block { get; set; } = default!;
 
-    protected override async Task OnInitializedAsync()
+    protected override async Task OnParametersSetAsync()
     {
+        if (ReferenceEquals(_initializedBlock, Block))
+        {
+            return;
+        }
+
+        _initializedBlock = Block;
+        _haiku = HaikuData.FromCall(Block.Call);
+
         if (!Block.IsComplete)
         {
             await Block.InvokeAsync();

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/GenerateHaikuAction.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/GenerateHaikuAction.razor.css
@@ -1,3 +1,12 @@
+.haiku-action {
+    display: grid;
+    gap: 0.5rem;
+}
+
+::deep .haiku-card {
+    min-height: 18rem;
+}
+
 .haiku-action-status {
     color: #495057;
     display: block;

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/GenerateHaikuAction.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/GenerateHaikuAction.razor.css
@@ -1,0 +1,6 @@
+.haiku-action-status {
+    color: #495057;
+    display: block;
+    font-size: 0.875rem;
+    margin: 0.5rem 1rem;
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/HaikuCard.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/HaikuCard.razor
@@ -1,0 +1,22 @@
+<article class="haiku-card" style="background: @Haiku.Gradient;">
+    <div class="haiku-card__overlay">
+        <div class="haiku-card__japanese" lang="ja">
+            @foreach (var line in Haiku.Japanese)
+            {
+                <p>@line</p>
+            }
+        </div>
+        <div class="haiku-card__divider"></div>
+        <div class="haiku-card__english">
+            @foreach (var line in Haiku.English)
+            {
+                <p>@line</p>
+            }
+        </div>
+    </div>
+</article>
+
+@code {
+    [Parameter, EditorRequired]
+    public HaikuData Haiku { get; set; } = default!;
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/HaikuCard.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/HaikuCard.razor
@@ -1,18 +1,28 @@
 <article class="haiku-card" style="background: @Haiku.Gradient;">
     <div class="haiku-card__overlay">
-        <div class="haiku-card__japanese" lang="ja">
-            @foreach (var line in Haiku.Japanese)
+        <div class="haiku-card__lines">
+            @for (var index = 0; index < Haiku.Japanese.Count; index++)
             {
-                <p>@line</p>
+                <div class="haiku-card__line">
+                    <p class="haiku-card__japanese" lang="ja">
+                        @Haiku.Japanese[index]
+                    </p>
+                    @if (index < Haiku.English.Count)
+                    {
+                        <p class="haiku-card__english">
+                            @Haiku.English[index]
+                        </p>
+                    }
+                </div>
             }
         </div>
-        <div class="haiku-card__divider"></div>
-        <div class="haiku-card__english">
-            @foreach (var line in Haiku.English)
-            {
-                <p>@line</p>
-            }
-        </div>
+
+        @if (Haiku.ImageName is not null)
+        {
+            <img class="haiku-card__image"
+                 src="/images/@Haiku.ImageName"
+                 alt="Illustration selected for the generated haiku" />
+        }
     </div>
 </article>
 

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/HaikuCard.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/HaikuCard.razor.css
@@ -1,0 +1,45 @@
+.haiku-card {
+    align-items: center;
+    border-radius: 1rem;
+    color: white;
+    display: flex;
+    justify-content: center;
+    min-height: 26rem;
+    overflow: hidden;
+    position: relative;
+    width: 100%;
+}
+
+.haiku-card__overlay {
+    padding: 2.5rem;
+    position: relative;
+    text-align: center;
+    text-shadow: 0 2px 8px rgb(0 0 0 / 30%);
+    z-index: 1;
+}
+
+.haiku-card__japanese {
+    font-family: "Noto Serif JP", serif;
+    font-size: 1.6rem;
+    line-height: 2;
+    margin-bottom: 1.2rem;
+}
+
+.haiku-card__japanese p,
+.haiku-card__english p {
+    margin: 0;
+}
+
+.haiku-card__divider {
+    background: rgb(255 255 255 / 50%);
+    height: 2px;
+    margin: 0.8rem auto;
+    width: 3.75rem;
+}
+
+.haiku-card__english {
+    font-size: 1rem;
+    font-style: italic;
+    line-height: 1.8;
+    opacity: 0.9;
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/HaikuCard.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/HaikuCard.razor.css
@@ -1,45 +1,87 @@
 .haiku-card {
     align-items: center;
+    border: 1px solid rgb(255 255 255 / 28%);
     border-radius: 1rem;
-    color: white;
+    box-shadow: 0 1.5rem 3rem rgb(15 23 42 / 24%);
+    color: #f8fafc;
     display: flex;
     justify-content: center;
-    min-height: 26rem;
+    min-height: 28rem;
     overflow: hidden;
     position: relative;
     width: 100%;
 }
 
 .haiku-card__overlay {
-    padding: 2.5rem;
+    align-items: center;
+    backdrop-filter: blur(0.15rem);
+    background: linear-gradient(
+        145deg,
+        rgb(15 23 42 / 12%),
+        rgb(15 23 42 / 42%));
+    display: flex;
+    flex-direction: column;
+    inset: 0;
+    justify-content: center;
+    padding: clamp(1.5rem, 4vw, 3rem);
     position: relative;
     text-align: center;
-    text-shadow: 0 2px 8px rgb(0 0 0 / 30%);
+    text-shadow: 0 2px 12px rgb(0 0 0 / 45%);
     z-index: 1;
+}
+
+.haiku-card__lines {
+    display: grid;
+    gap: 1.35rem;
+    width: 100%;
+}
+
+.haiku-card__line {
+    animation: haiku-line-enter 400ms ease-out both;
+}
+
+.haiku-card__line:nth-child(2) {
+    animation-delay: 100ms;
+}
+
+.haiku-card__line:nth-child(3) {
+    animation-delay: 200ms;
 }
 
 .haiku-card__japanese {
     font-family: "Noto Serif JP", serif;
-    font-size: 1.6rem;
-    line-height: 2;
-    margin-bottom: 1.2rem;
-}
-
-.haiku-card__japanese p,
-.haiku-card__english p {
+    font-size: clamp(1.75rem, 4vw, 2.75rem);
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    line-height: 1.35;
     margin: 0;
 }
 
-.haiku-card__divider {
-    background: rgb(255 255 255 / 50%);
-    height: 2px;
-    margin: 0.8rem auto;
-    width: 3.75rem;
+.haiku-card__english {
+    color: rgb(248 250 252 / 82%);
+    font-size: clamp(0.9rem, 2vw, 1.05rem);
+    font-style: italic;
+    line-height: 1.5;
+    margin: 0.3rem 0 0;
 }
 
-.haiku-card__english {
-    font-size: 1rem;
-    font-style: italic;
-    line-height: 1.8;
-    opacity: 0.9;
+.haiku-card__image {
+    border-radius: 0.75rem;
+    box-shadow: 0 0.75rem 1.5rem rgb(15 23 42 / 35%);
+    height: clamp(10rem, 24vw, 16rem);
+    margin-top: 2rem;
+    object-fit: cover;
+    width: min(100%, 28rem);
+}
+
+@keyframes haiku-line-enter {
+    from {
+        opacity: 0;
+        transform: translateY(0.75rem);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/HaikuCarousel.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/HaikuCarousel.razor
@@ -1,0 +1,36 @@
+<div class="haiku-carousel">
+    @if (Haikus.Count > 0)
+    {
+        <HaikuCard Haiku="Haikus[CurrentIndex]" />
+    }
+
+    @if (Haikus.Count > 1)
+    {
+        <nav class="haiku-carousel__nav" aria-label="Haiku carousel">
+            <button class="haiku-carousel__btn"
+                    aria-label="Previous haiku"
+                    disabled="@(CurrentIndex <= 0)"
+                    @onclick="() => OnNavigate.InvokeAsync(CurrentIndex - 1)">
+                &#x25c0;
+            </button>
+            <span class="haiku-carousel__counter">@(CurrentIndex + 1) / @Haikus.Count</span>
+            <button class="haiku-carousel__btn"
+                    aria-label="Next haiku"
+                    disabled="@(CurrentIndex >= Haikus.Count - 1)"
+                    @onclick="() => OnNavigate.InvokeAsync(CurrentIndex + 1)">
+                &#x25b6;
+            </button>
+        </nav>
+    }
+</div>
+
+@code {
+    [Parameter, EditorRequired]
+    public IReadOnlyList<HaikuData> Haikus { get; set; } = [];
+
+    [Parameter]
+    public int CurrentIndex { get; set; }
+
+    [Parameter]
+    public EventCallback<int> OnNavigate { get; set; }
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/HaikuCarousel.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/HaikuCarousel.razor.css
@@ -1,0 +1,44 @@
+.haiku-carousel {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: 100%;
+}
+
+.haiku-carousel__nav {
+    align-items: center;
+    display: flex;
+    gap: 1rem;
+}
+
+.haiku-carousel__btn {
+    align-items: center;
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    color: #333;
+    cursor: pointer;
+    display: flex;
+    font-size: 0.9rem;
+    height: 2.25rem;
+    justify-content: center;
+    transition: background 0.15s;
+    width: 2.25rem;
+}
+
+.haiku-carousel__btn:hover:not(:disabled) {
+    background: #f3f4f6;
+}
+
+.haiku-carousel__btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.35;
+}
+
+.haiku-carousel__counter {
+    color: #6b7280;
+    font-size: 0.85rem;
+    min-width: 3.125rem;
+    text-align: center;
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/HaikuData.cs
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/HaikuData.cs
@@ -1,15 +1,98 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.AI;
+
 namespace DojoClient.Components.Scenarios.ToolBasedGenerativeUI;
 
 public sealed class HaikuData
 {
+    internal const string AncientPondImage = "ancient-pond.svg";
+    internal const string DefaultGradient = "linear-gradient(135deg, #667eea, #764ba2)";
+    private static readonly Regex s_safeGradientPattern = new(
+        @"\Alinear-gradient\(\s*\d{1,3}deg\s*,\s*#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?\s*,\s*#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?\s*\)\z",
+        RegexOptions.CultureInvariant | RegexOptions.NonBacktracking);
+
     public List<string> Japanese { get; set; } = [];
 
     public List<string> English { get; set; } = [];
 
-    public string ImageName { get; set; } = "";
+    public string? ImageName { get; set; }
 
     public string Gradient { get; set; } = "";
+
+    internal static HaikuData Create(
+        IEnumerable<string>? japanese,
+        IEnumerable<string>? english,
+        string? imageName,
+        string? gradient)
+        => new()
+        {
+            Japanese = japanese is null ? [] : [.. japanese],
+            English = english is null ? [] : [.. english],
+            ImageName = NormalizeImageName(imageName),
+            Gradient = NormalizeGradient(gradient),
+        };
+
+    internal static HaikuData FromCall(FunctionCallContent call)
+    {
+        ArgumentNullException.ThrowIfNull(call);
+
+        var arguments = call.Arguments;
+        return Create(
+            GetStringList(arguments, "japanese"),
+            GetStringList(arguments, "english"),
+            GetString(arguments, "image_name"),
+            GetString(arguments, "gradient"));
+    }
+
+    internal static string NormalizeGradient(string? gradient)
+        => gradient is not null && s_safeGradientPattern.IsMatch(gradient)
+            ? gradient
+            : DefaultGradient;
+
+    private static string? NormalizeImageName(string? imageName)
+        => imageName == AncientPondImage ? imageName : null;
+
+    private static List<string> GetStringList(
+        IDictionary<string, object?>? arguments,
+        string name)
+    {
+        if (arguments is null ||
+            !arguments.TryGetValue(name, out var value) ||
+            value is null)
+        {
+            return [];
+        }
+
+        return value switch
+        {
+            JsonElement element => element.Deserialize<List<string>>() ?? [],
+            IEnumerable<string> strings => [.. strings],
+            _ => JsonSerializer.Deserialize<List<string>>(
+                JsonSerializer.Serialize(value)) ?? [],
+        };
+    }
+
+    private static string? GetString(
+        IDictionary<string, object?>? arguments,
+        string name)
+    {
+        if (arguments is null ||
+            !arguments.TryGetValue(name, out var value) ||
+            value is null)
+        {
+            return null;
+        }
+
+        return value switch
+        {
+            string text => text,
+            JsonElement { ValueKind: JsonValueKind.String } element =>
+                element.GetString(),
+            _ => value.ToString(),
+        };
+    }
 }

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/HaikuData.cs
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/HaikuData.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace DojoClient.Components.Scenarios.ToolBasedGenerativeUI;
+
+public sealed class HaikuData
+{
+    public List<string> Japanese { get; set; } = [];
+
+    public List<string> English { get; set; } = [];
+
+    public string ImageName { get; set; } = "";
+
+    public string Gradient { get; set; } = "";
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/HaikuData.cs
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/HaikuData.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.AI;
 
@@ -11,6 +12,8 @@ public sealed class HaikuData
 {
     internal const string AncientPondImage = "ancient-pond.svg";
     internal const string DefaultGradient = "linear-gradient(135deg, #667eea, #764ba2)";
+    private static readonly JsonSerializerOptions s_jsonOptions =
+        new(JsonSerializerDefaults.Web);
     private static readonly Regex s_safeGradientPattern = new(
         @"\Alinear-gradient\(\s*\d{1,3}deg\s*,\s*#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?\s*,\s*#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?\s*\)\z",
         RegexOptions.CultureInvariant | RegexOptions.NonBacktracking);
@@ -40,12 +43,14 @@ public sealed class HaikuData
     {
         ArgumentNullException.ThrowIfNull(call);
 
-        var arguments = call.Arguments;
+        var arguments = JsonSerializer
+            .SerializeToElement(call.Arguments, s_jsonOptions)
+            .Deserialize<HaikuArguments>(s_jsonOptions);
         return Create(
-            GetStringList(arguments, "japanese"),
-            GetStringList(arguments, "english"),
-            GetString(arguments, "image_name"),
-            GetString(arguments, "gradient"));
+            arguments?.Japanese,
+            arguments?.English,
+            arguments?.ImageName,
+            arguments?.Gradient);
     }
 
     internal static string NormalizeGradient(string? gradient)
@@ -56,43 +61,15 @@ public sealed class HaikuData
     private static string? NormalizeImageName(string? imageName)
         => imageName == AncientPondImage ? imageName : null;
 
-    private static List<string> GetStringList(
-        IDictionary<string, object?>? arguments,
-        string name)
+    private sealed class HaikuArguments
     {
-        if (arguments is null ||
-            !arguments.TryGetValue(name, out var value) ||
-            value is null)
-        {
-            return [];
-        }
+        public List<string>? Japanese { get; set; }
 
-        return value switch
-        {
-            JsonElement element => element.Deserialize<List<string>>() ?? [],
-            IEnumerable<string> strings => [.. strings],
-            _ => JsonSerializer.Deserialize<List<string>>(
-                JsonSerializer.Serialize(value)) ?? [],
-        };
-    }
+        public List<string>? English { get; set; }
 
-    private static string? GetString(
-        IDictionary<string, object?>? arguments,
-        string name)
-    {
-        if (arguments is null ||
-            !arguments.TryGetValue(name, out var value) ||
-            value is null)
-        {
-            return null;
-        }
+        [JsonPropertyName("image_name")]
+        public string? ImageName { get; set; }
 
-        return value switch
-        {
-            string text => text,
-            JsonElement { ValueKind: JsonValueKind.String } element =>
-                element.GetString(),
-            _ => value.ToString(),
-        };
+        public string? Gradient { get; set; }
     }
 }

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/ToolBasedGenerativeUIScenario.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/ToolBasedGenerativeUIScenario.razor
@@ -2,6 +2,7 @@
 @rendermode InteractiveServer
 @implements IDisposable
 @inject ILoggerFactory LoggerFactory
+@using System.Text.RegularExpressions
 
 <PageTitle>Tool-Based Generative UI</PageTitle>
 
@@ -34,6 +35,11 @@
 </div>
 
 @code {
+    private const string DefaultGradient = "linear-gradient(135deg, #667eea, #764ba2)";
+    private static readonly Regex s_safeGradientPattern = new(
+        @"\Alinear-gradient\(\s*\d{1,3}deg\s*,\s*#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?\s*,\s*#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?\s*\)\z",
+        RegexOptions.CultureInvariant | RegexOptions.NonBacktracking);
+
     private UIAgent _agent = default!;
     private List<HaikuData> _haikus = [];
     private int _currentIndex;
@@ -64,7 +70,7 @@
             Japanese = japanese,
             English = english,
             ImageName = image_name,
-            Gradient = gradient,
+            Gradient = GetSafeGradient(gradient),
         });
         _currentIndex = _haikus.Count - 1;
         _ = InvokeAsync(StateHasChanged);
@@ -88,11 +94,14 @@
             {
                 Japanese = ["\u3053\u3053\u306b\u4e00\u53e5", "\u4eee\u306e\u3046\u305f\u7f6e\u304f", "\u6625\u3092\u5f85\u3064"],
                 English = ["A placeholder verse\u2014", "Resting here for now,", "Awaiting your words."],
-                Gradient = "linear-gradient(135deg, #667eea, #764ba2)",
+                Gradient = DefaultGradient,
             }
         ];
         _currentIndex = 0;
     }
+
+    internal static string GetSafeGradient(string gradient)
+        => s_safeGradientPattern.IsMatch(gradient) ? gradient : DefaultGradient;
 
     public void Dispose() => _agent?.Dispose();
 }

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/ToolBasedGenerativeUIScenario.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/ToolBasedGenerativeUIScenario.razor
@@ -2,7 +2,6 @@
 @rendermode InteractiveServer
 @implements IDisposable
 @inject ILoggerFactory LoggerFactory
-@using System.Text.RegularExpressions
 
 <PageTitle>Tool-Based Generative UI</PageTitle>
 
@@ -35,13 +34,9 @@
 </div>
 
 @code {
-    private const string DefaultGradient = "linear-gradient(135deg, #667eea, #764ba2)";
-    private static readonly Regex s_safeGradientPattern = new(
-        @"\Alinear-gradient\(\s*\d{1,3}deg\s*,\s*#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?\s*,\s*#[0-9a-fA-F]{3}(?:[0-9a-fA-F]{3})?\s*\)\z",
-        RegexOptions.CultureInvariant | RegexOptions.NonBacktracking);
-
     private UIAgent _agent = default!;
     private List<HaikuData> _haikus = [];
+    private bool _hasGeneratedHaiku;
     private int _currentIndex;
 
     [Inject(Key = DojoScenarios.ToolBasedGenerativeUIEndpoint)]
@@ -55,7 +50,7 @@
             options.RegisterUIAction(AIFunctionFactory.Create(
                 GenerateHaiku,
                 name: "generate_haiku",
-                description: "Generate a haiku with Japanese text, English translation, an image, and a gradient background."));
+                description: $"Generate a haiku with Japanese text, English translation, image_name set to {HaikuData.AncientPondImage}, and a two-color linear-gradient background."));
         }, LoggerFactory);
     }
 
@@ -65,14 +60,18 @@
         string image_name,
         string gradient)
     {
-        _haikus.Add(new HaikuData
+        if (!_hasGeneratedHaiku)
         {
-            Japanese = japanese,
-            English = english,
-            ImageName = image_name,
-            Gradient = GetSafeGradient(gradient),
-        });
-        _currentIndex = _haikus.Count - 1;
+            _haikus.Clear();
+            _hasGeneratedHaiku = true;
+        }
+
+        _haikus.Insert(0, HaikuData.Create(
+            japanese,
+            english,
+            image_name,
+            gradient));
+        _currentIndex = 0;
         _ = InvokeAsync(StateHasChanged);
 
         return "Haiku displayed to user.";
@@ -94,14 +93,12 @@
             {
                 Japanese = ["\u3053\u3053\u306b\u4e00\u53e5", "\u4eee\u306e\u3046\u305f\u7f6e\u304f", "\u6625\u3092\u5f85\u3064"],
                 English = ["A placeholder verse\u2014", "Resting here for now,", "Awaiting your words."],
-                Gradient = DefaultGradient,
+                Gradient = HaikuData.DefaultGradient,
             }
         ];
+        _hasGeneratedHaiku = false;
         _currentIndex = 0;
     }
-
-    internal static string GetSafeGradient(string gradient)
-        => s_safeGradientPattern.IsMatch(gradient) ? gradient : DefaultGradient;
 
     public void Dispose() => _agent?.Dispose();
 }

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/ToolBasedGenerativeUIScenario.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/ToolBasedGenerativeUIScenario.razor
@@ -1,0 +1,98 @@
+@page "/tool_based_generative_ui"
+@rendermode InteractiveServer
+@implements IDisposable
+@inject ILoggerFactory LoggerFactory
+
+<PageTitle>Tool-Based Generative UI</PageTitle>
+
+<div class="tool-generative-ui" data-scenario="tool_based_generative_ui">
+    <section class="tool-generative-ui__display" aria-label="Generated haikus">
+        <HaikuCarousel Haikus="_haikus"
+                       CurrentIndex="_currentIndex"
+                       OnNavigate="NavigateToHaiku" />
+    </section>
+
+    <ChatPage Agent="_agent"
+              Placeholder="Ask for a haiku..."
+              class="tool-generative-ui__chat">
+        <Header>
+            <h1 class="dojo-scenario__title">Haiku Generator</h1>
+        </Header>
+        <WelcomeContent>
+            <p class="dojo-scenario__welcome">
+                Ask for a haiku to paint a new card while the agent response streams.
+            </p>
+        </WelcomeContent>
+        <MessageListContent>
+            <BlockRenderer TBlock="UIActionBlock"
+                           Context="action"
+                           When="@(block => block.ToolName == "generate_haiku")">
+                <GenerateHaikuAction Block="action" />
+            </BlockRenderer>
+        </MessageListContent>
+    </ChatPage>
+</div>
+
+@code {
+    private UIAgent _agent = default!;
+    private List<HaikuData> _haikus = [];
+    private int _currentIndex;
+
+    [Inject(Key = DojoScenarios.ToolBasedGenerativeUIEndpoint)]
+    public IChatClient ChatClient { get; set; } = default!;
+
+    protected override void OnInitialized()
+    {
+        ResetHaikus();
+        _agent = new UIAgent(ChatClient, options =>
+        {
+            options.RegisterUIAction(AIFunctionFactory.Create(
+                GenerateHaiku,
+                name: "generate_haiku",
+                description: "Generate a haiku with Japanese text, English translation, an image, and a gradient background."));
+        }, LoggerFactory);
+    }
+
+    private string GenerateHaiku(
+        List<string> japanese,
+        List<string> english,
+        string image_name,
+        string gradient)
+    {
+        _haikus.Add(new HaikuData
+        {
+            Japanese = japanese,
+            English = english,
+            ImageName = image_name,
+            Gradient = gradient,
+        });
+        _currentIndex = _haikus.Count - 1;
+        _ = InvokeAsync(StateHasChanged);
+
+        return "Haiku displayed to user.";
+    }
+
+    private void NavigateToHaiku(int index)
+    {
+        if (index >= 0 && index < _haikus.Count)
+        {
+            _currentIndex = index;
+        }
+    }
+
+    private void ResetHaikus()
+    {
+        _haikus =
+        [
+            new HaikuData
+            {
+                Japanese = ["\u3053\u3053\u306b\u4e00\u53e5", "\u4eee\u306e\u3046\u305f\u7f6e\u304f", "\u6625\u3092\u5f85\u3064"],
+                English = ["A placeholder verse\u2014", "Resting here for now,", "Awaiting your words."],
+                Gradient = "linear-gradient(135deg, #667eea, #764ba2)",
+            }
+        ];
+        _currentIndex = 0;
+    }
+
+    public void Dispose() => _agent?.Dispose();
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/ToolBasedGenerativeUIScenario.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/ToolBasedGenerativeUIScenario.razor
@@ -27,7 +27,7 @@
             <BlockRenderer TBlock="UIActionBlock"
                            Context="action"
                            When="@(block => block.ToolName == "generate_haiku")">
-                <GenerateHaikuAction Block="action" />
+                <GenerateHaikuAction @key="action.Id" Block="action" />
             </BlockRenderer>
         </MessageListContent>
     </ChatPage>

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/ToolBasedGenerativeUIScenario.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/ToolBasedGenerativeUIScenario.razor.css
@@ -1,36 +1,50 @@
 .tool-generative-ui {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(20rem, 24rem);
     min-height: 100vh;
     min-width: 0;
+    position: relative;
 }
 
 .tool-generative-ui__display {
     align-items: center;
-    background: #f5f5f7;
+    background:
+        radial-gradient(circle at 20% 20%, rgb(191 219 254 / 65%), transparent 32rem),
+        radial-gradient(circle at 80% 80%, rgb(221 214 254 / 65%), transparent 28rem),
+        #f8fafc;
     display: flex;
     justify-content: center;
+    min-height: 100vh;
     min-width: 0;
-    padding: 2rem;
+    padding: 3rem 29rem 3rem 3rem;
 }
 
 ::deep .tool-generative-ui__chat {
-    border-left: 1px solid #e5e7eb;
-    min-width: 0;
+    border: 1px solid #e2e8f0;
+    border-radius: 1rem;
+    bottom: 1.5rem;
+    box-shadow: 0 1.5rem 3.5rem rgb(15 23 42 / 22%);
+    overflow: hidden;
+    position: fixed;
+    right: 1.5rem;
+    top: 1.5rem;
+    width: 24rem;
+    z-index: 10;
 }
 
-@media (max-width: 48rem) {
-    .tool-generative-ui {
-        grid-template-columns: 1fr;
-    }
-
+@media (max-width: 64rem) {
     .tool-generative-ui__display {
-        padding: 1rem;
+        padding-right: 26rem;
+    }
+}
+
+@media (max-width: 40rem) {
+    .tool-generative-ui__display {
+        display: none;
     }
 
     ::deep .tool-generative-ui__chat {
-        border-left: 0;
-        border-top: 1px solid #e5e7eb;
-        min-height: 36rem;
+        border: 0;
+        border-radius: 0;
+        inset: 0;
+        width: 100%;
     }
 }

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/ToolBasedGenerativeUIScenario.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/ToolBasedGenerativeUIScenario.razor.css
@@ -1,0 +1,36 @@
+.tool-generative-ui {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(20rem, 24rem);
+    min-height: 100vh;
+    min-width: 0;
+}
+
+.tool-generative-ui__display {
+    align-items: center;
+    background: #f5f5f7;
+    display: flex;
+    justify-content: center;
+    min-width: 0;
+    padding: 2rem;
+}
+
+::deep .tool-generative-ui__chat {
+    border-left: 1px solid #e5e7eb;
+    min-width: 0;
+}
+
+@media (max-width: 48rem) {
+    .tool-generative-ui {
+        grid-template-columns: 1fr;
+    }
+
+    .tool-generative-ui__display {
+        padding: 1rem;
+    }
+
+    ::deep .tool-generative-ui__chat {
+        border-left: 0;
+        border-top: 1px solid #e5e7eb;
+        min-height: 36rem;
+    }
+}

--- a/src/Components/AI/testassets/DojoClient/Components/_Imports.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/_Imports.razor
@@ -10,4 +10,5 @@
 @using DojoClient.Components
 @using DojoClient.Components.Scenarios.BackendToolRendering
 @using DojoClient.Components.Scenarios.HumanInTheLoop
+@using DojoClient.Components.Scenarios.ToolBasedGenerativeUI
 @using DojoClient.Components.Layout

--- a/src/Components/AI/testassets/DojoClient/DojoScenarios.cs
+++ b/src/Components/AI/testassets/DojoClient/DojoScenarios.cs
@@ -13,4 +13,6 @@ internal static class DojoScenarios
     internal const string BackendToolRenderingEndpoint = "/backend_tool_rendering";
 
     internal const string HumanInTheLoopEndpoint = "/human_in_the_loop";
+
+    internal const string ToolBasedGenerativeUIEndpoint = "/tool_based_generative_ui";
 }

--- a/src/Components/AI/testassets/DojoClient/Program.cs
+++ b/src/Components/AI/testassets/DojoClient/Program.cs
@@ -31,6 +31,9 @@ builder.Services.AddKeyedScoped<IChatClient>(
 builder.Services.AddKeyedScoped<IChatClient>(
     DojoScenarios.HumanInTheLoopEndpoint,
     (sp, _) => CreateChatClient(sp, DojoScenarios.HumanInTheLoopEndpoint));
+builder.Services.AddKeyedScoped<IChatClient>(
+    DojoScenarios.ToolBasedGenerativeUIEndpoint,
+    (sp, _) => CreateChatClient(sp, DojoScenarios.ToolBasedGenerativeUIEndpoint));
 
 var app = builder.Build();
 

--- a/src/Components/AI/testassets/DojoClient/wwwroot/images/ancient-pond.svg
+++ b/src/Components/AI/testassets/DojoClient/wwwroot/images/ancient-pond.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400" role="img" aria-labelledby="title description">
+  <title id="title">Ancient pond at night</title>
+  <desc id="description">A stylized moonlit pond with reeds and mountain silhouettes.</desc>
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0f172a" />
+      <stop offset="1" stop-color="#334155" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="400" fill="url(#sky)" />
+  <circle cx="640" cy="90" r="48" fill="#f8fafc" opacity="0.9" />
+  <path d="M0 230 150 130 280 220 430 110 620 230 800 150 800 400 0 400Z" fill="#111827" />
+  <path d="M0 285 Q200 250 400 285 T800 285 V400 H0Z" fill="#164e63" />
+  <path d="M0 310 Q200 275 400 310 T800 310" fill="none" stroke="#67e8f9" stroke-width="5" opacity="0.45" />
+  <g stroke="#0f172a" stroke-width="8">
+    <path d="M80 350V245M105 360V260M130 355V235M705 355V245M730 360V260M755 350V230" />
+  </g>
+</svg>


### PR DESCRIPTION
## Overview

Adds the canonical Tool-Based Generative UI dojo scenario as position 6 in the native Components.AI stack tracked by #68340, stacked on #68329. This three-commit layer changes only dojo/test assets: it composes the existing client-action APIs to paint a streamed `generate_haiku` call as rich UI, without adding a shipping product API. The governing constraint is preserved end to end: the browser still uses DojoClient's `AGUIChatClient` over real HTTP/SSE to AGUIDojoApi; deterministic replay replaces only the API-side model.

## Design

The scenario introduces one internal protocol contract: `/tool_based_generative_ui` advertises `generate_haiku`, whose arguments contain exactly three Japanese lines, three English lines, an image name, and a CSS gradient. The UI accepts only the demonstrated two-color linear-gradient format and falls back to the placeholder gradient for other values. The API prompt owns the model-facing shape, while the UI registers the same route as a keyed `IChatClient` so scenario selection cannot silently fall back to another endpoint.

```csharp
// src/Components/AI/testassets/AGUIDojoApi/Program.cs
// The API endpoint injects the scenario prompt but otherwise uses the shared AG-UI request/SSE pipeline.
app.MapDojoEndpoint(
    "/tool_based_generative_ui",
    systemPrompt: ChatClientAgentFactory.ToolBasedGenerativeUISystemPrompt);
```

```csharp
// src/Components/AI/testassets/DojoClient/Program.cs
// A keyed client keeps this scenario on the real DojoClient -> AGUI.Client -> HTTP/SSE boundary.
builder.Services.AddKeyedScoped<IChatClient>(
    DojoScenarios.ToolBasedGenerativeUIEndpoint,
    (sp, _) => CreateChatClient(sp, DojoScenarios.ToolBasedGenerativeUIEndpoint));

static IChatClient CreateChatClient(IServiceProvider services, string endpoint)
{
    var httpClient = services.GetRequiredService<IHttpClientFactory>()
        .CreateClient(DojoScenarios.ApiHttpClientName);
    var aguiClient = new AGUIChatClient(new AGUIChatClientOptions(httpClient, endpoint));

    return new FormattedChatClient(aguiClient);
}
```

The deliberate alternative not taken is an in-process or directly mocked UI client: that would make the card test easier but would stop testing AG-UI tool serialization and SSE parsing. The remaining contract additions are internal scenario composition, not new framework surface: `UIActionBlock` selects `generate_haiku`, and `HaikuData` feeds the card/carousel renderers.

## Implementation

The user-facing entry point registers the existing client-action mechanism and maps the completed tool arguments into observable component state. Appending rather than replacing preserves the placeholder and prior generated cards; selecting the newest index makes progressive generation visible immediately.

```csharp
// src/Components/AI/testassets/DojoClient/Components/Scenarios/ToolBasedGenerativeUI/ToolBasedGenerativeUIScenario.razor
// Existing UIAgent infrastructure advertises the browser-side tool; no product handler is added.
_agent = new UIAgent(ChatClient, options =>
{
    options.RegisterUIAction(AIFunctionFactory.Create(
        GenerateHaiku,
        name: "generate_haiku",
        description: "Generate a haiku with Japanese text, English translation, an image, and a gradient background."));
}, LoggerFactory);

private string GenerateHaiku(
    List<string> japanese,
    List<string> english,
    string image_name,
    string gradient)
{
    _haikus.Add(new HaikuData
    {
        Japanese = japanese,
        English = english,
        ImageName = image_name,
        Gradient = GetSafeGradient(gradient),
    });
    _currentIndex = _haikus.Count - 1;
    _ = InvokeAsync(StateHasChanged);

    return "Haiku displayed to user.";
}
```

The repeated files fall into three equivalence classes. Scenario glue (`Home.razor`, `_Imports.razor`, `DojoScenarios.cs`, and both `Program.cs` files) only makes the route discoverable and keeps endpoint selection aligned. Presentation (`HaikuData`, `GenerateHaikuAction`, `HaikuCard`, `HaikuCarousel`, and their CSS) has one lifecycle rule: invoke the action once, then render the latest card while previous/next buttons clamp to valid indices. Deterministic coverage (`DojoModelOverrides`, the scenario test, and the generated recording) uses one representative nature haiku with two summary checkpoints; the scripted live fallback mirrors the same call/result shape for credential-free manual use.

The browser test proves the lifecycle rather than only checking final markup: the card exists while assistant text still has the streaming class, navigation works before completion, and only then does the API-side checkpoint release the continuation.

```csharp
// src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/ToolBasedGenerativeUIScenarioTests.cs
await AssertGeneratedHaikuAsync(carousel);
await AssertGeneratedCarouselControlsAsync(carousel);
await Expect(assistant).ToHaveClassAsync(
    "sc-ai-message__content sc-ai-message__content--streaming");
await Expect(_page.Locator("button.sc-ai-input__send")).ToBeDisabledAsync();

await previous.ClickAsync();
await AssertPlaceholderHaikuAsync(carousel);
await Expect(previous).ToBeDisabledAsync();
await Expect(next).ToBeEnabledAsync();

await next.ClickAsync();
await AssertGeneratedHaikuAsync(carousel);
await _checkpoints.ReleaseAsync(prompt, "haiku-summary-start");

await Expect(assistant).ToHaveTextAsync(
    "Your nature haiku is ready\u2014a quiet pond awakened by a frog.");
await Expect(_page.Locator("button.sc-ai-input__send")).ToBeEnabledAsync();
```

## Outcome

| Equivalence class | Reviewer acceptance criterion | Evidence |
|---|---|---|
| AG-UI transport | Tool declaration, arguments, result, and continuation cross DojoClient -> AGUIDojoApi rather than an in-process replacement. | Dual-host test starts both applications and overrides only the API model. |
| Generative UI lifecycle | The generated card paints before the response completes, then returns one tool result and finishes the assistant turn. | Streaming class and disabled input are asserted before checkpoint release; completed text and enabled input are asserted after it. |
| Carousel presentation | Placeholder and generated cards remain navigable while the stream is active, with boundary buttons disabled correctly. | Test moves 2/2 -> 1/2 -> 2/2 before releasing the continuation. |

**Review guidance:** read the endpoint/client pairing, `ToolBasedGenerativeUIScenario.razor`, `GenerateHaikuAction.razor`, and the checkpointed E2E flow closely. The card/carousel CSS and recorded Japanese/English fixture values are equivalent presentation data and can be spot-checked. Acceptance is met when the card appears from tool arguments during streaming, carousel navigation remains interactive, and the same turn completes over the real dual-host transport.

Validation: dependency-aware E2E build passed with 0 warnings and 0 errors; runtime build passed with 0 warnings and 0 errors; `AgentContextUIActionTests` passed 4/4; `ToolBasedGenerativeUIScenarioTests` passed 1/1.
