### PR TITLE
[Blazor] Add shared agent and UI state

### DIFF
--- a/src/Components/AI/src/Engine/AgentContext.cs
+++ b/src/Components/AI/src/Engine/AgentContext.cs
@@ -93,6 +93,43 @@ public class AgentContext : IDisposable
     }
 
     /// <summary>
+    /// Restores the committed turns from the agent's configured conversation thread.
+    /// </summary>
+    /// <param name="cancellationToken">A token that cancels restoration.</param>
+    /// <returns>A task that completes when the turns have been restored.</returns>
+    public async Task RestoreAsync(CancellationToken cancellationToken = default)
+    {
+        if (Status == ConversationStatus.Streaming)
+        {
+            throw new InvalidOperationException("A message is already being processed.");
+        }
+
+        var blocks = await _agent.RestoreAsync(cancellationToken);
+        _turns.Clear();
+
+        ConversationTurn? currentTurn = null;
+        foreach (var block in blocks)
+        {
+            if (block.Role == ChatRole.User)
+            {
+                currentTurn = new ConversationTurn();
+                _turns.Add(currentTurn);
+                currentTurn.AddRequestBlock(block);
+            }
+            else
+            {
+                if (currentTurn is null)
+                {
+                    currentTurn = new ConversationTurn();
+                    _turns.Add(currentTurn);
+                }
+
+                currentTurn.AddResponseBlock(block);
+            }
+        }
+    }
+
+    /// <summary>
     /// Replays the last message after a failed turn.
     /// </summary>
     /// <param name="cancellationToken">A token that cancels the response.</param>

--- a/src/Components/AI/src/Engine/IConversationThread.cs
+++ b/src/Components/AI/src/Engine/IConversationThread.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI;
+
+/// <summary>
+/// Represents a persistent conversation thread that stores streamed chat updates.
+/// </summary>
+/// <remarks>
+/// Implementations control where and how conversation updates are persisted.
+/// </remarks>
+public interface IConversationThread
+{
+    /// <summary>
+    /// Gets the unique identifier for this thread.
+    /// </summary>
+    string ThreadId { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the remote service manages the conversation history.
+    /// </summary>
+    bool IsStateful { get; }
+
+    /// <summary>
+    /// Gets the conversation identifier returned by a stateful remote service, if any.
+    /// </summary>
+    string? ConversationId { get; }
+
+    /// <summary>
+    /// Begins a turn by appending the message sent to the chat client.
+    /// </summary>
+    /// <param name="message">The message that begins the turn.</param>
+    void AppendUserMessage(ChatMessage message);
+
+    /// <summary>
+    /// Appends an update received from the chat client to the current turn.
+    /// </summary>
+    /// <param name="update">The streamed update.</param>
+    void AppendUpdate(ChatResponseUpdate update);
+
+    /// <summary>
+    /// Commits the current turn to the stored history.
+    /// </summary>
+    void CompleteTurn();
+
+    /// <summary>
+    /// Gets all committed updates in chronological order.
+    /// </summary>
+    /// <returns>The committed updates.</returns>
+    IReadOnlyList<ChatResponseUpdate> GetUpdates();
+}

--- a/src/Components/AI/src/Engine/UIAgent.cs
+++ b/src/Components/AI/src/Engine/UIAgent.cs
@@ -132,19 +132,6 @@ public class UIAgent : IDisposable
             _history.Add(message);
         }
 
-        if (messages.Count > 0)
-        {
-            thread?.AppendUserMessage(messages[0]);
-            foreach (var message in messages.Skip(1))
-            {
-                thread?.AppendUpdate(new ChatResponseUpdate
-                {
-                    Role = message.Role,
-                    Contents = [.. message.Contents],
-                });
-            }
-        }
-
         var pipeline = new BlockMappingPipeline(_options, _logger);
 
         // Process user messages through pipeline
@@ -168,6 +155,7 @@ public class UIAgent : IDisposable
 
         // Stream assistant response
         UIAgentLog.StreamingAssistantResponse(_logger);
+        var responseUpdates = new List<ChatResponseUpdate>();
         var assistantUpdates = new List<ChatResponseUpdate>();
         var updateIndex = 0;
         var chatOptions = BuildChatOptions();
@@ -185,8 +173,7 @@ public class UIAgent : IDisposable
             var contentTypes = string.Join(", ", update.Contents.Select(c => c.GetType().Name));
             UIAgentLog.ReceivedUpdate(_logger, updateIndex++, update.Role?.Value, contentTypes);
 
-            thread?.AppendUpdate(update);
-
+            responseUpdates.Add(update);
             var processUpdate = ApplyStateMapper(update);
             assistantUpdates.Add(processUpdate);
 
@@ -215,7 +202,26 @@ public class UIAgent : IDisposable
             _history.Add(msg);
         }
 
-        thread?.CompleteTurn();
+        if (thread is not null && messages.Count > 0)
+        {
+            thread.AppendUserMessage(messages[0]);
+            foreach (var message in messages.Skip(1))
+            {
+                thread.AppendUpdate(new ChatResponseUpdate
+                {
+                    Role = message.Role,
+                    Contents = [.. message.Contents],
+                });
+            }
+
+            foreach (var update in responseUpdates)
+            {
+                thread.AppendUpdate(update);
+            }
+
+            thread.CompleteTurn();
+        }
+
         UIAgentLog.AddedToHistory(_logger, response.Messages.Count);
     }
 

--- a/src/Components/AI/src/Engine/UIAgent.cs
+++ b/src/Components/AI/src/Engine/UIAgent.cs
@@ -171,14 +171,16 @@ public class UIAgent : IDisposable
         var assistantUpdates = new List<ChatResponseUpdate>();
         var updateIndex = 0;
         var chatOptions = BuildChatOptions();
+        IEnumerable<ChatMessage> requestMessages = _history;
         if (thread is { IsStateful: true, ConversationId: not null })
         {
             chatOptions = chatOptions?.Clone() ?? new ChatOptions();
             chatOptions.ConversationId = thread.ConversationId;
+            requestMessages = messages;
         }
 
         await foreach (var update in _chatClient.GetStreamingResponseAsync(
-            _history, chatOptions, cancellationToken).ConfigureAwait(false))
+            requestMessages, chatOptions, cancellationToken).ConfigureAwait(false))
         {
             var contentTypes = string.Join(", ", update.Contents.Select(c => c.GetType().Name));
             UIAgentLog.ReceivedUpdate(_logger, updateIndex++, update.Role?.Value, contentTypes);

--- a/src/Components/AI/src/Engine/UIAgent.cs
+++ b/src/Components/AI/src/Engine/UIAgent.cs
@@ -117,10 +117,24 @@ public class UIAgent : IDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
+        var thread = _options.Thread;
         foreach (var message in messages)
         {
             ArgumentNullException.ThrowIfNull(message);
             _history.Add(message);
+        }
+
+        if (messages.Count > 0)
+        {
+            thread?.AppendUserMessage(messages[0]);
+            foreach (var message in messages.Skip(1))
+            {
+                thread?.AppendUpdate(new ChatResponseUpdate
+                {
+                    Role = message.Role,
+                    Contents = [.. message.Contents],
+                });
+            }
         }
 
         var pipeline = new BlockMappingPipeline(_options, _logger);
@@ -149,12 +163,19 @@ public class UIAgent : IDisposable
         var assistantUpdates = new List<ChatResponseUpdate>();
         var updateIndex = 0;
         var chatOptions = BuildChatOptions();
+        if (thread is { IsStateful: true, ConversationId: not null })
+        {
+            chatOptions = chatOptions?.Clone() ?? new ChatOptions();
+            chatOptions.ConversationId = thread.ConversationId;
+        }
 
         await foreach (var update in _chatClient.GetStreamingResponseAsync(
             _history, chatOptions, cancellationToken).ConfigureAwait(false))
         {
             var contentTypes = string.Join(", ", update.Contents.Select(c => c.GetType().Name));
             UIAgentLog.ReceivedUpdate(_logger, updateIndex++, update.Role?.Value, contentTypes);
+
+            thread?.AppendUpdate(update);
 
             var processUpdate = ApplyStateMapper(update);
             assistantUpdates.Add(processUpdate);
@@ -184,7 +205,81 @@ public class UIAgent : IDisposable
             _history.Add(msg);
         }
 
+        thread?.CompleteTurn();
         UIAgentLog.AddedToHistory(_logger, response.Messages.Count);
+    }
+
+    /// <summary>
+    /// Restores the committed conversation and typed state from the configured thread.
+    /// </summary>
+    /// <param name="cancellationToken">A token that cancels restoration.</param>
+    /// <returns>The restored content blocks in chronological order.</returns>
+    public async Task<IReadOnlyList<ContentBlock>> RestoreAsync(
+        CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        var updates = _options.Thread?.GetUpdates();
+        if (updates is not { Count: > 0 })
+        {
+            return [];
+        }
+
+        _history.Clear();
+
+        var blocks = new List<ContentBlock>();
+        var pipeline = new BlockMappingPipeline(_options, _logger);
+        var assistantUpdates = new List<ChatResponseUpdate>();
+
+        foreach (var update in updates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (update.Role == ChatRole.User)
+            {
+                if (assistantUpdates.Count > 0)
+                {
+                    AddResponseToHistory(assistantUpdates);
+                    assistantUpdates.Clear();
+
+                    blocks.AddRange(pipeline.Finalize());
+                    pipeline = new BlockMappingPipeline(_options, _logger);
+                }
+
+                _history.Add(new ChatMessage(update.Role.Value, [.. update.Contents]));
+                await foreach (var block in pipeline.Process(update, cancellationToken).ConfigureAwait(false))
+                {
+                    blocks.Add(block);
+                }
+
+                blocks.AddRange(pipeline.Finalize());
+                pipeline = new BlockMappingPipeline(_options, _logger);
+            }
+            else
+            {
+                assistantUpdates.Add(update);
+
+                var processUpdate = ApplyStateMapper(update);
+                if (processUpdate.Contents.Count == 0 && update.Contents.Count > 0)
+                {
+                    continue;
+                }
+
+                await foreach (var block in pipeline.Process(processUpdate, cancellationToken).ConfigureAwait(false))
+                {
+                    blocks.Add(block);
+                }
+            }
+        }
+
+        if (assistantUpdates.Count > 0)
+        {
+            AddResponseToHistory(assistantUpdates);
+        }
+
+        blocks.AddRange(pipeline.Finalize());
+
+        return blocks;
     }
 
     internal virtual ChatResponseUpdate ApplyStateMapper(ChatResponseUpdate update)
@@ -198,6 +293,15 @@ public class UIAgent : IDisposable
         _options.StateMapper(context);
 
         return context.HasHandledContent ? context.GetFilteredUpdate() : update;
+    }
+
+    private void AddResponseToHistory(List<ChatResponseUpdate> updates)
+    {
+        var response = updates.ToChatResponse();
+        foreach (var message in response.Messages)
+        {
+            _history.Add(message);
+        }
     }
 
     private ChatOptions? BuildChatOptions()

--- a/src/Components/AI/src/Engine/UIAgent.cs
+++ b/src/Components/AI/src/Engine/UIAgent.cs
@@ -91,6 +91,14 @@ public class UIAgent : IDisposable
         _logger = (ILogger?)loggerFactory?.CreateLogger<BlockMappingPipeline>() ?? NullLogger.Instance;
     }
 
+    internal UIAgent(IChatClient chatClient, UIAgentOptions options, ILoggerFactory? loggerFactory)
+    {
+        ArgumentNullException.ThrowIfNull(chatClient);
+        _chatClient = chatClient;
+        _options = options;
+        _logger = (ILogger?)loggerFactory?.CreateLogger<BlockMappingPipeline>() ?? NullLogger.Instance;
+    }
+
     /// <summary>
     /// Sends a message and streams the resulting content blocks. Blocks are yielded as soon as
     /// they are created; a block keeps changing (raising <see cref="ContentBlock.OnChanged(Action)"/>)

--- a/src/Components/AI/src/Engine/UIAgentOfT.cs
+++ b/src/Components/AI/src/Engine/UIAgentOfT.cs
@@ -18,9 +18,8 @@ public class UIAgent<TState> : UIAgent where TState : class, new()
     /// <param name="chatClient">The chat client that produces model responses.</param>
     /// <param name="initialState">The initial state value.</param>
     public UIAgent(IChatClient chatClient, TState? initialState = null)
-        : base(chatClient)
+        : this(chatClient, new UIAgentOptions<TState>(initialState), configure: null, loggerFactory: null)
     {
-        State = new AgentState<TState>(initialState);
     }
 
     /// <summary>
@@ -30,9 +29,12 @@ public class UIAgent<TState> : UIAgent where TState : class, new()
     /// <param name="chatOptions">The options passed to the chat client.</param>
     /// <param name="initialState">The initial state value.</param>
     public UIAgent(IChatClient chatClient, ChatOptions chatOptions, TState? initialState = null)
-        : base(chatClient, chatOptions)
+        : this(
+            chatClient,
+            new UIAgentOptions<TState>(initialState),
+            options => options.ChatOptions = chatOptions,
+            loggerFactory: null)
     {
-        State = new AgentState<TState>(initialState);
     }
 
     /// <summary>
@@ -43,11 +45,10 @@ public class UIAgent<TState> : UIAgent where TState : class, new()
     /// <param name="initialState">The initial state value.</param>
     public UIAgent(
         IChatClient chatClient,
-        Action<UIAgentOptions> configure,
+        Action<UIAgentOptions<TState>> configure,
         TState? initialState = null)
-        : base(chatClient, configure)
+        : this(chatClient, new UIAgentOptions<TState>(initialState), configure, loggerFactory: null)
     {
-        State = new AgentState<TState>(initialState);
     }
 
     /// <summary>
@@ -59,12 +60,22 @@ public class UIAgent<TState> : UIAgent where TState : class, new()
     /// <param name="initialState">The initial state value.</param>
     public UIAgent(
         IChatClient chatClient,
-        Action<UIAgentOptions> configure,
+        Action<UIAgentOptions<TState>> configure,
         ILoggerFactory? loggerFactory,
         TState? initialState = null)
-        : base(chatClient, configure, loggerFactory)
+        : this(chatClient, new UIAgentOptions<TState>(initialState), configure, loggerFactory)
     {
-        State = new AgentState<TState>(initialState);
+    }
+
+    private UIAgent(
+        IChatClient chatClient,
+        UIAgentOptions<TState> options,
+        Action<UIAgentOptions<TState>>? configure,
+        ILoggerFactory? loggerFactory)
+        : base(chatClient, options, loggerFactory)
+    {
+        State = options.State;
+        configure?.Invoke(options);
     }
 
     /// <summary>

--- a/src/Components/AI/src/Pipeline/UIAgentOptions.cs
+++ b/src/Components/AI/src/Pipeline/UIAgentOptions.cs
@@ -28,6 +28,11 @@ public class UIAgentOptions
     /// </summary>
     public Action<StateMapperContext>? StateMapper { get; set; }
 
+    /// <summary>
+    /// Gets or sets the persistent conversation thread that receives completed turns.
+    /// </summary>
+    public IConversationThread? Thread { get; set; }
+
     internal List<IHandlerRegistration> HandlerRegistrations { get; } = new();
 
     internal Dictionary<string, AIFunction> UIActions { get; } =

--- a/src/Components/AI/src/Pipeline/UIAgentOptions.cs
+++ b/src/Components/AI/src/Pipeline/UIAgentOptions.cs
@@ -85,3 +85,20 @@ public class UIAgentOptions
         public IHandlerEntry CreateEntry() => new HandlerEntry<TState>(_handler);
     }
 }
+
+/// <summary>
+/// Configures a <see cref="UIAgent{TState}"/>.
+/// </summary>
+/// <typeparam name="TState">The type of state associated with the agent.</typeparam>
+public sealed class UIAgentOptions<TState> : UIAgentOptions where TState : class, new()
+{
+    internal UIAgentOptions(TState? initialState)
+    {
+        State = new AgentState<TState>(initialState);
+    }
+
+    /// <summary>
+    /// Gets the observable state associated with the agent.
+    /// </summary>
+    public AgentState<TState> State { get; }
+}

