### PR TITLE
[Blazor] Add agentic generative UI state rendering

### DIFF
--- a/src/Components/AI/src/Blocks/ActivityContentBlock.cs
+++ b/src/Components/AI/src/Blocks/ActivityContentBlock.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents activity or progress content that can change while a response streams.
+/// </summary>
+public class ActivityContentBlock : ContentBlock
+{
+    /// <summary>
+    /// Gets or sets the application-defined activity type.
+    /// </summary>
+    public string ActivityType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the current activity payload.
+    /// </summary>
+    public JsonElement Content { get; set; }
+}

--- a/src/Components/AI/src/Engine/AgentState.cs
+++ b/src/Components/AI/src/Engine/AgentState.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Holds observable state associated with a <see cref="UIAgent{TState}"/>.
+/// </summary>
+/// <typeparam name="T">The type of state.</typeparam>
+public class AgentState<T> where T : class, new()
+{
+    private readonly List<Action> _callbacks = new();
+    private T _value;
+
+    internal AgentState(T? initialValue = null)
+    {
+        _value = initialValue ?? new T();
+    }
+
+    /// <summary>
+    /// Gets or sets the current state value.
+    /// </summary>
+    public T Value
+    {
+        get => _value;
+        set
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            _value = value;
+            NotifyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Registers a callback invoked when <see cref="Value"/> changes.
+    /// </summary>
+    /// <param name="callback">The callback to invoke.</param>
+    /// <returns>A registration that removes the callback when disposed.</returns>
+    public IDisposable OnChanged(Action callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        _callbacks.Add(callback);
+        return new CallbackRegistration(_callbacks, callback);
+    }
+
+    private void NotifyChanged()
+    {
+        var snapshot = _callbacks.ToArray();
+        foreach (var callback in snapshot)
+        {
+            callback();
+        }
+    }
+
+    private sealed class CallbackRegistration : IDisposable
+    {
+        private List<Action>? _callbacks;
+        private Action? _callback;
+
+        internal CallbackRegistration(List<Action> callbacks, Action callback)
+        {
+            _callbacks = callbacks;
+            _callback = callback;
+        }
+
+        public void Dispose()
+        {
+            if (_callbacks is not null && _callback is not null)
+            {
+                _callbacks.Remove(_callback);
+                _callbacks = null;
+                _callback = null;
+            }
+        }
+    }
+}

--- a/src/Components/AI/src/Engine/UIAgent.cs
+++ b/src/Components/AI/src/Engine/UIAgent.cs
@@ -156,14 +156,13 @@ public class UIAgent : IDisposable
             var contentTypes = string.Join(", ", update.Contents.Select(c => c.GetType().Name));
             UIAgentLog.ReceivedUpdate(_logger, updateIndex++, update.Role?.Value, contentTypes);
 
-            assistantUpdates.Add(update);
-
             var processUpdate = ApplyStateMapper(update);
             if (processUpdate.Contents.Count == 0 && update.Contents.Count > 0)
             {
                 continue;
             }
 
+            assistantUpdates.Add(processUpdate);
             await foreach (var block in pipeline.Process(processUpdate, cancellationToken).ConfigureAwait(false))
             {
                 yield return block;

--- a/src/Components/AI/src/Engine/UIAgent.cs
+++ b/src/Components/AI/src/Engine/UIAgent.cs
@@ -157,12 +157,13 @@ public class UIAgent : IDisposable
             UIAgentLog.ReceivedUpdate(_logger, updateIndex++, update.Role?.Value, contentTypes);
 
             var processUpdate = ApplyStateMapper(update);
+            assistantUpdates.Add(processUpdate);
+
             if (processUpdate.Contents.Count == 0 && update.Contents.Count > 0)
             {
                 continue;
             }
 
-            assistantUpdates.Add(processUpdate);
             await foreach (var block in pipeline.Process(processUpdate, cancellationToken).ConfigureAwait(false))
             {
                 yield return block;

--- a/src/Components/AI/src/Engine/UIAgent.cs
+++ b/src/Components/AI/src/Engine/UIAgent.cs
@@ -158,7 +158,13 @@ public class UIAgent : IDisposable
 
             assistantUpdates.Add(update);
 
-            await foreach (var block in pipeline.Process(update, cancellationToken).ConfigureAwait(false))
+            var processUpdate = ApplyStateMapper(update);
+            if (processUpdate.Contents.Count == 0 && update.Contents.Count > 0)
+            {
+                continue;
+            }
+
+            await foreach (var block in pipeline.Process(processUpdate, cancellationToken).ConfigureAwait(false))
             {
                 yield return block;
             }
@@ -179,6 +185,19 @@ public class UIAgent : IDisposable
         }
 
         UIAgentLog.AddedToHistory(_logger, response.Messages.Count);
+    }
+
+    internal virtual ChatResponseUpdate ApplyStateMapper(ChatResponseUpdate update)
+    {
+        if (_options.StateMapper is null)
+        {
+            return update;
+        }
+
+        var context = new StateMapperContext(update);
+        _options.StateMapper(context);
+
+        return context.HasHandledContent ? context.GetFilteredUpdate() : update;
     }
 
     private ChatOptions? BuildChatOptions()

--- a/src/Components/AI/src/Engine/UIAgentOfT.cs
+++ b/src/Components/AI/src/Engine/UIAgentOfT.cs
@@ -82,8 +82,15 @@ public class UIAgent<TState> : UIAgent where TState : class, new()
         var context = new StateMapperContext(update);
         Options.StateMapper(context);
 
-        if (context.StateValue is TState typedState)
+        if (context.StateValue is not null)
         {
+            if (context.StateValue is not TState typedState)
+            {
+                throw new InvalidOperationException(
+                    $"The state mapper returned a value of type '{context.StateValue.GetType()}', " +
+                    $"but this agent requires state of type '{typeof(TState)}'.");
+            }
+
             State.Value = typedState;
         }
 

--- a/src/Components/AI/src/Engine/UIAgentOfT.cs
+++ b/src/Components/AI/src/Engine/UIAgentOfT.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Turns an <see cref="IChatClient"/> stream into renderable content blocks and typed observable state.
+/// </summary>
+/// <typeparam name="TState">The type of state associated with the agent.</typeparam>
+public class UIAgent<TState> : UIAgent where TState : class, new()
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UIAgent{TState}"/> class.
+    /// </summary>
+    /// <param name="chatClient">The chat client that produces model responses.</param>
+    /// <param name="initialState">The initial state value.</param>
+    public UIAgent(IChatClient chatClient, TState? initialState = null)
+        : base(chatClient)
+    {
+        State = new AgentState<TState>(initialState);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UIAgent{TState}"/> class.
+    /// </summary>
+    /// <param name="chatClient">The chat client that produces model responses.</param>
+    /// <param name="chatOptions">The options passed to the chat client.</param>
+    /// <param name="initialState">The initial state value.</param>
+    public UIAgent(IChatClient chatClient, ChatOptions chatOptions, TState? initialState = null)
+        : base(chatClient, chatOptions)
+    {
+        State = new AgentState<TState>(initialState);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UIAgent{TState}"/> class.
+    /// </summary>
+    /// <param name="chatClient">The chat client that produces model responses.</param>
+    /// <param name="configure">A callback that configures the agent.</param>
+    /// <param name="initialState">The initial state value.</param>
+    public UIAgent(
+        IChatClient chatClient,
+        Action<UIAgentOptions> configure,
+        TState? initialState = null)
+        : base(chatClient, configure)
+    {
+        State = new AgentState<TState>(initialState);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UIAgent{TState}"/> class.
+    /// </summary>
+    /// <param name="chatClient">The chat client that produces model responses.</param>
+    /// <param name="configure">A callback that configures the agent.</param>
+    /// <param name="loggerFactory">The logger factory used to trace block mapping.</param>
+    /// <param name="initialState">The initial state value.</param>
+    public UIAgent(
+        IChatClient chatClient,
+        Action<UIAgentOptions> configure,
+        ILoggerFactory? loggerFactory,
+        TState? initialState = null)
+        : base(chatClient, configure, loggerFactory)
+    {
+        State = new AgentState<TState>(initialState);
+    }
+
+    /// <summary>
+    /// Gets the observable state associated with this agent.
+    /// </summary>
+    public AgentState<TState> State { get; }
+
+    internal override ChatResponseUpdate ApplyStateMapper(ChatResponseUpdate update)
+    {
+        if (Options.StateMapper is null)
+        {
+            return update;
+        }
+
+        var context = new StateMapperContext(update);
+        Options.StateMapper(context);
+
+        if (context.StateValue is TState typedState)
+        {
+            State.Value = typedState;
+        }
+
+        return context.HasHandledContent ? context.GetFilteredUpdate() : update;
+    }
+}

--- a/src/Components/AI/src/Pipeline/ActivityHandler.cs
+++ b/src/Components/AI/src/Pipeline/ActivityHandler.cs
@@ -19,6 +19,11 @@ public abstract class ActivityHandler<TBlock> : ContentBlockHandler<TBlock>
         {
             if (TryCreateBlock(context, state))
             {
+                if (state.Id.Length == 0)
+                {
+                    state.Id = context.Update.MessageId ?? Guid.NewGuid().ToString("N");
+                }
+
                 OnContentUpdated(state);
                 return BlockMappingResult<TBlock>.Emit(state, state);
             }

--- a/src/Components/AI/src/Pipeline/ActivityHandler.cs
+++ b/src/Components/AI/src/Pipeline/ActivityHandler.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Maps activity snapshots and updates into a mutable content block.
+/// </summary>
+/// <typeparam name="TBlock">The activity block type.</typeparam>
+public abstract class ActivityHandler<TBlock> : ContentBlockHandler<TBlock>
+    where TBlock : ActivityContentBlock, new()
+{
+    /// <inheritdoc />
+    public sealed override BlockMappingResult<TBlock> Handle(
+        BlockMappingContext context,
+        TBlock state)
+    {
+        if (state.Id == string.Empty)
+        {
+            if (TryCreateBlock(context, state))
+            {
+                OnContentUpdated(state);
+                return BlockMappingResult<TBlock>.Emit(state, state);
+            }
+
+            return BlockMappingResult<TBlock>.Pass();
+        }
+
+        if (TryUpdateBlock(context, state, out var isCompleted))
+        {
+            OnContentUpdated(state);
+            return isCompleted
+                ? BlockMappingResult<TBlock>.Complete()
+                : BlockMappingResult<TBlock>.Update(state);
+        }
+
+        return BlockMappingResult<TBlock>.Pass();
+    }
+
+    /// <summary>
+    /// Attempts to initialize a block from an activity snapshot.
+    /// </summary>
+    /// <param name="context">The update being mapped.</param>
+    /// <param name="state">The block to initialize.</param>
+    /// <returns><see langword="true"/> when the update created the block.</returns>
+    protected abstract bool TryCreateBlock(BlockMappingContext context, TBlock state);
+
+    /// <summary>
+    /// Attempts to update an existing activity block.
+    /// </summary>
+    /// <param name="context">The update being mapped.</param>
+    /// <param name="state">The block to update.</param>
+    /// <param name="isCompleted">Whether the update completes the activity.</param>
+    /// <returns><see langword="true"/> when the update belongs to the block.</returns>
+    protected abstract bool TryUpdateBlock(
+        BlockMappingContext context,
+        TBlock state,
+        out bool isCompleted);
+
+    /// <summary>
+    /// Updates derived block state after the activity payload changes.
+    /// </summary>
+    /// <param name="state">The updated activity block.</param>
+    protected virtual void OnContentUpdated(TBlock state)
+    {
+    }
+}

--- a/src/Components/AI/src/Pipeline/StateMapperContext.cs
+++ b/src/Components/AI/src/Pipeline/StateMapperContext.cs
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Carries a model update through typed state mapping and tracks content consumed as state.
+/// </summary>
+public class StateMapperContext
+{
+    private readonly bool[] _handled;
+    private int _handledCount;
+
+    internal StateMapperContext(ChatResponseUpdate update)
+    {
+        Update = update;
+        _handled = new bool[update.Contents.Count];
+    }
+
+    /// <summary>
+    /// Gets the update being mapped.
+    /// </summary>
+    public ChatResponseUpdate Update { get; }
+
+    /// <summary>
+    /// Gets content items that have not been consumed by the state mapper.
+    /// </summary>
+    public IEnumerable<AIContent> UnhandledContents
+    {
+        get
+        {
+            var contents = Update.Contents;
+            for (var i = 0; i < contents.Count; i++)
+            {
+                if (!_handled[i])
+                {
+                    yield return contents[i];
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Marks a content item as consumed by the state mapper.
+    /// </summary>
+    /// <param name="content">The content item that was handled.</param>
+    public void MarkHandled(AIContent content)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        var contents = Update.Contents;
+        for (var i = 0; i < contents.Count; i++)
+        {
+            if (ReferenceEquals(contents[i], content))
+            {
+                if (!_handled[i])
+                {
+                    _handled[i] = true;
+                    _handledCount++;
+                }
+
+                return;
+            }
+        }
+    }
+
+    internal object? StateValue { get; private set; }
+
+    /// <summary>
+    /// Sets the next typed state value.
+    /// </summary>
+    /// <param name="value">The next state value.</param>
+    public void SetState(object value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        StateValue = value;
+    }
+
+    internal bool HasHandledContent => _handledCount > 0;
+
+    internal ChatResponseUpdate GetFilteredUpdate()
+    {
+        if (_handledCount == 0)
+        {
+            return Update;
+        }
+
+        var filtered = new List<AIContent>();
+        var contents = Update.Contents;
+        for (var i = 0; i < contents.Count; i++)
+        {
+            if (!_handled[i])
+            {
+                filtered.Add(contents[i]);
+            }
+        }
+
+        return new ChatResponseUpdate
+        {
+            Role = Update.Role,
+            AuthorName = Update.AuthorName,
+            MessageId = Update.MessageId,
+            ResponseId = Update.ResponseId,
+            FinishReason = Update.FinishReason,
+            Contents = filtered,
+        };
+    }
+}

--- a/src/Components/AI/src/Pipeline/StateMapperContext.cs
+++ b/src/Components/AI/src/Pipeline/StateMapperContext.cs
@@ -103,8 +103,13 @@ public class StateMapperContext
             AuthorName = Update.AuthorName,
             MessageId = Update.MessageId,
             ResponseId = Update.ResponseId,
+            ConversationId = Update.ConversationId,
+            CreatedAt = Update.CreatedAt,
             FinishReason = Update.FinishReason,
+            ModelId = Update.ModelId,
+            ContinuationToken = Update.ContinuationToken,
             RawRepresentation = Update.RawRepresentation,
+            AdditionalProperties = Update.AdditionalProperties,
             Contents = filtered,
         };
     }

--- a/src/Components/AI/src/Pipeline/StateMapperContext.cs
+++ b/src/Components/AI/src/Pipeline/StateMapperContext.cs
@@ -104,6 +104,7 @@ public class StateMapperContext
             MessageId = Update.MessageId,
             ResponseId = Update.ResponseId,
             FinishReason = Update.FinishReason,
+            RawRepresentation = Update.RawRepresentation,
             Contents = filtered,
         };
     }

--- a/src/Components/AI/src/Pipeline/UIAgentOptions.cs
+++ b/src/Components/AI/src/Pipeline/UIAgentOptions.cs
@@ -23,6 +23,11 @@ public class UIAgentOptions
     /// </summary>
     public ChatOptions? ChatOptions { get; set; }
 
+    /// <summary>
+    /// Gets or sets a callback that maps model updates into typed agent state.
+    /// </summary>
+    public Func<StateMapperContext, bool>? StateMapper { get; set; }
+
     internal List<IHandlerRegistration> HandlerRegistrations { get; } = new();
 
     internal Dictionary<string, AIFunction> UIActions { get; } =

--- a/src/Components/AI/src/Pipeline/UIAgentOptions.cs
+++ b/src/Components/AI/src/Pipeline/UIAgentOptions.cs
@@ -26,7 +26,7 @@ public class UIAgentOptions
     /// <summary>
     /// Gets or sets a callback that maps model updates into typed agent state.
     /// </summary>
-    public Func<StateMapperContext, bool>? StateMapper { get; set; }
+    public Action<StateMapperContext>? StateMapper { get; set; }
 
     internal List<IHandlerRegistration> HandlerRegistrations { get; } = new();
 

--- a/src/Components/AI/src/PublicAPI.Unshipped.txt
+++ b/src/Components/AI/src/PublicAPI.Unshipped.txt
@@ -318,7 +318,7 @@ Microsoft.AspNetCore.Components.AI.UIAgentOptions.AddBlockHandler<TState>(Micros
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.ChatOptions.get -> Microsoft.Extensions.AI.ChatOptions?
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.ChatOptions.set -> void
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.RegisterUIAction(Microsoft.Extensions.AI.AIFunction! function) -> void
-Microsoft.AspNetCore.Components.AI.UIAgentOptions.StateMapper.get -> System.Func<Microsoft.AspNetCore.Components.AI.StateMapperContext!, bool>?
+Microsoft.AspNetCore.Components.AI.UIAgentOptions.StateMapper.get -> System.Action<Microsoft.AspNetCore.Components.AI.StateMapperContext!>?
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.StateMapper.set -> void
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.UIAgentOptions() -> void
 Microsoft.AspNetCore.Components.AI.UIActionBlock

--- a/src/Components/AI/src/PublicAPI.Unshipped.txt
+++ b/src/Components/AI/src/PublicAPI.Unshipped.txt
@@ -6,6 +6,10 @@ Microsoft.AspNetCore.Components.AI.AgentBoundary.AgentBoundary() -> void
 Microsoft.AspNetCore.Components.AI.AgentBoundary.ChildContent.get -> Microsoft.AspNetCore.Components.RenderFragment?
 Microsoft.AspNetCore.Components.AI.AgentBoundary.ChildContent.set -> void
 Microsoft.AspNetCore.Components.AI.AgentBoundary.Dispose() -> void
+Microsoft.AspNetCore.Components.AI.AgentState<T>
+Microsoft.AspNetCore.Components.AI.AgentState<T>.OnChanged(System.Action! callback) -> System.IDisposable!
+Microsoft.AspNetCore.Components.AI.AgentState<T>.Value.get -> T!
+Microsoft.AspNetCore.Components.AI.AgentState<T>.Value.set -> void
 Microsoft.AspNetCore.Components.AI.AgentContext
 Microsoft.AspNetCore.Components.AI.AgentContext.AgentContext(Microsoft.AspNetCore.Components.AI.UIAgent! agent) -> void
 Microsoft.AspNetCore.Components.AI.AgentContext.CancelAsync() -> System.Threading.Tasks.Task!
@@ -23,6 +27,14 @@ Microsoft.AspNetCore.Components.AI.ApprovalStatus
 Microsoft.AspNetCore.Components.AI.ApprovalStatus.Approved = 1 -> Microsoft.AspNetCore.Components.AI.ApprovalStatus
 Microsoft.AspNetCore.Components.AI.ApprovalStatus.Pending = 0 -> Microsoft.AspNetCore.Components.AI.ApprovalStatus
 Microsoft.AspNetCore.Components.AI.ApprovalStatus.Rejected = 2 -> Microsoft.AspNetCore.Components.AI.ApprovalStatus
+Microsoft.AspNetCore.Components.AI.ActivityContentBlock
+Microsoft.AspNetCore.Components.AI.ActivityContentBlock.ActivityContentBlock() -> void
+Microsoft.AspNetCore.Components.AI.ActivityContentBlock.ActivityType.get -> string!
+Microsoft.AspNetCore.Components.AI.ActivityContentBlock.ActivityType.set -> void
+Microsoft.AspNetCore.Components.AI.ActivityContentBlock.Content.get -> System.Text.Json.JsonElement
+Microsoft.AspNetCore.Components.AI.ActivityContentBlock.Content.set -> void
+Microsoft.AspNetCore.Components.AI.ActivityHandler<TBlock>
+Microsoft.AspNetCore.Components.AI.ActivityHandler<TBlock>.ActivityHandler() -> void
 Microsoft.AspNetCore.Components.AI.BlockLifecycleState
 Microsoft.AspNetCore.Components.AI.BlockLifecycleState.Active = 1 -> Microsoft.AspNetCore.Components.AI.BlockLifecycleState
 Microsoft.AspNetCore.Components.AI.BlockLifecycleState.Inactive = 2 -> Microsoft.AspNetCore.Components.AI.BlockLifecycleState
@@ -251,6 +263,11 @@ Microsoft.AspNetCore.Components.AI.StrikethroughNode
 Microsoft.AspNetCore.Components.AI.StrikethroughNode.StrikethroughNode() -> void
 Microsoft.AspNetCore.Components.AI.StrongNode
 Microsoft.AspNetCore.Components.AI.StrongNode.StrongNode() -> void
+Microsoft.AspNetCore.Components.AI.StateMapperContext
+Microsoft.AspNetCore.Components.AI.StateMapperContext.MarkHandled(Microsoft.Extensions.AI.AIContent! content) -> void
+Microsoft.AspNetCore.Components.AI.StateMapperContext.SetState(object! value) -> void
+Microsoft.AspNetCore.Components.AI.StateMapperContext.UnhandledContents.get -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.AIContent!>!
+Microsoft.AspNetCore.Components.AI.StateMapperContext.Update.get -> Microsoft.Extensions.AI.ChatResponseUpdate!
 Microsoft.AspNetCore.Components.AI.TableCellNode
 Microsoft.AspNetCore.Components.AI.TableCellNode.TableCellNode() -> void
 Microsoft.AspNetCore.Components.AI.TableColumnAlignment
@@ -290,11 +307,19 @@ Microsoft.AspNetCore.Components.AI.UIAgent.UIAgent(Microsoft.Extensions.AI.IChat
 Microsoft.AspNetCore.Components.AI.UIAgent.UIAgent(Microsoft.Extensions.AI.IChatClient! chatClient, Microsoft.Extensions.AI.ChatOptions! chatOptions, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory) -> void
 Microsoft.AspNetCore.Components.AI.UIAgent.UIAgent(Microsoft.Extensions.AI.IChatClient! chatClient, System.Action<Microsoft.AspNetCore.Components.AI.UIAgentOptions!>? configure) -> void
 Microsoft.AspNetCore.Components.AI.UIAgent.UIAgent(Microsoft.Extensions.AI.IChatClient! chatClient, System.Action<Microsoft.AspNetCore.Components.AI.UIAgentOptions!>? configure, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory) -> void
+Microsoft.AspNetCore.Components.AI.UIAgent<TState>
+Microsoft.AspNetCore.Components.AI.UIAgent<TState>.State.get -> Microsoft.AspNetCore.Components.AI.AgentState<TState!>!
+Microsoft.AspNetCore.Components.AI.UIAgent<TState>.UIAgent(Microsoft.Extensions.AI.IChatClient! chatClient, Microsoft.Extensions.AI.ChatOptions! chatOptions, TState? initialState = null) -> void
+Microsoft.AspNetCore.Components.AI.UIAgent<TState>.UIAgent(Microsoft.Extensions.AI.IChatClient! chatClient, System.Action<Microsoft.AspNetCore.Components.AI.UIAgentOptions!>! configure, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory, TState? initialState = null) -> void
+Microsoft.AspNetCore.Components.AI.UIAgent<TState>.UIAgent(Microsoft.Extensions.AI.IChatClient! chatClient, System.Action<Microsoft.AspNetCore.Components.AI.UIAgentOptions!>! configure, TState? initialState = null) -> void
+Microsoft.AspNetCore.Components.AI.UIAgent<TState>.UIAgent(Microsoft.Extensions.AI.IChatClient! chatClient, TState? initialState = null) -> void
 Microsoft.AspNetCore.Components.AI.UIAgentOptions
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.AddBlockHandler<TState>(Microsoft.AspNetCore.Components.AI.ContentBlockHandler<TState>! handler) -> void
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.ChatOptions.get -> Microsoft.Extensions.AI.ChatOptions?
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.ChatOptions.set -> void
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.RegisterUIAction(Microsoft.Extensions.AI.AIFunction! function) -> void
+Microsoft.AspNetCore.Components.AI.UIAgentOptions.StateMapper.get -> System.Func<Microsoft.AspNetCore.Components.AI.StateMapperContext!, bool>?
+Microsoft.AspNetCore.Components.AI.UIAgentOptions.StateMapper.set -> void
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.UIAgentOptions() -> void
 Microsoft.AspNetCore.Components.AI.UIActionBlock
 Microsoft.AspNetCore.Components.AI.UIActionBlock.Call.get -> Microsoft.Extensions.AI.FunctionCallContent!
@@ -304,9 +329,13 @@ Microsoft.AspNetCore.Components.AI.UIActionBlock.IsComplete.get -> bool
 Microsoft.AspNetCore.Components.AI.UIActionBlock.Result.get -> Microsoft.Extensions.AI.FunctionResultContent?
 Microsoft.AspNetCore.Components.AI.UIActionBlock.ToolName.get -> string!
 abstract Microsoft.AspNetCore.Components.AI.ContentBlockHandler<TState>.Handle(Microsoft.AspNetCore.Components.AI.BlockMappingContext! context, TState state) -> Microsoft.AspNetCore.Components.AI.BlockMappingResult<TState>
+abstract Microsoft.AspNetCore.Components.AI.ActivityHandler<TBlock>.TryCreateBlock(Microsoft.AspNetCore.Components.AI.BlockMappingContext! context, TBlock! state) -> bool
+abstract Microsoft.AspNetCore.Components.AI.ActivityHandler<TBlock>.TryUpdateBlock(Microsoft.AspNetCore.Components.AI.BlockMappingContext! context, TBlock! state, out bool isCompleted) -> bool
+override sealed Microsoft.AspNetCore.Components.AI.ActivityHandler<TBlock>.Handle(Microsoft.AspNetCore.Components.AI.BlockMappingContext! context, TBlock! state) -> Microsoft.AspNetCore.Components.AI.BlockMappingResult<TBlock!>
 override Microsoft.AspNetCore.Components.AI.AgentBoundary.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder! builder) -> void
 override Microsoft.AspNetCore.Components.AI.AgentBoundary.OnInitialized() -> void
 override Microsoft.AspNetCore.Components.AI.AgentBoundary.OnParametersSet() -> void
+virtual Microsoft.AspNetCore.Components.AI.ActivityHandler<TBlock>.OnContentUpdated(TBlock! state) -> void
 static Microsoft.AspNetCore.Components.AI.BlockMappingResult<TState>.Complete() -> Microsoft.AspNetCore.Components.AI.BlockMappingResult<TState>
 static Microsoft.AspNetCore.Components.AI.BlockMappingResult<TState>.Emit(Microsoft.AspNetCore.Components.AI.ContentBlock! block, TState state) -> Microsoft.AspNetCore.Components.AI.BlockMappingResult<TState>
 static Microsoft.AspNetCore.Components.AI.BlockMappingResult<TState>.Pass() -> Microsoft.AspNetCore.Components.AI.BlockMappingResult<TState>

--- a/src/Components/AI/test/Engine/AgentStateTests.cs
+++ b/src/Components/AI/test/Engine/AgentStateTests.cs
@@ -1,0 +1,78 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class AgentStateTests
+{
+    [Fact]
+    public void Value_DefaultsToNewState()
+    {
+        var state = new AgentState<TestState>();
+
+        Assert.NotNull(state.Value);
+        Assert.Equal("", state.Value.Name);
+        Assert.Equal(0, state.Value.Count);
+    }
+
+    [Fact]
+    public void Value_UsesInitialState()
+    {
+        var initial = new TestState { Name = "initial", Count = 5 };
+        var state = new AgentState<TestState>(initial);
+
+        Assert.Same(initial, state.Value);
+    }
+
+    [Fact]
+    public void Value_NotifiesEverySubscriber()
+    {
+        var state = new AgentState<TestState>();
+        var callbackCount = 0;
+        state.OnChanged(() => callbackCount++);
+        state.OnChanged(() => callbackCount++);
+
+        state.Value = new TestState { Name = "updated" };
+
+        Assert.Equal(2, callbackCount);
+    }
+
+    [Fact]
+    public void OnChanged_DisposedRegistrationStopsNotifications()
+    {
+        var state = new AgentState<TestState>();
+        var callbackCount = 0;
+        var registration = state.OnChanged(() => callbackCount++);
+
+        state.Value = new TestState();
+        registration.Dispose();
+        state.Value = new TestState();
+
+        Assert.Equal(1, callbackCount);
+    }
+
+    [Fact]
+    public void OnChanged_CanDisposeRegistrationDuringNotification()
+    {
+        var state = new AgentState<TestState>();
+        IDisposable? registration = null;
+        var callbackCount = 0;
+        registration = state.OnChanged(() =>
+        {
+            callbackCount++;
+            registration!.Dispose();
+        });
+
+        state.Value = new TestState();
+        state.Value = new TestState();
+
+        Assert.Equal(1, callbackCount);
+    }
+
+    private sealed class TestState
+    {
+        public string Name { get; set; } = "";
+
+        public int Count { get; set; }
+    }
+}

--- a/src/Components/AI/test/Pipeline/ActivityHandlerTests.cs
+++ b/src/Components/AI/test/Pipeline/ActivityHandlerTests.cs
@@ -110,10 +110,28 @@ public class ActivityHandlerTests
         Assert.Equal(0, block.Content.GetProperty("progress").GetInt32());
     }
 
-    private static BlockMappingPipeline CreatePipeline()
+    [Fact]
+    public async Task Snapshot_HandlerDoesNotAssignId_AssignsFallbackId()
+    {
+        var pipeline = CreatePipeline(assignId: false);
+
+        var block = Assert.IsType<ActivityContentBlock>(Assert.Single(
+            await CollectBlocksAsync(
+                pipeline,
+                new ActivitySnapshot
+                {
+                    Id = "activity-1",
+                    ActivityType = "PLAN",
+                    Content = JsonSerializer.SerializeToElement(new { progress = 0 }),
+                })));
+
+        Assert.NotEmpty(block.Id);
+    }
+
+    private static BlockMappingPipeline CreatePipeline(bool assignId = true)
     {
         var options = new UIAgentOptions();
-        options.AddBlockHandler(new TestActivityHandler());
+        options.AddBlockHandler(new TestActivityHandler(assignId));
         return new BlockMappingPipeline(options);
     }
 
@@ -136,6 +154,13 @@ public class ActivityHandlerTests
 
     private sealed class TestActivityHandler : ActivityHandler<ActivityContentBlock>
     {
+        private readonly bool _assignId;
+
+        public TestActivityHandler(bool assignId)
+        {
+            _assignId = assignId;
+        }
+
         protected override bool TryCreateBlock(
             BlockMappingContext context,
             ActivityContentBlock state)
@@ -145,7 +170,11 @@ public class ActivityHandlerTests
                 return false;
             }
 
-            state.Id = snapshot.Id;
+            if (_assignId)
+            {
+                state.Id = snapshot.Id;
+            }
+
             state.ActivityType = snapshot.ActivityType;
             state.Content = snapshot.Content;
             context.MarkUpdateHandled();

--- a/src/Components/AI/test/Pipeline/ActivityHandlerTests.cs
+++ b/src/Components/AI/test/Pipeline/ActivityHandlerTests.cs
@@ -1,0 +1,191 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Pipeline;
+
+public class ActivityHandlerTests
+{
+    [Fact]
+    public async Task Snapshot_EmitsActiveActivityBlock()
+    {
+        var pipeline = CreatePipeline();
+
+        var blocks = await CollectBlocksAsync(
+            pipeline,
+            new ActivitySnapshot
+            {
+                Id = "activity-1",
+                ActivityType = "PLAN",
+                Content = JsonSerializer.SerializeToElement(new { progress = 0 }),
+            });
+
+        var block = Assert.IsType<ActivityContentBlock>(Assert.Single(blocks));
+        Assert.Equal("activity-1", block.Id);
+        Assert.Equal("PLAN", block.ActivityType);
+        Assert.Equal(0, block.Content.GetProperty("progress").GetInt32());
+        Assert.Equal(BlockLifecycleState.Active, block.LifecycleState);
+    }
+
+    [Fact]
+    public async Task Delta_UpdatesExistingBlockAndNotifies()
+    {
+        var pipeline = CreatePipeline();
+        var block = Assert.IsType<ActivityContentBlock>(Assert.Single(
+            await CollectBlocksAsync(
+                pipeline,
+                new ActivitySnapshot
+                {
+                    Id = "activity-1",
+                    ActivityType = "PLAN",
+                    Content = JsonSerializer.SerializeToElement(new { progress = 0 }),
+                })));
+        var callbackCount = 0;
+        block.OnChanged(() => callbackCount++);
+
+        var emitted = await CollectBlocksAsync(
+            pipeline,
+            new ActivityDelta
+            {
+                Id = "activity-1",
+                Content = JsonSerializer.SerializeToElement(new { progress = 50 }),
+            });
+
+        Assert.Empty(emitted);
+        Assert.Equal(50, block.Content.GetProperty("progress").GetInt32());
+        Assert.Equal(1, callbackCount);
+        Assert.Equal(BlockLifecycleState.Active, block.LifecycleState);
+    }
+
+    [Fact]
+    public async Task CompletingDelta_MarksExistingBlockInactive()
+    {
+        var pipeline = CreatePipeline();
+        var block = Assert.IsType<ActivityContentBlock>(Assert.Single(
+            await CollectBlocksAsync(
+                pipeline,
+                new ActivitySnapshot
+                {
+                    Id = "activity-1",
+                    ActivityType = "PLAN",
+                    Content = JsonSerializer.SerializeToElement(new { progress = 0 }),
+                })));
+
+        await CollectBlocksAsync(
+            pipeline,
+            new ActivityDelta
+            {
+                Id = "activity-1",
+                Content = JsonSerializer.SerializeToElement(new { progress = 100 }),
+                IsCompleted = true,
+            });
+
+        Assert.Equal(100, block.Content.GetProperty("progress").GetInt32());
+        Assert.Equal(BlockLifecycleState.Inactive, block.LifecycleState);
+    }
+
+    [Fact]
+    public async Task Delta_ForDifferentActivityDoesNotUpdateBlock()
+    {
+        var pipeline = CreatePipeline();
+        var block = Assert.IsType<ActivityContentBlock>(Assert.Single(
+            await CollectBlocksAsync(
+                pipeline,
+                new ActivitySnapshot
+                {
+                    Id = "activity-1",
+                    ActivityType = "PLAN",
+                    Content = JsonSerializer.SerializeToElement(new { progress = 0 }),
+                })));
+
+        await CollectBlocksAsync(
+            pipeline,
+            new ActivityDelta
+            {
+                Id = "activity-2",
+                Content = JsonSerializer.SerializeToElement(new { progress = 50 }),
+            });
+
+        Assert.Equal(0, block.Content.GetProperty("progress").GetInt32());
+    }
+
+    private static BlockMappingPipeline CreatePipeline()
+    {
+        var options = new UIAgentOptions();
+        options.AddBlockHandler(new TestActivityHandler());
+        return new BlockMappingPipeline(options);
+    }
+
+    private static async Task<List<ContentBlock>> CollectBlocksAsync(
+        BlockMappingPipeline pipeline,
+        object rawRepresentation)
+    {
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in pipeline.Process(
+            new Microsoft.Extensions.AI.ChatResponseUpdate
+            {
+                RawRepresentation = rawRepresentation,
+            }))
+        {
+            blocks.Add(block);
+        }
+
+        return blocks;
+    }
+
+    private sealed class TestActivityHandler : ActivityHandler<ActivityContentBlock>
+    {
+        protected override bool TryCreateBlock(
+            BlockMappingContext context,
+            ActivityContentBlock state)
+        {
+            if (context.Update.RawRepresentation is not ActivitySnapshot snapshot)
+            {
+                return false;
+            }
+
+            state.Id = snapshot.Id;
+            state.ActivityType = snapshot.ActivityType;
+            state.Content = snapshot.Content;
+            context.MarkUpdateHandled();
+            return true;
+        }
+
+        protected override bool TryUpdateBlock(
+            BlockMappingContext context,
+            ActivityContentBlock state,
+            out bool isCompleted)
+        {
+            isCompleted = false;
+            if (context.Update.RawRepresentation is not ActivityDelta delta ||
+                delta.Id != state.Id)
+            {
+                return false;
+            }
+
+            state.Content = delta.Content;
+            isCompleted = delta.IsCompleted;
+            context.MarkUpdateHandled();
+            return true;
+        }
+    }
+
+    private sealed class ActivitySnapshot
+    {
+        public required string Id { get; init; }
+
+        public required string ActivityType { get; init; }
+
+        public JsonElement Content { get; init; }
+    }
+
+    private sealed class ActivityDelta
+    {
+        public required string Id { get; init; }
+
+        public JsonElement Content { get; init; }
+
+        public bool IsCompleted { get; init; }
+    }
+}

--- a/src/Components/AI/test/Pipeline/StateMapperTests.cs
+++ b/src/Components/AI/test/Pipeline/StateMapperTests.cs
@@ -1,0 +1,177 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Pipeline;
+
+public class StateMapperTests
+{
+    [Fact]
+    public async Task StateMapper_ExtractsStateAndFiltersItFromBlocks()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((_, _, cancellationToken) => EmitStateAndText(cancellationToken));
+        var agent = CreateAgent(client);
+
+        var blocks = await CollectBlocksAsync(agent);
+
+        Assert.Equal("Spaghetti Carbonara", agent.State.Value.Title);
+        var assistantBlocks = blocks
+            .Where(block => block.Role == ChatRole.Assistant)
+            .ToList();
+        Assert.Single(assistantBlocks);
+        Assert.IsType<RichContentBlock>(assistantBlocks[0]);
+    }
+
+    [Fact]
+    public async Task StateMapper_MixedUpdatePreservesUnhandledText()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((_, _, cancellationToken) => EmitMixed(cancellationToken));
+        var agent = CreateAgent(client);
+
+        var blocks = await CollectBlocksAsync(agent);
+
+        Assert.Equal("Pasta", agent.State.Value.Title);
+        var textBlock = Assert.Single(blocks
+            .OfType<RichContentBlock>()
+            .Where(block => block.Role == ChatRole.Assistant));
+        Assert.Equal("Enjoy this recipe!", textBlock.RawText);
+    }
+
+    [Fact]
+    public async Task StateMapper_RawUpdateChangesStateAndNotifies()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((_, _, cancellationToken) => EmitRawState(cancellationToken));
+        var agent = new UIAgent<RecipeState>(client, options =>
+        {
+            options.StateMapper = context =>
+            {
+                if (context.Update.RawRepresentation is not RecipeState state)
+                {
+                    return false;
+                }
+
+                context.SetState(state);
+                return true;
+            };
+        });
+        var callbackCount = 0;
+        agent.State.OnChanged(() => callbackCount++);
+
+        await CollectBlocksAsync(agent);
+
+        Assert.Equal("Observable state", agent.State.Value.Title);
+        Assert.Equal(1, callbackCount);
+    }
+
+    private static UIAgent<RecipeState> CreateAgent(IChatClient client)
+    {
+        return new UIAgent<RecipeState>(client, options =>
+        {
+            options.StateMapper = context =>
+            {
+                foreach (var content in context.UnhandledContents)
+                {
+                    if (content is StateContent stateContent)
+                    {
+                        context.MarkHandled(stateContent);
+                        context.SetState(stateContent.StateValue);
+                        return true;
+                    }
+                }
+
+                return false;
+            };
+        });
+    }
+
+    private static async Task<List<ContentBlock>> CollectBlocksAsync(
+        UIAgent agent)
+    {
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(
+            new ChatMessage(ChatRole.User, "Give me a recipe")))
+        {
+            blocks.Add(block);
+        }
+
+        return blocks;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitStateAndText(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents =
+            [
+                new StateContent
+                {
+                    StateValue = new RecipeState
+                    {
+                        Title = "Spaghetti Carbonara",
+                    },
+                },
+            ],
+        };
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "message-1",
+            Contents = [new TextContent("Here's a classic Italian recipe!")],
+        };
+
+        await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitMixed(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "message-1",
+            Contents =
+            [
+                new StateContent
+                {
+                    StateValue = new RecipeState { Title = "Pasta" },
+                },
+                new TextContent("Enjoy this recipe!"),
+            ],
+        };
+
+        await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitRawState(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            RawRepresentation = new RecipeState { Title = "Observable state" },
+        };
+
+        await Task.CompletedTask;
+    }
+
+    private sealed class RecipeState
+    {
+        public string Title { get; set; } = "";
+    }
+
+    private sealed class StateContent : AIContent
+    {
+        public object StateValue { get; set; } = new();
+    }
+}