--- a/src/Components/AI/src/PublicAPI.Unshipped.txt
+++ b/src/Components/AI/src/PublicAPI.Unshipped.txt
@@ -320,14 +320,16 @@ Microsoft.AspNetCore.Components.AI.UIAgent.UIAgent(Microsoft.Extensions.AI.IChat
 Microsoft.AspNetCore.Components.AI.UIAgent<TState>
 Microsoft.AspNetCore.Components.AI.UIAgent<TState>.State.get -> Microsoft.AspNetCore.Components.AI.AgentState<TState!>!
 Microsoft.AspNetCore.Components.AI.UIAgent<TState>.UIAgent(Microsoft.Extensions.AI.IChatClient! chatClient, Microsoft.Extensions.AI.ChatOptions! chatOptions, TState? initialState = null) -> void
-Microsoft.AspNetCore.Components.AI.UIAgent<TState>.UIAgent(Microsoft.Extensions.AI.IChatClient! chatClient, System.Action<Microsoft.AspNetCore.Components.AI.UIAgentOptions!>! configure, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory, TState? initialState = null) -> void
-Microsoft.AspNetCore.Components.AI.UIAgent<TState>.UIAgent(Microsoft.Extensions.AI.IChatClient! chatClient, System.Action<Microsoft.AspNetCore.Components.AI.UIAgentOptions!>! configure, TState? initialState = null) -> void
+Microsoft.AspNetCore.Components.AI.UIAgent<TState>.UIAgent(Microsoft.Extensions.AI.IChatClient! chatClient, System.Action<Microsoft.AspNetCore.Components.AI.UIAgentOptions<TState!>!>! configure, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory, TState? initialState = null) -> void
+Microsoft.AspNetCore.Components.AI.UIAgent<TState>.UIAgent(Microsoft.Extensions.AI.IChatClient! chatClient, System.Action<Microsoft.AspNetCore.Components.AI.UIAgentOptions<TState!>!>! configure, TState? initialState = null) -> void
 Microsoft.AspNetCore.Components.AI.UIAgent<TState>.UIAgent(Microsoft.Extensions.AI.IChatClient! chatClient, TState? initialState = null) -> void
 Microsoft.AspNetCore.Components.AI.UIAgentOptions
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.AddBlockHandler<TState>(Microsoft.AspNetCore.Components.AI.ContentBlockHandler<TState>! handler) -> void
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.ChatOptions.get -> Microsoft.Extensions.AI.ChatOptions?
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.ChatOptions.set -> void
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.RegisterUIAction(Microsoft.Extensions.AI.AIFunction! function) -> void
+Microsoft.AspNetCore.Components.AI.UIAgentOptions<TState>
+Microsoft.AspNetCore.Components.AI.UIAgentOptions<TState>.State.get -> Microsoft.AspNetCore.Components.AI.AgentState<TState!>!
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.StateMapper.get -> System.Action<Microsoft.AspNetCore.Components.AI.StateMapperContext!>?
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.StateMapper.set -> void
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.Thread.get -> Microsoft.AspNetCore.Components.AI.IConversationThread?

--- a/src/Components/AI/src/PublicAPI.Unshipped.txt
+++ b/src/Components/AI/src/PublicAPI.Unshipped.txt
@@ -19,6 +19,7 @@ Microsoft.AspNetCore.Components.AI.AgentContext.RegisterOnBlockAdded(System.Acti
 Microsoft.AspNetCore.Components.AI.AgentContext.RegisterOnStatusChanged(System.Action<Microsoft.AspNetCore.Components.AI.ConversationStatus>! callback) -> System.IDisposable!
 Microsoft.AspNetCore.Components.AI.AgentContext.RegisterOnTurnAdded(System.Action<Microsoft.AspNetCore.Components.AI.ConversationTurn!>! callback) -> System.IDisposable!
 Microsoft.AspNetCore.Components.AI.AgentContext.RetryAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.AI.AgentContext.RestoreAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.AI.AgentContext.SendMessageAsync(Microsoft.Extensions.AI.ChatMessage! message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.AI.AgentContext.SendMessageAsync(string! text, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.AI.AgentContext.Status.get -> Microsoft.AspNetCore.Components.AI.ConversationStatus
@@ -167,6 +168,14 @@ Microsoft.AspNetCore.Components.AI.HtmlNode.Value.get -> string!
 Microsoft.AspNetCore.Components.AI.HtmlNode.Value.set -> void
 Microsoft.AspNetCore.Components.AI.IInteractiveBlock
 Microsoft.AspNetCore.Components.AI.IInteractiveBlock.GetResultAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.Extensions.AI.AIContent!>!
+Microsoft.AspNetCore.Components.AI.IConversationThread
+Microsoft.AspNetCore.Components.AI.IConversationThread.AppendUpdate(Microsoft.Extensions.AI.ChatResponseUpdate! update) -> void
+Microsoft.AspNetCore.Components.AI.IConversationThread.AppendUserMessage(Microsoft.Extensions.AI.ChatMessage! message) -> void
+Microsoft.AspNetCore.Components.AI.IConversationThread.CompleteTurn() -> void
+Microsoft.AspNetCore.Components.AI.IConversationThread.ConversationId.get -> string?
+Microsoft.AspNetCore.Components.AI.IConversationThread.GetUpdates() -> System.Collections.Generic.IReadOnlyList<Microsoft.Extensions.AI.ChatResponseUpdate!>!
+Microsoft.AspNetCore.Components.AI.IConversationThread.IsStateful.get -> bool
+Microsoft.AspNetCore.Components.AI.IConversationThread.ThreadId.get -> string!
 Microsoft.AspNetCore.Components.AI.ImageNode
 Microsoft.AspNetCore.Components.AI.ImageNode.Alt.get -> string?
 Microsoft.AspNetCore.Components.AI.ImageNode.Alt.set -> void
@@ -301,6 +310,7 @@ Microsoft.AspNetCore.Components.AI.ToolResultAttribute.Name.set -> void
 Microsoft.AspNetCore.Components.AI.ToolResultAttribute.ToolResultAttribute() -> void
 Microsoft.AspNetCore.Components.AI.UIAgent
 Microsoft.AspNetCore.Components.AI.UIAgent.Dispose() -> void
+Microsoft.AspNetCore.Components.AI.UIAgent.RestoreAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.AI.ContentBlock!>!>!
 Microsoft.AspNetCore.Components.AI.UIAgent.SendMessageAsync(Microsoft.Extensions.AI.ChatMessage! message, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Collections.Generic.IAsyncEnumerable<Microsoft.AspNetCore.Components.AI.ContentBlock!>!
 Microsoft.AspNetCore.Components.AI.UIAgent.UIAgent(Microsoft.Extensions.AI.IChatClient! chatClient) -> void
 Microsoft.AspNetCore.Components.AI.UIAgent.UIAgent(Microsoft.Extensions.AI.IChatClient! chatClient, Microsoft.Extensions.AI.ChatOptions! chatOptions) -> void
@@ -320,6 +330,8 @@ Microsoft.AspNetCore.Components.AI.UIAgentOptions.ChatOptions.set -> void
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.RegisterUIAction(Microsoft.Extensions.AI.AIFunction! function) -> void
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.StateMapper.get -> System.Action<Microsoft.AspNetCore.Components.AI.StateMapperContext!>?
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.StateMapper.set -> void
+Microsoft.AspNetCore.Components.AI.UIAgentOptions.Thread.get -> Microsoft.AspNetCore.Components.AI.IConversationThread?
+Microsoft.AspNetCore.Components.AI.UIAgentOptions.Thread.set -> void
 Microsoft.AspNetCore.Components.AI.UIAgentOptions.UIAgentOptions() -> void
 Microsoft.AspNetCore.Components.AI.UIActionBlock
 Microsoft.AspNetCore.Components.AI.UIActionBlock.Call.get -> Microsoft.Extensions.AI.FunctionCallContent!

--- a/src/Components/AI/test/Engine/AgentContextThreadTests.cs
+++ b/src/Components/AI/test/Engine/AgentContextThreadTests.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class AgentContextThreadTests
+{
+    [Fact]
+    public async Task RestoreAsync_RecreatesTurnsWithoutFiringCallbacks()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        var client = new DelegatingStreamingChatClient();
+        var callCount = 0;
+        client.SetHandler((_, _, _) =>
+            ResponseEmitters.EmitTextResponse($"Response {++callCount}"));
+        var firstContext = new AgentContext(CreateAgent(client, thread));
+        await firstContext.SendMessageAsync("First");
+        await firstContext.SendMessageAsync("Second");
+
+        var restoredContext = new AgentContext(CreateAgent(client, thread));
+        var turnAddedCount = 0;
+        var blockAddedCount = 0;
+        var statusChangedCount = 0;
+        using var turnRegistration =
+            restoredContext.RegisterOnTurnAdded(_ => turnAddedCount++);
+        using var blockRegistration =
+            restoredContext.RegisterOnBlockAdded((_, _) => blockAddedCount++);
+        using var statusRegistration =
+            restoredContext.RegisterOnStatusChanged(_ => statusChangedCount++);
+
+        await restoredContext.RestoreAsync();
+
+        Assert.Equal(2, restoredContext.Turns.Count);
+        Assert.Equal("First", GetRequestText(restoredContext.Turns[0]));
+        Assert.Equal("Response 1", GetResponseText(restoredContext.Turns[0]));
+        Assert.Equal("Second", GetRequestText(restoredContext.Turns[1]));
+        Assert.Equal("Response 2", GetResponseText(restoredContext.Turns[1]));
+        Assert.Equal(0, turnAddedCount);
+        Assert.Equal(0, blockAddedCount);
+        Assert.Equal(0, statusChangedCount);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_EmptyThread_RemainsIdle()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        var client = new DelegatingStreamingChatClient();
+        var context = new AgentContext(CreateAgent(client, thread));
+
+        await context.RestoreAsync();
+
+        Assert.Empty(context.Turns);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+    }
+
+    private static UIAgent CreateAgent(
+        IChatClient client,
+        IConversationThread thread)
+        => new(client, options => options.Thread = thread);
+
+    private static string GetRequestText(ConversationTurn turn)
+        => Assert.IsType<RichContentBlock>(Assert.Single(turn.RequestBlocks)).RawText;
+
+    private static string GetResponseText(ConversationTurn turn)
+        => Assert.IsType<RichContentBlock>(Assert.Single(turn.ResponseBlocks)).RawText;
+}

--- a/src/Components/AI/test/Engine/UIAgentThreadTests.cs
+++ b/src/Components/AI/test/Engine/UIAgentThreadTests.cs
@@ -1,0 +1,193 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class UIAgentThreadTests
+{
+    [Fact]
+    public async Task SendMessageAsync_WithThread_CommitsUserAndAssistantUpdates()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((_, _, cancellationToken) =>
+            ResponseEmitters.EmitMultiTokenTextResponse(cancellationToken, "A", "B", "C"));
+        var agent = CreateAgent(client, thread);
+
+        await CollectAsync(agent, "Hello");
+
+        var updates = thread.GetUpdates();
+        Assert.Equal(4, updates.Count);
+        Assert.Equal(ChatRole.User, updates[0].Role);
+        Assert.All(updates.Skip(1), update => Assert.Equal(ChatRole.Assistant, update.Role));
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_FailedStream_DoesNotCommitTurn()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((_, _, _) =>
+            ResponseEmitters.EmitErrorAfterTokens(
+                ["partial"],
+                new InvalidOperationException("boom")));
+        var agent = CreateAgent(client, thread);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => CollectAsync(agent, "Hello"));
+
+        Assert.Empty(thread.GetUpdates());
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_StatefulThread_ForwardsConversationId()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        var client = new DelegatingStreamingChatClient();
+        ChatOptions? secondOptions = null;
+        var callCount = 0;
+        client.SetHandler((_, options, cancellationToken) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return EmitConversationId("conversation-1", cancellationToken);
+            }
+
+            secondOptions = options;
+            return ResponseEmitters.EmitTextResponse("Second response");
+        });
+        var agent = CreateAgent(client, thread);
+
+        await CollectAsync(agent, "First");
+        await CollectAsync(agent, "Second");
+
+        Assert.Equal("conversation-1", secondOptions?.ConversationId);
+    }
+
+    [Fact]
+    public async Task RestoreAsync_RestoresBlocksAndTypedState()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((_, _, cancellationToken) => EmitState(cancellationToken));
+        var firstAgent = CreateStateAgent(client, thread);
+
+        await CollectAsync(firstAgent, "Create state");
+
+        var restoredAgent = CreateStateAgent(client, thread);
+        var blocks = await restoredAgent.RestoreAsync();
+
+        Assert.Equal("Updated", restoredAgent.State.Value.Name);
+        Assert.Equal(
+            ["Create state", "State updated"],
+            blocks.OfType<RichContentBlock>().Select(block => block.RawText));
+    }
+
+    [Fact]
+    public async Task RestoreAsync_ThenSendMessage_IncludesRestoredHistory()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((_, _, _) => ResponseEmitters.EmitTextResponse("First response"));
+        var firstAgent = CreateAgent(client, thread);
+        await CollectAsync(firstAgent, "First");
+
+        List<ChatMessage>? observedMessages = null;
+        client.SetHandler((messages, _, _) =>
+        {
+            observedMessages = messages.ToList();
+            return ResponseEmitters.EmitTextResponse("Second response");
+        });
+        var restoredAgent = CreateAgent(client, thread);
+        await restoredAgent.RestoreAsync();
+
+        await CollectAsync(restoredAgent, "Second");
+
+        Assert.Equal(
+            ["First", "First response", "Second"],
+            observedMessages?.Select(message => message.Text));
+    }
+
+    private static UIAgent CreateAgent(
+        IChatClient client,
+        IConversationThread thread)
+        => new(client, options => options.Thread = thread);
+
+    private static UIAgent<TestState> CreateStateAgent(
+        IChatClient client,
+        IConversationThread thread)
+        => new(client, options =>
+        {
+            options.Thread = thread;
+            options.StateMapper = context =>
+            {
+                var state = context.UnhandledContents.OfType<TestStateContent>().SingleOrDefault();
+                if (state is null)
+                {
+                    return false;
+                }
+
+                context.MarkHandled(state);
+                context.SetState(state.Value);
+                return true;
+            };
+        });
+
+    private static async Task<List<ContentBlock>> CollectAsync(UIAgent agent, string text)
+    {
+        var blocks = new List<ContentBlock>();
+        await foreach (var block in agent.SendMessageAsync(new ChatMessage(ChatRole.User, text)))
+        {
+            blocks.Add(block);
+        }
+
+        return blocks;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitConversationId(
+        string conversationId,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            ConversationId = conversationId,
+            Contents = [new TextContent("First response")],
+        };
+        await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitState(
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            Contents =
+            [
+                new TestStateContent
+                {
+                    Value = new TestState { Name = "Updated" },
+                },
+                new TextContent("State updated"),
+            ],
+        };
+        await Task.CompletedTask;
+    }
+
+    private sealed class TestState
+    {
+        public string Name { get; set; } = "";
+    }
+
+    private sealed class TestStateContent : AIContent
+    {
+        public required TestState Value { get; init; }
+    }
+}

--- a/src/Components/AI/test/Engine/UIAgentThreadTests.cs
+++ b/src/Components/AI/test/Engine/UIAgentThreadTests.cs
@@ -27,7 +27,7 @@ public class UIAgentThreadTests
     }
 
     [Fact]
-    public async Task SendMessageAsync_FailedStream_DoesNotCommitTurn()
+    public async Task SendMessageAsync_FailedStream_DoesNotWriteToThread()
     {
         var thread = new InMemoryConversationThread("thread-1");
         var client = new DelegatingStreamingChatClient();
@@ -40,6 +40,7 @@ public class UIAgentThreadTests
         await Assert.ThrowsAsync<InvalidOperationException>(() => CollectAsync(agent, "Hello"));
 
         Assert.Empty(thread.GetUpdates());
+        Assert.False(thread.HasPendingTurn);
     }
 
     [Fact]

--- a/src/Components/AI/test/Engine/UIAgentThreadTests.cs
+++ b/src/Components/AI/test/Engine/UIAgentThreadTests.cs
@@ -128,12 +128,11 @@ public class UIAgentThreadTests
                 var state = context.UnhandledContents.OfType<TestStateContent>().SingleOrDefault();
                 if (state is null)
                 {
-                    return false;
+                    return;
                 }
 
                 context.MarkHandled(state);
                 context.SetState(state.Value);
-                return true;
             };
         });
 

--- a/src/Components/AI/test/Engine/UIAgentThreadTests.cs
+++ b/src/Components/AI/test/Engine/UIAgentThreadTests.cs
@@ -43,13 +43,14 @@ public class UIAgentThreadTests
     }
 
     [Fact]
-    public async Task SendMessageAsync_StatefulThread_ForwardsConversationId()
+    public async Task SendMessageAsync_StatefulThread_ForwardsConversationIdWithoutReplayingHistory()
     {
         var thread = new InMemoryConversationThread("thread-1");
         var client = new DelegatingStreamingChatClient();
         ChatOptions? secondOptions = null;
+        List<ChatMessage>? secondMessages = null;
         var callCount = 0;
-        client.SetHandler((_, options, cancellationToken) =>
+        client.SetHandler((messages, options, cancellationToken) =>
         {
             callCount++;
             if (callCount == 1)
@@ -57,6 +58,7 @@ public class UIAgentThreadTests
                 return EmitConversationId("conversation-1", cancellationToken);
             }
 
+            secondMessages = messages.ToList();
             secondOptions = options;
             return ResponseEmitters.EmitTextResponse("Second response");
         });
@@ -66,6 +68,7 @@ public class UIAgentThreadTests
         await CollectAsync(agent, "Second");
 
         Assert.Equal("conversation-1", secondOptions?.ConversationId);
+        Assert.Equal(["Second"], secondMessages?.Select(message => message.Text));
     }
 
     [Fact]

--- a/src/Components/AI/test/Pipeline/StateMapperTests.cs
+++ b/src/Components/AI/test/Pipeline/StateMapperTests.cs
@@ -69,6 +69,41 @@ public class StateMapperTests
     }
 
     [Fact]
+    public void TypedOptionsExposeAgentState()
+    {
+        var initialState = new RecipeState { Title = "Initial state" };
+        UIAgentOptions<RecipeState>? configuredOptions = null;
+
+        var agent = new UIAgent<RecipeState>(
+            new DelegatingStreamingChatClient(),
+            options => configuredOptions = options,
+            initialState);
+
+        Assert.NotNull(configuredOptions);
+        Assert.Same(agent.State, configuredOptions.State);
+        Assert.Same(initialState, configuredOptions.State.Value);
+
+        var updatedState = new RecipeState { Title = "Updated state" };
+        agent.State.Value = updatedState;
+
+        Assert.Same(updatedState, configuredOptions.State.Value);
+    }
+
+    [Fact]
+    public void TypedAgentAcceptsBaseOptionsConfiguration()
+    {
+        UIAgentOptions? configuredOptions = null;
+        Action<UIAgentOptions> configure = options => configuredOptions = options;
+
+        var agent = new UIAgent<RecipeState>(
+            new DelegatingStreamingChatClient(),
+            configure);
+
+        Assert.IsType<UIAgentOptions<RecipeState>>(configuredOptions);
+        Assert.Same(agent.State, ((UIAgentOptions<RecipeState>)configuredOptions).State);
+    }
+
+    [Fact]
     public void StateMapper_FilteredUpdatePreservesMetadata()
     {
         var agent = CreateAgent(new DelegatingStreamingChatClient());

--- a/src/Components/AI/test/TestHelpers/InMemoryConversationThread.cs
+++ b/src/Components/AI/test/TestHelpers/InMemoryConversationThread.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+
+internal sealed class InMemoryConversationThread : IConversationThread
+{
+    private readonly List<ChatResponseUpdate> _updates = [];
+    private List<ChatResponseUpdate>? _currentTurn;
+
+    internal InMemoryConversationThread(string threadId)
+    {
+        ThreadId = threadId;
+    }
+
+    public string ThreadId { get; }
+
+    public bool IsStateful { get; private set; }
+
+    public string? ConversationId { get; private set; }
+
+    public void AppendUserMessage(ChatMessage message)
+    {
+        _currentTurn =
+        [
+            new ChatResponseUpdate
+            {
+                Role = message.Role,
+                Contents = [.. message.Contents],
+            },
+        ];
+    }
+
+    public void AppendUpdate(ChatResponseUpdate update)
+    {
+        _currentTurn?.Add(update);
+        if (update.ConversationId is not null)
+        {
+            IsStateful = true;
+            ConversationId = update.ConversationId;
+        }
+    }
+
+    public void CompleteTurn()
+    {
+        if (_currentTurn is not null)
+        {
+            _updates.AddRange(_currentTurn);
+            _currentTurn = null;
+        }
+    }
+
+    public IReadOnlyList<ChatResponseUpdate> GetUpdates() => _updates;
+}

--- a/src/Components/AI/test/TestHelpers/InMemoryConversationThread.cs
+++ b/src/Components/AI/test/TestHelpers/InMemoryConversationThread.cs
@@ -21,6 +21,8 @@ internal sealed class InMemoryConversationThread : IConversationThread
 
     public string? ConversationId { get; private set; }
 
+    internal bool HasPendingTurn => _currentTurn is not null;
+
     public void AppendUserMessage(ChatMessage message)
     {
         _currentTurn =

--- a/src/Components/AI/testassets/AGUIDojoApi/ChatClientAgentFactory.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/ChatClientAgentFactory.cs
@@ -62,7 +62,7 @@ internal static class ChatClientAgentFactory
           `generate_recipe` tool with a COMPLETE recipe: a title, skill_level, cooking_time,
           special_preferences, the full list of ingredients (each with an icon, name and
           amount), and the step-by-step instructions.
-        - Always include every ingredient the recipe needs, keeping any the user already added.
+        - Always include every ingredient the recipe needs.
         - When the user only asks a question about the recipe, answer in plain text and do
           NOT call the tool.
         """;

--- a/src/Components/AI/testassets/AGUIDojoApi/ChatClientAgentFactory.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/ChatClientAgentFactory.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using AGUI.Server;
 using AGUIDojoApi.AgenticGenerativeUI;
 using AGUIDojoApi.BackendToolRendering;
+using AGUIDojoApi.SharedState;
 using Microsoft.Extensions.AI;
 using OpenAI;
 
@@ -51,6 +52,19 @@ internal static class ChatClientAgentFactory
 
         Only one plan can be active at a time, so do not call the `create_plan` tool
         again until all the steps in current plan are completed.
+        """;
+
+    internal const string SharedStateSystemPrompt = """
+        You are a helpful recipe assistant that maintains a shared recipe state with the user.
+
+        IMPORTANT:
+        - When the user asks you to create, change, or improve a recipe, call the
+          `generate_recipe` tool with a COMPLETE recipe: a title, skill_level, cooking_time,
+          special_preferences, the full list of ingredients (each with an icon, name and
+          amount), and the step-by-step instructions.
+        - Always include every ingredient the recipe needs, keeping any the user already added.
+        - When the user only asks a question about the recipe, answer in plain text and do
+          NOT call the tool.
         """;
 
     internal static IChatClient CreateAgenticChat(IConfiguration configuration)
@@ -129,6 +143,28 @@ internal static class ChatClientAgentFactory
         return options;
     }
 
+    internal static IList<AITool> CreateSharedStateTools(JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        return
+        [
+            AIFunctionFactory.Create(
+                GenerateRecipe,
+                name: "generate_recipe",
+                description: "Generate or update the shared recipe and display it to the user.",
+                options),
+        ];
+    }
+
+    internal static AGUIStreamOptions CreateSharedStateStreamOptions()
+    {
+        var options = new AGUIStreamOptions();
+        options.MapResultAsStateSnapshot("generate_recipe");
+
+        return options;
+    }
+
     [Description("Get the weather for a given location.")]
     private static WeatherInfo GetWeather(
         [Description("The location to get the weather for.")] string location) => new()
@@ -138,5 +174,12 @@ internal static class ChatClientAgentFactory
             Humidity = 50,
             WindSpeed = 10,
             FeelsLike = 25,
+        };
+
+    [Description("Generate or update the shared recipe and display it to the user.")]
+    private static RecipeResponse GenerateRecipe(
+        [Description("The complete recipe to display.")] Recipe recipe) => new()
+        {
+            Recipe = recipe,
         };
 }

--- a/src/Components/AI/testassets/AGUIDojoApi/Program.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/Program.cs
@@ -48,6 +48,12 @@ app.MapDojoEndpoint(
     systemPrompt: ChatClientAgentFactory.AgenticGenerativeUISystemPrompt,
     configureStreamOptions: _ =>
         ChatClientAgentFactory.CreateAgenticGenerativeUIStreamOptions());
+app.MapDojoEndpoint(
+    "/shared_state",
+    serverTools: ChatClientAgentFactory.CreateSharedStateTools(
+        jsonOptions.Value.SerializerOptions),
+    systemPrompt: ChatClientAgentFactory.SharedStateSystemPrompt,
+    configureStreamOptions: _ => ChatClientAgentFactory.CreateSharedStateStreamOptions());
 
 await app.RunAsync();
 

--- a/src/Components/AI/testassets/AGUIDojoApi/ScriptedChatClient.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/ScriptedChatClient.cs
@@ -14,6 +14,7 @@ namespace AGUIDojoApi;
 // rendering) without any credentials.
 internal sealed class ScriptedChatClient : IChatClient
 {
+    private static readonly TimeSpan ModelDelay = TimeSpan.FromMilliseconds(750);
     private static readonly TimeSpan TokenDelay = TimeSpan.FromMilliseconds(60);
     private static readonly string[] MarsPlanSteps =
     [
@@ -89,10 +90,38 @@ internal sealed class ScriptedChatClient : IChatClient
                     when callId == $"agentic-plan-step-{planSteps.Length}" =>
                     $"All {planSteps.Length} steps in the " +
                     $"{(planSteps.Length == PizzaPlanSteps.Length ? "pizza" : "Mars mission")} plan are complete.",
+                { CallId: "shared-state-recipe-1" }
+                    when prompt.Contains("Italian", StringComparison.OrdinalIgnoreCase) =>
+                    "The state now includes a detailed recipe for Classic Italian Carbonara, " +
+                    "with specific ingredients, cooking instructions, and customization options " +
+                    "for preferences like vegetarian alternatives. It also outlines the skill " +
+                    "level, cooking time, and key steps for preparation.",
                 { CallId: "shared-state-recipe-1" } =>
-                    "I updated the shared recipe while preserving your existing ingredients.",
+                    "I updated the shared recipe.",
                 _ => "Background changed to a sunset gradient.",
             };
+            if (functionResult is { CallId: "shared-state-recipe-1" })
+            {
+                var responseMessageId = Guid.NewGuid().ToString("N");
+                var tokens = response.Split(' ');
+
+                for (var i = 0; i < tokens.Length; i++)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await Task.Delay(TokenDelay, cancellationToken);
+
+                    yield return new ChatResponseUpdate
+                    {
+                        Role = ChatRole.Assistant,
+                        MessageId = responseMessageId,
+                        Contents = [new TextContent(tokens[i] + " ")],
+                        FinishReason = i == tokens.Length - 1 ? ChatFinishReason.Stop : null,
+                    };
+                }
+
+                yield break;
+            }
+
             yield return new ChatResponseUpdate
             {
                 Role = ChatRole.Assistant,
@@ -107,6 +136,29 @@ internal sealed class ScriptedChatClient : IChatClient
         if (options?.Tools?.OfType<AIFunctionDeclaration>()
                 .Any(tool => tool.Name == "generate_recipe") == true)
         {
+            await Task.Delay(ModelDelay, cancellationToken);
+
+            if (prompt.Contains("Italian", StringComparison.OrdinalIgnoreCase))
+            {
+                yield return new ChatResponseUpdate
+                {
+                    Role = ChatRole.Assistant,
+                    MessageId = messageId,
+                    Contents =
+                    [
+                        new FunctionCallContent(
+                            "shared-state-recipe-1",
+                            "generate_recipe",
+                            new Dictionary<string, object?>
+                            {
+                                ["recipe"] = CreateItalianCarbonara(),
+                            })
+                    ],
+                    FinishReason = ChatFinishReason.ToolCalls,
+                };
+                yield break;
+            }
+
             options.TryGetRunAgentInput(out var input);
             var current = input?.State?.Deserialize<RecipeResponse>(
                 AIJsonUtilities.DefaultOptions)?.Recipe ?? new Recipe();
@@ -315,6 +367,32 @@ internal sealed class ScriptedChatClient : IChatClient
     public void Dispose()
     {
     }
+
+    private static Recipe CreateItalianCarbonara() => new()
+    {
+        Title = "Classic Italian Carbonara",
+        SkillLevel = "Intermediate",
+        CookingTime = "45 min",
+        Ingredients =
+        [
+            new() { Icon = "\U0001F35D", Name = "Spaghetti", Amount = "400g" },
+            new() { Icon = "\U0001F953", Name = "Guanciale (Pork Jowl)", Amount = "150g" },
+            new() { Icon = "\U0001F95A", Name = "Egg Yolks", Amount = "4 yolks" },
+            new() { Icon = "\U0001F9C0", Name = "Pecorino Romano Cheese", Amount = "100g, grated" },
+            new() { Icon = "\U0001F9C2", Name = "Salt", Amount = "to taste" },
+            new() { Icon = "\u26AB", Name = "Black Pepper", Amount = "Freshly ground, to taste" },
+        ],
+        Instructions =
+        [
+            "Start cooking your spaghetti in a large pot of lightly salted water until it's al dente.",
+            "Meanwhile, dice the guanciale into small cubes and cook it in a skillet over medium heat until crispy.",
+            "In a bowl, whisk together the egg yolks and grated cheese until smooth.",
+            "Once the pasta is cooked, drain it, reserving half a cup of the cooking water.",
+            "Combine the hot pasta with the guanciale, then remove the pan from the heat.",
+            "Stir in the egg and cheese mixture, adding reserved pasta water until creamy.",
+            "Season with freshly ground black pepper and serve immediately.",
+        ],
+    };
 
     private static ChatResponseUpdate CreatePlanStepUpdate(string messageId, int stepIndex)
     {

--- a/src/Components/AI/testassets/AGUIDojoApi/ScriptedChatClient.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/ScriptedChatClient.cs
@@ -3,6 +3,8 @@
 
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using AGUI.Server;
+using AGUIDojoApi.SharedState;
 using Microsoft.Extensions.AI;
 
 namespace AGUIDojoApi;
@@ -87,6 +89,8 @@ internal sealed class ScriptedChatClient : IChatClient
                     when callId == $"agentic-plan-step-{planSteps.Length}" =>
                     $"All {planSteps.Length} steps in the " +
                     $"{(planSteps.Length == PizzaPlanSteps.Length ? "pizza" : "Mars mission")} plan are complete.",
+                { CallId: "shared-state-recipe-1" } =>
+                    "I updated the shared recipe while preserving your existing ingredients.",
                 _ => "Background changed to a sunset gradient.",
             };
             yield return new ChatResponseUpdate
@@ -100,6 +104,55 @@ internal sealed class ScriptedChatClient : IChatClient
         }
 
         var messageId = Guid.NewGuid().ToString("N");
+        if (options?.Tools?.OfType<AIFunctionDeclaration>()
+                .Any(tool => tool.Name == "generate_recipe") == true)
+        {
+            options.TryGetRunAgentInput(out var input);
+            var current = input?.State?.Deserialize<RecipeResponse>(
+                AIJsonUtilities.DefaultOptions)?.Recipe ?? new Recipe();
+            var ingredients = current.Ingredients.ToList();
+            if (!ingredients.Any(ingredient =>
+                ingredient.Name.Equals("Fresh Basil", StringComparison.OrdinalIgnoreCase)))
+            {
+                ingredients.Add(new Ingredient
+                {
+                    Icon = "\U0001F33F",
+                    Name = "Fresh Basil",
+                    Amount = "1 handful",
+                });
+            }
+
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = messageId,
+                Contents =
+                [
+                    new FunctionCallContent(
+                        "shared-state-recipe-1",
+                        "generate_recipe",
+                        new Dictionary<string, object?>
+                        {
+                            ["recipe"] = new Recipe
+                            {
+                                Title = $"Italian {current.Title}",
+                                SkillLevel = current.SkillLevel,
+                                CookingTime = current.CookingTime,
+                                SpecialPreferences = current.SpecialPreferences,
+                                Ingredients = ingredients,
+                                Instructions =
+                                [
+                                    .. current.Instructions,
+                                    "Finish with fresh basil",
+                                ],
+                            },
+                        })
+                ],
+                FinishReason = ChatFinishReason.ToolCalls,
+            };
+            yield break;
+        }
+
         if (prompt.Contains("plan", StringComparison.OrdinalIgnoreCase) &&
             options?.Tools?.OfType<AIFunctionDeclaration>()
                 .Any(tool => tool.Name == "create_plan") == true)

--- a/src/Components/AI/testassets/AGUIDojoApi/SharedState/Ingredient.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/SharedState/Ingredient.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace AGUIDojoApi.SharedState;
+
+internal sealed class Ingredient
+{
+    [JsonPropertyName("icon")]
+    public string Icon { get; set; } = "";
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    [JsonPropertyName("amount")]
+    public string Amount { get; set; } = "";
+}

--- a/src/Components/AI/testassets/AGUIDojoApi/SharedState/Recipe.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/SharedState/Recipe.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace AGUIDojoApi.SharedState;
+
+internal sealed class Recipe
+{
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = "";
+
+    [JsonPropertyName("skill_level")]
+    public string SkillLevel { get; set; } = "";
+
+    [JsonPropertyName("cooking_time")]
+    public string CookingTime { get; set; } = "";
+
+    [JsonPropertyName("special_preferences")]
+    public List<string> SpecialPreferences { get; set; } = [];
+
+    [JsonPropertyName("ingredients")]
+    public List<Ingredient> Ingredients { get; set; } = [];
+
+    [JsonPropertyName("instructions")]
+    public List<string> Instructions { get; set; } = [];
+}