--- a/src/Components/AI/test/Pipeline/StateMapperTests.cs
+++ b/src/Components/AI/test/Pipeline/StateMapperTests.cs
@@ -69,23 +69,49 @@ public class StateMapperTests
     }
 
     [Fact]
-    public void StateMapper_FilteredUpdatePreservesRawRepresentation()
+    public void StateMapper_FilteredUpdatePreservesMetadata()
     {
         var agent = CreateAgent(new DelegatingStreamingChatClient());
         var rawRepresentation = new object();
+        var additionalProperties = new AdditionalPropertiesDictionary
+        {
+            ["property"] = "value",
+        };
+        var continuationToken = ResponseContinuationToken.FromBytes(new byte[] { 1, 2, 3 });
+        var createdAt = new DateTimeOffset(2026, 8, 26, 8, 0, 0, TimeSpan.Zero);
         var stateContent = new StateContent
         {
             StateValue = new RecipeState { Title = "Pasta" },
         };
         var update = new ChatResponseUpdate
         {
+            Role = ChatRole.Assistant,
+            AuthorName = "Test assistant",
+            MessageId = "message-1",
+            ResponseId = "response-1",
+            ConversationId = "conversation-1",
+            CreatedAt = createdAt,
+            FinishReason = ChatFinishReason.Stop,
+            ModelId = "test-model",
+            ContinuationToken = continuationToken,
             RawRepresentation = rawRepresentation,
+            AdditionalProperties = additionalProperties,
             Contents = [stateContent, new TextContent("Enjoy this recipe!")],
         };
 
         var mappedUpdate = agent.ApplyStateMapper(update);
 
+        Assert.Equal(update.Role, mappedUpdate.Role);
+        Assert.Equal(update.AuthorName, mappedUpdate.AuthorName);
+        Assert.Equal(update.MessageId, mappedUpdate.MessageId);
+        Assert.Equal(update.ResponseId, mappedUpdate.ResponseId);
+        Assert.Equal(update.ConversationId, mappedUpdate.ConversationId);
+        Assert.Equal(createdAt, mappedUpdate.CreatedAt);
+        Assert.Equal(update.FinishReason, mappedUpdate.FinishReason);
+        Assert.Equal(update.ModelId, mappedUpdate.ModelId);
+        Assert.Same(continuationToken, mappedUpdate.ContinuationToken);
         Assert.Same(rawRepresentation, mappedUpdate.RawRepresentation);
+        Assert.Same(additionalProperties, mappedUpdate.AdditionalProperties);
         Assert.DoesNotContain(stateContent, mappedUpdate.Contents);
     }
 

--- a/src/Components/AI/test/Pipeline/StateMapperTests.cs
+++ b/src/Components/AI/test/Pipeline/StateMapperTests.cs
@@ -53,11 +53,10 @@ public class StateMapperTests
             {
                 if (context.Update.RawRepresentation is not RecipeState state)
                 {
-                    return false;
+                    return;
                 }
 
                 context.SetState(state);
-                return true;
             };
         });
         var callbackCount = 0;
@@ -67,6 +66,71 @@ public class StateMapperTests
 
         Assert.Equal("Observable state", agent.State.Value.Title);
         Assert.Equal(1, callbackCount);
+    }
+
+    [Fact]
+    public void StateMapper_FilteredUpdatePreservesRawRepresentation()
+    {
+        var agent = CreateAgent(new DelegatingStreamingChatClient());
+        var rawRepresentation = new object();
+        var stateContent = new StateContent
+        {
+            StateValue = new RecipeState { Title = "Pasta" },
+        };
+        var update = new ChatResponseUpdate
+        {
+            RawRepresentation = rawRepresentation,
+            Contents = [stateContent, new TextContent("Enjoy this recipe!")],
+        };
+
+        var mappedUpdate = agent.ApplyStateMapper(update);
+
+        Assert.Same(rawRepresentation, mappedUpdate.RawRepresentation);
+        Assert.DoesNotContain(stateContent, mappedUpdate.Contents);
+    }
+
+    [Fact]
+    public void StateMapper_IncompatibleStateTypeThrows()
+    {
+        var agent = new UIAgent<RecipeState>(
+            new DelegatingStreamingChatClient(),
+            options => options.StateMapper = context => context.SetState(new object()));
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => agent.ApplyStateMapper(new ChatResponseUpdate()));
+
+        Assert.Contains(typeof(RecipeState).ToString(), exception.Message);
+    }
+
+    [Fact]
+    public async Task StateMapper_HandledContentIsFilteredFromHistory()
+    {
+        var client = new DelegatingStreamingChatClient();
+        List<ChatMessage>? secondRequest = null;
+        var callCount = 0;
+        client.SetHandler((messages, _, cancellationToken) =>
+        {
+            callCount++;
+            if (callCount == 2)
+            {
+                secondRequest = messages.ToList();
+            }
+
+            return callCount == 1
+                ? EmitMixed(cancellationToken)
+                : EmitRawState(cancellationToken);
+        });
+        var agent = CreateAgent(client);
+
+        await CollectBlocksAsync(agent);
+        await CollectBlocksAsync(agent);
+
+        Assert.NotNull(secondRequest);
+        var assistantMessage = Assert.Single(
+            secondRequest.Where(message => message.Role == ChatRole.Assistant));
+        Assert.Collection(
+            assistantMessage.Contents,
+            content => Assert.IsType<TextContent>(content));
     }
 
     private static UIAgent<RecipeState> CreateAgent(IChatClient client)