--- a/src/Components/AI/testassets/AGUIDojoApi/SharedState/RecipeResponse.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/SharedState/RecipeResponse.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace AGUIDojoApi.SharedState;
+
+internal sealed class RecipeResponse
+{
+    [JsonPropertyName("recipe")]
+    public Recipe Recipe { get; set; } = new();
+}

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Baselines/SharedState.recording.json
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Baselines/SharedState.recording.json
@@ -1,0 +1,292 @@
+{
+  "calls": [
+    {
+      "prompt": "Create a delicious Italian pasta recipe.",
+      "messageCount": 2,
+      "toolNames": [
+        "generate_recipe"
+      ],
+      "state": {
+        "recipe": {
+          "title": "Sunday Garden Pasta",
+          "skill_level": "Beginner",
+          "cooking_time": "45 min",
+          "special_preferences": [
+            "High Protein"
+          ],
+          "ingredients": [
+            {
+              "icon": "\ud83e\udd55",
+              "name": "Zucchini",
+              "amount": "2, sliced"
+            },
+            {
+              "icon": "\ud83c\udf3e",
+              "name": "All-Purpose Flour",
+              "amount": "2 cups"
+            }
+          ],
+          "instructions": [
+            "Preheat oven to 350\u00b0F (175\u00b0C)"
+          ]
+        }
+      },
+      "requireStableThread": true,
+      "frames": [
+        {
+          "name": "before-italian-recipe"
+        },
+        {
+          "name": "italian-recipe",
+          "functionCall": {
+            "callId": "shared-state-recipe-1",
+            "name": "generate_recipe",
+            "arguments": {
+              "recipe": {
+                "title": "Italian Garden Pasta",
+                "skill_level": "Beginner",
+                "cooking_time": "30 min",
+                "special_preferences": [
+                  "High Protein"
+                ],
+                "ingredients": [
+                  {
+                    "icon": "\ud83c\udf5d",
+                    "name": "Pasta",
+                    "amount": "12 oz"
+                  },
+                  {
+                    "icon": "\ud83e\udd52",
+                    "name": "Zucchini",
+                    "amount": "2, sliced"
+                  },
+                  {
+                    "icon": "\ud83c\udf3e",
+                    "name": "All-Purpose Flour",
+                    "amount": "2 cups"
+                  },
+                  {
+                    "icon": "\ud83c\udf45",
+                    "name": "Cherry Tomatoes",
+                    "amount": "2 cups"
+                  }
+                ],
+                "instructions": [
+                  "Boil the pasta until al dente.",
+                  "Saute the zucchini and tomatoes.",
+                  "Toss everything together and serve."
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "prompt": "Create a delicious Italian pasta recipe.",
+      "messageCount": 4,
+      "toolNames": [
+        "generate_recipe"
+      ],
+      "toolResultCallIds": [
+        "shared-state-recipe-1"
+      ],
+      "state": {
+        "recipe": {
+          "title": "Sunday Garden Pasta",
+          "skill_level": "Beginner",
+          "cooking_time": "45 min",
+          "special_preferences": [
+            "High Protein"
+          ],
+          "ingredients": [
+            {
+              "icon": "\ud83e\udd55",
+              "name": "Zucchini",
+              "amount": "2, sliced"
+            },
+            {
+              "icon": "\ud83c\udf3e",
+              "name": "All-Purpose Flour",
+              "amount": "2 cups"
+            }
+          ],
+          "instructions": [
+            "Preheat oven to 350\u00b0F (175\u00b0C)"
+          ]
+        }
+      },
+      "requireStableThread": true,
+      "frames": [
+        {
+          "name": "before-italian-summary"
+        },
+        {
+          "name": "italian-summary",
+          "chunks": [
+            "I created an Italian garden pasta and kept your zucchini."
+          ]
+        }
+      ]
+    },
+    {
+      "prompt": "Improve the recipe with fresh herbs.",
+      "messageCount": 6,
+      "toolNames": [
+        "generate_recipe"
+      ],
+      "state": {
+        "recipe": {
+          "title": "Italian Garden Pasta",
+          "skill_level": "Beginner",
+          "cooking_time": "30 min",
+          "special_preferences": [
+            "High Protein"
+          ],
+          "ingredients": [
+            {
+              "icon": "\ud83c\udf5d",
+              "name": "Pasta",
+              "amount": "12 oz"
+            },
+            {
+              "icon": "\ud83e\udd52",
+              "name": "Zucchini",
+              "amount": "3, sliced"
+            },
+            {
+              "icon": "\ud83c\udf3e",
+              "name": "All-Purpose Flour",
+              "amount": "2 cups"
+            },
+            {
+              "icon": "\ud83c\udf45",
+              "name": "Cherry Tomatoes",
+              "amount": "2 cups"
+            }
+          ],
+          "instructions": [
+            "Boil the pasta until al dente.",
+            "Saute the zucchini and tomatoes.",
+            "Toss everything together and serve."
+          ]
+        }
+      },
+      "requireStableThread": true,
+      "frames": [
+        {
+          "name": "before-herbed-recipe"
+        },
+        {
+          "name": "herbed-recipe",
+          "functionCall": {
+            "callId": "shared-state-recipe-2",
+            "name": "generate_recipe",
+            "arguments": {
+              "recipe": {
+                "title": "Herbed Italian Garden Pasta",
+                "skill_level": "Beginner",
+                "cooking_time": "30 min",
+                "special_preferences": [
+                  "High Protein"
+                ],
+                "ingredients": [
+                  {
+                    "icon": "\ud83c\udf5d",
+                    "name": "Pasta",
+                    "amount": "12 oz"
+                  },
+                  {
+                    "icon": "\ud83e\udd52",
+                    "name": "Zucchini",
+                    "amount": "3, sliced"
+                  },
+                  {
+                    "icon": "\ud83c\udf3e",
+                    "name": "All-Purpose Flour",
+                    "amount": "2 cups"
+                  },
+                  {
+                    "icon": "\ud83c\udf45",
+                    "name": "Cherry Tomatoes",
+                    "amount": "2 cups"
+                  },
+                  {
+                    "icon": "\ud83c\udf3f",
+                    "name": "Fresh Basil",
+                    "amount": "1 handful"
+                  }
+                ],
+                "instructions": [
+                  "Boil the pasta until al dente.",
+                  "Saute the zucchini and tomatoes.",
+                  "Toss with fresh basil and serve."
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "prompt": "Improve the recipe with fresh herbs.",
+      "messageCount": 8,
+      "toolNames": [
+        "generate_recipe"
+      ],
+      "toolResultCallIds": [
+        "shared-state-recipe-1",
+        "shared-state-recipe-2"
+      ],
+      "state": {
+        "recipe": {
+          "title": "Italian Garden Pasta",
+          "skill_level": "Beginner",
+          "cooking_time": "30 min",
+          "special_preferences": [
+            "High Protein"
+          ],
+          "ingredients": [
+            {
+              "icon": "\ud83c\udf5d",
+              "name": "Pasta",
+              "amount": "12 oz"
+            },
+            {
+              "icon": "\ud83e\udd52",
+              "name": "Zucchini",
+              "amount": "3, sliced"
+            },
+            {
+              "icon": "\ud83c\udf3e",
+              "name": "All-Purpose Flour",
+              "amount": "2 cups"
+            },
+            {
+              "icon": "\ud83c\udf45",
+              "name": "Cherry Tomatoes",
+              "amount": "2 cups"
+            }
+          ],
+          "instructions": [
+            "Boil the pasta until al dente.",
+            "Saute the zucchini and tomatoes.",
+            "Toss everything together and serve."
+          ]
+        }
+      },
+      "requireStableThread": true,
+      "frames": [
+        {
+          "name": "before-herbed-summary"
+        },
+        {
+          "name": "herbed-summary",
+          "chunks": [
+            "I added fresh basil while preserving your latest recipe edits."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Baselines/SharedState.recording.json
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Baselines/SharedState.recording.json
@@ -43,38 +43,50 @@
             "name": "generate_recipe",
             "arguments": {
               "recipe": {
-                "title": "Italian Garden Pasta",
-                "skill_level": "Beginner",
-                "cooking_time": "30 min",
-                "special_preferences": [
-                  "High Protein"
-                ],
+                "title": "Classic Italian Carbonara",
+                "skill_level": "Intermediate",
+                "cooking_time": "45 min",
+                "special_preferences": [],
                 "ingredients": [
                   {
                     "icon": "\ud83c\udf5d",
-                    "name": "Pasta",
-                    "amount": "12 oz"
+                    "name": "Spaghetti",
+                    "amount": "400g"
                   },
                   {
-                    "icon": "\ud83e\udd52",
-                    "name": "Zucchini",
-                    "amount": "2, sliced"
+                    "icon": "\ud83e\udd53",
+                    "name": "Guanciale (Pork Jowl)",
+                    "amount": "150g"
                   },
                   {
-                    "icon": "\ud83c\udf3e",
-                    "name": "All-Purpose Flour",
-                    "amount": "2 cups"
+                    "icon": "\ud83e\udd5a",
+                    "name": "Egg Yolks",
+                    "amount": "4 yolks"
                   },
                   {
-                    "icon": "\ud83c\udf45",
-                    "name": "Cherry Tomatoes",
-                    "amount": "2 cups"
+                    "icon": "\ud83e\uddc0",
+                    "name": "Pecorino Romano Cheese",
+                    "amount": "100g, grated"
+                  },
+                  {
+                    "icon": "\ud83e\uddc2",
+                    "name": "Salt",
+                    "amount": "to taste"
+                  },
+                  {
+                    "icon": "\u26ab",
+                    "name": "Black Pepper",
+                    "amount": "Freshly ground, to taste"
                   }
                 ],
                 "instructions": [
-                  "Boil the pasta until al dente.",
-                  "Saute the zucchini and tomatoes.",
-                  "Toss everything together and serve."
+                  "Start cooking your spaghetti in a large pot of lightly salted water until it's al dente.",
+                  "Meanwhile, dice the guanciale into small cubes and cook it in a skillet over medium heat until crispy.",
+                  "In a bowl, whisk together the egg yolks and grated cheese until smooth.",
+                  "Once the pasta is cooked, drain it, reserving half a cup of the cooking water.",
+                  "Combine the hot pasta with the guanciale, then remove the pan from the heat.",
+                  "Stir in the egg and cheese mixture, adding reserved pasta water until creamy.",
+                  "Season with freshly ground black pepper and serve immediately."
                 ]
               }
             }
@@ -124,7 +136,7 @@
         {
           "name": "italian-summary",
           "chunks": [
-            "I created an Italian garden pasta and kept your zucchini."
+            "The state now includes a detailed recipe for Classic Italian Carbonara, with specific ingredients, cooking instructions, and customization options for preferences like vegetarian alternatives. It also outlines the skill level, cooking time, and key steps for preparation."
           ]
         }
       ]

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/DojoModelOverrides.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/DojoModelOverrides.cs
@@ -42,6 +42,14 @@ internal class DojoModelOverrides
             new FunctionInvokingChatClient(sp.GetRequiredService<RecordedChatClient>()));
     }
 
+    public static void SharedState(IServiceCollection services)
+    {
+        services.AddSingleton(_ => RecordedScript.Load("SharedState.recording.json"));
+        services.AddScoped<RecordedChatClient>();
+        services.AddScoped<IChatClient>(sp =>
+            new FunctionInvokingChatClient(sp.GetRequiredService<RecordedChatClient>()));
+    }
+
     private static void AddRecordedModel(IServiceCollection services, string recordingFileName)
     {
         services.AddSingleton(_ => RecordedScript.Load(recordingFileName));

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/RecordedChatClient.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/RecordedChatClient.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using System.Text.Json;
+using AGUI.Abstractions;
 using Microsoft.AspNetCore.Components.Testing.Infrastructure;
 using Microsoft.Extensions.AI;
 
@@ -81,7 +83,7 @@ internal sealed class RecordedChatClient : IChatClient
     internal static string GetLockKey(string lastUserMessage, string frameName)
         => $"replay:{lastUserMessage}:{frameName}";
 
-    private static void AssertRequest(
+    private void AssertRequest(
         RecordedCall call,
         IReadOnlyList<ChatMessage> messages,
         ChatOptions? options)
@@ -135,6 +137,28 @@ internal sealed class RecordedChatClient : IChatClient
                         $"[{string.Join(", ", call.ToolResults.Select(result => $"{result.CallId}: {result.Result}"))}], " +
                         $"received [{string.Join(", ", actualResults.Select(result => $"{result.CallId}: {result.Result}"))}].");
                 }
+            }
+        }
+
+        if (call.State is { } || call.RequireStableThread)
+        {
+            var input = options?.AdditionalProperties?.Values
+                .OfType<RunAgentInput>()
+                .SingleOrDefault()
+                ?? throw new InvalidOperationException("Expected an AG-UI RunAgentInput.");
+
+            if (call.State is { } expectedState &&
+                (input.State is not { } actualState ||
+                    !JsonElement.DeepEquals(expectedState, actualState)))
+            {
+                throw new InvalidOperationException(
+                    $"Expected state {expectedState.GetRawText()}, received " +
+                    $"{input.State?.GetRawText() ?? "<null>"}.");
+            }
+
+            if (call.RequireStableThread)
+            {
+                _script.AssertStableThread(input.ThreadId);
             }
         }
     }

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/RecordedScript.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/RecordedScript.cs
@@ -12,6 +12,8 @@ namespace DojoClient.E2E.Tests.ServiceOverrides;
 internal sealed class RecordedScript
 {
     private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+    private readonly object _threadLock = new();
+    private string? _threadId;
 
     public required List<RecordedCall> Calls { get; init; }
 
@@ -47,6 +49,21 @@ internal sealed class RecordedScript
             $"with {messageCount} messages. " +
             $"Recorded prompts: {string.Join(", ", Calls.Select(call => call.Prompt))}.");
     }
+
+    public void AssertStableThread(string threadId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(threadId);
+
+        lock (_threadLock)
+        {
+            _threadId ??= threadId;
+            if (_threadId != threadId)
+            {
+                throw new InvalidOperationException(
+                    $"Expected AG-UI thread '{_threadId}', received '{threadId}'.");
+            }
+        }
+    }
 }
 
 internal sealed class RecordedCall
@@ -65,6 +82,12 @@ internal sealed class RecordedCall
 
     /// <summary>The function results expected on this model request.</summary>
     public List<RecordedToolResult>? ToolResults { get; init; }
+
+    /// <summary>The AG-UI state expected on this model request.</summary>
+    public JsonElement? State { get; init; }
+
+    /// <summary>Whether this call must use the same non-empty AG-UI thread as prior calls.</summary>
+    public bool RequireStableThread { get; init; }
 
     /// <summary>The response, split into the checkpoints a test can stop at.</summary>
     public required List<RecordedFrame> Frames { get; init; }

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/SharedStateScenarioTests.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/SharedStateScenarioTests.cs
@@ -1,0 +1,109 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using AGUIDojoApi;
+using DojoClient.E2E.Tests.Fixtures;
+using DojoClient.E2E.Tests.ServiceOverrides;
+using Microsoft.AspNetCore.Components.Testing.Infrastructure;
+using Microsoft.AspNetCore.Components.Testing.Playwright;
+using Microsoft.Playwright;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DojoClient.E2E.Tests.Tests;
+
+// The browser edits typed state in DojoClient, which serializes it through AGUIChatClient.
+// Only the API's model is recorded; thread identity, state, HTTP, and SSE remain real.
+[UITest]
+public partial class SharedStateScenarioTests : BrowserTest
+{
+    private ServerInstance _api = null!;
+    private ServerInstance _ui = null!;
+    private ApiCheckpointClient _checkpoints = null!;
+    private IPage _page = null!;
+    private string _firstPrompt = null!;
+    private string _secondPrompt = null!;
+
+    protected override async Task InitializeCoreAsync()
+    {
+        await base.InitializeCoreAsync();
+
+        var runId = Guid.NewGuid().ToString("N");
+        _firstPrompt = $"Create a delicious Italian pasta recipe. ({runId})";
+        _secondPrompt = $"Improve the recipe with fresh herbs. ({runId})";
+        _api = await StartServerAsync<AGUIDojoApiAssembly>(TestRoot.Servers, options =>
+        {
+            options.ConfigureServices<DojoModelOverrides>(
+                nameof(DojoModelOverrides.SharedState));
+        });
+        _ui = await StartServerAsync<global::DojoClient.Components.App>(TestRoot.Servers, options =>
+        {
+            options.EnvironmentVariables["AGUI_DOJO_API_URL"] = _api.AppUrl;
+        });
+        _checkpoints = new ApiCheckpointClient(_api);
+
+        var context = await NewContext(new BrowserNewContextOptions().WithServerRouting(_ui));
+        _page = await context.NewPageAsync();
+        await _page.GotoAsync($"{_ui.TestUrl}/shared_state");
+        await _page.WaitForInteractiveAsync("textarea.sc-ai-input__textarea");
+    }
+
+    [TestMethod]
+    public async Task RecipeEditor_ForwardsLocalEditsAndPreservesThemAcrossAgentUpdates()
+    {
+        var scenario = _page.Locator("[data-scenario='shared_state']");
+        var editor = scenario.Locator(".recipe-editor");
+        var input = scenario.Locator("textarea.sc-ai-input__textarea");
+        var send = scenario.Locator("button.sc-ai-input__send");
+
+        await Expect(editor.GetByLabel("Recipe title"))
+            .ToHaveValueAsync("Make Your Recipe");
+        await editor.GetByLabel("Recipe title").FillAsync("Sunday Garden Pasta");
+        await editor.GetByLabel("Skill level").SelectOptionAsync("Beginner");
+        await editor.GetByLabel("High Protein", new() { Exact = true }).CheckAsync();
+        await editor.GetByLabel("Ingredient name").First.FillAsync("Zucchini");
+        await editor.GetByLabel("Ingredient amount").First.FillAsync("2, sliced");
+
+        await input.FillAsync(_firstPrompt);
+        await send.ClickAsync();
+        await Expect(send).ToBeDisabledAsync();
+        await Expect(editor.GetByLabel("Recipe title"))
+            .ToHaveValueAsync("Sunday Garden Pasta");
+
+        await _checkpoints.ReleaseAsync(_firstPrompt, "before-italian-recipe");
+
+        await Expect(editor.GetByLabel("Recipe title"))
+            .ToHaveValueAsync("Italian Garden Pasta");
+        await Expect(editor.GetByLabel("Cooking time")).ToHaveValueAsync("30 min");
+        await Expect(editor.GetByLabel("Ingredient name")).ToHaveCountAsync(4);
+        await Expect(editor.GetByLabel("Ingredient name").Nth(1)).ToHaveValueAsync("Zucchini");
+        await Expect(editor.GetByLabel("Ingredient amount").Nth(1)).ToHaveValueAsync("2, sliced");
+        await Expect(editor.GetByLabel("High Protein", new() { Exact = true })).ToBeCheckedAsync();
+
+        await _checkpoints.ReleaseAsync(_firstPrompt, "before-italian-summary");
+        await Expect(scenario.Locator(
+            ".sc-ai-message--assistant .sc-ai-message__content").Last)
+            .ToHaveTextAsync("I created an Italian garden pasta and kept your zucchini.");
+        await Expect(send).ToBeEnabledAsync();
+
+        await editor.GetByLabel("Ingredient amount").Nth(1).FillAsync("3, sliced");
+        await input.FillAsync(_secondPrompt);
+        await send.ClickAsync();
+        await Expect(send).ToBeDisabledAsync();
+
+        await _checkpoints.ReleaseAsync(_secondPrompt, "before-herbed-recipe");
+
+        await Expect(editor.GetByLabel("Recipe title"))
+            .ToHaveValueAsync("Herbed Italian Garden Pasta");
+        await Expect(editor.GetByLabel("Ingredient name")).ToHaveCountAsync(5);
+        await Expect(editor.GetByLabel("Ingredient name").Nth(1)).ToHaveValueAsync("Zucchini");
+        await Expect(editor.GetByLabel("Ingredient amount").Nth(1)).ToHaveValueAsync("3, sliced");
+        await Expect(editor.GetByLabel("Ingredient name").Last).ToHaveValueAsync("Fresh Basil");
+        await Expect(editor.GetByLabel("High Protein", new() { Exact = true })).ToBeCheckedAsync();
+
+        await _checkpoints.ReleaseAsync(_secondPrompt, "before-herbed-summary");
+        await Expect(scenario.Locator(
+            ".sc-ai-message--assistant .sc-ai-message__content").Last)
+            .ToHaveTextAsync("I added fresh basil while preserving your latest recipe edits.");
+        await Expect(send).ToBeEnabledAsync();
+    }
+}

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/SharedStateScenarioTests.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/SharedStateScenarioTests.cs
@@ -21,7 +21,6 @@ public partial class SharedStateScenarioTests : BrowserTest
     private ApiCheckpointClient _checkpoints = null!;
     private IPage _page = null!;
     private string _firstPrompt = null!;
-    private string _secondPrompt = null!;
 
     protected override async Task InitializeCoreAsync()
     {
@@ -29,7 +28,6 @@ public partial class SharedStateScenarioTests : BrowserTest
 
         var runId = Guid.NewGuid().ToString("N");
         _firstPrompt = $"Create a delicious Italian pasta recipe. ({runId})";
-        _secondPrompt = $"Improve the recipe with fresh herbs. ({runId})";
         _api = await StartServerAsync<AGUIDojoApiAssembly>(TestRoot.Servers, options =>
         {
             options.ConfigureServices<DojoModelOverrides>(
@@ -48,7 +46,7 @@ public partial class SharedStateScenarioTests : BrowserTest
     }
 
     [TestMethod]
-    public async Task RecipeEditor_ForwardsLocalEditsAndPreservesThemAcrossAgentUpdates()
+    public async Task RecipeEditor_ReplacesLocalStateWithItalianRecipeSnapshot()
     {
         var scenario = _page.Locator("[data-scenario='shared_state']");
         var editor = scenario.Locator(".recipe-editor");
@@ -66,44 +64,73 @@ public partial class SharedStateScenarioTests : BrowserTest
         await input.FillAsync(_firstPrompt);
         await send.ClickAsync();
         await Expect(send).ToBeDisabledAsync();
+        var improve = editor.Locator(".recipe-editor__improve-btn");
+        await Expect(improve).ToBeDisabledAsync();
+        await Expect(improve).ToHaveAttributeAsync("aria-busy", "true");
+        await Expect(improve.GetByRole(AriaRole.Status)).ToHaveTextAsync("Please Wait...");
+        await Expect(scenario.GetByRole(AriaRole.Button, new() { Name = "Stop response" }))
+            .ToBeVisibleAsync();
         await Expect(editor.GetByLabel("Recipe title"))
             .ToHaveValueAsync("Sunday Garden Pasta");
 
         await _checkpoints.ReleaseAsync(_firstPrompt, "before-italian-recipe");
 
         await Expect(editor.GetByLabel("Recipe title"))
-            .ToHaveValueAsync("Italian Garden Pasta");
-        await Expect(editor.GetByLabel("Cooking time")).ToHaveValueAsync("30 min");
-        await Expect(editor.GetByLabel("Ingredient name")).ToHaveCountAsync(4);
-        await Expect(editor.GetByLabel("Ingredient name").Nth(1)).ToHaveValueAsync("Zucchini");
-        await Expect(editor.GetByLabel("Ingredient amount").Nth(1)).ToHaveValueAsync("2, sliced");
-        await Expect(editor.GetByLabel("High Protein", new() { Exact = true })).ToBeCheckedAsync();
+            .ToHaveValueAsync("Classic Italian Carbonara");
+        await Expect(editor.GetByLabel("Skill level")).ToHaveValueAsync("Intermediate");
+        await Expect(editor.GetByLabel("Cooking time")).ToHaveValueAsync("45 min");
+        await Expect(editor.GetByLabel("Ingredient name")).ToHaveCountAsync(6);
+        await Expect(editor.GetByLabel("Ingredient name").Nth(0)).ToHaveValueAsync("Spaghetti");
+        await Expect(editor.GetByLabel("Ingredient amount").Nth(0)).ToHaveValueAsync("400g");
+        await Expect(editor.GetByLabel("Ingredient name").Nth(1))
+            .ToHaveValueAsync("Guanciale (Pork Jowl)");
+        await Expect(editor.GetByLabel("Ingredient name").Nth(5)).ToHaveValueAsync("Black Pepper");
+        await Expect(editor.GetByLabel("High Protein", new() { Exact = true }))
+            .Not.ToBeCheckedAsync();
 
         await _checkpoints.ReleaseAsync(_firstPrompt, "before-italian-summary");
         await Expect(scenario.Locator(
             ".sc-ai-message--assistant .sc-ai-message__content").Last)
-            .ToHaveTextAsync("I created an Italian garden pasta and kept your zucchini.");
+            .ToContainTextAsync("Classic Italian Carbonara");
         await Expect(send).ToBeEnabledAsync();
+        await Expect(scenario.GetByRole(AriaRole.Button, new() { Name = "Stop response" }))
+            .ToBeHiddenAsync();
+    }
 
-        await editor.GetByLabel("Ingredient amount").Nth(1).FillAsync("3, sliced");
-        await input.FillAsync(_secondPrompt);
-        await send.ClickAsync();
-        await Expect(send).ToBeDisabledAsync();
+    [TestMethod]
+    public async Task RecipeEditor_MatchesDojoChatAndResponsiveControls()
+    {
+        var scenario = _page.Locator("[data-scenario='shared_state']");
+        var editor = scenario.Locator(".recipe-editor");
+        var chat = scenario.GetByRole(
+            AriaRole.Complementary,
+            new() { Name = "Copilot chat sidebar" });
 
-        await _checkpoints.ReleaseAsync(_secondPrompt, "before-herbed-recipe");
+        await Expect(editor.GetByLabel("Cooking time").Locator("option"))
+            .ToHaveTextAsync(["5 min", "15 min", "30 min", "45 min", "60+ min"]);
+        await Expect(editor.GetByLabel("Budget-Friendly")).ToBeVisibleAsync();
+        await Expect(editor.GetByLabel("One-Pot Meal")).ToBeVisibleAsync();
+        await Expect(editor.GetByLabel("Gluten-Free")).ToHaveCountAsync(0);
 
-        await Expect(editor.GetByLabel("Recipe title"))
-            .ToHaveValueAsync("Herbed Italian Garden Pasta");
-        await Expect(editor.GetByLabel("Ingredient name")).ToHaveCountAsync(5);
-        await Expect(editor.GetByLabel("Ingredient name").Nth(1)).ToHaveValueAsync("Zucchini");
-        await Expect(editor.GetByLabel("Ingredient amount").Nth(1)).ToHaveValueAsync("3, sliced");
-        await Expect(editor.GetByLabel("Ingredient name").Last).ToHaveValueAsync("Fresh Basil");
-        await Expect(editor.GetByLabel("High Protein", new() { Exact = true })).ToBeCheckedAsync();
+        await scenario.GetByRole(AriaRole.Button, new() { Name = "Close chat" }).ClickAsync();
+        await Expect(chat).ToBeHiddenAsync();
+        await Expect(editor.GetByLabel("Recipe title")).ToHaveValueAsync("Make Your Recipe");
 
-        await _checkpoints.ReleaseAsync(_secondPrompt, "before-herbed-summary");
-        await Expect(scenario.Locator(
-            ".sc-ai-message--assistant .sc-ai-message__content").Last)
-            .ToHaveTextAsync("I added fresh basil while preserving your latest recipe edits.");
-        await Expect(send).ToBeEnabledAsync();
+        await scenario.GetByRole(AriaRole.Button, new() { Name = "Open chat" }).ClickAsync();
+        await Expect(chat).ToBeVisibleAsync();
+
+        await _page.SetViewportSizeAsync(390, 844);
+        var mobileToggle = scenario.GetByRole(
+            AriaRole.Button,
+            new() { Name = "AI Recipe Assistant Ask me to craft recipes" });
+        var chatContent = scenario.Locator("#shared-state-chat-content");
+
+        await Expect(mobileToggle).ToBeVisibleAsync();
+        await Expect(mobileToggle).ToHaveAttributeAsync("aria-expanded", "false");
+        await Expect(chatContent).ToBeHiddenAsync();
+
+        await mobileToggle.ClickAsync();
+        await Expect(mobileToggle).ToHaveAttributeAsync("aria-expanded", "true");
+        await Expect(chatContent).ToBeVisibleAsync();
     }
 }

--- a/src/Components/AI/testassets/DojoClient/Components/Pages/Home.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Pages/Home.razor
@@ -12,4 +12,5 @@
     <li><a href="/human_in_the_loop" data-scenario="human_in_the_loop">Human in the Loop</a></li>
     <li><a href="/tool_based_generative_ui" data-scenario="tool_based_generative_ui">Tool-Based Generative UI</a></li>
     <li><a href="/agentic_generative_ui" data-scenario="agentic_generative_ui">Agentic Generative UI</a></li>
+    <li><a href="/shared_state" data-scenario="shared_state">Shared State</a></li>
 </ul>

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/IngredientRow.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/IngredientRow.razor
@@ -1,21 +1,19 @@
 <div class="ingredient-row">
-    <input type="text"
-           class="ingredient-row__icon"
-           aria-label="Ingredient icon"
-           value="@Ingredient.Icon"
-           @oninput="args => UpdateAsync(nameof(Ingredient.Icon), args)" />
-    <input type="text"
-           class="ingredient-row__name"
-           aria-label="Ingredient name"
-           value="@Ingredient.Name"
-           @oninput="args => UpdateAsync(nameof(Ingredient.Name), args)"
-           placeholder="Ingredient name" />
-    <input type="text"
-           class="ingredient-row__amount"
-           aria-label="Ingredient amount"
-           value="@Ingredient.Amount"
-           @oninput="args => UpdateAsync(nameof(Ingredient.Amount), args)"
-           placeholder="Amount" />
+    <span class="ingredient-row__icon" aria-hidden="true">@Ingredient.Icon</span>
+    <span class="ingredient-row__fields">
+        <input type="text"
+               class="ingredient-row__name"
+               aria-label="Ingredient name"
+               value="@Ingredient.Name"
+               @oninput="args => UpdateAsync(nameof(Ingredient.Name), args)"
+               placeholder="Ingredient name" />
+        <input type="text"
+               class="ingredient-row__amount"
+               aria-label="Ingredient amount"
+               value="@Ingredient.Amount"
+               @oninput="args => UpdateAsync(nameof(Ingredient.Amount), args)"
+               placeholder="Amount" />
+    </span>
     <button class="recipe-editor__remove-btn"
             aria-label="Remove ingredient"
             @onclick="OnRemove">&times;</button>
@@ -36,7 +34,6 @@
         var value = args.Value?.ToString() ?? "";
         var ingredient = propertyName switch
         {
-            nameof(Ingredient.Icon) => Ingredient with { Icon = value },
             nameof(Ingredient.Name) => Ingredient with { Name = value },
             nameof(Ingredient.Amount) => Ingredient with { Amount = value },
             _ => throw new InvalidOperationException(

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/IngredientRow.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/IngredientRow.razor
@@ -1,0 +1,48 @@
+<div class="ingredient-row">
+    <input type="text"
+           class="ingredient-row__icon"
+           aria-label="Ingredient icon"
+           value="@Ingredient.Icon"
+           @oninput="args => UpdateAsync(nameof(Ingredient.Icon), args)" />
+    <input type="text"
+           class="ingredient-row__name"
+           aria-label="Ingredient name"
+           value="@Ingredient.Name"
+           @oninput="args => UpdateAsync(nameof(Ingredient.Name), args)"
+           placeholder="Ingredient name" />
+    <input type="text"
+           class="ingredient-row__amount"
+           aria-label="Ingredient amount"
+           value="@Ingredient.Amount"
+           @oninput="args => UpdateAsync(nameof(Ingredient.Amount), args)"
+           placeholder="Amount" />
+    <button class="recipe-editor__remove-btn"
+            aria-label="Remove ingredient"
+            @onclick="OnRemove">&times;</button>
+</div>
+
+@code {
+    [Parameter, EditorRequired]
+    public Ingredient Ingredient { get; set; } = default!;
+
+    [Parameter]
+    public EventCallback OnRemove { get; set; }
+
+    [Parameter]
+    public EventCallback<Ingredient> IngredientChanged { get; set; }
+
+    private Task UpdateAsync(string propertyName, ChangeEventArgs args)
+    {
+        var value = args.Value?.ToString() ?? "";
+        var ingredient = propertyName switch
+        {
+            nameof(Ingredient.Icon) => Ingredient with { Icon = value },
+            nameof(Ingredient.Name) => Ingredient with { Name = value },
+            nameof(Ingredient.Amount) => Ingredient with { Amount = value },
+            _ => throw new InvalidOperationException(
+                $"Unknown ingredient property '{propertyName}'."),
+        };
+
+        return IngredientChanged.InvokeAsync(ingredient);
+    }
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/IngredientRow.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/IngredientRow.razor.css
@@ -1,27 +1,71 @@
 .ingredient-row {
     align-items: center;
     background: #fff;
-    border: 1px solid #e5e7eb;
-    border-radius: 8px;
+    border-radius: 11px;
+    box-shadow: 0 4px 12px rgb(0 0 0 / 9%);
+    box-sizing: border-box;
     display: flex;
-    gap: 8px;
-    margin-bottom: 6px;
-    padding: 8px 12px;
+    gap: 10px;
+    min-height: 67px;
+    min-width: 0;
+    padding: 10px 12px;
+    position: relative;
 }
 
 .ingredient-row__icon {
+    align-items: center;
+    background: #f5f5f7;
+    border-radius: 50%;
+    display: flex;
     flex-shrink: 0;
-    font-size: 1.2em;
-    text-align: center;
-    width: 40px !important;
+    font-size: 1.25rem;
+    height: 38px;
+    justify-content: center;
+    width: 38px;
+}
+
+.ingredient-row__fields {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.ingredient-row input {
+    background: transparent;
+    border: 0;
+    box-sizing: border-box;
+    font-family: inherit;
+    min-width: 0;
+    outline: 0;
+    padding: 1px 0;
+    text-overflow: ellipsis;
+    width: 100%;
 }
 
 .ingredient-row__name {
-    flex: 2;
+    color: #222;
+    font-size: 0.82rem;
+    font-weight: 600;
 }
 
 .ingredient-row__amount {
-    color: #6b7280;
-    flex: 1;
-    font-size: 0.85em;
+    color: #727278;
+    font-size: 0.78rem;
+}
+
+.ingredient-row input:focus {
+    box-shadow: 0 1px #ff6542;
+}
+
+.ingredient-row .recipe-editor__remove-btn {
+    opacity: 0;
+    position: absolute;
+    right: 1px;
+    top: 1px;
+}
+
+.ingredient-row:hover .recipe-editor__remove-btn,
+.ingredient-row:focus-within .recipe-editor__remove-btn {
+    opacity: 1;
 }

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/IngredientRow.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/IngredientRow.razor.css
@@ -1,0 +1,27 @@
+.ingredient-row {
+    align-items: center;
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    display: flex;
+    gap: 8px;
+    margin-bottom: 6px;
+    padding: 8px 12px;
+}
+
+.ingredient-row__icon {
+    flex-shrink: 0;
+    font-size: 1.2em;
+    text-align: center;
+    width: 40px !important;
+}
+
+.ingredient-row__name {
+    flex: 2;
+}
+
+.ingredient-row__amount {
+    color: #6b7280;
+    flex: 1;
+    font-size: 0.85em;
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/Recipe.cs
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/Recipe.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+
+namespace DojoClient.Components.Scenarios.SharedState;
+
+public sealed record RecipeState
+{
+    public Recipe Recipe { get; init; } = new();
+}
+
+public sealed record Recipe
+{
+    public string Title { get; init; } = "";
+
+    [JsonPropertyName("skill_level")]
+    public string SkillLevel { get; init; } = "";
+
+    [JsonPropertyName("cooking_time")]
+    public string CookingTime { get; init; } = "";
+
+    [JsonPropertyName("special_preferences")]
+    public List<string> SpecialPreferences { get; init; } = [];
+
+    public List<Ingredient> Ingredients { get; init; } = [];
+
+    public List<string> Instructions { get; init; } = [];
+}
+
+public sealed record Ingredient
+{
+    [Description("A single Unicode emoji grapheme.")]
+    public string Icon { get; init; } = "";
+
+    public string Name { get; init; } = "";
+
+    public string Amount { get; init; } = "";
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/RecipeEditor.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/RecipeEditor.razor
@@ -1,0 +1,230 @@
+@implements IDisposable
+
+<div class="recipe-editor">
+    <div class="@GetSectionClass("title")"
+         data-section="title"
+         data-agent-changed="@IsChanged("title").ToString().ToLowerInvariant()">
+        <label>Title</label>
+        <input type="text"
+               aria-label="Recipe title"
+               value="@Recipe.Title"
+               @oninput="UpdateTitleAsync" />
+    </div>
+
+    <div class="@GetSectionClass("details")"
+         data-section="details"
+         data-agent-changed="@IsChanged("details").ToString().ToLowerInvariant()">
+        <div class="recipe-editor__row">
+            <div class="recipe-editor__field">
+                <label>Skill Level</label>
+                <select aria-label="Skill level"
+                        value="@Recipe.SkillLevel"
+                        @onchange="UpdateSkillLevelAsync">
+                    <option>Beginner</option>
+                    <option>Intermediate</option>
+                    <option>Advanced</option>
+                </select>
+            </div>
+            <div class="recipe-editor__field">
+                <label>Cooking Time</label>
+                <select aria-label="Cooking time"
+                        value="@Recipe.CookingTime"
+                        @onchange="UpdateCookingTimeAsync">
+                    <option>15 min</option>
+                    <option>30 min</option>
+                    <option>45 min</option>
+                    <option>1 hr</option>
+                    <option>1.5 hr</option>
+                    <option>2 hr</option>
+                </select>
+            </div>
+        </div>
+    </div>
+
+    <div class="@GetSectionClass("preferences")"
+         data-section="preferences"
+         data-agent-changed="@IsChanged("preferences").ToString().ToLowerInvariant()">
+        <label>Dietary Preferences</label>
+        <div class="recipe-editor__checkboxes">
+            @foreach (var preference in _allPreferences)
+            {
+                <label class="recipe-editor__checkbox">
+                    <input type="checkbox"
+                           checked="@Recipe.SpecialPreferences.Contains(preference)"
+                           @onchange="() => TogglePreferenceAsync(preference)" />
+                    @preference
+                </label>
+            }
+        </div>
+    </div>
+
+    <div class="@GetSectionClass("ingredients")"
+         data-section="ingredients"
+         data-agent-changed="@IsChanged("ingredients").ToString().ToLowerInvariant()">
+        <label>Ingredients</label>
+        @for (var index = 0; index < Recipe.Ingredients.Count; index++)
+        {
+            var capturedIndex = index;
+            <IngredientRow Ingredient="Recipe.Ingredients[capturedIndex]"
+                           OnRemove="() => RemoveIngredientAsync(capturedIndex)"
+                           IngredientChanged="ingredient => UpdateIngredientAsync(capturedIndex, ingredient)" />
+        }
+        <button class="recipe-editor__add-btn" @onclick="AddIngredientAsync">
+            + Add Ingredient
+        </button>
+    </div>
+
+    <div class="@GetSectionClass("instructions")"
+         data-section="instructions"
+         data-agent-changed="@IsChanged("instructions").ToString().ToLowerInvariant()">
+        <label>Instructions</label>
+        @for (var index = 0; index < Recipe.Instructions.Count; index++)
+        {
+            var capturedIndex = index;
+            <div class="recipe-editor__instruction">
+                <span class="recipe-editor__step-num">@(capturedIndex + 1).</span>
+                <input type="text"
+                       aria-label="@($"Instruction {capturedIndex + 1}")"
+                       value="@Recipe.Instructions[capturedIndex]"
+                       @oninput="args => UpdateInstructionAsync(capturedIndex, args)" />
+                <button class="recipe-editor__remove-btn"
+                        aria-label="Remove instruction"
+                        @onclick="() => RemoveInstructionAsync(capturedIndex)">&times;</button>
+            </div>
+        }
+        <button class="recipe-editor__add-btn" @onclick="AddInstructionAsync">
+            + Add Step
+        </button>
+    </div>
+
+    <button class="recipe-editor__improve-btn"
+            disabled="@IsRunning"
+            @onclick="ImproveAsync">
+        @(IsRunning ? "Please Wait..." : "Improve with AI")
+    </button>
+</div>
+
+@code {
+    private static readonly string[] _allPreferences =
+    [
+        "Vegetarian",
+        "Vegan",
+        "Gluten-Free",
+        "High Protein",
+        "Low Carb",
+        "Spicy",
+    ];
+
+    private AgentContext? _registeredContext;
+    private IDisposable? _statusChangedRegistration;
+
+    [CascadingParameter]
+    public AgentContext AgentContext { get; set; } = default!;
+
+    [Parameter, EditorRequired]
+    public Recipe Recipe { get; set; } = default!;
+
+    [Parameter, EditorRequired]
+    public EventCallback<Recipe> RecipeChanged { get; set; }
+
+    [Parameter]
+    public IReadOnlySet<string> ChangedSections { get; set; } = new HashSet<string>();
+
+    private bool IsRunning
+        => AgentContext.Status is ConversationStatus.Streaming or ConversationStatus.AwaitingInput;
+
+    protected override void OnParametersSet()
+    {
+        if (!ReferenceEquals(_registeredContext, AgentContext))
+        {
+            _statusChangedRegistration?.Dispose();
+            _registeredContext = AgentContext;
+            _statusChangedRegistration = AgentContext.RegisterOnStatusChanged(OnStatusChanged);
+        }
+    }
+
+    private void OnStatusChanged(ConversationStatus status)
+    {
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private Task UpdateTitleAsync(ChangeEventArgs args)
+        => RecipeChanged.InvokeAsync(Recipe with { Title = GetValue(args) });
+
+    private Task UpdateSkillLevelAsync(ChangeEventArgs args)
+        => RecipeChanged.InvokeAsync(Recipe with { SkillLevel = GetValue(args) });
+
+    private Task UpdateCookingTimeAsync(ChangeEventArgs args)
+        => RecipeChanged.InvokeAsync(Recipe with { CookingTime = GetValue(args) });
+
+    private Task TogglePreferenceAsync(string preference)
+    {
+        var preferences = Recipe.SpecialPreferences.Contains(preference, StringComparer.Ordinal)
+            ? Recipe.SpecialPreferences.Where(value => value != preference).ToList()
+            : [.. Recipe.SpecialPreferences, preference];
+
+        return RecipeChanged.InvokeAsync(Recipe with { SpecialPreferences = preferences });
+    }
+
+    private Task AddIngredientAsync()
+        => RecipeChanged.InvokeAsync(Recipe with
+        {
+            Ingredients =
+            [
+                .. Recipe.Ingredients,
+                new Ingredient { Icon = "\U0001F37D\uFE0F" },
+            ],
+        });
+
+    private Task UpdateIngredientAsync(int index, Ingredient ingredient)
+    {
+        var ingredients = Recipe.Ingredients.ToList();
+        ingredients[index] = ingredient;
+
+        return RecipeChanged.InvokeAsync(Recipe with { Ingredients = ingredients });
+    }
+
+    private Task RemoveIngredientAsync(int index)
+    {
+        var ingredients = Recipe.Ingredients.ToList();
+        ingredients.RemoveAt(index);
+
+        return RecipeChanged.InvokeAsync(Recipe with { Ingredients = ingredients });
+    }
+
+    private Task AddInstructionAsync()
+        => RecipeChanged.InvokeAsync(Recipe with
+        {
+            Instructions = [.. Recipe.Instructions, ""],
+        });
+
+    private Task UpdateInstructionAsync(int index, ChangeEventArgs args)
+    {
+        var instructions = Recipe.Instructions.ToList();
+        instructions[index] = GetValue(args);
+
+        return RecipeChanged.InvokeAsync(Recipe with { Instructions = instructions });
+    }
+
+    private Task RemoveInstructionAsync(int index)
+    {
+        var instructions = Recipe.Instructions.ToList();
+        instructions.RemoveAt(index);
+
+        return RecipeChanged.InvokeAsync(Recipe with { Instructions = instructions });
+    }
+
+    private Task ImproveAsync() => AgentContext.SendMessageAsync("Improve the recipe");
+
+    private bool IsChanged(string section)
+        => IsRunning && ChangedSections.Contains(section);
+
+    private string GetSectionClass(string section)
+        => IsChanged(section)
+            ? "recipe-editor__section recipe-editor__section--changed"
+            : "recipe-editor__section";
+
+    private static string GetValue(ChangeEventArgs args) => args.Value?.ToString() ?? "";
+
+    public void Dispose() => _statusChangedRegistration?.Dispose();
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/RecipeEditor.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/RecipeEditor.razor
@@ -4,8 +4,8 @@
     <div class="@GetSectionClass("title")"
          data-section="title"
          data-agent-changed="@IsChanged("title").ToString().ToLowerInvariant()">
-        <label>Title</label>
         <input type="text"
+               class="recipe-editor__title"
                aria-label="Recipe title"
                value="@Recipe.Title"
                @oninput="UpdateTitleAsync" />
@@ -14,28 +14,35 @@
     <div class="@GetSectionClass("details")"
          data-section="details"
          data-agent-changed="@IsChanged("details").ToString().ToLowerInvariant()">
-        <div class="recipe-editor__row">
-            <div class="recipe-editor__field">
-                <label>Skill Level</label>
-                <select aria-label="Skill level"
+        <div class="recipe-editor__details">
+            <div class="recipe-editor__detail">
+                <span aria-hidden="true">🕒</span>
+                <label class="recipe-editor__sr-only" for="shared-state-cooking-time">
+                    Cooking Time
+                </label>
+                <select id="shared-state-cooking-time"
+                        aria-label="Cooking time"
+                        value="@Recipe.CookingTime"
+                        @onchange="UpdateCookingTimeAsync">
+                    <option>5 min</option>
+                    <option>15 min</option>
+                    <option>30 min</option>
+                    <option>45 min</option>
+                    <option>60+ min</option>
+                </select>
+            </div>
+            <div class="recipe-editor__detail">
+                <span aria-hidden="true">🏆</span>
+                <label class="recipe-editor__sr-only" for="shared-state-skill-level">
+                    Skill Level
+                </label>
+                <select id="shared-state-skill-level"
+                        aria-label="Skill level"
                         value="@Recipe.SkillLevel"
                         @onchange="UpdateSkillLevelAsync">
                     <option>Beginner</option>
                     <option>Intermediate</option>
                     <option>Advanced</option>
-                </select>
-            </div>
-            <div class="recipe-editor__field">
-                <label>Cooking Time</label>
-                <select aria-label="Cooking time"
-                        value="@Recipe.CookingTime"
-                        @onchange="UpdateCookingTimeAsync">
-                    <option>15 min</option>
-                    <option>30 min</option>
-                    <option>45 min</option>
-                    <option>1 hr</option>
-                    <option>1.5 hr</option>
-                    <option>2 hr</option>
                 </select>
             </div>
         </div>
@@ -44,7 +51,7 @@
     <div class="@GetSectionClass("preferences")"
          data-section="preferences"
          data-agent-changed="@IsChanged("preferences").ToString().ToLowerInvariant()">
-        <label>Dietary Preferences</label>
+        <h2>Dietary Preferences</h2>
         <div class="recipe-editor__checkboxes">
             @foreach (var preference in _allPreferences)
             {
@@ -61,58 +68,76 @@
     <div class="@GetSectionClass("ingredients")"
          data-section="ingredients"
          data-agent-changed="@IsChanged("ingredients").ToString().ToLowerInvariant()">
-        <label>Ingredients</label>
-        @for (var index = 0; index < Recipe.Ingredients.Count; index++)
-        {
-            var capturedIndex = index;
-            <IngredientRow Ingredient="Recipe.Ingredients[capturedIndex]"
-                           OnRemove="() => RemoveIngredientAsync(capturedIndex)"
-                           IngredientChanged="ingredient => UpdateIngredientAsync(capturedIndex, ingredient)" />
-        }
-        <button class="recipe-editor__add-btn" @onclick="AddIngredientAsync">
-            + Add Ingredient
-        </button>
+        <div class="recipe-editor__section-header">
+            <h2>Ingredients</h2>
+            <button class="recipe-editor__add-btn" @onclick="AddIngredientAsync">
+                + Add Ingredient
+            </button>
+        </div>
+        <div class="recipe-editor__ingredients">
+            @for (var index = 0; index < Recipe.Ingredients.Count; index++)
+            {
+                var capturedIndex = index;
+                <IngredientRow Ingredient="Recipe.Ingredients[capturedIndex]"
+                               OnRemove="() => RemoveIngredientAsync(capturedIndex)"
+                               IngredientChanged="ingredient => UpdateIngredientAsync(capturedIndex, ingredient)" />
+            }
+        </div>
     </div>
 
     <div class="@GetSectionClass("instructions")"
          data-section="instructions"
          data-agent-changed="@IsChanged("instructions").ToString().ToLowerInvariant()">
-        <label>Instructions</label>
-        @for (var index = 0; index < Recipe.Instructions.Count; index++)
-        {
-            var capturedIndex = index;
-            <div class="recipe-editor__instruction">
-                <span class="recipe-editor__step-num">@(capturedIndex + 1).</span>
-                <input type="text"
-                       aria-label="@($"Instruction {capturedIndex + 1}")"
-                       value="@Recipe.Instructions[capturedIndex]"
-                       @oninput="args => UpdateInstructionAsync(capturedIndex, args)" />
-                <button class="recipe-editor__remove-btn"
-                        aria-label="Remove instruction"
-                        @onclick="() => RemoveInstructionAsync(capturedIndex)">&times;</button>
-            </div>
-        }
-        <button class="recipe-editor__add-btn" @onclick="AddInstructionAsync">
-            + Add Step
-        </button>
+        <div class="recipe-editor__section-header">
+            <h2>Instructions</h2>
+            <button class="recipe-editor__add-btn" @onclick="AddInstructionAsync">
+                + Add Step
+            </button>
+        </div>
+        <div class="recipe-editor__instructions">
+            @for (var index = 0; index < Recipe.Instructions.Count; index++)
+            {
+                var capturedIndex = index;
+                <div class="recipe-editor__instruction">
+                    <span class="recipe-editor__step-num">@(capturedIndex + 1)</span>
+                    <textarea aria-label="@($"Instruction {capturedIndex + 1}")"
+                              value="@Recipe.Instructions[capturedIndex]"
+                              @oninput="args => UpdateInstructionAsync(capturedIndex, args)"></textarea>
+                    <button class="recipe-editor__remove-btn"
+                            aria-label="Remove instruction"
+                            @onclick="() => RemoveInstructionAsync(capturedIndex)">&times;</button>
+                </div>
+            }
+        </div>
     </div>
 
     <button class="recipe-editor__improve-btn"
             disabled="@IsRunning"
+            aria-label="@(IsRunning ? "Please Wait..." : "Improve with AI")"
+            aria-busy="@IsRunning.ToString().ToLowerInvariant()"
             @onclick="ImproveAsync">
-        @(IsRunning ? "Please Wait..." : "Improve with AI")
+        @if (IsRunning)
+        {
+            <span class="recipe-editor__spinner" aria-hidden="true"></span>
+            <span role="status" aria-live="polite">Please Wait...</span>
+        }
+        else
+        {
+            <span>Improve with AI</span>
+        }
     </button>
 </div>
 
 @code {
     private static readonly string[] _allPreferences =
     [
-        "Vegetarian",
-        "Vegan",
-        "Gluten-Free",
         "High Protein",
         "Low Carb",
         "Spicy",
+        "Budget-Friendly",
+        "One-Pot Meal",
+        "Vegetarian",
+        "Vegan",
     ];
 
     private AgentContext? _registeredContext;

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/RecipeEditor.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/RecipeEditor.razor.css
@@ -1,24 +1,34 @@
 .recipe-editor {
     background: #fff;
-    border-radius: 12px;
-    box-shadow: 0 1px 3px rgb(0 0 0 / 6%);
-    max-width: 600px;
-    padding: 24px;
+    border-radius: 16px;
+    box-shadow: 0 12px 24px rgb(0 0 0 / 16%);
+    box-sizing: border-box;
+    max-width: 640px;
+    padding: 28px 32px 34px;
+    width: 100%;
 }
 
 .recipe-editor__section {
     border-radius: 8px;
-    margin-bottom: 20px;
+    margin-bottom: 30px;
     position: relative;
     transition: background 0.2s ease;
 }
 
+.recipe-editor__section:first-child {
+    margin-bottom: 13px;
+}
+
+.recipe-editor__section:nth-child(2) {
+    margin-bottom: 31px;
+}
+
 .recipe-editor__section--changed {
-    background: rgb(232 121 90 / 4%);
+    background: rgb(255 101 66 / 5%);
 }
 
 .recipe-editor__section--changed::after {
-    background: #e8795a;
+    background: #ff6542;
     border-radius: 50%;
     content: "";
     height: 8px;
@@ -28,40 +38,94 @@
     width: 8px;
 }
 
-.recipe-editor__section > label:first-child,
-.recipe-editor__field > label:first-child {
-    color: #1a1a1a;
-    display: block;
-    font-size: 1em;
-    font-weight: 700;
-    margin-bottom: 8px;
-}
-
-.recipe-editor__row {
-    display: flex;
-    gap: 16px;
-}
-
-.recipe-editor__field {
-    flex: 1;
-}
-
-.recipe-editor input[type="text"],
-.recipe-editor select {
-    background: #fff;
-    border: 1px solid #e5e7eb;
-    border-radius: 6px;
-    box-sizing: border-box;
+.recipe-editor h2 {
     color: #333;
-    font-size: 0.9em;
-    padding: 8px 12px;
+    font-size: 1.25rem;
+    margin: 0;
+    padding-bottom: 12px;
+    position: relative;
+}
+
+.recipe-editor h2::after {
+    background: #ff6542;
+    bottom: 0;
+    content: "";
+    height: 2px;
+    left: 0;
+    position: absolute;
+    width: 40px;
+}
+
+.recipe-editor__sr-only {
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+}
+
+.recipe-editor__title {
+    background: transparent;
+    border: 0;
+    box-sizing: border-box;
+    color: #151515;
+    font-family: inherit;
+    font-size: 1.55rem;
+    font-weight: 700;
+    outline: 0;
+    padding: 0;
     width: 100%;
+}
+
+.recipe-editor__title:focus-visible {
+    box-shadow: 0 2px #ff6542;
+}
+
+.recipe-editor__details {
+    align-items: center;
+    display: flex;
+    gap: 27px;
+}
+
+.recipe-editor__detail {
+    align-items: center;
+    display: flex;
+    gap: 7px;
+}
+
+.recipe-editor__detail > span {
+    font-size: 1.25rem;
+}
+
+.recipe-editor__detail select {
+    appearance: none;
+    background: transparent;
+    background-image: linear-gradient(45deg, transparent 50%, #929298 50%),
+        linear-gradient(135deg, #929298 50%, transparent 50%);
+    background-position: calc(100% - 10px) 55%, calc(100% - 6px) 55%;
+    background-repeat: no-repeat;
+    background-size: 4px 4px, 4px 4px;
+    border: 0;
+    color: #666;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 1rem;
+    font-weight: 600;
+    outline: 0;
+    padding: 6px 24px 6px 0;
+}
+
+.recipe-editor__detail select:focus-visible {
+    box-shadow: 0 2px #ff6542;
 }
 
 .recipe-editor__checkboxes {
     display: flex;
     flex-wrap: wrap;
-    gap: 12px;
+    gap: 14px 18px;
+    padding-top: 14px;
 }
 
 .recipe-editor__checkbox {
@@ -69,44 +133,104 @@
     color: #333;
     cursor: pointer;
     display: flex;
-    font-size: 0.9em;
+    font-size: 0.875rem;
     gap: 6px;
 }
 
-.recipe-editor__instruction {
-    align-items: center;
+.recipe-editor__checkbox input {
+    accent-color: #ff6542;
+    height: 13px;
+    margin: 0;
+    width: 13px;
+}
+
+.recipe-editor__section-header {
+    align-items: flex-start;
     display: flex;
-    gap: 8px;
-    margin-bottom: 6px;
+    justify-content: space-between;
+}
+
+.recipe-editor__ingredients {
+    display: grid;
+    gap: 10px;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    padding-top: 17px;
+}
+
+.recipe-editor__instructions {
+    padding-top: 18px;
+}
+
+.recipe-editor__instruction {
+    align-items: flex-start;
+    display: flex;
+    gap: 12px;
+    margin-bottom: 14px;
+    position: relative;
 }
 
 .recipe-editor__step-num {
     align-items: center;
-    background: #e8795a;
+    background: #ff6542;
     border-radius: 50%;
+    box-shadow: 0 4px 10px rgb(255 101 66 / 24%);
     color: #fff;
     display: flex;
     flex-shrink: 0;
-    font-size: 0.75em;
+    font-size: 0.95rem;
     font-weight: 600;
-    height: 24px;
+    height: 27px;
     justify-content: center;
-    width: 24px;
+    margin-top: 1px;
+    position: relative;
+    width: 27px;
+    z-index: 1;
+}
+
+.recipe-editor__instruction:not(:last-child)::before {
+    background: #ff6542;
+    content: "";
+    height: calc(100% + 15px);
+    left: 13px;
+    position: absolute;
+    top: 14px;
+    width: 2px;
+}
+
+.recipe-editor__instruction textarea {
+    background: #fff;
+    border: 1px solid #ececf0;
+    border-radius: 11px;
+    box-shadow: 0 3px 8px rgb(0 0 0 / 8%);
+    box-sizing: border-box;
+    color: #333;
+    font-family: inherit;
+    font-size: 0.875rem;
+    line-height: 1.45;
+    min-height: 61px;
+    padding: 14px;
+    resize: vertical;
+    width: 100%;
+}
+
+.recipe-editor__instruction textarea:focus {
+    border-color: #ff6542;
+    outline: 0;
 }
 
 .recipe-editor__add-btn,
 .recipe-editor__improve-btn {
-    border-radius: 8px;
     cursor: pointer;
     font-weight: 600;
 }
 
 .recipe-editor__add-btn {
     background: transparent;
-    border: 1px solid #e8795a;
-    color: #e8795a;
-    margin-top: 4px;
-    padding: 6px 14px;
+    border: 1px dashed #ff6542;
+    border-radius: 9px;
+    color: #ff5935;
+    font-size: 0.875rem;
+    padding: 11px 16px;
 }
 
 .recipe-editor__remove-btn {
@@ -120,17 +244,91 @@
     width: 24px;
 }
 
+.recipe-editor__instruction .recipe-editor__remove-btn {
+    opacity: 0;
+    position: absolute;
+    right: 3px;
+    top: 3px;
+}
+
+.recipe-editor__instruction:hover .recipe-editor__remove-btn,
+.recipe-editor__instruction:focus-within .recipe-editor__remove-btn {
+    opacity: 1;
+}
+
 .recipe-editor__improve-btn {
-    background: #e8795a;
+    align-items: center;
+    background: #ff6542;
     border: 0;
+    border-radius: 999px;
+    box-shadow: 0 8px 16px rgb(255 101 66 / 30%);
     color: #fff;
-    display: block;
-    margin-top: 16px;
-    padding: 12px;
-    width: 100%;
+    display: flex;
+    font-size: 1rem;
+    gap: 8px;
+    justify-content: center;
+    margin: 44px auto 0;
+    min-width: 186px;
+    padding: 16px 25px;
 }
 
 .recipe-editor__improve-btn:disabled {
     cursor: wait;
-    opacity: 0.7;
+    opacity: 0.8;
+}
+
+.recipe-editor__spinner {
+    animation: recipe-editor-spin 800ms linear infinite;
+    border: 2px solid rgb(255 255 255 / 45%);
+    border-radius: 50%;
+    border-top-color: #fff;
+    height: 15px;
+    width: 15px;
+}
+
+@keyframes recipe-editor-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@media (max-width: 48rem) {
+    .recipe-editor {
+        border-radius: 16px;
+        box-shadow: none;
+        max-width: none;
+        padding: 25px 33px 0;
+    }
+
+    .recipe-editor__section {
+        margin-bottom: 30px;
+    }
+
+    .recipe-editor__section:first-child {
+        margin-bottom: 11px;
+    }
+
+    .recipe-editor__details {
+        gap: 19px;
+    }
+
+    .recipe-editor__detail {
+        gap: 6px;
+    }
+
+    .recipe-editor__detail select {
+        font-size: 0.95rem;
+    }
+
+    .recipe-editor__checkboxes {
+        gap: 16px 18px;
+    }
+
+    .recipe-editor__ingredients {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .recipe-editor__improve-btn {
+        margin-top: 47px;
+    }
 }

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/RecipeEditor.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/RecipeEditor.razor.css
@@ -1,0 +1,136 @@
+.recipe-editor {
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgb(0 0 0 / 6%);
+    max-width: 600px;
+    padding: 24px;
+}
+
+.recipe-editor__section {
+    border-radius: 8px;
+    margin-bottom: 20px;
+    position: relative;
+    transition: background 0.2s ease;
+}
+
+.recipe-editor__section--changed {
+    background: rgb(232 121 90 / 4%);
+}
+
+.recipe-editor__section--changed::after {
+    background: #e8795a;
+    border-radius: 50%;
+    content: "";
+    height: 8px;
+    position: absolute;
+    right: 6px;
+    top: 6px;
+    width: 8px;
+}
+
+.recipe-editor__section > label:first-child,
+.recipe-editor__field > label:first-child {
+    color: #1a1a1a;
+    display: block;
+    font-size: 1em;
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+
+.recipe-editor__row {
+    display: flex;
+    gap: 16px;
+}
+
+.recipe-editor__field {
+    flex: 1;
+}
+
+.recipe-editor input[type="text"],
+.recipe-editor select {
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+    box-sizing: border-box;
+    color: #333;
+    font-size: 0.9em;
+    padding: 8px 12px;
+    width: 100%;
+}
+
+.recipe-editor__checkboxes {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.recipe-editor__checkbox {
+    align-items: center;
+    color: #333;
+    cursor: pointer;
+    display: flex;
+    font-size: 0.9em;
+    gap: 6px;
+}
+
+.recipe-editor__instruction {
+    align-items: center;
+    display: flex;
+    gap: 8px;
+    margin-bottom: 6px;
+}
+
+.recipe-editor__step-num {
+    align-items: center;
+    background: #e8795a;
+    border-radius: 50%;
+    color: #fff;
+    display: flex;
+    flex-shrink: 0;
+    font-size: 0.75em;
+    font-weight: 600;
+    height: 24px;
+    justify-content: center;
+    width: 24px;
+}
+
+.recipe-editor__add-btn,
+.recipe-editor__improve-btn {
+    border-radius: 8px;
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.recipe-editor__add-btn {
+    background: transparent;
+    border: 1px solid #e8795a;
+    color: #e8795a;
+    margin-top: 4px;
+    padding: 6px 14px;
+}
+
+.recipe-editor__remove-btn {
+    background: transparent;
+    border: 0;
+    color: #9ca3af;
+    cursor: pointer;
+    flex-shrink: 0;
+    font-size: 0.8em;
+    height: 24px;
+    width: 24px;
+}
+
+.recipe-editor__improve-btn {
+    background: #e8795a;
+    border: 0;
+    color: #fff;
+    display: block;
+    margin-top: 16px;
+    padding: 12px;
+    width: 100%;
+}
+
+.recipe-editor__improve-btn:disabled {
+    cursor: wait;
+    opacity: 0.7;
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/RecipeSuggestions.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/RecipeSuggestions.razor
@@ -1,0 +1,40 @@
+@implements IDisposable
+
+<div class="recipe-suggestions">
+    <button disabled="@IsRunning"
+            @onclick='() => SendAsync("Create a delicious Italian pasta recipe.")'>
+        Create Italian recipe
+    </button>
+    <button disabled="@IsRunning"
+            @onclick='() => SendAsync("Make the recipe healthier with more vegetables.")'>
+        Make it healthier
+    </button>
+    <button disabled="@IsRunning"
+            @onclick='() => SendAsync("Suggest some creative variations of this recipe.")'>
+        Suggest variations
+    </button>
+</div>
+
+@code {
+    private IDisposable? _statusChangedRegistration;
+
+    [CascadingParameter]
+    public AgentContext AgentContext { get; set; } = default!;
+
+    private bool IsRunning
+        => AgentContext.Status is ConversationStatus.Streaming or ConversationStatus.AwaitingInput;
+
+    protected override void OnInitialized()
+    {
+        _statusChangedRegistration = AgentContext.RegisterOnStatusChanged(OnStatusChanged);
+    }
+
+    private void OnStatusChanged(ConversationStatus status)
+    {
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private Task SendAsync(string prompt) => AgentContext.SendMessageAsync(prompt);
+
+    public void Dispose() => _statusChangedRegistration?.Dispose();
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/RecipeSuggestions.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/RecipeSuggestions.razor.css
@@ -2,19 +2,27 @@
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
-    padding: 0 16px 12px;
+    padding: 0 48px 12px;
 }
 
 .recipe-suggestions button {
     background: #fff;
-    border: 1px solid #e8795a;
+    border: 1px solid #e5e5e8;
     border-radius: 999px;
-    color: #b84f35;
+    color: #111;
     cursor: pointer;
-    padding: 6px 10px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 7px 12px;
 }
 
 .recipe-suggestions button:disabled {
     cursor: wait;
     opacity: 0.6;
+}
+
+@media (max-width: 48rem) {
+    .recipe-suggestions {
+        padding: 0 16px 12px;
+    }
 }

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/RecipeSuggestions.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/RecipeSuggestions.razor.css
@@ -1,0 +1,20 @@
+.recipe-suggestions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 0 16px 12px;
+}
+
+.recipe-suggestions button {
+    background: #fff;
+    border: 1px solid #e8795a;
+    border-radius: 999px;
+    color: #b84f35;
+    cursor: pointer;
+    padding: 6px 10px;
+}
+
+.recipe-suggestions button:disabled {
+    cursor: wait;
+    opacity: 0.6;
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/SharedStateConversationThread.cs
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/SharedStateConversationThread.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.AI;
+using Microsoft.Extensions.AI;
+
+namespace DojoClient.Components.Scenarios.SharedState;
+
+internal sealed class SharedStateConversationThread : IConversationThread
+{
+    private readonly List<ChatResponseUpdate> _updates = [];
+    private List<ChatResponseUpdate>? _currentTurn;
+
+    internal SharedStateConversationThread(string threadId)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(threadId);
+        ThreadId = threadId;
+    }
+
+    public string ThreadId { get; }
+
+    public bool IsStateful { get; private set; }
+
+    public string? ConversationId { get; private set; }
+
+    public void AppendUserMessage(ChatMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        _currentTurn =
+        [
+            new ChatResponseUpdate
+            {
+                Role = message.Role,
+                Contents = [.. message.Contents],
+            },
+        ];
+    }
+
+    public void AppendUpdate(ChatResponseUpdate update)
+    {
+        ArgumentNullException.ThrowIfNull(update);
+        _currentTurn?.Add(update);
+
+        if (update.ConversationId is not null)
+        {
+            IsStateful = true;
+            ConversationId = update.ConversationId;
+        }
+    }
+
+    public void CompleteTurn()
+    {
+        if (_currentTurn is not null)
+        {
+            _updates.AddRange(_currentTurn);
+            _currentTurn = null;
+        }
+    }
+
+    public IReadOnlyList<ChatResponseUpdate> GetUpdates() => _updates;
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/SharedStateScenario.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/SharedStateScenario.razor
@@ -14,26 +14,51 @@
                               RecipeChanged="HandleRecipeChanged"
                               ChangedSections="_changedSections" />
             </main>
-            <aside class="shared-state-chat">
-                <header class="shared-state-chat__header">
+            <button class="shared-state-chat__open"
+                    aria-label="Open chat"
+                    @onclick="OpenChat">
+                <span aria-hidden="true">Chat</span>
+            </button>
+            <aside class="@GetChatClass()" aria-label="Copilot chat sidebar">
+                <header class="shared-state-chat__desktop-header">
                     <h1>AI Recipe Assistant</h1>
-                    <button aria-label="Reset recipe" @onclick="Reset">&times;</button>
+                    <button aria-label="Close chat" @onclick="CloseChat">&times;</button>
                 </header>
-                <div class="sc-ai-root sc-ai-chat-page dojo-chat-panel">
+                <button class="shared-state-chat__mobile-header"
+                        type="button"
+                        aria-expanded="@_isMobileChatOpen.ToString().ToLowerInvariant()"
+                        aria-controls="shared-state-chat-content"
+                        @onclick="ToggleMobileChat">
+                    <span>
+                        <strong>AI Recipe Assistant</strong>
+                        <small>Ask me to craft recipes</small>
+                    </span>
+                    <span class="shared-state-chat__chevron" aria-hidden="true"></span>
+                </button>
+                <div id="shared-state-chat-content"
+                     class="sc-ai-root sc-ai-chat-page dojo-chat-panel">
                     <div class="sc-ai-chat-page__body">
                         <MessageList>
                             <EmptyContent>
-                                <p class="dojo-scenario__welcome">
-                                    Edit the recipe yourself or ask the agent to improve it.
-                                </p>
+                                <h2 class="shared-state-chat__welcome">How can I help you today?</h2>
                             </EmptyContent>
                         </MessageList>
                     </div>
                     <RecipeSuggestions />
                     <div class="sc-ai-chat-page__footer">
                         <div class="sc-ai-chat-page__input-container">
-                            <MessageInput Placeholder="Type a message..." />
+                            <MessageInput Placeholder="Type a message...">
+                                <LeadingActions>
+                                    <button class="shared-state-chat__add"
+                                            type="button"
+                                            aria-label="Add attachment">+</button>
+                                </LeadingActions>
+                            </MessageInput>
+                            <StopResponseButton />
                         </div>
+                        <p class="shared-state-chat__disclaimer">
+                            AI can make mistakes. Please verify important information.
+                        </p>
                     </div>
                 </div>
             </aside>
@@ -51,6 +76,8 @@
     private IDisposable? _stateChangedRegistration;
     private Recipe _lastRecipe = default!;
     private bool _isApplyingLocalState;
+    private bool _isDesktopChatClosed;
+    private bool _isMobileChatOpen;
 
     [Inject(Key = DojoScenarios.SharedStateEndpoint)]
     public IChatClient ChatClient { get; set; } = default!;
@@ -112,6 +139,27 @@
         _lastRecipe = _agent.State.Value.Recipe;
         _changedSections.Clear();
         _stateChangedRegistration = _agent.State.OnChanged(OnStateChanged);
+    }
+
+    private void CloseChat() => _isDesktopChatClosed = true;
+
+    private void OpenChat() => _isDesktopChatClosed = false;
+
+    private void ToggleMobileChat() => _isMobileChatOpen = !_isMobileChatOpen;
+
+    private string GetChatClass()
+    {
+        var cssClass = "shared-state-chat";
+        if (_isDesktopChatClosed)
+        {
+            cssClass += " shared-state-chat--desktop-closed";
+        }
+        if (_isMobileChatOpen)
+        {
+            cssClass += " shared-state-chat--mobile-open";
+        }
+
+        return cssClass;
     }
 
     private void OnStateChanged()

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/SharedStateScenario.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/SharedStateScenario.razor
@@ -76,17 +76,16 @@
             {
                 if (context.Update.RawRepresentation is not StateSnapshotEvent snapshot)
                 {
-                    return false;
+                    return;
                 }
 
                 var state = snapshot.Snapshot.Deserialize<RecipeState>(_jsonOptions);
                 if (state?.Recipe is null)
                 {
-                    return false;
+                    return;
                 }
 
                 context.SetState(state);
-                return true;
             };
         }, LoggerFactory, initialState);
     }

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/SharedStateScenario.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/SharedStateScenario.razor
@@ -96,7 +96,7 @@
                 RawRepresentationFactory = _ => new RunAgentInput
                 {
                     ThreadId = _thread.ThreadId,
-                    State = JsonSerializer.SerializeToElement(_agent.State.Value, _jsonOptions),
+                    State = JsonSerializer.SerializeToElement(options.State.Value, _jsonOptions),
                 },
             };
             options.StateMapper = context =>

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/SharedStateScenario.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/SharedStateScenario.razor
@@ -1,0 +1,189 @@
+@page "/shared_state"
+@rendermode InteractiveServer
+@implements IDisposable
+@using System.Text.Json
+@inject ILoggerFactory LoggerFactory
+
+<PageTitle>Shared State</PageTitle>
+
+<div class="shared-state" data-scenario="shared_state">
+    <AgentBoundary @key="_agent" Agent="_agent">
+        <div class="shared-state-layout">
+            <main class="recipe-panel">
+                <RecipeEditor Recipe="_agent.State.Value.Recipe"
+                              RecipeChanged="HandleRecipeChanged"
+                              ChangedSections="_changedSections" />
+            </main>
+            <aside class="shared-state-chat">
+                <header class="shared-state-chat__header">
+                    <h1>AI Recipe Assistant</h1>
+                    <button aria-label="Reset recipe" @onclick="Reset">&times;</button>
+                </header>
+                <div class="sc-ai-root sc-ai-chat-page dojo-chat-panel">
+                    <div class="sc-ai-chat-page__body">
+                        <MessageList>
+                            <EmptyContent>
+                                <p class="dojo-scenario__welcome">
+                                    Edit the recipe yourself or ask the agent to improve it.
+                                </p>
+                            </EmptyContent>
+                        </MessageList>
+                    </div>
+                    <RecipeSuggestions />
+                    <div class="sc-ai-chat-page__footer">
+                        <div class="sc-ai-chat-page__input-container">
+                            <MessageInput Placeholder="Type a message..." />
+                        </div>
+                    </div>
+                </div>
+            </aside>
+        </div>
+    </AgentBoundary>
+</div>
+
+@code {
+    private static readonly JsonSerializerOptions _jsonOptions =
+        new(JsonSerializerDefaults.Web);
+
+    private readonly HashSet<string> _changedSections = new(StringComparer.Ordinal);
+    private UIAgent<RecipeState> _agent = default!;
+    private SharedStateConversationThread _thread = default!;
+    private IDisposable? _stateChangedRegistration;
+    private Recipe _lastRecipe = default!;
+    private bool _isApplyingLocalState;
+
+    [Inject(Key = DojoScenarios.SharedStateEndpoint)]
+    public IChatClient ChatClient { get; set; } = default!;
+
+    protected override void OnInitialized() => Reset();
+
+    private UIAgent<RecipeState> CreateAgent(RecipeState initialState)
+    {
+        _thread = new SharedStateConversationThread(Guid.NewGuid().ToString("N"));
+
+        return new UIAgent<RecipeState>(ChatClient, options =>
+        {
+            options.Thread = _thread;
+            options.ChatOptions = new ChatOptions
+            {
+                RawRepresentationFactory = _ => new RunAgentInput
+                {
+                    ThreadId = _thread.ThreadId,
+                    State = JsonSerializer.SerializeToElement(_agent.State.Value, _jsonOptions),
+                },
+            };
+            options.StateMapper = context =>
+            {
+                if (context.Update.RawRepresentation is not StateSnapshotEvent snapshot)
+                {
+                    return false;
+                }
+
+                var state = snapshot.Snapshot.Deserialize<RecipeState>(_jsonOptions);
+                if (state?.Recipe is null)
+                {
+                    return false;
+                }
+
+                context.SetState(state);
+                return true;
+            };
+        }, LoggerFactory, initialState);
+    }
+
+    private void HandleRecipeChanged(Recipe recipe)
+    {
+        _isApplyingLocalState = true;
+        try
+        {
+            _agent.State.Value = new RecipeState { Recipe = recipe };
+        }
+        finally
+        {
+            _isApplyingLocalState = false;
+        }
+    }
+
+    private void Reset()
+    {
+        var nextAgent = CreateAgent(CreateDefaultRecipe());
+        _stateChangedRegistration?.Dispose();
+        _agent?.Dispose();
+        _agent = nextAgent;
+        _lastRecipe = _agent.State.Value.Recipe;
+        _changedSections.Clear();
+        _stateChangedRegistration = _agent.State.OnChanged(OnStateChanged);
+    }
+
+    private void OnStateChanged()
+    {
+        var recipe = _agent.State.Value.Recipe;
+        _changedSections.Clear();
+        if (!_isApplyingLocalState)
+        {
+            AddChangedSections(_lastRecipe, recipe);
+        }
+
+        _lastRecipe = recipe;
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private void AddChangedSections(Recipe previous, Recipe current)
+    {
+        if (previous.Title != current.Title)
+        {
+            _changedSections.Add("title");
+        }
+        if (previous.SkillLevel != current.SkillLevel ||
+            previous.CookingTime != current.CookingTime)
+        {
+            _changedSections.Add("details");
+        }
+        if (!previous.SpecialPreferences.SequenceEqual(
+            current.SpecialPreferences,
+            StringComparer.Ordinal))
+        {
+            _changedSections.Add("preferences");
+        }
+        if (!previous.Ingredients.SequenceEqual(current.Ingredients))
+        {
+            _changedSections.Add("ingredients");
+        }
+        if (!previous.Instructions.SequenceEqual(current.Instructions, StringComparer.Ordinal))
+        {
+            _changedSections.Add("instructions");
+        }
+    }
+
+    private static RecipeState CreateDefaultRecipe() => new()
+    {
+        Recipe = new Recipe
+        {
+            Title = "Make Your Recipe",
+            SkillLevel = "Intermediate",
+            CookingTime = "45 min",
+            Ingredients =
+            [
+                new Ingredient
+                {
+                    Icon = "\U0001F955",
+                    Name = "Carrots",
+                    Amount = "3 large, grated",
+                },
+                new Ingredient
+                {
+                    Icon = "\U0001F33E",
+                    Name = "All-Purpose Flour",
+                    Amount = "2 cups",
+                },
+            ],
+            Instructions = ["Preheat oven to 350\u00B0F (175\u00B0C)"],
+        },
+    };
+
+    public void Dispose()
+    {
+        _stateChangedRegistration?.Dispose();
+        _agent?.Dispose();
+    }
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/SharedStateScenario.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/SharedStateScenario.razor.css
@@ -1,0 +1,69 @@
+.shared-state {
+    height: 100vh;
+    min-height: 0;
+    min-width: 0;
+}
+
+.shared-state-layout {
+    display: flex;
+    height: 100%;
+    min-height: 0;
+    min-width: 0;
+}
+
+.recipe-panel {
+    background: #f9fafb;
+    flex: 1;
+    min-height: 0;
+    min-width: 0;
+    overflow-y: auto;
+    padding: 24px;
+}
+
+.shared-state-chat {
+    background: #fff;
+    border-left: 1px solid #e5e7eb;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    min-width: 320px;
+    width: 380px;
+}
+
+.shared-state-chat__header {
+    align-items: center;
+    border-bottom: 1px solid #e5e7eb;
+    display: flex;
+    justify-content: space-between;
+    padding: 12px 16px;
+}
+
+.shared-state-chat__header h1 {
+    font-size: 1.125rem;
+    margin: 0;
+}
+
+.shared-state-chat__header button {
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    font-size: 1.25rem;
+}
+
+.shared-state-chat .dojo-chat-panel {
+    flex: 1;
+    min-height: 0;
+}
+
+@media (max-width: 48rem) {
+    .shared-state-layout {
+        flex-direction: column;
+    }
+
+    .shared-state-chat {
+        border-left: 0;
+        border-top: 1px solid #e5e7eb;
+        min-height: 36rem;
+        width: 100%;
+    }
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/SharedStateScenario.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/SharedStateScenario.razor.css
@@ -1,23 +1,27 @@
 .shared-state {
-    height: 100vh;
-    min-height: 0;
+    background: #f8f8fb;
+    min-height: 100vh;
+    min-height: 100dvh;
     min-width: 0;
 }
 
 .shared-state-layout {
     display: flex;
-    height: 100%;
-    min-height: 0;
+    min-height: 100vh;
+    min-height: 100dvh;
     min-width: 0;
 }
 
 .recipe-panel {
-    background: #f9fafb;
+    align-items: flex-start;
+    background: #f8f8fb;
+    display: flex;
     flex: 1;
+    justify-content: center;
     min-height: 0;
     min-width: 0;
     overflow-y: auto;
-    padding: 24px;
+    padding: 118px 24px 96px;
 }
 
 .shared-state-chat {
@@ -27,43 +31,277 @@
     flex-direction: column;
     min-height: 0;
     min-width: 320px;
-    width: 380px;
+    width: 480px;
 }
 
-.shared-state-chat__header {
+.shared-state-chat--desktop-closed {
+    display: none;
+}
+
+.shared-state-chat__desktop-header {
     align-items: center;
     border-bottom: 1px solid #e5e7eb;
     display: flex;
-    justify-content: space-between;
-    padding: 12px 16px;
+    flex: 0 0 64px;
+    justify-content: center;
+    padding: 0 32px;
+    position: relative;
 }
 
-.shared-state-chat__header h1 {
-    font-size: 1.125rem;
+.shared-state-chat__desktop-header h1 {
+    font-size: 1rem;
     margin: 0;
 }
 
-.shared-state-chat__header button {
+.shared-state-chat__desktop-header button {
     background: transparent;
     border: 0;
+    color: #6b6b6b;
     cursor: pointer;
-    font-size: 1.25rem;
+    font-size: 1.5rem;
+    line-height: 1;
+    padding: 8px;
+    position: absolute;
+    right: 17px;
+    top: 12px;
 }
 
 .shared-state-chat .dojo-chat-panel {
     flex: 1;
+    height: auto;
     min-height: 0;
+}
+
+.shared-state-chat__mobile-header {
+    display: none;
+}
+
+.shared-state-chat__welcome {
+    align-items: center;
+    display: flex;
+    font-size: 1.55rem;
+    height: 100%;
+    justify-content: center;
+    margin: 0;
+    text-align: center;
+}
+
+.shared-state-chat__open {
+    background: #fff;
+    border: 1px solid #d9d9de;
+    border-radius: 999px 0 0 999px;
+    box-shadow: 0 4px 16px rgb(0 0 0 / 12%);
+    cursor: pointer;
+    display: none;
+    font-weight: 600;
+    padding: 12px 18px;
+    position: fixed;
+    right: 0;
+    top: 20px;
+    z-index: 2;
+}
+
+.shared-state-chat__open {
+    display: none;
+}
+
+.shared-state-layout:has(.shared-state-chat--desktop-closed) > .shared-state-chat__open {
+    display: block;
+}
+
+.shared-state-chat ::deep .sc-ai-message-list {
+    max-width: none;
+    padding: 40px 32px 24px;
+}
+
+.shared-state-chat ::deep .sc-ai-message-list:has(.shared-state-chat__welcome) {
+    height: 100%;
+}
+
+.shared-state-chat ::deep .sc-ai-chat-page__footer {
+    border-top: 0;
+    padding: 16px 32px 23px;
+}
+
+.shared-state-chat ::deep .sc-ai-chat-page__input-container {
+    max-width: none;
+    position: relative;
+}
+
+.shared-state-chat ::deep .sc-ai-input {
+    align-items: center;
+    border-color: #d9d9de;
+    border-radius: 28px;
+    gap: 4px;
+    min-height: 68px;
+    padding: 5px 12px 5px 18px;
+}
+
+.shared-state-chat ::deep .sc-ai-input:focus-within {
+    border-color: #a6a6ab;
+}
+
+.shared-state-chat ::deep .sc-ai-input__textarea {
+    min-height: 48px;
+    padding: 13px 8px;
+}
+
+.shared-state-chat ::deep .sc-ai-input__send {
+    background: #ededf0;
+    color: #8a8a90;
+}
+
+.shared-state-chat ::deep .sc-ai-input:not(:has(.sc-ai-input__textarea:placeholder-shown)) .sc-ai-input__send {
+    background: #1a1a1a;
+    color: #fff;
+}
+
+.shared-state-chat ::deep .sc-ai-input:has(.sc-ai-input__textarea:placeholder-shown) .sc-ai-input__send {
+    pointer-events: none;
+}
+
+.shared-state-chat ::deep .sc-ai-input__send svg {
+    transform: rotate(-45deg);
+}
+
+.shared-state-chat ::deep .shared-state-chat__add {
+    background: transparent;
+    border: 0;
+    color: #9a9a9f;
+    cursor: pointer;
+    font-size: 1.7rem;
+    line-height: 1;
+    padding: 0 4px;
+}
+
+.shared-state-chat__disclaimer {
+    color: #77777d;
+    font-size: 0.75rem;
+    margin: 12px 0 0;
+    text-align: center;
+}
+
+.shared-state-chat ::deep .shared-state-stop {
+    align-items: center;
+    background: #050505;
+    border: 0;
+    border-radius: 50%;
+    bottom: 13px;
+    color: #fff;
+    cursor: pointer;
+    display: flex;
+    height: 36px;
+    justify-content: center;
+    position: absolute;
+    right: 13px;
+    width: 36px;
+}
+
+.shared-state-chat ::deep .shared-state-stop::after {
+    background: currentColor;
+    border-radius: 2px;
+    content: "";
+    height: 13px;
+    width: 13px;
+}
+
+.shared-state-chat ::deep .sc-ai-input:has(+ .shared-state-stop) .sc-ai-input__send {
+    visibility: hidden;
 }
 
 @media (max-width: 48rem) {
     .shared-state-layout {
-        flex-direction: column;
+        display: block;
+        min-height: 100dvh;
+    }
+
+    .recipe-panel {
+        display: block;
+        overflow: visible;
+        padding: 24px 0 22px;
     }
 
     .shared-state-chat {
+        border-bottom: 0;
         border-left: 0;
         border-top: 1px solid #e5e7eb;
-        min-height: 36rem;
+        display: flex;
+        min-height: 0;
+        min-width: 0;
+        position: sticky;
+        bottom: 0;
         width: 100%;
+        z-index: 3;
+    }
+
+    .shared-state-chat--desktop-closed {
+        display: flex;
+    }
+
+    .shared-state-chat__desktop-header {
+        display: none;
+    }
+
+    .shared-state-chat__mobile-header {
+        align-items: center;
+        background: #fff;
+        border: 0;
+        cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        min-height: 69px;
+        padding: 12px 17px;
+        text-align: left;
+        width: 100%;
+    }
+
+    .shared-state-chat__mobile-header span:first-child {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+    }
+
+    .shared-state-chat__mobile-header strong {
+        font-size: 1rem;
+    }
+
+    .shared-state-chat__mobile-header small {
+        color: #77777d;
+        font-size: 0.875rem;
+    }
+
+    .shared-state-chat__chevron {
+        border-left: 2px solid #9ca3af;
+        border-top: 2px solid #9ca3af;
+        height: 10px;
+        margin-right: 6px;
+        transform: rotate(45deg);
+        transition: transform 150ms ease;
+        width: 10px;
+    }
+
+    .shared-state-chat--mobile-open .shared-state-chat__chevron {
+        transform: rotate(225deg);
+    }
+
+    .shared-state-chat .dojo-chat-panel {
+        display: none;
+    }
+
+    .shared-state-chat--mobile-open .dojo-chat-panel {
+        display: flex;
+        height: min(70dvh, 36rem);
+    }
+
+    .shared-state-chat__open {
+        display: none !important;
+    }
+
+    .shared-state-chat ::deep .sc-ai-chat-page__footer {
+        padding: 12px 16px 18px;
+    }
+
+    .shared-state-chat ::deep .sc-ai-message-list {
+        padding: 24px 16px;
     }
 }

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/StopResponseButton.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/StopResponseButton.razor
@@ -1,0 +1,31 @@
+@implements IDisposable
+
+@if (IsRunning)
+{
+    <button class="shared-state-stop"
+            type="button"
+            aria-label="Stop response"
+            @onclick="AgentContext.CancelAsync"></button>
+}
+
+@code {
+    private IDisposable? _statusChangedRegistration;
+
+    [CascadingParameter]
+    public AgentContext AgentContext { get; set; } = default!;
+
+    private bool IsRunning
+        => AgentContext.Status is ConversationStatus.Streaming or ConversationStatus.AwaitingInput;
+
+    protected override void OnInitialized()
+    {
+        _statusChangedRegistration = AgentContext.RegisterOnStatusChanged(OnStatusChanged);
+    }
+
+    private void OnStatusChanged(ConversationStatus status)
+    {
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose() => _statusChangedRegistration?.Dispose();
+}

--- a/src/Components/AI/testassets/DojoClient/Components/_Imports.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/_Imports.razor
@@ -13,4 +13,5 @@
 @using DojoClient.Components.Scenarios.HumanInTheLoop
 @using DojoClient.Components.Scenarios.ToolBasedGenerativeUI
 @using DojoClient.Components.Scenarios.AgenticGenerativeUI
+@using DojoClient.Components.Scenarios.SharedState
 @using DojoClient.Components.Layout

--- a/src/Components/AI/testassets/DojoClient/DojoScenarios.cs
+++ b/src/Components/AI/testassets/DojoClient/DojoScenarios.cs
@@ -17,4 +17,6 @@ internal static class DojoScenarios
     internal const string ToolBasedGenerativeUIEndpoint = "/tool_based_generative_ui";
 
     internal const string AgenticGenerativeUIEndpoint = "/agentic_generative_ui";
+
+    internal const string SharedStateEndpoint = "/shared_state";
 }

--- a/src/Components/AI/testassets/DojoClient/Program.cs
+++ b/src/Components/AI/testassets/DojoClient/Program.cs
@@ -37,6 +37,9 @@ builder.Services.AddKeyedScoped<IChatClient>(
 builder.Services.AddKeyedScoped<IChatClient>(
     DojoScenarios.AgenticGenerativeUIEndpoint,
     (sp, _) => CreateChatClient(sp, DojoScenarios.AgenticGenerativeUIEndpoint));
+builder.Services.AddKeyedScoped<IChatClient>(
+    DojoScenarios.SharedStateEndpoint,
+    (sp, _) => CreateChatClient(sp, DojoScenarios.SharedStateEndpoint));
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Overview

Position 8 in the native Components.AI stack tracked by #68340, this layer depends on #68333 and adds persistent conversation threads plus the canonical Shared State recipe dojo. Relative to parent `javiercn-components-ai-07-agentic-generative-ui` (`913754f3988a8d4ebc6ddb29785a25bbe796c458`), the stack-relative diff contains the product runtime contracts, the recipe scenario, focused tests, and its generated replay. The cross-cutting constraint is that product code remains provider/protocol-neutral while DojoClient keeps the real `AGUIChatClient` 0.0.5 -> HTTP/SSE -> AGUIDojoApi/AGUI.Server 0.0.5 path.

## Design

The new product contract stores raw streamed chat updates rather than rendered UI blocks or AG-UI events. That keeps persistence owned by the application, lets restoration reuse the existing block/state mapping pipeline, and avoids coupling Components.AI to a transport protocol.

```csharp
// src/Components/AI/src/Engine/IConversationThread.cs
// The thread owns persistence and service identity; Components.AI only defines lifecycle boundaries.
public interface IConversationThread
{
    string ThreadId { get; }
    bool IsStateful { get; }
    string? ConversationId { get; }

    void AppendMessages(IEnumerable<ChatMessage> messages);
    void AppendUpdate(ChatResponseUpdate update);
    void CompleteTurn();
    IReadOnlyList<ChatResponseUpdate> GetUpdates();
}
```

```csharp
// src/Components/AI/src/Pipeline/UIAgentOptions.cs
// Opt-in preserves existing stateless behavior when no thread is configured.
public IConversationThread? Thread { get; set; }

// src/Components/AI/src/Engine/UIAgent.cs
// Replays committed updates through the same state mapper and content pipeline used live.
public Task<IReadOnlyList<ContentBlock>> RestoreAsync(
    CancellationToken cancellationToken = default);

// src/Components/AI/src/Engine/AgentContext.cs
// Reconstructs ConversationTurn instances for UI consumers without firing live-stream callbacks.
public Task RestoreAsync(CancellationToken cancellationToken = default);
```

The lifecycle has three equivalence classes, each represented once in the implementation and tests: a successful stream appends every request message and response update before committing atomically; a failed or cancelled partial stream never reaches `CompleteTurn`; restoration replays only committed updates into temporary history and a clean typed-state scope, then commits both together. A failed or cancelled restore leaves the previous history and state unchanged, while an empty thread clears both. For stateful providers, the thread-captured `ConversationId` is forwarded on the next request; stateless providers continue to receive the full reconstructed history.

## Implementation

`UIAgent` starts a pending turn before model invocation, forwards service conversation identity when present, and deliberately commits only after streaming, mapping, finalization, and history reconstruction all complete. The placement of `CompleteTurn` is the failure-safety guarantee: an exception or cancellation inside the loop leaves no committed partial turn.

```csharp
// src/Components/AI/src/Engine/UIAgent.cs
var thread = _options.Thread;
foreach (var message in messages)
{
    _history.Add(message);
}

thread?.AppendMessages(messages);

var chatOptions = BuildChatOptions();
if (thread is { IsStateful: true, ConversationId: not null })
{
    // A service-managed conversation resumes by ID; other threads retain full local history.
    chatOptions = chatOptions?.Clone() ?? new ChatOptions();
    chatOptions.ConversationId = thread.ConversationId;
}

await foreach (var update in _chatClient.GetStreamingResponseAsync(
    _history, chatOptions, cancellationToken).ConfigureAwait(false))
{
    thread?.AppendUpdate(update);

    // Live and restored updates share the same typed-state mapper and block pipeline.
    var processUpdate = ApplyStateMapper(update);
    if (processUpdate.Contents.Count == 0 && update.Contents.Count > 0)
    {
        continue;
    }

    assistantUpdates.Add(processUpdate);
    await foreach (var block in pipeline.Process(processUpdate, cancellationToken).ConfigureAwait(false))
    {
        yield return block;
    }
}

// This line is unreachable for a failed/cancelled stream, so partial updates are not persisted.
thread?.CompleteTurn();
```

Restoration treats both user and tool messages as request boundaries, groups assistant updates back into messages, and feeds every assistant update through `ApplyStateMapper`. History is rebuilt separately while typed state suppresses intermediate notifications and resets to a new `TState` before replay, which lets state deltas read the restored value rather than stale live state. `AgentContext.RestoreAsync` rejects active turns and replaces turns, status, error, retry state, and the previous cancellation source only after agent restoration succeeds.

The dojo is the protocol adapter. Local editor changes replace the same typed `RecipeState` read by `RunAgentInput.State`; AG-UI state snapshots deserialize back into that state. A stable thread ID is supplied on every request, while the product runtime sees only `IConversationThread`, `ChatOptions`, and `ChatResponseUpdate`.

```csharp
// src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/SharedStateScenario.razor
_thread = new SharedStateConversationThread(Guid.NewGuid().ToString("N"));

return new UIAgent<RecipeState>(ChatClient, options =>
{
    options.Thread = _thread;
    options.ChatOptions = new ChatOptions
    {
        RawRepresentationFactory = _ => new RunAgentInput
        {
            ThreadId = _thread.ThreadId,
            // Each turn serializes the latest user-or-agent-edited recipe, not the initial copy.
            State = JsonSerializer.SerializeToElement(_agent.State.Value, _jsonOptions),
        },
    };
    options.StateMapper = context =>
    {
        if (context.Update.RawRepresentation is not StateSnapshotEvent snapshot)
        {
            return;
        }

        var state = snapshot.Snapshot.Deserialize<RecipeState>(_jsonOptions);
        if (state?.Recipe is not null)
        {
            context.SetState(state);
        }
    };
}, LoggerFactory, initialState);
```

Recipe fields form one editor equivalence class: title, details, preferences, ingredients, and instructions all update immutable recipe records through `RecipeChanged`; section comparison only adds presentation highlighting for agent-originated changes. On the API side, one `generate_recipe` tool returns the complete recipe and AGUI.Server maps that result to a state snapshot:

```csharp
// src/Components/AI/testassets/AGUIDojoApi/ChatClientAgentFactory.cs
var options = new AGUIStreamOptions();
options.MapResultAsStateSnapshot("generate_recipe");
return options;
```

The permanent browser replay replaces only AGUIDojoApi's model. Request assertions inspect the real API-side `RunAgentInput` for exact JSON state and one stable non-empty thread ID; DojoClient's keyed `AGUIChatClient`, both hosts, HTTP POST, SSE stream, tool invocation, and state mapping remain production code.

```csharp
// src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/SharedStateScenarioTests.cs
// First local edits must reach the model request and survive the first agent snapshot.
await editor.GetByLabel("Ingredient name").First.FillAsync("Zucchini");
await editor.GetByLabel("Ingredient amount").First.FillAsync("2, sliced");
await input.FillAsync(_firstPrompt);
await send.ClickAsync();
await _checkpoints.ReleaseAsync(_firstPrompt, "before-italian-recipe");
await Expect(editor.GetByLabel("Ingredient amount").Nth(1)).ToHaveValueAsync("2, sliced");

// The same field is edited again before turn two; the second snapshot must preserve the new value.
await editor.GetByLabel("Ingredient amount").Nth(1).FillAsync("3, sliced");
await input.FillAsync(_secondPrompt);
await send.ClickAsync();
await _checkpoints.ReleaseAsync(_secondPrompt, "before-herbed-recipe");
await Expect(editor.GetByLabel("Ingredient amount").Nth(1)).ToHaveValueAsync("3, sliced");
await Expect(editor.GetByLabel("Ingredient name").Last).ToHaveValueAsync("Fresh Basil");
```

## Outcome

| Equivalence class | Result |
|---|---|
| Dependency-aware Dojo E2E build | Passed with 0 warnings and 0 errors |
| Thread lifecycle, conversation identity, restoration, and typed state | 14/14 focused runtime tests passed |
| Shared recipe state over the real dual-host AG-UI transport | 1/1 filtered `SharedStateScenarioTests` passed |

Review the product contract and `UIAgent` commit/restore boundaries first, then the DojoClient `RunAgentInput` serialization and API snapshot mapping; the recipe CSS and repeated editor-field markup can be skimmed. Acceptance criteria: manual recipe edits must be present in the next API request, a stable thread must span model calls and browser turns, agent snapshots must preserve unrelated/latest user edits, failed streams must not commit partial history, and restored state/history must behave like live state/history.