@@ -81,11 +145,9 @@ public class StateMapperTests
                     {
                         context.MarkHandled(stateContent);
                         context.SetState(stateContent.StateValue);
-                        return true;
+                        return;
                     }
                 }
-
-                return false;
             };
         });
     }

--- a/src/Components/AI/test/Pipeline/StateMapperTests.cs
+++ b/src/Components/AI/test/Pipeline/StateMapperTests.cs
@@ -133,6 +133,37 @@ public class StateMapperTests
             content => Assert.IsType<TextContent>(content));
     }
 
+    [Fact]
+    public async Task StateMapper_FullyHandledUpdatePreservesMessageIdentityForLaterText()
+    {
+        var client = new DelegatingStreamingChatClient();
+        List<ChatMessage>? secondRequest = null;
+        var callCount = 0;
+        client.SetHandler((messages, _, cancellationToken) =>
+        {
+            callCount++;
+            if (callCount == 2)
+            {
+                secondRequest = messages.ToList();
+            }
+
+            return callCount == 1
+                ? EmitHandledStateThenUnidentifiedText(cancellationToken)
+                : EmitRawState(cancellationToken);
+        });
+        var agent = CreateAgent(client);
+
+        await CollectBlocksAsync(agent);
+        await CollectBlocksAsync(agent);
+
+        Assert.NotNull(secondRequest);
+        var assistantMessage = Assert.Single(
+            secondRequest.Where(message => message.Role == ChatRole.Assistant));
+        var textContent = Assert.IsType<TextContent>(Assert.Single(assistantMessage.Contents));
+        Assert.Equal("Enjoy this recipe!", textContent.Text);
+        Assert.Equal("message-1", assistantMessage.MessageId);
+    }
+
     private static UIAgent<RecipeState> CreateAgent(IChatClient client)
     {
         return new UIAgent<RecipeState>(client, options =>
@@ -209,6 +240,31 @@ public class StateMapperTests
                 },
                 new TextContent("Enjoy this recipe!"),
             ],
+        };
+
+        await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitHandledStateThenUnidentifiedText(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "message-1",
+            ResponseId = "response-1",
+            Contents =
+            [
+                new StateContent
+                {
+                    StateValue = new RecipeState { Title = "Pasta" },
+                },
+            ],
+        };
+        yield return new ChatResponseUpdate
+        {
+            Contents = [new TextContent("Enjoy this recipe!")],
         };
 
         await Task.CompletedTask;

--- a/src/Components/AI/testassets/AGUIDojoApi/AgenticGenerativeUI/AgenticPlanningTools.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/AgenticGenerativeUI/AgenticPlanningTools.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+
+namespace AGUIDojoApi.AgenticGenerativeUI;
+
+internal static class AgenticPlanningTools
+{
+    [Description("Create a plan with multiple steps.")]
+    internal static Plan CreatePlan(
+        [Description("List of step descriptions to create the plan.")] List<string> steps)
+    {
+        return new Plan
+        {
+            Steps =
+            [
+                .. steps.Select(description => new PlanStep
+                {
+                    Description = description,
+                    Status = PlanStepStatus.Pending,
+                }),
+            ],
+        };
+    }
+
+    [Description("Update a step in the plan with new description or status.")]
+    internal static async Task<List<JsonPatchOperation>> UpdatePlanStepAsync(
+        [Description("The index of the step to update.")] int index,
+        [Description("The new description for the step (optional).")] string? description = null,
+        [Description("The new status for the step (optional).")] PlanStepStatus? status = null)
+    {
+        var changes = new List<JsonPatchOperation>();
+
+        if (description is not null)
+        {
+            changes.Add(new JsonPatchOperation
+            {
+                Op = "replace",
+                Path = $"/steps/{index}/description",
+                Value = description,
+            });
+        }
+
+        if (status is not null)
+        {
+            changes.Add(new JsonPatchOperation
+            {
+                Op = "replace",
+                Path = $"/steps/{index}/status",
+                Value = status is PlanStepStatus.Pending ? "pending" : "completed",
+            });
+        }
+
+        await Task.Delay(1000);
+
+        return changes;
+    }
+}

--- a/src/Components/AI/testassets/AGUIDojoApi/AgenticGenerativeUI/JsonPatchOperation.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/AgenticGenerativeUI/JsonPatchOperation.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace AGUIDojoApi.AgenticGenerativeUI;
+
+internal sealed class JsonPatchOperation
+{
+    [JsonPropertyName("op")]
+    public required string Op { get; set; }
+
+    [JsonPropertyName("path")]
+    public required string Path { get; set; }
+
+    [JsonPropertyName("value")]
+    public object? Value { get; set; }
+
+    [JsonPropertyName("from")]
+    public string? From { get; set; }
+}

--- a/src/Components/AI/testassets/AGUIDojoApi/AgenticGenerativeUI/Plan.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/AgenticGenerativeUI/Plan.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace AGUIDojoApi.AgenticGenerativeUI;
+
+internal sealed class Plan
+{
+    [JsonPropertyName("steps")]
+    public List<PlanStep> Steps { get; set; } = [];
+}

--- a/src/Components/AI/testassets/AGUIDojoApi/AgenticGenerativeUI/PlanStep.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/AgenticGenerativeUI/PlanStep.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace AGUIDojoApi.AgenticGenerativeUI;
+
+internal sealed class PlanStep
+{
+    [JsonPropertyName("description")]
+    public required string Description { get; set; }
+
+    [JsonPropertyName("status")]
+    public PlanStepStatus Status { get; set; } = PlanStepStatus.Pending;
+}

--- a/src/Components/AI/testassets/AGUIDojoApi/AgenticGenerativeUI/PlanStepStatus.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/AgenticGenerativeUI/PlanStepStatus.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace AGUIDojoApi.AgenticGenerativeUI;
+
+[JsonConverter(typeof(JsonStringEnumConverter<PlanStepStatus>))]
+internal enum PlanStepStatus
+{
+    [JsonStringEnumMemberName("pending")]
+    Pending,
+
+    [JsonStringEnumMemberName("completed")]
+    Completed,
+}

--- a/src/Components/AI/testassets/AGUIDojoApi/ChatClientAgentFactory.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/ChatClientAgentFactory.cs
@@ -4,6 +4,8 @@
 using System.ClientModel;
 using System.ComponentModel;
 using System.Text.Json;
+using AGUI.Server;
+using AGUIDojoApi.AgenticGenerativeUI;
 using AGUIDojoApi.BackendToolRendering;
 using Microsoft.Extensions.AI;
 using OpenAI;
@@ -34,6 +36,21 @@ internal static class ChatClientAgentFactory
         three English translation lines, image_name set to ancient-pond.svg, and a two-color CSS
         linear-gradient written as linear-gradient(<angle>deg, <hex color>, <hex color>).
         Do not print the haiku as ordinary chat text before calling the tool.
+        """;
+
+    internal const string AgenticGenerativeUISystemPrompt = """
+        When planning use tools only, without any other messages.
+        IMPORTANT:
+        - Use the `create_plan` tool to set the initial state of the steps
+        - Use the `update_plan_step` tool to update the status of each step
+        - Do NOT repeat the plan or summarise it in a message
+        - Do NOT confirm the creation or updates in a message
+        - Do NOT ask the user for additional information or next steps
+        - Do NOT leave a plan hanging, always complete the plan via `update_plan_step` if one is ongoing.
+        - Continue calling update_plan_step until all steps are marked as completed.
+
+        Only one plan can be active at a time, so do not call the `create_plan` tool
+        again until all the steps in current plan are completed.
         """;
 
     internal static IChatClient CreateAgenticChat(IConfiguration configuration)
@@ -82,6 +99,34 @@ internal static class ChatClientAgentFactory
                 description: "Get the weather for a given location.",
                 options)
         ];
+    }
+
+    internal static IList<AITool> CreateAgenticGenerativeUITools(JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        return
+        [
+            AIFunctionFactory.Create(
+                AgenticPlanningTools.CreatePlan,
+                name: "create_plan",
+                description: "Create a plan with multiple steps.",
+                options),
+            AIFunctionFactory.Create(
+                AgenticPlanningTools.UpdatePlanStepAsync,
+                name: "update_plan_step",
+                description: "Update a step in the plan with new description or status.",
+                options),
+        ];
+    }
+
+    internal static AGUIStreamOptions CreateAgenticGenerativeUIStreamOptions()
+    {
+        var options = new AGUIStreamOptions();
+        options.MapResultAsStateSnapshot("create_plan");
+        options.MapResultAsStateDelta("update_plan_step");
+
+        return options;
     }
 
     [Description("Get the weather for a given location.")]

--- a/src/Components/AI/testassets/AGUIDojoApi/Program.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/Program.cs
@@ -41,6 +41,13 @@ app.MapDojoEndpoint(
 app.MapDojoEndpoint(
     "/tool_based_generative_ui",
     systemPrompt: ChatClientAgentFactory.ToolBasedGenerativeUISystemPrompt);
+app.MapDojoEndpoint(
+    "/agentic_generative_ui",
+    serverTools: ChatClientAgentFactory.CreateAgenticGenerativeUITools(
+        jsonOptions.Value.SerializerOptions),
+    systemPrompt: ChatClientAgentFactory.AgenticGenerativeUISystemPrompt,
+    configureStreamOptions: _ =>
+        ChatClientAgentFactory.CreateAgenticGenerativeUIStreamOptions());
 
 await app.RunAsync();
 

--- a/src/Components/AI/testassets/AGUIDojoApi/ScriptedChatClient.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/ScriptedChatClient.cs
@@ -13,6 +13,27 @@ namespace AGUIDojoApi;
 internal sealed class ScriptedChatClient : IChatClient
 {
     private static readonly TimeSpan TokenDelay = TimeSpan.FromMilliseconds(60);
+    private static readonly string[] MarsPlanSteps =
+    [
+        "Develop a comprehensive mission plan, detailing objectives, budget, and timeline.",
+        "Design and test a spacecraft capable of transporting humans and cargo to Mars.",
+        "Select and train astronaut crew for the mission.",
+        "Establish communication systems and infrastructure for Mars exploration.",
+        "Launch the spacecraft and execute the mission to Mars.",
+    ];
+    private static readonly string[] PizzaPlanSteps =
+    [
+        "Choose the pizza style and serving size.",
+        "Gather flour, yeast, water, salt, and olive oil.",
+        "Mix and knead the pizza dough.",
+        "Let the dough rise until doubled in size.",
+        "Prepare the tomato sauce.",
+        "Slice and organize the toppings.",
+        "Preheat the oven and baking surface.",
+        "Shape the dough and add sauce and toppings.",
+        "Bake the pizza until the crust is golden.",
+        "Rest, slice, and serve the pizza.",
+    ];
 
     public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
         IEnumerable<ChatMessage> messages,
@@ -22,6 +43,11 @@ internal sealed class ScriptedChatClient : IChatClient
         ArgumentNullException.ThrowIfNull(messages);
 
         var messageList = messages.ToList();
+        var prompt = messageList.LastOrDefault(message => message.Role == ChatRole.User)?.Text ?? string.Empty;
+        var planSteps = prompt.Contains("pizza", StringComparison.OrdinalIgnoreCase)
+            ? PizzaPlanSteps
+            : MarsPlanSteps;
+
         if (messageList.LastOrDefault()?.Role == ChatRole.Tool)
         {
             var functionResult = messageList[^1].Contents
@@ -37,7 +63,8 @@ internal sealed class ScriptedChatClient : IChatClient
                 "agentic-plan-step-",
                 StringComparison.Ordinal) == true &&
                 int.TryParse(functionResult.CallId["agentic-plan-step-".Length..], out var stepNumber) &&
-                stepNumber is >= 1 and < 5)
+                stepNumber >= 1 &&
+                stepNumber < planSteps.Length)
             {
                 yield return CreatePlanStepUpdate(
                     messageId: Guid.NewGuid().ToString("N"),
@@ -56,8 +83,10 @@ internal sealed class ScriptedChatClient : IChatClient
                         "tool-generative-ui-haiku-",
                         StringComparison.Ordinal) =>
                     "Your nature haiku is ready\u2014a quiet pond awakened by a frog.",
-                { CallId: "agentic-plan-step-5" } =>
-                    "All five steps in the Mars mission plan are complete.",
+                { CallId: var callId }
+                    when callId == $"agentic-plan-step-{planSteps.Length}" =>
+                    $"All {planSteps.Length} steps in the " +
+                    $"{(planSteps.Length == PizzaPlanSteps.Length ? "pizza" : "Mars mission")} plan are complete.",
                 _ => "Background changed to a sunset gradient.",
             };
             yield return new ChatResponseUpdate
@@ -68,15 +97,6 @@ internal sealed class ScriptedChatClient : IChatClient
                 FinishReason = ChatFinishReason.Stop,
             };
             yield break;
-        }
-
-        var prompt = string.Empty;
-        foreach (var message in messageList)
-        {
-            if (message.Role == ChatRole.User)
-            {
-                prompt = message.Text;
-            }
         }
 
         var messageId = Guid.NewGuid().ToString("N");
@@ -95,14 +115,7 @@ internal sealed class ScriptedChatClient : IChatClient
                         "create_plan",
                         new Dictionary<string, object?>
                         {
-                            ["steps"] = new[]
-                            {
-                                "Develop a comprehensive mission plan, detailing objectives, budget, and timeline.",
-                                "Design and test a spacecraft capable of transporting humans and cargo to Mars.",
-                                "Select and train astronaut crew for the mission.",
-                                "Establish communication systems and infrastructure for Mars exploration.",
-                                "Launch the spacecraft and execute the mission to Mars.",
-                            },
+                            ["steps"] = planSteps,
                         })
                 ],
                 FinishReason = ChatFinishReason.ToolCalls,

--- a/src/Components/AI/testassets/AGUIDojoApi/ScriptedChatClient.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/ScriptedChatClient.cs
@@ -27,6 +27,24 @@ internal sealed class ScriptedChatClient : IChatClient
             var functionResult = messageList[^1].Contents
                 .OfType<FunctionResultContent>()
                 .FirstOrDefault();
+            if (functionResult is { CallId: "agentic-plan-create-1" })
+            {
+                yield return CreatePlanStepUpdate(messageId: Guid.NewGuid().ToString("N"), stepIndex: 0);
+                yield break;
+            }
+
+            if (functionResult?.CallId.StartsWith(
+                "agentic-plan-step-",
+                StringComparison.Ordinal) == true &&
+                int.TryParse(functionResult.CallId["agentic-plan-step-".Length..], out var stepNumber) &&
+                stepNumber is >= 1 and < 5)
+            {
+                yield return CreatePlanStepUpdate(
+                    messageId: Guid.NewGuid().ToString("N"),
+                    stepIndex: stepNumber);
+                yield break;
+            }
+
             var response = functionResult switch
             {
                 { CallId: "backend-tool-weather-1" } =>
@@ -38,6 +56,8 @@ internal sealed class ScriptedChatClient : IChatClient
                         "tool-generative-ui-haiku-",
                         StringComparison.Ordinal) =>
                     "Your nature haiku is ready\u2014a quiet pond awakened by a frog.",
+                { CallId: "agentic-plan-step-5" } =>
+                    "All five steps in the Mars mission plan are complete.",
                 _ => "Background changed to a sunset gradient.",
             };
             yield return new ChatResponseUpdate
@@ -60,6 +80,36 @@ internal sealed class ScriptedChatClient : IChatClient
         }
 
         var messageId = Guid.NewGuid().ToString("N");
+        if (prompt.Contains("plan", StringComparison.OrdinalIgnoreCase) &&
+            options?.Tools?.OfType<AIFunctionDeclaration>()
+                .Any(tool => tool.Name == "create_plan") == true)
+        {
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = messageId,
+                Contents =
+                [
+                    new FunctionCallContent(
+                        "agentic-plan-create-1",
+                        "create_plan",
+                        new Dictionary<string, object?>
+                        {
+                            ["steps"] = new[]
+                            {
+                                "Develop a comprehensive mission plan, detailing objectives, budget, and timeline.",
+                                "Design and test a spacecraft capable of transporting humans and cargo to Mars.",
+                                "Select and train astronaut crew for the mission.",
+                                "Establish communication systems and infrastructure for Mars exploration.",
+                                "Launch the spacecraft and execute the mission to Mars.",
+                            },
+                        })
+                ],
+                FinishReason = ChatFinishReason.ToolCalls,
+            };
+            yield break;
+        }
+
         if (prompt.Contains("weather", StringComparison.OrdinalIgnoreCase) &&
             options?.Tools?.OfType<AIFunctionDeclaration>()
                 .Any(tool => tool.Name == "get_weather") == true)
@@ -198,6 +248,27 @@ internal sealed class ScriptedChatClient : IChatClient
 
     public void Dispose()
     {
+    }
+
+    private static ChatResponseUpdate CreatePlanStepUpdate(string messageId, int stepIndex)
+    {
+        return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = messageId,
+            Contents =
+            [
+                new FunctionCallContent(
+                    $"agentic-plan-step-{stepIndex + 1}",
+                    "update_plan_step",
+                    new Dictionary<string, object?>
+                    {
+                        ["index"] = stepIndex,
+                        ["status"] = "completed",
+                    })
+            ],
+            FinishReason = ChatFinishReason.ToolCalls,
+        };
     }
 
     private static string CreateTaskStepsSummary(object? result)

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Baselines/AgenticGenerativeUI.recording.json
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Baselines/AgenticGenerativeUI.recording.json
@@ -1,0 +1,205 @@
+{
+  "calls": [
+    {
+      "prompt": "Please build a plan to go to mars in 5 steps.",
+      "messageCount": 2,
+      "toolNames": [
+        "create_plan",
+        "update_plan_step"
+      ],
+      "frames": [
+        {
+          "name": "plan-created",
+          "functionCall": {
+            "callId": "agentic-plan-create-1",
+            "name": "create_plan",
+            "arguments": {
+              "steps": [
+                "Develop a comprehensive mission plan, detailing objectives, budget, and timeline.",
+                "Design and test a spacecraft capable of transporting humans and cargo to Mars.",
+                "Select and train astronaut crew for the mission.",
+                "Establish communication systems and infrastructure for Mars exploration.",
+                "Launch the spacecraft and execute the mission to Mars."
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "prompt": "Please build a plan to go to mars in 5 steps.",
+      "messageCount": 4,
+      "toolNames": [
+        "create_plan",
+        "update_plan_step"
+      ],
+      "toolResultCallIds": [
+        "agentic-plan-create-1"
+      ],
+      "frames": [
+        {
+          "name": "before-step-1"
+        },
+        {
+          "name": "step-1-call",
+          "functionCall": {
+            "callId": "agentic-plan-step-1",
+            "name": "update_plan_step",
+            "arguments": {
+              "index": 0,
+              "status": "completed"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "prompt": "Please build a plan to go to mars in 5 steps.",
+      "messageCount": 6,
+      "toolNames": [
+        "create_plan",
+        "update_plan_step"
+      ],
+      "toolResultCallIds": [
+        "agentic-plan-create-1",
+        "agentic-plan-step-1"
+      ],
+      "frames": [
+        {
+          "name": "before-step-2"
+        },
+        {
+          "name": "step-2-call",
+          "functionCall": {
+            "callId": "agentic-plan-step-2",
+            "name": "update_plan_step",
+            "arguments": {
+              "index": 1,
+              "status": "completed"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "prompt": "Please build a plan to go to mars in 5 steps.",
+      "messageCount": 8,
+      "toolNames": [
+        "create_plan",
+        "update_plan_step"
+      ],
+      "toolResultCallIds": [
+        "agentic-plan-create-1",
+        "agentic-plan-step-1",
+        "agentic-plan-step-2"
+      ],
+      "frames": [
+        {
+          "name": "before-step-3"
+        },
+        {
+          "name": "step-3-call",
+          "functionCall": {
+            "callId": "agentic-plan-step-3",
+            "name": "update_plan_step",
+            "arguments": {
+              "index": 2,
+              "status": "completed"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "prompt": "Please build a plan to go to mars in 5 steps.",
+      "messageCount": 10,
+      "toolNames": [
+        "create_plan",
+        "update_plan_step"
+      ],
+      "toolResultCallIds": [
+        "agentic-plan-create-1",
+        "agentic-plan-step-1",
+        "agentic-plan-step-2",
+        "agentic-plan-step-3"
+      ],
+      "frames": [
+        {
+          "name": "before-step-4"
+        },
+        {
+          "name": "step-4-call",
+          "functionCall": {
+            "callId": "agentic-plan-step-4",
+            "name": "update_plan_step",
+            "arguments": {
+              "index": 3,
+              "status": "completed"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "prompt": "Please build a plan to go to mars in 5 steps.",
+      "messageCount": 12,
+      "toolNames": [
+        "create_plan",
+        "update_plan_step"
+      ],
+      "toolResultCallIds": [
+        "agentic-plan-create-1",
+        "agentic-plan-step-1",
+        "agentic-plan-step-2",
+        "agentic-plan-step-3",
+        "agentic-plan-step-4"
+      ],
+      "frames": [
+        {
+          "name": "before-step-5"
+        },
+        {
+          "name": "step-5-call",
+          "functionCall": {
+            "callId": "agentic-plan-step-5",
+            "name": "update_plan_step",
+            "arguments": {
+              "index": 4,
+              "status": "completed"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "prompt": "Please build a plan to go to mars in 5 steps.",
+      "messageCount": 14,
+      "toolNames": [
+        "create_plan",
+        "update_plan_step"
+      ],
+      "toolResultCallIds": [
+        "agentic-plan-create-1",
+        "agentic-plan-step-1",
+        "agentic-plan-step-2",
+        "agentic-plan-step-3",
+        "agentic-plan-step-4",
+        "agentic-plan-step-5"
+      ],
+      "frames": [
+        {
+          "name": "before-summary"
+        },
+        {
+          "name": "summary-complete",
+          "chunks": [
+            "All five steps in the Mars mission plan are complete."
+          ]
+        },
+        {
+          "name": "response-complete"
+        }
+      ]
+    }
+  ]
+}

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/DojoModelOverrides.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/DojoModelOverrides.cs
@@ -34,6 +34,14 @@ internal class DojoModelOverrides
     public static void ToolBasedGenerativeUI(IServiceCollection services)
         => AddRecordedModel(services, "ToolBasedGenerativeUI.recording.json");
 
+    public static void AgenticGenerativeUI(IServiceCollection services)
+    {
+        services.AddSingleton(_ => RecordedScript.Load("AgenticGenerativeUI.recording.json"));
+        services.AddScoped<RecordedChatClient>();
+        services.AddScoped<IChatClient>(sp =>
+            new FunctionInvokingChatClient(sp.GetRequiredService<RecordedChatClient>()));
+    }
+
     private static void AddRecordedModel(IServiceCollection services, string recordingFileName)
     {
         services.AddSingleton(_ => RecordedScript.Load(recordingFileName));

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/AgenticGenerativeUIScenarioTests.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/AgenticGenerativeUIScenarioTests.cs
@@ -16,6 +16,8 @@ namespace DojoClient.E2E.Tests.Tests;
 [UITest]
 public partial class AgenticGenerativeUIScenarioTests : BrowserTest
 {
+    private const string SimplePlanPrompt = "Please build a plan to go to mars in 5 steps.";
+
     private static readonly string[] s_stepDescriptions =
     [
         "Develop a comprehensive mission plan, detailing objectives, budget, and timeline.",
@@ -35,7 +37,7 @@ public partial class AgenticGenerativeUIScenarioTests : BrowserTest
     {
         await base.InitializeCoreAsync();
 
-        _prompt = $"Please build a plan to go to mars in 5 steps. ({Guid.NewGuid():N})";
+        _prompt = SimplePlanPrompt;
         _api = await StartServerAsync<AGUIDojoApiAssembly>(TestRoot.Servers, options =>
         {
             options.ConfigureServices<DojoModelOverrides>(
@@ -59,12 +61,16 @@ public partial class AgenticGenerativeUIScenarioTests : BrowserTest
         var scenario = _page.Locator("[data-scenario='agentic_generative_ui']");
         var activity = scenario.Locator(".plan-activity");
         var send = scenario.Locator("button.sc-ai-input__send");
+        var suggestions = scenario.Locator(".plan-suggestion");
 
         await Expect(activity).ToHaveCountAsync(0);
-        await _page.FillAsync("textarea.sc-ai-input__textarea", _prompt);
-        await send.ClickAsync();
+        await Expect(suggestions).ToHaveCountAsync(2);
+        await Expect(suggestions.Nth(0)).ToContainTextAsync("Simple plan");
+        await Expect(suggestions.Nth(1)).ToContainTextAsync("Complex plan");
+        await suggestions.Nth(0).ClickAsync();
 
         await AssertPlanAsync(activity, completedCount: 0, isRunning: true);
+        await Expect(suggestions).ToHaveCountAsync(0);
         await Expect(send).ToBeDisabledAsync();
 
         for (var completedCount = 1; completedCount <= s_stepDescriptions.Length; completedCount++)
@@ -127,5 +133,57 @@ public partial class AgenticGenerativeUIScenarioTests : BrowserTest
             await Expect(step.Locator(".plan-step__processing"))
                 .ToHaveCountAsync(expectedState == "current" ? 1 : 0);
         }
+    }
+}
+
+[UITest]
+public partial class AgenticGenerativeUISuggestionTests : BrowserTest
+{
+    private const string ComplexPlanPrompt = "Please build a plan to go to make pizza in 10 steps.";
+
+    private ServerInstance _api = null!;
+    private ServerInstance _ui = null!;
+    private IPage _page = null!;
+
+    protected override async Task InitializeCoreAsync()
+    {
+        await base.InitializeCoreAsync();
+
+        _api = await StartServerAsync<AGUIDojoApiAssembly>(TestRoot.Servers, options =>
+        {
+            options.EnvironmentVariables["OPENAI_BASE_URL"] = "";
+            options.EnvironmentVariables["OPENAI_API_KEY"] = "";
+        });
+        _ui = await StartServerAsync<global::DojoClient.Components.App>(TestRoot.Servers, options =>
+        {
+            options.EnvironmentVariables["AGUI_DOJO_API_URL"] = _api.AppUrl;
+        });
+
+        var context = await NewContext(new BrowserNewContextOptions().WithServerRouting(_ui));
+        _page = await context.NewPageAsync();
+        await _page.GotoAsync($"{_ui.TestUrl}/agentic_generative_ui");
+        await _page.WaitForInteractiveAsync("textarea.sc-ai-input__textarea");
+    }
+
+    [TestMethod]
+    public async Task ComplexPlanSuggestion_SubmitsTenStepPizzaPlan()
+    {
+        var scenario = _page.Locator("[data-scenario='agentic_generative_ui']");
+        var suggestion = scenario.Locator(".plan-suggestion").Filter(
+            new LocatorFilterOptions { HasText = "Complex plan" });
+
+        await Expect(suggestion).ToHaveCountAsync(1);
+        await suggestion.ClickAsync();
+
+        await Expect(scenario.Locator(".sc-ai-message--user"))
+            .ToContainTextAsync(ComplexPlanPrompt);
+        await Expect(scenario.Locator(".plan-step")).ToHaveCountAsync(10);
+        await Expect(scenario.Locator(".plan-progress-card__count"))
+            .ToHaveTextAsync("10/10 Complete", new() { Timeout = 20_000 });
+        await Expect(scenario.Locator(".sc-ai-message--assistant .sc-ai-message__content"))
+            .ToHaveTextAsync(
+                "All 10 steps in the pizza plan are complete.",
+                new() { Timeout = 20_000 });
+        await Expect(scenario.Locator("button.sc-ai-input__send")).ToBeEnabledAsync();
     }
 }

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/AgenticGenerativeUIScenarioTests.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/AgenticGenerativeUIScenarioTests.cs
@@ -114,6 +114,7 @@ public partial class AgenticGenerativeUIScenarioTests : BrowserTest
             .ToHaveTextAsync($"{completedCount}/{s_stepDescriptions.Length} Complete");
         await Expect(card.Locator(".plan-progress-card__bar-fill"))
             .ToHaveAttributeAsync("style", $"width: {completedCount * 20}%");
+        await Expect(card.Locator(".plan-progress-card__bar-shimmer")).ToHaveCountAsync(1);
 
         var steps = card.Locator(".plan-step");
         await Expect(steps).ToHaveCountAsync(s_stepDescriptions.Length);

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/AgenticGenerativeUIScenarioTests.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/AgenticGenerativeUIScenarioTests.cs
@@ -1,0 +1,131 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using AGUIDojoApi;
+using DojoClient.E2E.Tests.Fixtures;
+using DojoClient.E2E.Tests.ServiceOverrides;
+using Microsoft.AspNetCore.Components.Testing.Infrastructure;
+using Microsoft.AspNetCore.Components.Testing.Playwright;
+using Microsoft.Playwright;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DojoClient.E2E.Tests.Tests;
+
+// The browser and DojoClient use the real AG-UI HTTP/SSE transport. Only the API model is
+// recorded so snapshots, JSON Patch deltas, and typed state mapping all cross the wire.
+[UITest]
+public partial class AgenticGenerativeUIScenarioTests : BrowserTest
+{
+    private static readonly string[] s_stepDescriptions =
+    [
+        "Develop a comprehensive mission plan, detailing objectives, budget, and timeline.",
+        "Design and test a spacecraft capable of transporting humans and cargo to Mars.",
+        "Select and train astronaut crew for the mission.",
+        "Establish communication systems and infrastructure for Mars exploration.",
+        "Launch the spacecraft and execute the mission to Mars.",
+    ];
+
+    private ServerInstance _api = null!;
+    private ServerInstance _ui = null!;
+    private ApiCheckpointClient _checkpoints = null!;
+    private IPage _page = null!;
+    private string _prompt = null!;
+
+    protected override async Task InitializeCoreAsync()
+    {
+        await base.InitializeCoreAsync();
+
+        _prompt = $"Please build a plan to go to mars in 5 steps. ({Guid.NewGuid():N})";
+        _api = await StartServerAsync<AGUIDojoApiAssembly>(TestRoot.Servers, options =>
+        {
+            options.ConfigureServices<DojoModelOverrides>(
+                nameof(DojoModelOverrides.AgenticGenerativeUI));
+        });
+        _ui = await StartServerAsync<global::DojoClient.Components.App>(TestRoot.Servers, options =>
+        {
+            options.EnvironmentVariables["AGUI_DOJO_API_URL"] = _api.AppUrl;
+        });
+        _checkpoints = new ApiCheckpointClient(_api);
+
+        var context = await NewContext(new BrowserNewContextOptions().WithServerRouting(_ui));
+        _page = await context.NewPageAsync();
+        await _page.GotoAsync($"{_ui.TestUrl}/agentic_generative_ui");
+        await _page.WaitForInteractiveAsync("textarea.sc-ai-input__textarea");
+    }
+
+    [TestMethod]
+    public async Task PlanTask_StreamsSnapshotAndEachDeltaBeforeCompleting()
+    {
+        var scenario = _page.Locator("[data-scenario='agentic_generative_ui']");
+        var activity = scenario.Locator(".plan-activity");
+        var send = scenario.Locator("button.sc-ai-input__send");
+
+        await Expect(activity).ToHaveCountAsync(0);
+        await _page.FillAsync("textarea.sc-ai-input__textarea", _prompt);
+        await send.ClickAsync();
+
+        await AssertPlanAsync(activity, completedCount: 0, isRunning: true);
+        await Expect(send).ToBeDisabledAsync();
+
+        for (var completedCount = 1; completedCount <= s_stepDescriptions.Length; completedCount++)
+        {
+            await _checkpoints.ReleaseAsync(_prompt, $"before-step-{completedCount}");
+            await AssertPlanAsync(activity, completedCount, isRunning: true);
+            await Expect(send).ToBeDisabledAsync();
+        }
+
+        await _checkpoints.ReleaseAsync(_prompt, "before-summary");
+
+        var assistant = scenario.Locator(
+            ".sc-ai-message--assistant .sc-ai-message__content");
+        await Expect(assistant).ToHaveTextAsync(
+            "All five steps in the Mars mission plan are complete.");
+        await Expect(assistant).ToHaveClassAsync(
+            "sc-ai-message__content sc-ai-message__content--streaming");
+        await AssertPlanAsync(activity, completedCount: 5, isRunning: true);
+
+        await _checkpoints.ReleaseAsync(_prompt, "summary-complete");
+
+        await AssertPlanAsync(activity, completedCount: 5, isRunning: false);
+        await Expect(assistant).ToHaveClassAsync("sc-ai-message__content");
+        await Expect(send).ToBeEnabledAsync();
+    }
+
+    private static async Task AssertPlanAsync(
+        ILocator activity,
+        int completedCount,
+        bool isRunning)
+    {
+        await Expect(activity).ToHaveCountAsync(1);
+        await Expect(activity).ToHaveAttributeAsync(
+            "data-task-status",
+            isRunning ? "running" : "done");
+        await Expect(activity.Locator(".plan-activity__status"))
+            .ToHaveTextAsync(isRunning ? "Running" : "Done");
+
+        var card = activity.Locator(".plan-progress-card");
+        await Expect(card.Locator(".plan-progress-card__count"))
+            .ToHaveTextAsync($"{completedCount}/{s_stepDescriptions.Length} Complete");
+        await Expect(card.Locator(".plan-progress-card__bar-fill"))
+            .ToHaveAttributeAsync("style", $"width: {completedCount * 20}%");
+
+        var steps = card.Locator(".plan-step");
+        await Expect(steps).ToHaveCountAsync(s_stepDescriptions.Length);
+        for (var index = 0; index < s_stepDescriptions.Length; index++)
+        {
+            var step = steps.Nth(index);
+            await Expect(step.Locator(".plan-step__description"))
+                .ToHaveTextAsync(s_stepDescriptions[index]);
+
+            var expectedState = index < completedCount
+                ? "completed"
+                : completedCount < s_stepDescriptions.Length && index == completedCount
+                    ? "current"
+                    : "pending";
+            await Expect(step).ToHaveAttributeAsync("data-step-state", expectedState);
+            await Expect(step).ToHaveClassAsync($"plan-step plan-step--{expectedState}");
+            await Expect(step.Locator(".plan-step__processing"))
+                .ToHaveCountAsync(expectedState == "current" ? 1 : 0);
+        }
+    }
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Pages/Home.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Pages/Home.razor
@@ -11,4 +11,5 @@
     <li><a href="/backend_tool_rendering" data-scenario="backend_tool_rendering">Backend Tool Rendering</a></li>
     <li><a href="/human_in_the_loop" data-scenario="human_in_the_loop">Human in the Loop</a></li>
     <li><a href="/tool_based_generative_ui" data-scenario="tool_based_generative_ui">Tool-Based Generative UI</a></li>
+    <li><a href="/agentic_generative_ui" data-scenario="agentic_generative_ui">Agentic Generative UI</a></li>
 </ul>

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/AgenticGenerativeUIScenario.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/AgenticGenerativeUIScenario.razor
@@ -1,0 +1,150 @@
+@page "/agentic_generative_ui"
+@rendermode InteractiveServer
+@implements IDisposable
+@using System.Text.Json
+@inject ILoggerFactory LoggerFactory
+
+<PageTitle>Agentic Generative UI</PageTitle>
+
+<div class="agentic-generative-ui" data-scenario="agentic_generative_ui">
+    <AgentBoundary Agent="_agent">
+        <div class="sc-ai-root sc-ai-chat-page dojo-chat-panel">
+            <div class="sc-ai-chat-page__header">
+                <h1 class="dojo-scenario__title">Agentic Generative UI</h1>
+            </div>
+            <div class="sc-ai-chat-page__body plan-content">
+                <MessageList>
+                    <EmptyContent>
+                        <p class="dojo-scenario__welcome">
+                            Ask the agent to create and complete a multi-step plan.
+                        </p>
+                    </EmptyContent>
+                    <Footer Context="context">
+                        @if (_agent.State.Value.Steps.Count > 0)
+                        {
+                            var isRunning = IsRunning(context.Status);
+                            <div class="plan-activity"
+                                 data-task-status="@(isRunning ? "running" : "done")">
+                                <div class="plan-activity__header">
+                                    <span class="plan-activity__title">create_plan</span>
+                                    <span class="plan-activity__status"
+                                          role="status">@(isRunning ? "Running" : "Done")</span>
+                                </div>
+                                <PlanProgressCard Plan="_agent.State.Value" />
+                            </div>
+                        }
+                        else if (IsRunning(context.Status))
+                        {
+                            <div class="sc-ai-typing" role="status" aria-label="Agent is typing">
+                                <span class="sc-ai-typing__dot"></span>
+                                <span class="sc-ai-typing__dot"></span>
+                                <span class="sc-ai-typing__dot"></span>
+                            </div>
+                        }
+                    </Footer>
+                </MessageList>
+            </div>
+            <div class="sc-ai-chat-page__footer">
+                <div class="sc-ai-chat-page__input-container">
+                    <MessageInput Placeholder="Ask for a plan..." />
+                </div>
+            </div>
+        </div>
+    </AgentBoundary>
+</div>
+
+@code {
+    private static readonly JsonSerializerOptions _jsonOptions =
+        new(JsonSerializerDefaults.Web);
+
+    private UIAgent<PlanState> _agent = default!;
+    private IDisposable? _stateChangedRegistration;
+
+    [Inject(Key = DojoScenarios.AgenticGenerativeUIEndpoint)]
+    public IChatClient ChatClient { get; set; } = default!;
+
+    protected override void OnInitialized()
+    {
+        _agent = new UIAgent<PlanState>(ChatClient, options =>
+        {
+            options.StateMapper = context =>
+            {
+                if (context.Update.RawRepresentation is StateDeltaEvent delta)
+                {
+                    context.SetState(ApplyPlanDelta(_agent.State.Value, delta.Delta));
+                    return true;
+                }
+
+                if (context.Update.RawRepresentation is not StateSnapshotEvent snapshot)
+                {
+                    return false;
+                }
+
+                var state = snapshot.Snapshot.Deserialize<PlanState>(_jsonOptions);
+                if (state is null)
+                {
+                    return false;
+                }
+
+                context.SetState(state);
+                return true;
+            };
+        }, LoggerFactory);
+        _stateChangedRegistration = _agent.State.OnChanged(
+            () => _ = InvokeAsync(StateHasChanged));
+    }
+
+    private static PlanState ApplyPlanDelta(PlanState current, JsonElement delta)
+    {
+        var next = new PlanState
+        {
+            Steps =
+            [
+                .. current.Steps.Select(step => new PlanStep
+                {
+                    Description = step.Description,
+                    Status = step.Status,
+                }),
+            ],
+        };
+
+        foreach (var operation in delta.EnumerateArray())
+        {
+            if (operation.GetProperty("op").GetString() != "replace")
+            {
+                continue;
+            }
+
+            var pathSegments = operation.GetProperty("path").GetString()?
+                .Split('/', StringSplitOptions.RemoveEmptyEntries);
+            if (pathSegments is not ["steps", var indexText, var property] ||
+                !int.TryParse(indexText, out var index) ||
+                index < 0 ||
+                index >= next.Steps.Count)
+            {
+                continue;
+            }
+
+            var value = operation.GetProperty("value").GetString() ?? "";
+            if (property == "description")
+            {
+                next.Steps[index].Description = value;
+            }
+            else if (property == "status")
+            {
+                next.Steps[index].Status = value;
+            }
+        }
+
+        return next;
+    }
+
+    private static bool IsRunning(ConversationStatus status)
+        => status is ConversationStatus.Streaming or ConversationStatus.AwaitingInput;
+
+    public void Dispose()
+    {
+        _stateChangedRegistration?.Dispose();
+        _agent?.Dispose();
+    }
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/AgenticGenerativeUIScenario.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/AgenticGenerativeUIScenario.razor
@@ -72,22 +72,19 @@
                 if (context.Update.RawRepresentation is StateDeltaEvent delta)
                 {
                     context.SetState(ApplyPlanDelta(_agent.State.Value, delta.Delta));
-                    return true;
+                    return;
                 }
 
                 if (context.Update.RawRepresentation is not StateSnapshotEvent snapshot)
                 {
-                    return false;
+                    return;
                 }
 
                 var state = snapshot.Snapshot.Deserialize<PlanState>(_jsonOptions);
-                if (state is null)
+                if (state is not null)
                 {
-                    return false;
+                    context.SetState(state);
                 }
-
-                context.SetState(state);
-                return true;
             };
         }, LoggerFactory);
         _stateChangedRegistration = _agent.State.OnChanged(
@@ -110,9 +107,11 @@
 
         foreach (var operation in delta.EnumerateArray())
         {
-            if (operation.GetProperty("op").GetString() != "replace")
+            var operationName = operation.GetProperty("op").GetString();
+            if (operationName is not "replace")
             {
-                continue;
+                throw new InvalidOperationException(
+                    $"The JSON Patch operation '{operationName}' is not supported.");
             }
 
             var pathSegments = operation.GetProperty("path").GetString()?

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/AgenticGenerativeUIScenario.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/AgenticGenerativeUIScenario.razor
@@ -18,6 +18,7 @@
                         <p class="dojo-scenario__welcome">
                             Ask the agent to create and complete a multi-step plan.
                         </p>
+                        <InitialPlanSuggestions />
                     </EmptyContent>
                     <Footer Context="context">
                         @if (_agent.State.Value.Steps.Count > 0)

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/AgenticGenerativeUIScenario.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/AgenticGenerativeUIScenario.razor.css
@@ -1,0 +1,45 @@
+.agentic-generative-ui {
+    height: 100%;
+    min-height: 0;
+    min-width: 0;
+}
+
+.agentic-generative-ui .dojo-chat-panel {
+    height: 100%;
+}
+
+.plan-content {
+    min-width: 0;
+}
+
+.plan-content ::deep .sc-ai-message-list__footer {
+    display: block;
+}
+
+.plan-content ::deep .plan-activity {
+    max-width: var(--sc-ai-max-width, 48rem);
+    width: calc(100% - 2 * var(--sc-ai-spacing-lg, 1.5rem));
+    margin: 0 auto var(--sc-ai-spacing-md, 1rem);
+}
+
+.plan-content ::deep .plan-activity__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 6px;
+    color: #4b5563;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.plan-content ::deep .plan-activity__status {
+    border-radius: 999px;
+    padding: 3px 9px;
+    background: #eef2ff;
+    color: #4338ca;
+}
+
+.plan-content ::deep .plan-activity[data-task-status="done"] .plan-activity__status {
+    background: #dcfce7;
+    color: #166534;
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/InitialPlanSuggestions.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/InitialPlanSuggestions.razor
@@ -1,0 +1,44 @@
+<div class="plan-suggestions" aria-label="Suggested prompts">
+    <button type="button"
+            class="plan-suggestion"
+            disabled="@_isSending"
+            @onclick="() => SendAsync(SimplePlanPrompt)">
+        <span class="plan-suggestion__title">Simple plan</span>
+        <span class="plan-suggestion__description">Plan a five-step trip to Mars</span>
+    </button>
+    <button type="button"
+            class="plan-suggestion"
+            disabled="@_isSending"
+            @onclick="() => SendAsync(ComplexPlanPrompt)">
+        <span class="plan-suggestion__title">Complex plan</span>
+        <span class="plan-suggestion__description">Plan making pizza in ten steps</span>
+    </button>
+</div>
+
+@code {
+    internal const string SimplePlanPrompt = "Please build a plan to go to mars in 5 steps.";
+    internal const string ComplexPlanPrompt = "Please build a plan to go to make pizza in 10 steps.";
+
+    private bool _isSending;
+
+    [CascadingParameter]
+    private AgentContext AgentContext { get; set; } = default!;
+
+    private async Task SendAsync(string prompt)
+    {
+        if (_isSending)
+        {
+            return;
+        }
+
+        _isSending = true;
+        try
+        {
+            await AgentContext.SendMessageAsync(prompt);
+        }
+        finally
+        {
+            _isSending = false;
+        }
+    }
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/InitialPlanSuggestions.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/InitialPlanSuggestions.razor
@@ -4,14 +4,12 @@
             disabled="@_isSending"
             @onclick="() => SendAsync(SimplePlanPrompt)">
         <span class="plan-suggestion__title">Simple plan</span>
-        <span class="plan-suggestion__description">Plan a five-step trip to Mars</span>
     </button>
     <button type="button"
             class="plan-suggestion"
             disabled="@_isSending"
             @onclick="() => SendAsync(ComplexPlanPrompt)">
         <span class="plan-suggestion__title">Complex plan</span>
-        <span class="plan-suggestion__description">Plan making pizza in ten steps</span>
     </button>
 </div>
 

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/InitialPlanSuggestions.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/InitialPlanSuggestions.razor.css
@@ -41,12 +41,6 @@
     font-weight: 600;
 }
 
-.plan-suggestion__description {
-    color: #6b7280;
-    font-size: 0.85rem;
-    line-height: 1.35;
-}
-
 @media (max-width: 36rem) {
     .plan-suggestions {
         grid-template-columns: 1fr;

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/InitialPlanSuggestions.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/InitialPlanSuggestions.razor.css
@@ -1,0 +1,54 @@
+.plan-suggestions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+    width: min(100%, 36rem);
+    margin: 1rem auto 0;
+}
+
+.plan-suggestion {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.875rem 1rem;
+    border: 1px solid #d1d5db;
+    border-radius: 0.75rem;
+    background: #fff;
+    color: #111827;
+    text-align: left;
+    cursor: pointer;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.plan-suggestion:hover:not(:disabled) {
+    border-color: #818cf8;
+    box-shadow: 0 4px 12px rgb(79 70 229 / 12%);
+    transform: translateY(-1px);
+}
+
+.plan-suggestion:focus-visible {
+    outline: 2px solid #4f46e5;
+    outline-offset: 2px;
+}
+
+.plan-suggestion:disabled {
+    cursor: wait;
+    opacity: 0.65;
+}
+
+.plan-suggestion__title {
+    font-weight: 600;
+}
+
+.plan-suggestion__description {
+    color: #6b7280;
+    font-size: 0.85rem;
+    line-height: 1.35;
+}
+
+@media (max-width: 36rem) {
+    .plan-suggestions {
+        grid-template-columns: 1fr;
+    }
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/PlanProgressCard.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/PlanProgressCard.razor
@@ -1,14 +1,17 @@
 <div class="plan-progress-card">
-    <div class="plan-progress-card__header">
-        <h3>Task Progress</h3>
-        <span class="plan-progress-card__count">
-            @CompletedCount/@TotalCount Complete
-        </span>
-    </div>
+    <div class="plan-progress-card__summary">
+        <div class="plan-progress-card__header">
+            <h3>Task Progress</h3>
+            <span class="plan-progress-card__count">
+                @CompletedCount/@TotalCount Complete
+            </span>
+        </div>
 
-    <div class="plan-progress-card__bar">
-        <div class="plan-progress-card__bar-fill"
-             style="width: @ProgressPercent%"></div>
+        <div class="plan-progress-card__bar">
+            <div class="plan-progress-card__bar-fill"
+                 style="width: @ProgressPercent%"></div>
+            <div class="plan-progress-card__bar-shimmer"></div>
+        </div>
     </div>
 
     <ul class="plan-progress-card__steps">

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/PlanProgressCard.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/PlanProgressCard.razor
@@ -1,0 +1,84 @@
+<div class="plan-progress-card">
+    <div class="plan-progress-card__header">
+        <h3>Task Progress</h3>
+        <span class="plan-progress-card__count">
+            @CompletedCount/@TotalCount Complete
+        </span>
+    </div>
+
+    <div class="plan-progress-card__bar">
+        <div class="plan-progress-card__bar-fill"
+             style="width: @ProgressPercent%"></div>
+    </div>
+
+    <ul class="plan-progress-card__steps">
+        @for (var i = 0; i < Plan.Steps.Count; i++)
+        {
+            var step = Plan.Steps[i];
+            var stepClass = GetStepClass(step, i);
+            var state = GetStepState(step, i);
+            <li class="plan-step @stepClass" data-step-state="@state">
+                <span class="plan-step__icon">@GetStepIcon(step, i)</span>
+                <span class="plan-step__content">
+                    <span class="plan-step__description">@step.Description</span>
+                    @if (state == "current")
+                    {
+                        <span class="plan-step__processing">Processing...</span>
+                    }
+                </span>
+            </li>
+        }
+    </ul>
+</div>
+
+@code {
+    [Parameter, EditorRequired]
+    public PlanState Plan { get; set; } = default!;
+
+    private int CompletedCount => Plan.Steps.Count(step => step.Status == "completed");
+
+    private int TotalCount => Plan.Steps.Count;
+
+    private double ProgressPercent => TotalCount > 0
+        ? (double)CompletedCount / TotalCount * 100
+        : 0;
+
+    private int CurrentStepIndex
+    {
+        get
+        {
+            for (var i = 0; i < Plan.Steps.Count; i++)
+            {
+                if (Plan.Steps[i].Status == "pending")
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+    }
+
+    private string GetStepClass(PlanStep step, int index)
+        => $"plan-step--{GetStepState(step, index)}";
+
+    private string GetStepState(PlanStep step, int index)
+    {
+        if (step.Status == "completed")
+        {
+            return "completed";
+        }
+
+        return index == CurrentStepIndex ? "current" : "pending";
+    }
+
+    private string GetStepIcon(PlanStep step, int index)
+    {
+        if (step.Status == "completed")
+        {
+            return "\u2713";
+        }
+
+        return index == CurrentStepIndex ? "\u27f3" : "\u23f0";
+    }
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/PlanProgressCard.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/PlanProgressCard.razor.css
@@ -1,0 +1,123 @@
+.plan-progress-card {
+    border-radius: 12px;
+    border: 1px solid #e5e7eb;
+    overflow: hidden;
+    margin: 8px 0;
+}
+
+.plan-progress-card__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    background: #f9fafb;
+}
+
+.plan-progress-card__header h3 {
+    margin: 0;
+    font-size: 1em;
+    font-weight: 600;
+}
+
+.plan-progress-card__count {
+    font-size: 0.85em;
+    color: #6b7280;
+    font-weight: 500;
+}
+
+.plan-progress-card__bar {
+    height: 4px;
+    background: #f3f4f6;
+}
+
+.plan-progress-card__bar-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #22c55e, #16a34a);
+    transition: width 0.5s ease;
+}
+
+.plan-progress-card__steps {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.plan-step {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    border-bottom: 1px solid #e5e7eb;
+    transition: background 0.3s ease;
+}
+
+.plan-step:last-child {
+    border-bottom: none;
+}
+
+.plan-step__icon {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75em;
+    flex-shrink: 0;
+}
+
+.plan-step__description {
+    font-size: 0.9em;
+}
+
+.plan-step__content {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+}
+
+.plan-step__processing {
+    margin-top: 2px;
+    color: #4f46e5;
+    font-size: 0.78em;
+    font-weight: 600;
+}
+
+.plan-step--completed {
+    background: color-mix(in srgb, #22c55e 5%, transparent);
+}
+
+.plan-step--completed .plan-step__icon {
+    background: linear-gradient(135deg, #22c55e, #16a34a);
+    color: white;
+}
+
+.plan-step--current {
+    background: color-mix(in srgb, #6366f1 5%, transparent);
+}
+
+.plan-step--current .plan-step__icon {
+    background: linear-gradient(135deg, #6366f1, #8b5cf6);
+    color: white;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    from {
+        transform: rotate(0deg);
+    }
+
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.plan-step--pending {
+    opacity: 0.6;
+}
+
+.plan-step--pending .plan-step__icon {
+    background: #f3f4f6;
+    color: #9ca3af;
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/PlanProgressCard.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/PlanProgressCard.razor.css
@@ -1,39 +1,59 @@
 .plan-progress-card {
+    position: relative;
+    width: min(700px, 100%);
+    border: 1px solid rgb(229 231 235 / 80%);
     border-radius: 12px;
-    border: 1px solid #e5e7eb;
-    overflow: hidden;
     margin: 8px 0;
+    padding: 24px;
+    background: linear-gradient(to bottom right, #fff, #f9fafb, #fff);
+    box-shadow: 0 10px 15px -3px rgb(0 0 0 / 10%), 0 4px 6px -4px rgb(0 0 0 / 10%);
+}
+
+.plan-progress-card__summary {
+    margin-bottom: 20px;
 }
 
 .plan-progress-card__header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 12px 16px;
-    background: #f9fafb;
+    margin-bottom: 12px;
 }
 
 .plan-progress-card__header h3 {
     margin: 0;
-    font-size: 1em;
-    font-weight: 600;
+    color: #7c3aed;
+    font-size: 1.25em;
+    font-weight: 700;
 }
 
 .plan-progress-card__count {
-    font-size: 0.85em;
     color: #6b7280;
-    font-weight: 500;
+    font-size: 0.875em;
 }
 
 .plan-progress-card__bar {
-    height: 4px;
-    background: #f3f4f6;
+    position: relative;
+    height: 8px;
+    overflow: hidden;
+    border-radius: 9999px;
+    background: #e5e7eb;
 }
 
 .plan-progress-card__bar-fill {
+    position: absolute;
+    inset: 0 auto 0 0;
     height: 100%;
-    background: linear-gradient(90deg, #22c55e, #16a34a);
-    transition: width 0.5s ease;
+    border-radius: 9999px;
+    background: linear-gradient(to right, #3b82f6, #a855f7);
+    transition: width 1s ease-out;
+}
+
+.plan-progress-card__bar-shimmer {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to right, transparent, rgb(255 255 255 / 40%), transparent);
+    animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
 .plan-progress-card__steps {
@@ -46,60 +66,92 @@
     position: relative;
     display: flex;
     align-items: center;
-    gap: 10px;
-    padding: 10px 16px;
-    border-bottom: 1px solid #e5e7eb;
-    transition: background 0.3s ease;
+    min-height: 46px;
+    margin-bottom: 8px;
+    border: 1px solid rgb(229 231 235 / 60%);
+    border-radius: 8px;
+    padding: 10px;
+    background: rgb(249 250 251 / 50%);
+    transition: all 0.5s;
 }
 
 .plan-step:last-child {
-    border-bottom: none;
+    margin-bottom: 0;
 }
 
 .plan-step__icon {
+    display: inline-flex;
     width: 24px;
     height: 24px;
-    border-radius: 50%;
-    display: flex;
+    flex: none;
     align-items: center;
     justify-content: center;
+    border-radius: 50%;
+    margin-right: 8px;
     font-size: 0.75em;
-    flex-shrink: 0;
 }
 
 .plan-step__description {
-    font-size: 0.9em;
+    color: #6b7280;
+    font-size: 0.875em;
+    font-weight: 600;
 }
 
 .plan-step__content {
+    z-index: 1;
     display: flex;
     min-width: 0;
+    flex: 1;
     flex-direction: column;
 }
 
 .plan-step__processing {
-    margin-top: 2px;
-    color: #4f46e5;
-    font-size: 0.78em;
-    font-weight: 600;
+    margin-top: 4px;
+    color: #2563eb;
+    font-size: 0.875em;
+    animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
 .plan-step--completed {
-    background: color-mix(in srgb, #22c55e 5%, transparent);
+    border-color: rgb(187 247 208 / 60%);
+    background: linear-gradient(to right, #f0fdf4, #ecfdf5);
+}
+
+.plan-step--completed .plan-step__description {
+    color: #15803d;
 }
 
 .plan-step--completed .plan-step__icon {
-    background: linear-gradient(135deg, #22c55e, #16a34a);
     color: white;
+    background: linear-gradient(to bottom right, #22c55e, #059669);
+    box-shadow: 0 4px 6px -1px rgb(187 247 208), 0 2px 4px -2px rgb(187 247 208);
 }
 
 .plan-step--current {
-    background: color-mix(in srgb, #6366f1 5%, transparent);
+    border-color: rgb(191 219 254 / 60%);
+    background: linear-gradient(to right, #eff6ff, #faf5ff);
+    box-shadow: 0 4px 6px -1px rgb(191 219 254 / 50%), 0 2px 4px -2px rgb(191 219 254 / 50%);
+}
+
+.plan-step--current::after {
+    position: absolute;
+    border-radius: 8px;
+    background: linear-gradient(to right, rgb(219 234 254 / 50%), rgb(243 232 255 / 50%));
+    content: "";
+    inset: 0;
+    animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+.plan-step--current .plan-step__description {
+    color: #1d4ed8;
+    font-size: 1em;
 }
 
 .plan-step--current .plan-step__icon {
-    background: linear-gradient(135deg, #6366f1, #8b5cf6);
+    z-index: 1;
     color: white;
+    background: linear-gradient(to bottom right, #3b82f6, #9333ea);
+    box-shadow: 0 4px 6px -1px rgb(191 219 254), 0 2px 4px -2px rgb(191 219 254);
     animation: spin 1s linear infinite;
 }
 
@@ -113,11 +165,14 @@
     }
 }
 
-.plan-step--pending {
-    opacity: 0.6;
+.plan-step--pending .plan-step__icon {
+    border: 1px solid #9ca3af;
+    color: #4b5563;
+    background: #d1d5db;
 }
 
-.plan-step--pending .plan-step__icon {
-    background: #f3f4f6;
-    color: #9ca3af;
+@keyframes pulse {
+    50% {
+        opacity: 0.5;
+    }
 }

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/PlanState.cs
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/PlanState.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace DojoClient.Components.Scenarios.AgenticGenerativeUI;
+
+public sealed class PlanState
+{
+    public List<PlanStep> Steps { get; set; } = [];
+}
+
+public sealed class PlanStep
+{
+    public string Description { get; set; } = "";
+
+    public string Status { get; set; } = "pending";
+}

--- a/src/Components/AI/testassets/DojoClient/Components/_Imports.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/_Imports.razor
@@ -1,4 +1,5 @@
 @using System.Net.Http
+@using AGUI.Abstractions
 @using Microsoft.AspNetCore.Components.AI
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
@@ -11,4 +12,5 @@
 @using DojoClient.Components.Scenarios.BackendToolRendering
 @using DojoClient.Components.Scenarios.HumanInTheLoop
 @using DojoClient.Components.Scenarios.ToolBasedGenerativeUI
+@using DojoClient.Components.Scenarios.AgenticGenerativeUI
 @using DojoClient.Components.Layout

--- a/src/Components/AI/testassets/DojoClient/DojoScenarios.cs
+++ b/src/Components/AI/testassets/DojoClient/DojoScenarios.cs
@@ -15,4 +15,6 @@ internal static class DojoScenarios
     internal const string HumanInTheLoopEndpoint = "/human_in_the_loop";
 
     internal const string ToolBasedGenerativeUIEndpoint = "/tool_based_generative_ui";
+
+    internal const string AgenticGenerativeUIEndpoint = "/agentic_generative_ui";
 }

--- a/src/Components/AI/testassets/DojoClient/Program.cs
+++ b/src/Components/AI/testassets/DojoClient/Program.cs
@@ -34,6 +34,9 @@ builder.Services.AddKeyedScoped<IChatClient>(
 builder.Services.AddKeyedScoped<IChatClient>(
     DojoScenarios.ToolBasedGenerativeUIEndpoint,
     (sp, _) => CreateChatClient(sp, DojoScenarios.ToolBasedGenerativeUIEndpoint));
+builder.Services.AddKeyedScoped<IChatClient>(
+    DojoScenarios.AgenticGenerativeUIEndpoint,
+    (sp, _) => CreateChatClient(sp, DojoScenarios.AgenticGenerativeUIEndpoint));
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Overview

This is position 7 in the native Components.AI stack tracked by #68340 and depends on #68330. Relative only to parent `javiercn-components-ai-06-tool-generative-ui` (`cf1d845394a3dc815941446e78c79dfc49ce4a89`), the stack-relative diff adds protocol-neutral typed observable state to Components.AI and uses it to implement the canonical Agentic Generative UI plan scenario; AG-UI types remain confined to test assets, and the browser still reaches a separate API host through `AGUI.Client` 0.0.5 over HTTP/SSE. Handwritten runtime/browser coverage and the deterministic model recording remain separate from product and dojo commits.

## Design

The product contract adds a typed agent whose state is replaced atomically and observed independently of rendered chat blocks:

```csharp
// src/Components/AI/src/Engine/UIAgentOfT.cs
// The generic agent retains every existing UIAgent behavior and adds one typed observable value.
public class UIAgent<TState> : UIAgent where TState : class, new()
{
    public AgentState<TState> State { get; }

    internal override ChatResponseUpdate ApplyStateMapper(ChatResponseUpdate update)
    {
        var context = new StateMapperContext(update);
        Options.StateMapper?.Invoke(context);

        if (context.StateValue is not null)
        {
            if (context.StateValue is not TState typedState)
            {
                throw new InvalidOperationException(
                    $"The state mapper returned a value of type '{context.StateValue.GetType()}', " +
                    $"but this agent requires state of type '{typeof(TState)}'.");
            }

            State.Value = typedState;
        }

        // State content can be removed without discarding unrelated text in the same update.
        return context.HasHandledContent ? context.GetFilteredUpdate() : update;
    }
}
```

```csharp
// src/Components/AI/src/Engine/AgentState.cs
// Replacement triggers all current observers; snapshotting permits a callback to unsubscribe safely.
public T Value
{
    get => _value;
    set
    {
        ArgumentNullException.ThrowIfNull(value);
        _value = value;
        foreach (var callback in _callbacks.ToArray())
        {
            callback();
        }
    }
}

public IDisposable OnChanged(Action callback);
```

`UIAgentOptions.StateMapper` is the extension point, while `StateMapperContext.Update`, `UnhandledContents`, `MarkHandled`, and `SetState` separate two concerns: extracting structured state and deciding which `AIContent` should continue into block rendering. This boundary was chosen instead of adding AG-UI event types to the shipping assembly; any `IChatClient` provider can map its own raw representation or content shape.

Progress-like content is the other public equivalence class. `ActivityContentBlock` carries an application-defined `ActivityType` and `JsonElement` payload, while one generic handler owns the common snapshot/update/completion lifecycle:

```csharp
// src/Components/AI/src/Pipeline/ActivityHandler.cs
// Derived handlers only recognize and mutate their protocol-specific payloads.
if (state.Id == string.Empty)
{
    if (TryCreateBlock(context, state))
    {
        if (state.Id.Length == 0)
        {
            state.Id = context.Update.MessageId ?? Guid.NewGuid().ToString("N");
        }

        OnContentUpdated(state);
        return BlockMappingResult<TBlock>.Emit(state, state);
    }

    return BlockMappingResult<TBlock>.Pass();
}

if (TryUpdateBlock(context, state, out var isCompleted))
{
    OnContentUpdated(state);
    return isCompleted
        ? BlockMappingResult<TBlock>.Complete()
        : BlockMappingResult<TBlock>.Update(state);
}

return BlockMappingResult<TBlock>.Pass();
```

Snapshot creation, in-place delta notification, completion, and unrelated-activity pass-through are implemented once; concrete activity protocols vary only in `TryCreateBlock` and `TryUpdateBlock`.

## Implementation

The mapper runs at the existing streaming boundary. The filtered update reaches both conversation history and the block pipeline, so handled state content is not sent back to the model on the next turn. Fully filtered state-only updates do not create empty assistant history messages:

```csharp
// src/Components/AI/src/Engine/UIAgent.cs
await foreach (var update in _chatClient.GetStreamingResponseAsync(
    _history, chatOptions, cancellationToken).ConfigureAwait(false))
{
    var processUpdate = ApplyStateMapper(update);
    if (processUpdate.Contents.Count == 0 && update.Contents.Count > 0)
    {
        continue;
    }

    assistantUpdates.Add(processUpdate);
    await foreach (var block in pipeline.Process(processUpdate, cancellationToken)
        .ConfigureAwait(false))
    {
        yield return block;
    }
}
```

The dojo server exposes two tool-result classes through one endpoint: `create_plan` becomes a full snapshot, and every `update_plan_step` result becomes an RFC 6902 delta. The five step updates are equivalent instances of the same path rather than five bespoke behaviors.

```csharp
// src/Components/AI/testassets/AGUIDojoApi/ChatClientAgentFactory.cs
var options = new AGUIStreamOptions();
options.MapResultAsStateSnapshot("create_plan");
options.MapResultAsStateDelta("update_plan_step");
return options;
```

```csharp
// src/Components/AI/testassets/AGUIDojoApi/AgenticGenerativeUI/AgenticPlanningTools.cs
// For step index 2, this path is "/steps/2/status" and the value is "completed".
changes.Add(new JsonPatchOperation
{
    Op = "replace",
    Path = $"/steps/{index}/status",
    Value = status is PlanStepStatus.Pending ? "pending" : "completed",
});
```

The Blazor scenario maps the two event classes into one `PlanState`. Snapshots replace the whole plan; deltas clone the current plan before applying valid `replace` operations, so assigning the returned instance reliably notifies observers and rerenders the board.

```csharp
// src/Components/AI/testassets/DojoClient/Components/Scenarios/AgenticGenerativeUI/AgenticGenerativeUIScenario.razor
options.StateMapper = context =>
{
    if (context.Update.RawRepresentation is StateDeltaEvent delta)
    {
        context.SetState(ApplyPlanDelta(_agent.State.Value, delta.Delta));
        return;
    }

    if (context.Update.RawRepresentation is not StateSnapshotEvent snapshot)
    {
        return;
    }

    var state = snapshot.Snapshot.Deserialize<PlanState>(_jsonOptions);
    if (state is not null)
    {
        context.SetState(state);
    }
};

_stateChangedRegistration = _agent.State.OnChanged(
    () => _ = InvokeAsync(StateHasChanged));
```

The E2E model replacement is applied only to `AGUIDojoApi`; `DojoClient` receives only the API URL and continues to construct its keyed `AGUIChatClient`. This proves the transport instead of short-circuiting it in-process.

```csharp
// src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/AgenticGenerativeUIScenarioTests.cs
_api = await StartServerAsync<AGUIDojoApiAssembly>(TestRoot.Servers, options =>
{
    options.ConfigureServices<DojoModelOverrides>(
        nameof(DojoModelOverrides.AgenticGenerativeUI));
});

_ui = await StartServerAsync<global::DojoClient.Components.App>(TestRoot.Servers, options =>
{
    options.EnvironmentVariables["AGUI_DOJO_API_URL"] = _api.AppUrl;
});
```

## Outcome

The 16 runtime tests are compressed into three behavior classes: observable state semantics (5), state extraction/filtering including mixed and raw updates (6), and activity snapshot/delta/completion/isolation (5). The single browser test loops over all five equivalent deltas, independently gates the final summary, and checks progress, current/completed styling, running/done state, and input enablement.

**Review guidance:** Read `UIAgent.ApplyStateMapper`, `StateMapperContext` filtering, `UIAgent<TState>` assignment, `ApplyPlanDelta`, and the API-only replay registration closely. The plan DTOs, repeated step markup, CSS, and generated recording are representative data/presentation and can be skimmed.

**Acceptance criteria:**

1. A `create_plan` snapshot renders one five-step board at `0/5`, with the first pending step current.
2. Each released `update_plan_step` delta completes exactly one additional step and advances progress by 20%, reaching `5/5` without duplicating the activity.
3. The final summary streams while the activity is running; completion marks it done and re-enables input.
4. The browser request crosses DojoClient → `AGUIChatClient` → HTTP/SSE → AGUIDojoApi; only the API model is replayed.

| Validation class | Result |
|---|---|
| Dependency-aware `DojoClient.E2E.Tests` build | **Passed** — 0 warnings, 0 errors |
| Typed-state runtime tests | **16/16 passed** — 0 failed, 0 skipped |
| Real dual-host `AgenticGenerativeUIScenarioTests` | **1/1 passed** — 0 failed, 0 skipped; HTTP/SSE response **200** |
