### PR TITLE
[Blazor] Add predictive state updates

### DIFF
--- a/src/Components/AI/src/Engine/AgentContext.cs
+++ b/src/Components/AI/src/Engine/AgentContext.cs
@@ -215,6 +215,7 @@ public class AgentContext : IDisposable
         _disposed = true;
         _streamingCts?.Cancel();
         _streamingCts?.Dispose();
+        _agent.RejectPendingPredictiveState();
         _turnAddedCallbacks.Clear();
         _statusChangedCallbacks.Clear();
         _blockAddedCallbacks.Clear();
@@ -275,6 +276,7 @@ public class AgentContext : IDisposable
                 NotifyStatusChanged();
             }
 
+            _agent.RejectPendingPredictiveState();
             Status = ConversationStatus.Idle;
             if (cancellationToken.IsCancellationRequested)
             {
@@ -285,6 +287,7 @@ public class AgentContext : IDisposable
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             turn.ClearResponseBlocks();
+            _agent.RejectPendingPredictiveState();
             Status = ConversationStatus.Idle;
             NotifyStatusChanged();
         }
@@ -293,6 +296,7 @@ public class AgentContext : IDisposable
             // A failing turn is surfaced as conversation state (Status/Error) rather than a
             // faulted Task: the UI renders the error and RetryAsync replays the last message.
             // This is the engine's error contract, not a swallowed exception.
+            _agent.RejectPendingPredictiveState();
             Error = ex;
             Status = ConversationStatus.Error;
             NotifyStatusChanged();

--- a/src/Components/AI/src/Engine/AgentState.cs
+++ b/src/Components/AI/src/Engine/AgentState.cs
@@ -11,6 +11,7 @@ public class AgentState<T> where T : class, new()
 {
     private readonly List<Action> _callbacks = new();
     private T _value;
+    private T? _valueBeforePrediction;
 
     internal AgentState(T? initialValue = null)
     {
@@ -26,9 +27,44 @@ public class AgentState<T> where T : class, new()
         set
         {
             ArgumentNullException.ThrowIfNull(value);
+            _valueBeforePrediction = null;
             _value = value;
             NotifyChanged();
         }
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether <see cref="Value"/> contains provisional predictive state.
+    /// </summary>
+    public bool HasPendingPredictiveState => _valueBeforePrediction is not null;
+
+    /// <summary>
+    /// Accepts the current predictive state as the committed value.
+    /// </summary>
+    public void AcceptPredictiveState()
+    {
+        if (_valueBeforePrediction is null)
+        {
+            return;
+        }
+
+        _valueBeforePrediction = null;
+        NotifyChanged();
+    }
+
+    /// <summary>
+    /// Rejects the current predictive state and restores the value from before the prediction.
+    /// </summary>
+    public void RejectPredictiveState()
+    {
+        if (_valueBeforePrediction is not { } previousValue)
+        {
+            return;
+        }
+
+        _valueBeforePrediction = null;
+        _value = previousValue;
+        NotifyChanged();
     }
 
     /// <summary>
@@ -41,6 +77,14 @@ public class AgentState<T> where T : class, new()
         ArgumentNullException.ThrowIfNull(callback);
         _callbacks.Add(callback);
         return new CallbackRegistration(_callbacks, callback);
+    }
+
+    internal void SetPredictiveValue(T value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        _valueBeforePrediction ??= _value;
+        _value = value;
+        NotifyChanged();
     }
 
     private void NotifyChanged()

--- a/src/Components/AI/src/Engine/UIAgent.cs
+++ b/src/Components/AI/src/Engine/UIAgent.cs
@@ -36,6 +36,10 @@ public class UIAgent : IDisposable
 
     internal UIAgentOptions Options => _options;
 
+    internal virtual void RejectPendingPredictiveState()
+    {
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="UIAgent"/> class.
     /// </summary>

--- a/src/Components/AI/src/Engine/UIAgent.cs
+++ b/src/Components/AI/src/Engine/UIAgent.cs
@@ -298,6 +298,7 @@ public class UIAgent : IDisposable
         }
 
         blocks.AddRange(pipeline.Finalize());
+        RejectPendingPredictiveState();
 
         return blocks;
     }

--- a/src/Components/AI/src/Engine/UIAgentOfT.cs
+++ b/src/Components/AI/src/Engine/UIAgentOfT.cs
@@ -102,9 +102,21 @@ public class UIAgent<TState> : UIAgent where TState : class, new()
                     $"but this agent requires state of type '{typeof(TState)}'.");
             }
 
-            State.Value = typedState;
+            if (context.IsPredictiveState)
+            {
+                State.SetPredictiveValue(typedState);
+            }
+            else
+            {
+                State.Value = typedState;
+            }
         }
 
         return context.HasHandledContent ? context.GetFilteredUpdate() : update;
+    }
+
+    internal override void RejectPendingPredictiveState()
+    {
+        State.RejectPredictiveState();
     }
 }

--- a/src/Components/AI/src/Pipeline/StateMapperContext.cs
+++ b/src/Components/AI/src/Pipeline/StateMapperContext.cs
@@ -68,6 +68,8 @@ public class StateMapperContext
 
     internal object? StateValue { get; private set; }
 
+    internal bool IsPredictiveState { get; private set; }
+
     /// <summary>
     /// Sets the next typed state value.
     /// </summary>
@@ -76,6 +78,19 @@ public class StateMapperContext
     {
         ArgumentNullException.ThrowIfNull(value);
         StateValue = value;
+        IsPredictiveState = false;
+    }
+
+    /// <summary>
+    /// Sets a provisional typed state value that must be accepted or rejected before the turn
+    /// completes.
+    /// </summary>
+    /// <param name="value">The next provisional state value.</param>
+    public void SetPredictiveState(object value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        StateValue = value;
+        IsPredictiveState = true;
     }
 
     internal bool HasHandledContent => _handledCount > 0;

--- a/src/Components/AI/src/PublicAPI.Unshipped.txt
+++ b/src/Components/AI/src/PublicAPI.Unshipped.txt
@@ -7,7 +7,10 @@ Microsoft.AspNetCore.Components.AI.AgentBoundary.ChildContent.get -> Microsoft.A
 Microsoft.AspNetCore.Components.AI.AgentBoundary.ChildContent.set -> void
 Microsoft.AspNetCore.Components.AI.AgentBoundary.Dispose() -> void
 Microsoft.AspNetCore.Components.AI.AgentState<T>
+Microsoft.AspNetCore.Components.AI.AgentState<T>.AcceptPredictiveState() -> void
+Microsoft.AspNetCore.Components.AI.AgentState<T>.HasPendingPredictiveState.get -> bool
 Microsoft.AspNetCore.Components.AI.AgentState<T>.OnChanged(System.Action! callback) -> System.IDisposable!
+Microsoft.AspNetCore.Components.AI.AgentState<T>.RejectPredictiveState() -> void
 Microsoft.AspNetCore.Components.AI.AgentState<T>.Value.get -> T!
 Microsoft.AspNetCore.Components.AI.AgentState<T>.Value.set -> void
 Microsoft.AspNetCore.Components.AI.AgentContext
@@ -274,6 +277,7 @@ Microsoft.AspNetCore.Components.AI.StrongNode
 Microsoft.AspNetCore.Components.AI.StrongNode.StrongNode() -> void
 Microsoft.AspNetCore.Components.AI.StateMapperContext
 Microsoft.AspNetCore.Components.AI.StateMapperContext.MarkHandled(Microsoft.Extensions.AI.AIContent! content) -> void
+Microsoft.AspNetCore.Components.AI.StateMapperContext.SetPredictiveState(object! value) -> void
 Microsoft.AspNetCore.Components.AI.StateMapperContext.SetState(object! value) -> void
 Microsoft.AspNetCore.Components.AI.StateMapperContext.UnhandledContents.get -> System.Collections.Generic.IEnumerable<Microsoft.Extensions.AI.AIContent!>!
 Microsoft.AspNetCore.Components.AI.StateMapperContext.Update.get -> Microsoft.Extensions.AI.ChatResponseUpdate!

--- a/src/Components/AI/test/Engine/PredictiveStateTests.cs
+++ b/src/Components/AI/test/Engine/PredictiveStateTests.cs
@@ -142,21 +142,38 @@ public class PredictiveStateTests
         Assert.Equal(ConversationStatus.Idle, context.Status);
     }
 
+    [Fact]
+    public async Task RestoreAsync_RejectsRestoredPredictiveState()
+    {
+        var thread = new InMemoryConversationThread("thread-1");
+        thread.AppendUserMessage(new ChatMessage(ChatRole.User, "Edit the document"));
+        thread.AppendUpdate(CreateStateUpdate("Rejected draft"));
+        thread.CompleteTurn();
+        var client = new DelegatingStreamingChatClient();
+        using var agent = CreateAgent(client, thread: thread);
+
+        await agent.RestoreAsync();
+
+        Assert.Equal("Original", agent.State.Value.Document);
+        Assert.False(agent.State.HasPendingPredictiveState);
+    }
+
     private static UIAgent<DocumentState> CreateAgent(
         IChatClient client,
-        Func<bool, string>? confirm = null)
+        Func<bool, string>? confirm = null,
+        IConversationThread? thread = null)
     {
         return new UIAgent<DocumentState>(client, options =>
         {
+            options.Thread = thread;
             options.StateMapper = context =>
             {
                 if (context.Update.RawRepresentation is not DocumentState state)
                 {
-                    return false;
+                    return;
                 }
 
                 context.SetPredictiveState(state);
-                return true;
             };
             if (confirm is not null)
             {

--- a/src/Components/AI/test/Engine/PredictiveStateTests.cs
+++ b/src/Components/AI/test/Engine/PredictiveStateTests.cs
@@ -1,0 +1,216 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components.AI.Tests.TestHelpers;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.AspNetCore.Components.AI.Tests.Engine;
+
+public class PredictiveStateTests
+{
+    [Theory]
+    [InlineData(true, "Complete draft")]
+    [InlineData(false, "Original")]
+    public async Task Confirmation_AcceptsOrRejectsPredictiveStateAndContinues(
+        bool accepted,
+        string expectedDocument)
+    {
+        var callCount = 0;
+        List<ChatMessage>? continuationMessages = null;
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((messages, options, cancellationToken) =>
+        {
+            callCount++;
+            if (callCount == 1)
+            {
+                return EmitPredictionWithConfirmation(cancellationToken);
+            }
+
+            continuationMessages = messages.ToList();
+            return ResponseEmitters.EmitTextResponse("Reviewed.", cancellationToken);
+        });
+
+        UIAgent<DocumentState> agent = null!;
+
+        string ConfirmChanges(bool accepted)
+        {
+            if (accepted)
+            {
+                agent.State.AcceptPredictiveState();
+            }
+            else
+            {
+                agent.State.RejectPredictiveState();
+            }
+
+            return accepted ? "Accepted." : "Rejected.";
+        }
+
+        agent = CreateAgent(client, ConfirmChanges);
+        using (agent)
+        using (var context = new AgentContext(agent))
+        {
+            var documents = new List<string>();
+            using var stateSubscription = agent.State.OnChanged(
+                () => documents.Add(agent.State.Value.Document));
+            using var statusSubscription = context.RegisterOnStatusChanged(status =>
+            {
+                if (status == ConversationStatus.AwaitingInput)
+                {
+                    var action = context.Turns[^1].ResponseBlocks
+                        .OfType<UIActionBlock>()
+                        .Single();
+                    action.Call.Arguments ??= new Dictionary<string, object?>();
+                    action.Call.Arguments["accepted"] = accepted;
+                    _ = action.InvokeAsync();
+                }
+            });
+
+            await context.SendMessageAsync("Edit the document");
+
+            Assert.Equal(["Draft", "Complete draft", expectedDocument], documents);
+            Assert.Equal(expectedDocument, agent.State.Value.Document);
+            Assert.False(agent.State.HasPendingPredictiveState);
+            Assert.Equal(2, callCount);
+            Assert.NotNull(continuationMessages);
+            var result = Assert.IsType<FunctionResultContent>(
+                Assert.Single(continuationMessages.Last().Contents));
+            Assert.Equal(accepted ? "Accepted." : "Rejected.", result.Result?.ToString());
+        }
+    }
+
+    [Fact]
+    public async Task CancelAsync_RollsBackPredictiveState()
+    {
+        var stateObserved = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((_, _, cancellationToken) =>
+            EmitPredictionUntilCanceled(stateObserved, cancellationToken));
+        using var agent = CreateAgent(client);
+        using var context = new AgentContext(agent);
+
+        var sendTask = context.SendMessageAsync("Edit the document");
+        await stateObserved.Task;
+        await context.CancelAsync();
+        await sendTask;
+
+        Assert.Equal("Original", agent.State.Value.Document);
+        Assert.False(agent.State.HasPendingPredictiveState);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+        Assert.Empty(Assert.Single(context.Turns).ResponseBlocks);
+    }
+
+    [Fact]
+    public async Task CallerCancellation_RollsBackPredictiveStateAndCancelsTask()
+    {
+        var stateObserved = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((_, _, cancellationToken) =>
+            EmitPredictionUntilCanceled(stateObserved, cancellationToken));
+        using var agent = CreateAgent(client);
+        using var context = new AgentContext(agent);
+        using var cancellationSource = new CancellationTokenSource();
+
+        var sendTask = context.SendMessageAsync(
+            "Edit the document",
+            cancellationSource.Token);
+        await stateObserved.Task;
+        cancellationSource.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => sendTask);
+        Assert.Equal("Original", agent.State.Value.Document);
+        Assert.False(agent.State.HasPendingPredictiveState);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+    }
+
+    [Fact]
+    public async Task CompletedTurnWithoutConfirmation_RollsBackPredictiveState()
+    {
+        var client = new DelegatingStreamingChatClient();
+        client.SetHandler((_, _, cancellationToken) =>
+            EmitPredictionWithoutConfirmation(cancellationToken));
+        using var agent = CreateAgent(client);
+        using var context = new AgentContext(agent);
+
+        await context.SendMessageAsync("Edit the document");
+
+        Assert.Equal("Original", agent.State.Value.Document);
+        Assert.False(agent.State.HasPendingPredictiveState);
+        Assert.Equal(ConversationStatus.Idle, context.Status);
+    }
+
+    private static UIAgent<DocumentState> CreateAgent(
+        IChatClient client,
+        Func<bool, string>? confirm = null)
+    {
+        return new UIAgent<DocumentState>(client, options =>
+        {
+            options.StateMapper = context =>
+            {
+                if (context.Update.RawRepresentation is not DocumentState state)
+                {
+                    return false;
+                }
+
+                context.SetPredictiveState(state);
+                return true;
+            };
+            if (confirm is not null)
+            {
+                options.RegisterUIAction(AIFunctionFactory.Create(
+                    confirm,
+                    "confirm_changes",
+                    "Confirm the document changes."));
+            }
+        }, new DocumentState { Document = "Original" });
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate>
+        EmitPredictionWithConfirmation(
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        yield return CreateStateUpdate("Draft");
+        yield return CreateStateUpdate("Complete draft");
+        yield return new ChatResponseUpdate
+        {
+            Role = ChatRole.Assistant,
+            MessageId = "confirmation-message",
+            Contents = [new FunctionCallContent("confirmation-call", "confirm_changes")],
+            FinishReason = ChatFinishReason.ToolCalls,
+        };
+        await Task.CompletedTask;
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate> EmitPredictionUntilCanceled(
+        TaskCompletionSource stateObserved,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        yield return CreateStateUpdate("Draft");
+        stateObserved.SetResult();
+        await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+    }
+
+    private static async IAsyncEnumerable<ChatResponseUpdate>
+        EmitPredictionWithoutConfirmation(
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        yield return CreateStateUpdate("Unconfirmed draft");
+        await Task.CompletedTask;
+    }
+
+    private static ChatResponseUpdate CreateStateUpdate(string document) => new()
+    {
+        Role = ChatRole.Assistant,
+        RawRepresentation = new DocumentState { Document = document },
+    };
+
+    private sealed class DocumentState
+    {
+        public string Document { get; set; } = "";
+    }
+}

--- a/src/Components/AI/testassets/AGUIDojoApi/AGUIEndpoint.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/AGUIEndpoint.cs
@@ -24,18 +24,19 @@ internal static class AGUIEndpoint
         string pattern,
         IList<AITool>? serverTools = null,
         string? systemPrompt = null,
-        Func<JsonSerializerOptions, AGUIStreamOptions>? configureStreamOptions = null)
+        Func<JsonSerializerOptions, AGUIStreamOptions>? configureStreamOptions = null,
+        object? chatClientKey = null)
     {
         return endpoints.MapPost(pattern, (
             [FromBody] RunAgentInput input,
-            // The model client is resolved from DI rather than captured at map time so that the
-            // E2E tests can replace it with a recorded one through a service override.
-            [FromServices] IChatClient chatClient,
             [FromServices] IOptions<JsonOptions> jsonOptions,
             HttpContext httpContext,
             CancellationToken cancellationToken) =>
         {
             var jsonSerializerOptions = jsonOptions.Value.SerializerOptions;
+            var chatClient = chatClientKey is null
+                ? httpContext.RequestServices.GetRequiredService<IChatClient>()
+                : httpContext.RequestServices.GetRequiredKeyedService<IChatClient>(chatClientKey);
 
             var streamOptions = configureStreamOptions?.Invoke(jsonSerializerOptions)
                 ?? new AGUIStreamOptions();

--- a/src/Components/AI/testassets/AGUIDojoApi/AGUIEndpoint.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/AGUIEndpoint.cs
@@ -25,7 +25,8 @@ internal static class AGUIEndpoint
         IList<AITool>? serverTools = null,
         string? systemPrompt = null,
         Func<JsonSerializerOptions, AGUIStreamOptions>? configureStreamOptions = null,
-        object? chatClientKey = null)
+        object? chatClientKey = null,
+        bool treatClientToolsAsDeclarations = false)
     {
         return endpoints.MapPost(pattern, (
             [FromBody] RunAgentInput input,
@@ -38,10 +39,33 @@ internal static class AGUIEndpoint
                 ? httpContext.RequestServices.GetRequiredService<IChatClient>()
                 : httpContext.RequestServices.GetRequiredKeyedService<IChatClient>(chatClientKey);
 
-            var streamOptions = configureStreamOptions?.Invoke(jsonSerializerOptions)
-                ?? new AGUIStreamOptions();
+            var streamOptions = configureStreamOptions?.Invoke(jsonSerializerOptions) ??
+                new AGUIStreamOptions();
+            var clientTools = input.Tools;
+            if (treatClientToolsAsDeclarations)
+            {
+                input.Tools = null;
+            }
 
             var ctx = input.ToChatRequestContext(jsonSerializerOptions, streamOptions);
+            input.Tools = clientTools;
+
+            // A raw model returns these calls to the browser instead of executing them in the
+            // mixed-invocation pipeline. Server-owned tools supersede duplicate declarations.
+            if (treatClientToolsAsDeclarations && clientTools is { Count: > 0 })
+            {
+                var serverToolNames = serverTools?
+                    .Select(tool => tool.Name)
+                    .ToHashSet(StringComparer.Ordinal) ?? [];
+                ctx.ChatOptions.Tools ??= [];
+                foreach (var tool in clientTools.AsAITools())
+                {
+                    if (!serverToolNames.Contains(tool.Name))
+                    {
+                        ctx.ChatOptions.Tools.Add(tool);
+                    }
+                }
+            }
 
             // Inject system prompt if provided
             if (systemPrompt is not null)

--- a/src/Components/AI/testassets/AGUIDojoApi/ChatClientAgentFactory.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/ChatClientAgentFactory.cs
@@ -213,6 +213,7 @@ internal static class ChatClientAgentFactory
         ArgumentNullException.ThrowIfNull(options);
 
         string? lastEmittedDocument = null;
+        var hasEmittedConfirmation = false;
         var streamOptions = new AGUIStreamOptions();
         streamOptions.MapContent(content => content is DataContent data &&
             data.MediaType == PredictiveStateMediaType
@@ -256,19 +257,23 @@ internal static class ChatClientAgentFactory
                 Role = "tool",
             });
 
-            var confirmationCallId = Guid.NewGuid().ToString("N");
-            events.Add(new ToolCallStartEvent
+            if (!hasEmittedConfirmation)
             {
-                ToolCallId = confirmationCallId,
-                ToolCallName = "confirm_changes",
-                ParentMessageId = Guid.NewGuid().ToString("N"),
-            });
-            events.Add(new ToolCallArgsEvent
-            {
-                ToolCallId = confirmationCallId,
-                Delta = "{}",
-            });
-            events.Add(new ToolCallEndEvent { ToolCallId = confirmationCallId });
+                hasEmittedConfirmation = true;
+                var confirmationCallId = Guid.NewGuid().ToString("N");
+                events.Add(new ToolCallStartEvent
+                {
+                    ToolCallId = confirmationCallId,
+                    ToolCallName = "confirm_changes",
+                    ParentMessageId = Guid.NewGuid().ToString("N"),
+                });
+                events.Add(new ToolCallArgsEvent
+                {
+                    ToolCallId = confirmationCallId,
+                    Delta = "{}",
+                });
+                events.Add(new ToolCallEndEvent { ToolCallId = confirmationCallId });
+            }
 
             lastEmittedDocument = document;
             return events;

--- a/src/Components/AI/testassets/AGUIDojoApi/ChatClientAgentFactory.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/ChatClientAgentFactory.cs
@@ -23,6 +23,8 @@ namespace AGUIDojoApi;
 // recorded client through a service override.
 internal static class ChatClientAgentFactory
 {
+    private const string PredictiveStateMediaType =
+        "application/vnd.aspnetcore.ai.predictive-state+json";
     internal const string PredictiveStateUpdatesServiceKey = "predictive-state-updates-model";
 
     internal const string HumanInTheLoopSystemPrompt = """
@@ -212,6 +214,13 @@ internal static class ChatClientAgentFactory
 
         string? lastEmittedDocument = null;
         var streamOptions = new AGUIStreamOptions();
+        streamOptions.MapContent(content => content is DataContent data &&
+            data.MediaType == PredictiveStateMediaType
+            ? [new StateSnapshotEvent
+            {
+                Snapshot = JsonSerializer.Deserialize<JsonElement>(data.Data.Span),
+            }]
+            : null);
         streamOptions.MapCall("write_document_local", call =>
         {
             var document = call.Arguments?.TryGetValue("document", out var value) == true

--- a/src/Components/AI/testassets/AGUIDojoApi/ChatClientAgentFactory.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/ChatClientAgentFactory.cs
@@ -4,9 +4,11 @@
 using System.ClientModel;
 using System.ComponentModel;
 using System.Text.Json;
+using AGUI.Abstractions;
 using AGUI.Server;
 using AGUIDojoApi.AgenticGenerativeUI;
 using AGUIDojoApi.BackendToolRendering;
+using AGUIDojoApi.PredictiveStateUpdates;
 using AGUIDojoApi.SharedState;
 using Microsoft.Extensions.AI;
 using OpenAI;
@@ -21,6 +23,8 @@ namespace AGUIDojoApi;
 // recorded client through a service override.
 internal static class ChatClientAgentFactory
 {
+    internal const string PredictiveStateUpdatesServiceKey = "predictive-state-updates-model";
+
     internal const string HumanInTheLoopSystemPrompt = """
         You are a planning assistant.
         When asked to create a plan, call generate_task_steps so the user can review the steps.
@@ -67,7 +71,31 @@ internal static class ChatClientAgentFactory
           NOT call the tool.
         """;
 
+    internal const string PredictiveStateUpdatesSystemPrompt = """
+        You are a document editor assistant. When asked to write or edit content:
+
+        IMPORTANT:
+        - Use the `write_document_local` tool with the full document text in Markdown format
+        - Format the document extensively so it's easy to read
+        - You can use all kinds of markdown (headings, lists, bold, etc.)
+        - However, do NOT use italic or strike-through formatting
+        - You MUST write the full document, even when changing only a few words
+        - When making edits to the document, try to make them minimal - do not change every word
+        - Keep stories SHORT!
+
+        After writing the document, briefly summarize the changes you made in at most two sentences.
+        """;
+
     internal static IChatClient CreateAgenticChat(IConfiguration configuration)
+        => CreateModelClient(configuration)
+            .AsBuilder()
+            .UseFunctionInvocation()
+            .Build();
+
+    internal static IChatClient CreatePredictiveStateUpdates(IConfiguration configuration)
+        => CreateModelClient(configuration);
+
+    private static IChatClient CreateModelClient(IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
 
@@ -95,10 +123,7 @@ internal static class ChatClientAgentFactory
             modelClient = openAIClient.GetChatClient(modelName).AsIChatClient();
         }
 
-        return modelClient
-            .AsBuilder()
-            .UseFunctionInvocation()
-            .Build();
+        return modelClient;
     }
 
     internal static IList<AITool> CreateBackendToolRenderingTools(JsonSerializerOptions options)
@@ -165,6 +190,84 @@ internal static class ChatClientAgentFactory
         return options;
     }
 
+    internal static IList<AITool> CreatePredictiveStateUpdatesTools(
+        JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        return
+        [
+            AIFunctionFactory.Create(
+                WriteDocument,
+                name: "write_document_local",
+                description: "Write a document using Markdown formatting.",
+                options),
+        ];
+    }
+
+    internal static AGUIStreamOptions CreatePredictiveStateUpdatesStreamOptions(
+        JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        string? lastEmittedDocument = null;
+        var streamOptions = new AGUIStreamOptions();
+        streamOptions.MapCall("write_document_local", call =>
+        {
+            var document = call.Arguments?.TryGetValue("document", out var value) == true
+                ? value?.ToString()
+                : null;
+            if (document is null || document == lastEmittedDocument)
+            {
+                return [];
+            }
+
+            var events = new List<BaseEvent>();
+            var startIndex = lastEmittedDocument is not null &&
+                document.StartsWith(lastEmittedDocument, StringComparison.Ordinal)
+                    ? lastEmittedDocument.Length
+                    : 0;
+
+            const int chunkSize = 10;
+            for (var index = startIndex; index < document.Length; index += chunkSize)
+            {
+                var length = Math.Min(chunkSize, document.Length - index);
+                var state = new DocumentState { Document = document[..(index + length)] };
+                events.Add(new StateSnapshotEvent
+                {
+                    Snapshot = JsonSerializer.SerializeToElement(state, options),
+                });
+            }
+
+            events.Add(new ToolCallResultEvent
+            {
+                MessageId = Guid.NewGuid().ToString("N"),
+                ToolCallId = call.CallId,
+                Content = "Document written.",
+                Role = "tool",
+            });
+
+            var confirmationCallId = Guid.NewGuid().ToString("N");
+            events.Add(new ToolCallStartEvent
+            {
+                ToolCallId = confirmationCallId,
+                ToolCallName = "confirm_changes",
+                ParentMessageId = Guid.NewGuid().ToString("N"),
+            });
+            events.Add(new ToolCallArgsEvent
+            {
+                ToolCallId = confirmationCallId,
+                Delta = "{}",
+            });
+            events.Add(new ToolCallEndEvent { ToolCallId = confirmationCallId });
+
+            lastEmittedDocument = document;
+            return events;
+        });
+
+        return streamOptions;
+    }
+
     [Description("Get the weather for a given location.")]
     private static WeatherInfo GetWeather(
         [Description("The location to get the weather for.")] string location) => new()
@@ -182,4 +285,9 @@ internal static class ChatClientAgentFactory
         {
             Recipe = recipe,
         };
+
+    [Description("Write a document in Markdown format.")]
+    private static string WriteDocument(
+        [Description("The complete document content.")] string document)
+        => "Document written.";
 }

--- a/src/Components/AI/testassets/AGUIDojoApi/PredictiveStateUpdates/DocumentState.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/PredictiveStateUpdates/DocumentState.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text.Json.Serialization;
+
+namespace AGUIDojoApi.PredictiveStateUpdates;
+
+internal sealed class DocumentState
+{
+    [JsonPropertyName("document")]
+    public string Document { get; set; } = "";
+}

--- a/src/Components/AI/testassets/AGUIDojoApi/Program.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/Program.cs
@@ -25,6 +25,10 @@ builder.Services.Configure<JsonOptions>(options =>
 
 builder.Services.AddSingleton<IChatClient>(sp =>
     ChatClientAgentFactory.CreateAgenticChat(sp.GetRequiredService<IConfiguration>()));
+builder.Services.AddKeyedSingleton<IChatClient>(
+    ChatClientAgentFactory.PredictiveStateUpdatesServiceKey,
+    (sp, _) => ChatClientAgentFactory.CreatePredictiveStateUpdates(
+        sp.GetRequiredService<IConfiguration>()));
 
 var app = builder.Build();
 var jsonOptions = app.Services.GetRequiredService<IOptions<JsonOptions>>();
@@ -54,6 +58,13 @@ app.MapDojoEndpoint(
         jsonOptions.Value.SerializerOptions),
     systemPrompt: ChatClientAgentFactory.SharedStateSystemPrompt,
     configureStreamOptions: _ => ChatClientAgentFactory.CreateSharedStateStreamOptions());
+app.MapDojoEndpoint(
+    "/predictive_state_updates",
+    serverTools: ChatClientAgentFactory.CreatePredictiveStateUpdatesTools(
+        jsonOptions.Value.SerializerOptions),
+    systemPrompt: ChatClientAgentFactory.PredictiveStateUpdatesSystemPrompt,
+    configureStreamOptions: ChatClientAgentFactory.CreatePredictiveStateUpdatesStreamOptions,
+    chatClientKey: ChatClientAgentFactory.PredictiveStateUpdatesServiceKey);
 
 await app.RunAsync();
 

--- a/src/Components/AI/testassets/AGUIDojoApi/Program.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/Program.cs
@@ -64,7 +64,8 @@ app.MapDojoEndpoint(
         jsonOptions.Value.SerializerOptions),
     systemPrompt: ChatClientAgentFactory.PredictiveStateUpdatesSystemPrompt,
     configureStreamOptions: ChatClientAgentFactory.CreatePredictiveStateUpdatesStreamOptions,
-    chatClientKey: ChatClientAgentFactory.PredictiveStateUpdatesServiceKey);
+    chatClientKey: ChatClientAgentFactory.PredictiveStateUpdatesServiceKey,
+    treatClientToolsAsDeclarations: true);
 
 await app.RunAsync();
 

--- a/src/Components/AI/testassets/AGUIDojoApi/ScriptedChatClient.cs
+++ b/src/Components/AI/testassets/AGUIDojoApi/ScriptedChatClient.cs
@@ -4,6 +4,7 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using AGUI.Server;
+using AGUIDojoApi.PredictiveStateUpdates;
 using AGUIDojoApi.SharedState;
 using Microsoft.Extensions.AI;
 
@@ -56,6 +57,12 @@ internal sealed class ScriptedChatClient : IChatClient
             var functionResult = messageList[^1].Contents
                 .OfType<FunctionResultContent>()
                 .FirstOrDefault();
+            var functionCall = functionResult is null
+                ? null
+                : messageList
+                    .SelectMany(message => message.Contents)
+                    .OfType<FunctionCallContent>()
+                    .LastOrDefault(call => call.CallId == functionResult.CallId);
             if (functionResult is { CallId: "agentic-plan-create-1" })
             {
                 yield return CreatePlanStepUpdate(messageId: Guid.NewGuid().ToString("N"), stepIndex: 0);
@@ -98,6 +105,13 @@ internal sealed class ScriptedChatClient : IChatClient
                     "level, cooking time, and key steps for preparation.",
                 { CallId: "shared-state-recipe-1" } =>
                     "I updated the shared recipe.",
+                _ when functionCall?.Name == "confirm_changes" &&
+                    functionResult?.Result?.ToString()?.Contains(
+                        "rejected",
+                        StringComparison.OrdinalIgnoreCase) == true =>
+                    "I left the document unchanged.",
+                _ when functionCall?.Name == "confirm_changes" =>
+                    "The document changes are ready.",
                 _ => "Background changed to a sunset gradient.",
             };
             if (functionResult is { CallId: "shared-state-recipe-1" })
@@ -133,6 +147,39 @@ internal sealed class ScriptedChatClient : IChatClient
         }
 
         var messageId = Guid.NewGuid().ToString("N");
+        if (options?.Tools?.OfType<AIFunctionDeclaration>()
+                .Any(tool => tool.Name == "write_document_local") == true)
+        {
+            options.TryGetRunAgentInput(out var input);
+            var current = input?.State?.Deserialize<DocumentState>(
+                AIJsonUtilities.DefaultOptions)?.Document ?? "";
+            var document = prompt.Contains("Courage", StringComparison.OrdinalIgnoreCase)
+                ? current +
+                    "\n\nCourage joined the crew and offered to guide them through Mermaid Lagoon."
+                : """
+                    # Candy Beard's Voyage
+
+                    Candy Beard sailed from Gumdrop Harbor in search of the Sugar Star.
+
+                    When dark clouds gathered, the crew shared their courage and found the way home.
+                    """;
+
+            yield return new ChatResponseUpdate
+            {
+                Role = ChatRole.Assistant,
+                MessageId = messageId,
+                Contents =
+                [
+                    new FunctionCallContent(
+                        $"predictive-document-{Guid.NewGuid():N}",
+                        "write_document_local",
+                        new Dictionary<string, object?> { ["document"] = document }),
+                ],
+                FinishReason = ChatFinishReason.ToolCalls,
+            };
+            yield break;
+        }
+
         if (options?.Tools?.OfType<AIFunctionDeclaration>()
                 .Any(tool => tool.Name == "generate_recipe") == true)
         {

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Baselines/PredictiveStateUpdates.recording.json
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Baselines/PredictiveStateUpdates.recording.json
@@ -1,0 +1,122 @@
+{
+  "calls": [
+    {
+      "prompt": "Please write a story about a pirate named Candy Beard.",
+      "messageCount": 2,
+      "toolNames": [
+        "confirm_changes",
+        "write_document_local"
+      ],
+      "state": {
+        "document": "# Harbor Notes\n\nThe crew is preparing for a quiet voyage."
+      },
+      "requireStableThread": true,
+      "frames": [
+        {
+          "name": "pirate-opening",
+          "state": {
+            "document": "# Candy Beard's Voyage\n\nCandy Beard sailed from Gumdrop Harbor in search of the Sugar Star."
+          }
+        },
+        {
+          "name": "pirate-complete",
+          "state": {
+            "document": "# Candy Beard's Voyage\n\nCandy Beard sailed from Gumdrop Harbor in search of the Sugar Star.\n\nWhen dark clouds gathered, the crew shared their courage and found the way home."
+          }
+        },
+        {
+          "name": "pirate-confirmation",
+          "functionCall": {
+            "callId": "predictive-write-1",
+            "name": "write_document_local",
+            "arguments": {
+              "document": "# Candy Beard's Voyage\n\nCandy Beard sailed from Gumdrop Harbor in search of the Sugar Star.\n\nWhen dark clouds gathered, the crew shared their courage and found the way home."
+            }
+          }
+        }
+      ]
+    },
+    {
+      "prompt": "Please write a story about a pirate named Candy Beard.",
+      "messageCount": 6,
+      "toolNames": [
+        "confirm_changes",
+        "write_document_local"
+      ],
+      "state": {
+        "document": "# Candy Beard's Voyage\n\nCandy Beard sailed from Gumdrop Harbor in search of the Sugar Star.\n\nWhen dark clouds gathered, the crew shared their courage and found the way home."
+      },
+      "requireStableThread": true,
+      "frames": [
+        {
+          "name": "before-pirate-summary"
+        },
+        {
+          "name": "pirate-summary",
+          "chunks": [
+            "Candy Beard's voyage is ready."
+          ]
+        }
+      ]
+    },
+    {
+      "prompt": "Please add a character named Courage.",
+      "messageCount": 8,
+      "toolNames": [
+        "confirm_changes",
+        "write_document_local"
+      ],
+      "state": {
+        "document": "# Candy Beard's Voyage\n\nCandy Beard sailed from Gumdrop Harbor in search of the Sugar Star.\n\nWhen dark clouds gathered, the crew shared their courage and found the way home.\n\nThe map now points toward Mermaid Lagoon."
+      },
+      "requireStableThread": true,
+      "frames": [
+        {
+          "name": "courage-draft",
+          "state": {
+            "document": "# Candy Beard's Voyage\n\nCandy Beard sailed from Gumdrop Harbor in search of the Sugar Star.\n\nWhen dark clouds gathered, the crew shared their courage and found the way home.\n\nThe map now points toward Mermaid Lagoon.\n\nCourage joined the crew"
+          }
+        },
+        {
+          "name": "courage-complete",
+          "state": {
+            "document": "# Candy Beard's Voyage\n\nCandy Beard sailed from Gumdrop Harbor in search of the Sugar Star.\n\nWhen dark clouds gathered, the crew shared their courage and found the way home.\n\nThe map now points toward Mermaid Lagoon.\n\nCourage joined the crew and offered to guide them through Mermaid Lagoon."
+          }
+        },
+        {
+          "name": "courage-confirmation",
+          "functionCall": {
+            "callId": "predictive-write-2",
+            "name": "write_document_local",
+            "arguments": {
+              "document": "# Candy Beard's Voyage\n\nCandy Beard sailed from Gumdrop Harbor in search of the Sugar Star.\n\nWhen dark clouds gathered, the crew shared their courage and found the way home.\n\nThe map now points toward Mermaid Lagoon.\n\nCourage joined the crew and offered to guide them through Mermaid Lagoon."
+            }
+          }
+        }
+      ]
+    },
+    {
+      "prompt": "Please add a character named Courage.",
+      "messageCount": 12,
+      "toolNames": [
+        "confirm_changes",
+        "write_document_local"
+      ],
+      "state": {
+        "document": "# Candy Beard's Voyage\n\nCandy Beard sailed from Gumdrop Harbor in search of the Sugar Star.\n\nWhen dark clouds gathered, the crew shared their courage and found the way home.\n\nThe map now points toward Mermaid Lagoon."
+      },
+      "requireStableThread": true,
+      "frames": [
+        {
+          "name": "before-courage-summary"
+        },
+        {
+          "name": "courage-summary",
+          "chunks": [
+            "I left the document unchanged."
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/DojoModelOverrides.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/DojoModelOverrides.cs
@@ -50,6 +50,15 @@ internal class DojoModelOverrides
             new FunctionInvokingChatClient(sp.GetRequiredService<RecordedChatClient>()));
     }
 
+    public static void PredictiveStateUpdates(IServiceCollection services)
+    {
+        services.AddSingleton(_ => RecordedScript.Load("PredictiveStateUpdates.recording.json"));
+        services.AddScoped<RecordedChatClient>();
+        services.AddKeyedScoped<IChatClient>(
+            "predictive-state-updates-model",
+            (sp, _) => sp.GetRequiredService<RecordedChatClient>());
+    }
+
     private static void AddRecordedModel(IServiceCollection services, string recordingFileName)
     {
         services.AddSingleton(_ => RecordedScript.Load(recordingFileName));

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/RecordedChatClient.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/RecordedChatClient.cs
@@ -17,6 +17,8 @@ namespace DojoClient.E2E.Tests.ServiceOverrides;
 // partially streamed UI before letting the response finish.
 internal sealed class RecordedChatClient : IChatClient
 {
+    private const string PredictiveStateMediaType =
+        "application/vnd.aspnetcore.ai.predictive-state+json";
     private readonly RecordedScript _script;
     private readonly TestLockProvider _locks;
 
@@ -45,6 +47,21 @@ internal sealed class RecordedChatClient : IChatClient
         for (var frameIndex = 0; frameIndex < call.Frames.Count; frameIndex++)
         {
             var frame = call.Frames[frameIndex];
+            if (frame.State is { } state)
+            {
+                yield return new ChatResponseUpdate
+                {
+                    Role = ChatRole.Assistant,
+                    MessageId = messageId,
+                    Contents =
+                    [
+                        new DataContent(
+                            JsonSerializer.SerializeToUtf8Bytes(state),
+                            PredictiveStateMediaType),
+                    ],
+                };
+            }
+
             if (frame.FunctionCall is not null)
             {
                 yield return new ChatResponseUpdate

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/RecordedScript.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/ServiceOverrides/RecordedScript.cs
@@ -101,6 +101,9 @@ internal sealed class RecordedFrame
     /// <summary>The text chunks streamed for this checkpoint.</summary>
     public List<string> Chunks { get; init; } = [];
 
+    /// <summary>A predictive state snapshot emitted at this checkpoint.</summary>
+    public JsonElement? State { get; init; }
+
     /// <summary>A function call emitted at this checkpoint.</summary>
     public RecordedFunctionCall? FunctionCall { get; init; }
 }

--- a/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/PredictiveStateUpdatesScenarioTests.cs
+++ b/src/Components/AI/testassets/DojoClient.E2E.Tests/Tests/PredictiveStateUpdatesScenarioTests.cs
@@ -1,0 +1,165 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using AGUIDojoApi;
+using DojoClient.E2E.Tests.Fixtures;
+using DojoClient.E2E.Tests.ServiceOverrides;
+using Microsoft.AspNetCore.Components.Testing.Infrastructure;
+using Microsoft.AspNetCore.Components.Testing.Playwright;
+using Microsoft.Playwright;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DojoClient.E2E.Tests.Tests;
+
+// Only the API model is recorded. DojoClient still crosses HTTP/SSE through AGUIChatClient.
+[UITest]
+public partial class PredictiveStateUpdatesScenarioTests : BrowserTest
+{
+    private const string InitialDocument =
+        "# Harbor Notes\n\nThe crew is preparing for a quiet voyage.";
+    private const string PirateOpening =
+        "# Candy Beard's Voyage\n\nCandy Beard sailed from Gumdrop Harbor in search of the Sugar Star.";
+    private const string PirateDocument =
+        PirateOpening +
+        "\n\nWhen dark clouds gathered, the crew shared their courage and found the way home.";
+    private const string EditedPirateDocument =
+        PirateDocument + "\n\nThe map now points toward Mermaid Lagoon.";
+    private const string CourageDocument =
+        EditedPirateDocument +
+        "\n\nCourage joined the crew and offered to guide them through Mermaid Lagoon.";
+
+    private ServerInstance _api = null!;
+    private ServerInstance _ui = null!;
+    private ApiCheckpointClient _checkpoints = null!;
+    private IPage _page = null!;
+
+    protected override async Task InitializeCoreAsync()
+    {
+        await base.InitializeCoreAsync();
+
+        _api = await StartServerAsync<AGUIDojoApiAssembly>(TestRoot.Servers, options =>
+        {
+            options.ConfigureServices<DojoModelOverrides>(
+                nameof(DojoModelOverrides.PredictiveStateUpdates));
+        });
+        _ui = await StartServerAsync<global::DojoClient.Components.App>(TestRoot.Servers, options =>
+        {
+            options.EnvironmentVariables["AGUI_DOJO_API_URL"] = _api.AppUrl;
+        });
+        _checkpoints = new ApiCheckpointClient(_api);
+
+        var context = await NewContext(new BrowserNewContextOptions().WithServerRouting(_ui));
+        _page = await context.NewPageAsync();
+        await _page.GotoAsync($"{_ui.TestUrl}/predictive_state_updates");
+        await _page.WaitForInteractiveAsync("[aria-label='Document editor']");
+    }
+
+    [TestMethod]
+    public async Task DocumentEditor_StreamsPredictionAndSupportsAcceptAndReject()
+    {
+        var scenario = _page.Locator("[data-scenario='predictive_state_updates']");
+        var editor = scenario.GetByRole(
+            AriaRole.Textbox,
+            new() { Name = "Document editor", Exact = true });
+        var send = scenario.Locator(".sc-ai-input__send");
+
+        await editor.FillAsync(InitialDocument);
+
+        var piratePrompt = "Please write a story about a pirate named Candy Beard.";
+        await scenario.GetByRole(
+            AriaRole.Button,
+            new() { Name = "Write a pirate story", Exact = true }).ClickAsync();
+
+        await AssertReadOnlyDiffAsync(editor, PirateOpening);
+        await Expect(scenario.Locator(".confirm-changes")).ToHaveCountAsync(0);
+        await Expect(send).ToBeDisabledAsync();
+
+        await _checkpoints.ReleaseAsync(piratePrompt, "pirate-opening");
+
+        await AssertReadOnlyDiffAsync(editor, PirateDocument);
+        await Expect(scenario.Locator(".confirm-changes")).ToHaveCountAsync(0);
+
+        await _checkpoints.ReleaseAsync(piratePrompt, "pirate-complete");
+
+        var dialog = scenario.Locator(".confirm-changes").Last;
+        await Expect(dialog.Locator(".confirm-changes__message"))
+            .ToHaveTextAsync("Do you want to accept the changes?");
+        await dialog.GetByRole(
+            AriaRole.Button,
+            new() { Name = "Confirm", Exact = true }).ClickAsync();
+
+        await _checkpoints.ReleaseAsync(piratePrompt, "before-pirate-summary");
+        await Expect(scenario.Locator(
+            ".sc-ai-message--assistant .sc-ai-message__content").Last)
+            .ToHaveTextAsync("Candy Beard's voyage is ready.");
+
+        await Expect(editor).ToHaveClassAsync("document-editor__input");
+        await Expect(editor).ToHaveValueAsync(PirateDocument);
+        await AssertNoInternalMetadataAsync(editor);
+
+        await editor.FillAsync(EditedPirateDocument);
+        var couragePrompt = "Please add a character named Courage.";
+        await scenario.GetByRole(
+            AriaRole.Button,
+            new() { Name = "Add character", Exact = true }).ClickAsync();
+
+        await AssertReadOnlyDiffAsync(editor, "Courage joined the crew");
+        await Expect(scenario.Locator(".confirm-changes")).ToHaveCountAsync(1);
+
+        await _checkpoints.ReleaseAsync(couragePrompt, "courage-draft");
+
+        await AssertReadOnlyDiffAsync(editor, CourageDocument);
+
+        await _checkpoints.ReleaseAsync(couragePrompt, "courage-complete");
+
+        await Expect(scenario.Locator(".confirm-changes")).ToHaveCountAsync(2);
+        dialog = scenario.Locator(".confirm-changes").Last;
+        await dialog.GetByRole(
+            AriaRole.Button,
+            new() { Name = "Reject", Exact = true }).ClickAsync();
+
+        await _checkpoints.ReleaseAsync(couragePrompt, "before-courage-summary");
+        await Expect(scenario.Locator(
+            ".sc-ai-message--assistant .sc-ai-message__content").Last)
+            .ToHaveTextAsync("I left the document unchanged.");
+
+        await Expect(editor).ToHaveClassAsync("document-editor__input");
+        await Expect(editor).ToHaveValueAsync(EditedPirateDocument);
+        await AssertNoInternalMetadataAsync(editor);
+        await Expect(send).ToBeEnabledAsync();
+    }
+
+    private static async Task AssertReadOnlyDiffAsync(ILocator editor, string expected)
+    {
+        await Expect(editor).ToHaveClassAsync("document-editor__surface");
+        await Expect(editor).ToHaveAttributeAsync("aria-readonly", "true");
+        await Expect(editor.Locator("em").First).ToBeVisibleAsync();
+        var proposedDocument = await editor.Locator(".document-editor__diff")
+            .EvaluateAsync<string>(
+                """
+                element => {
+                    const clone = element.cloneNode(true);
+                    clone.querySelectorAll('s').forEach(item => item.remove());
+                    return clone.textContent;
+                }
+                """);
+        StringAssert.Contains(proposedDocument, expected);
+        Assert.IsGreaterThan(0, await editor.Locator("em").CountAsync());
+        await AssertNoInternalMetadataAsync(editor);
+    }
+
+    private static async Task AssertNoInternalMetadataAsync(ILocator editor)
+    {
+        var html = await editor.EvaluateAsync<string>("element => element.outerHTML");
+        foreach (var value in new[]
+        {
+            "runStartDocument",
+            "_runStartDocument",
+            "write_document_local",
+            "confirm_changes",
+        })
+        {
+            Assert.DoesNotContain(value, html, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Pages/Home.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Pages/Home.razor
@@ -13,4 +13,5 @@
     <li><a href="/tool_based_generative_ui" data-scenario="tool_based_generative_ui">Tool-Based Generative UI</a></li>
     <li><a href="/agentic_generative_ui" data-scenario="agentic_generative_ui">Agentic Generative UI</a></li>
     <li><a href="/shared_state" data-scenario="shared_state">Shared State</a></li>
+    <li><a href="/predictive_state_updates" data-scenario="predictive_state_updates">Predictive State Updates</a></li>
 </ul>

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/ConfirmChangesDialog.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/ConfirmChangesDialog.razor
@@ -1,0 +1,46 @@
+@if (_isResponded)
+{
+    <div class="confirm-changes confirm-changes--responded">
+        <span class="confirm-changes__status @(_wasAccepted
+            ? "confirm-changes__status--accepted"
+            : "confirm-changes__status--rejected")">
+            @(_wasAccepted ? "\u2713 Accepted" : "\u2717 Rejected")
+        </span>
+    </div>
+}
+else
+{
+    <div class="confirm-changes">
+        <div class="confirm-changes__header">
+            <h3>Confirm Changes</h3>
+        </div>
+        <p class="confirm-changes__message">Do you want to accept the changes?</p>
+        <div class="confirm-changes__actions">
+            <button class="confirm-changes__btn confirm-changes__btn--reject"
+                    @onclick="RejectAsync">Reject</button>
+            <button class="confirm-changes__btn confirm-changes__btn--accept"
+                    @onclick="AcceptAsync">Confirm</button>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter]
+    public UIActionBlock Block { get; set; } = default!;
+
+    private bool _isResponded;
+    private bool _wasAccepted;
+
+    private Task AcceptAsync() => RespondAsync(accepted: true);
+
+    private Task RejectAsync() => RespondAsync(accepted: false);
+
+    private async Task RespondAsync(bool accepted)
+    {
+        Block.Call.Arguments ??= new Dictionary<string, object?>();
+        Block.Call.Arguments["accepted"] = accepted;
+        await Block.InvokeAsync();
+        _wasAccepted = accepted;
+        _isResponded = true;
+    }
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/ConfirmChangesDialog.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/ConfirmChangesDialog.razor
@@ -17,8 +17,10 @@ else
         <p class="confirm-changes__message">Do you want to accept the changes?</p>
         <div class="confirm-changes__actions">
             <button class="confirm-changes__btn confirm-changes__btn--reject"
+                    disabled="@_isResponding"
                     @onclick="RejectAsync">Reject</button>
             <button class="confirm-changes__btn confirm-changes__btn--accept"
+                    disabled="@_isResponding"
                     @onclick="AcceptAsync">Confirm</button>
         </div>
     </div>
@@ -29,6 +31,7 @@ else
     public UIActionBlock Block { get; set; } = default!;
 
     private bool _isResponded;
+    private bool _isResponding;
     private bool _wasAccepted;
 
     private Task AcceptAsync() => RespondAsync(accepted: true);
@@ -37,10 +40,23 @@ else
 
     private async Task RespondAsync(bool accepted)
     {
-        Block.Call.Arguments ??= new Dictionary<string, object?>();
-        Block.Call.Arguments["accepted"] = accepted;
-        await Block.InvokeAsync();
-        _wasAccepted = accepted;
-        _isResponded = true;
+        if (_isResponded || _isResponding)
+        {
+            return;
+        }
+
+        _isResponding = true;
+        try
+        {
+            Block.Call.Arguments ??= new Dictionary<string, object?>();
+            Block.Call.Arguments["accepted"] = accepted;
+            await Block.InvokeAsync();
+            _wasAccepted = accepted;
+            _isResponded = true;
+        }
+        finally
+        {
+            _isResponding = false;
+        }
     }
 }

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/ConfirmChangesDialog.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/ConfirmChangesDialog.razor.css
@@ -1,0 +1,69 @@
+.confirm-changes {
+    border: 1px solid var(--sc-ai-color-border);
+    border-radius: 12px;
+    margin: 8px 0;
+    max-width: 360px;
+    overflow: hidden;
+}
+
+.confirm-changes--responded {
+    background: var(--sc-ai-color-surface-subtle);
+    padding: 12px 16px;
+}
+
+.confirm-changes__header {
+    background: var(--sc-ai-color-surface-subtle);
+    border-bottom: 1px solid var(--sc-ai-color-border);
+    padding: 12px 16px;
+}
+
+.confirm-changes__header h3,
+.confirm-changes__message {
+    margin: 0;
+}
+
+.confirm-changes__message {
+    color: var(--sc-ai-color-text-secondary);
+    font-size: 0.9em;
+    padding: 12px 16px;
+}
+
+.confirm-changes__actions {
+    border-top: 1px solid var(--sc-ai-color-border);
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    padding: 12px 16px;
+}
+
+.confirm-changes__btn {
+    border: 0;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.85em;
+    font-weight: 500;
+    padding: 6px 16px;
+}
+
+.confirm-changes__btn--reject {
+    background: var(--sc-ai-color-surface-subtle);
+    color: var(--sc-ai-color-text-primary);
+}
+
+.confirm-changes__btn--accept {
+    background: #171717;
+    color: #fff;
+}
+
+.confirm-changes__status {
+    font-size: 0.9em;
+    font-weight: 600;
+}
+
+.confirm-changes__status--accepted {
+    color: #22c55e;
+}
+
+.confirm-changes__status--rejected {
+    color: #ef4444;
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/DocumentPreview.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/DocumentPreview.razor
@@ -1,0 +1,171 @@
+@using System.Text.Encodings.Web
+@using System.Text.RegularExpressions
+@implements IDisposable
+
+@if (!IsReadOnly)
+{
+    <textarea class="document-editor__input"
+              aria-label="Document editor"
+              placeholder="Write whatever you want here in Markdown format..."
+              value="@Document"
+              @oninput="UpdateDocumentAsync"></textarea>
+}
+else
+{
+    <div class="document-editor__surface"
+         role="textbox"
+         aria-label="Document editor"
+         aria-readonly="true">
+        <pre class="document-editor__diff">@((MarkupString)RenderDocument())</pre>
+    </div>
+}
+
+@code {
+    private AgentContext? _registeredContext;
+    private IDisposable? _statusChangedRegistration;
+
+    [CascadingParameter]
+    public AgentContext AgentContext { get; set; } = default!;
+
+    [Parameter]
+    public string Document { get; set; } = "";
+
+    [Parameter]
+    public string BaselineDocument { get; set; } = "";
+
+    [Parameter]
+    public bool IsReadOnly { get; set; }
+
+    [Parameter]
+    public bool ShowDiff { get; set; }
+
+    [Parameter]
+    public bool IsComplete { get; set; }
+
+    [Parameter]
+    public EventCallback<string> DocumentChanged { get; set; }
+
+    [Parameter]
+    public Action<ConversationStatus>? StatusChanged { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        if (!ReferenceEquals(_registeredContext, AgentContext))
+        {
+            _statusChangedRegistration?.Dispose();
+            _registeredContext = AgentContext;
+            _statusChangedRegistration = AgentContext.RegisterOnStatusChanged(OnStatusChanged);
+        }
+    }
+
+    private Task UpdateDocumentAsync(ChangeEventArgs args)
+        => DocumentChanged.InvokeAsync(args.Value?.ToString() ?? "");
+
+    private void OnStatusChanged(ConversationStatus status)
+    {
+        StatusChanged?.Invoke(status);
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private string RenderDocument()
+    {
+        if (!ShowDiff)
+        {
+            return HtmlEncoder.Default.Encode(Document);
+        }
+
+        var oldText = BaselineDocument;
+        var oldTextToCompare = oldText.Length > Document.Length && !IsComplete
+            ? oldText[..Document.Length]
+            : oldText;
+        var parts = DiffWords(oldTextToCompare, Document);
+        if (oldText.Length > Document.Length && !IsComplete)
+        {
+            parts.Add(new DiffPart(oldText[Document.Length..], DiffKind.Unchanged));
+        }
+
+        return string.Concat(parts.Select(part =>
+        {
+            var encoded = HtmlEncoder.Default.Encode(part.Value);
+            return part.Kind switch
+            {
+                DiffKind.Added => $"<em>{encoded}</em>",
+                DiffKind.Removed => $"<s>{encoded}</s>",
+                _ => encoded,
+            };
+        }));
+    }
+
+    private static List<DiffPart> DiffWords(string oldText, string newText)
+    {
+        var oldTokens = Regex.Split(oldText, @"(\s+)").Where(value => value.Length > 0).ToArray();
+        var newTokens = Regex.Split(newText, @"(\s+)").Where(value => value.Length > 0).ToArray();
+        var lengths = new int[oldTokens.Length + 1, newTokens.Length + 1];
+
+        for (var oldIndex = oldTokens.Length - 1; oldIndex >= 0; oldIndex--)
+        {
+            for (var newIndex = newTokens.Length - 1; newIndex >= 0; newIndex--)
+            {
+                lengths[oldIndex, newIndex] = oldTokens[oldIndex] == newTokens[newIndex]
+                    ? lengths[oldIndex + 1, newIndex + 1] + 1
+                    : Math.Max(lengths[oldIndex + 1, newIndex], lengths[oldIndex, newIndex + 1]);
+            }
+        }
+
+        var parts = new List<DiffPart>();
+        var oldPosition = 0;
+        var newPosition = 0;
+        while (oldPosition < oldTokens.Length || newPosition < newTokens.Length)
+        {
+            if (oldPosition < oldTokens.Length &&
+                newPosition < newTokens.Length &&
+                oldTokens[oldPosition] == newTokens[newPosition])
+            {
+                AddPart(parts, oldTokens[oldPosition], DiffKind.Unchanged);
+                oldPosition++;
+                newPosition++;
+            }
+            else if (newPosition < newTokens.Length &&
+                (oldPosition == oldTokens.Length ||
+                    lengths[oldPosition, newPosition + 1] >=
+                    lengths[oldPosition + 1, newPosition]))
+            {
+                AddPart(parts, newTokens[newPosition], DiffKind.Added);
+                newPosition++;
+            }
+            else
+            {
+                AddPart(parts, oldTokens[oldPosition], DiffKind.Removed);
+                oldPosition++;
+            }
+        }
+
+        return parts;
+    }
+
+    private static void AddPart(List<DiffPart> parts, string value, DiffKind kind)
+    {
+        if (parts.Count > 0 && parts[^1].Kind == kind)
+        {
+            parts[^1] = parts[^1] with { Value = parts[^1].Value + value };
+        }
+        else
+        {
+            parts.Add(new DiffPart(value, kind));
+        }
+    }
+
+    public void Dispose()
+    {
+        _statusChangedRegistration?.Dispose();
+    }
+
+    private sealed record DiffPart(string Value, DiffKind Kind);
+
+    private enum DiffKind
+    {
+        Unchanged,
+        Added,
+        Removed,
+    }
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/DocumentPreview.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/DocumentPreview.razor
@@ -15,7 +15,9 @@ else
     <div class="document-editor__surface"
          role="textbox"
          aria-label="Document editor"
-         aria-readonly="true">
+         aria-readonly="true"
+         aria-multiline="true"
+         tabindex="0">
         <pre class="document-editor__diff">@((MarkupString)RenderDocument())</pre>
     </div>
 }

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/DocumentPreview.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/DocumentPreview.razor.css
@@ -1,0 +1,47 @@
+.document-editor__input,
+.document-editor__surface {
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 10px;
+    color: #111827;
+    font: 0.95rem/1.7 ui-monospace, SFMono-Regular, Consolas, monospace;
+    min-height: calc(100vh - 190px);
+    padding: 28px;
+    white-space: pre-wrap;
+    width: 100%;
+}
+
+.document-editor__input {
+    resize: vertical;
+}
+
+.document-editor__input:focus {
+    border-color: #6366f1;
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+    outline: none;
+}
+
+.document-editor__surface {
+    background: #f9fafb;
+}
+
+.document-editor__diff {
+    font: inherit;
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+::deep .document-editor__diff em {
+    background: #dcfce7;
+    border-radius: 3px;
+    color: #166534;
+    font-style: normal;
+    text-decoration: none;
+}
+
+::deep .document-editor__diff s {
+    background: #fee2e2;
+    border-radius: 3px;
+    color: #991b1b;
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/DocumentState.cs
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/DocumentState.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace DojoClient.Components.Scenarios.PredictiveStateUpdates;
+
+public sealed class DocumentState
+{
+    public string Document { get; set; } = "";
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/DocumentSuggestions.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/DocumentSuggestions.razor
@@ -1,0 +1,39 @@
+@implements IDisposable
+
+<div class="document-suggestions">
+    <button disabled="@IsRunning"
+            @onclick='() => SendAsync("Please write a story about a pirate named Candy Beard.")'>
+        Write a pirate story
+    </button>
+    <button disabled="@IsRunning"
+            @onclick='() => SendAsync("Please write a story about a mermaid named Luna.")'>
+        Write a mermaid story
+    </button>
+    <button disabled="@IsRunning"
+            @onclick='() => SendAsync("Please add a character named Courage.")'>
+        Add character
+    </button>
+</div>
+
+@code {
+    private IDisposable? _statusChangedRegistration;
+
+    [CascadingParameter]
+    public AgentContext AgentContext { get; set; } = default!;
+
+    private bool IsRunning
+        => AgentContext.Status is ConversationStatus.Streaming or ConversationStatus.AwaitingInput;
+
+    protected override void OnInitialized()
+    {
+        _statusChangedRegistration = AgentContext.RegisterOnStatusChanged(
+            status =>
+            {
+                _ = InvokeAsync(StateHasChanged);
+            });
+    }
+
+    private Task SendAsync(string prompt) => AgentContext.SendMessageAsync(prompt);
+
+    public void Dispose() => _statusChangedRegistration?.Dispose();
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/DocumentSuggestions.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/DocumentSuggestions.razor.css
@@ -1,0 +1,20 @@
+.document-suggestions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 0 16px 12px;
+}
+
+.document-suggestions button {
+    background: #fff;
+    border: 1px solid #6366f1;
+    border-radius: 999px;
+    color: #4f46e5;
+    cursor: pointer;
+    padding: 6px 10px;
+}
+
+.document-suggestions button:disabled {
+    cursor: wait;
+    opacity: 0.6;
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/PredictiveStateUpdatesScenario.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/PredictiveStateUpdatesScenario.razor
@@ -1,0 +1,197 @@
+@page "/predictive_state_updates"
+@rendermode InteractiveServer
+@implements IDisposable
+@using System.Text.Json
+@inject ILoggerFactory LoggerFactory
+
+<PageTitle>Predictive State Updates</PageTitle>
+
+<div class="predictive-state-updates" data-scenario="predictive_state_updates">
+    <AgentBoundary @key="_agent" Agent="_agent">
+        <div class="predictive-layout">
+            <div class="document-panel @(_runActive ? "document-panel--streaming" : "")">
+                <DocumentPreview Document="@_agent.State.Value.Document"
+                                 BaselineDocument="@_runStartDocument"
+                                 IsReadOnly="_runActive"
+                                 ShowDiff="_showDiff"
+                                 IsComplete="_candidateComplete"
+                                 DocumentChanged="UpdateDocument"
+                                 StatusChanged="HandleConversationStatusChanged" />
+            </div>
+            <aside class="predictive-chat">
+                <header class="predictive-chat__header">
+                    <h1>AI Document Editor</h1>
+                    <button aria-label="Reset document"
+                            disabled="@_runActive"
+                            @onclick="Reset">&times;</button>
+                </header>
+                <div class="sc-ai-root sc-ai-chat-page dojo-chat-panel">
+                    <div class="sc-ai-chat-page__body">
+                        <MessageList>
+                            <EmptyContent>
+                                <p class="dojo-scenario__welcome">
+                                    Write directly or ask the agent to propose an edit.
+                                </p>
+                            </EmptyContent>
+                            <ChildContent>
+                                <BlockRenderer TBlock="UIActionBlock"
+                                               Context="action"
+                                               When="@(block => block.ToolName == "confirm_changes")">
+                                    <ConfirmChangesDialog Block="action" />
+                                </BlockRenderer>
+                            </ChildContent>
+                        </MessageList>
+                    </div>
+                    <DocumentSuggestions />
+                    <div class="sc-ai-chat-page__footer">
+                        <div class="sc-ai-chat-page__input-container">
+                            <MessageInput Placeholder="Type a message..." />
+                        </div>
+                    </div>
+                </div>
+            </aside>
+        </div>
+    </AgentBoundary>
+</div>
+
+@code {
+    private static readonly JsonSerializerOptions _jsonOptions =
+        new(JsonSerializerDefaults.Web);
+
+    private UIAgent<DocumentState> _agent = default!;
+    private DojoConversationThread _thread = default!;
+    private IDisposable? _stateChangedRegistration;
+    private string _runStartDocument = "";
+    private bool _runActive;
+    private bool _showDiff;
+    private bool _candidateComplete;
+
+    [Inject(Key = DojoScenarios.PredictiveStateUpdatesEndpoint)]
+    public IChatClient ChatClient { get; set; } = default!;
+
+    protected override void OnInitialized() => Reset();
+
+    private UIAgent<DocumentState> CreateAgent(DocumentState initialState)
+    {
+        _thread = new DojoConversationThread(Guid.NewGuid().ToString("N"));
+
+        return new UIAgent<DocumentState>(ChatClient, options =>
+        {
+            options.Thread = _thread;
+            options.ChatOptions = new ChatOptions
+            {
+                RawRepresentationFactory = _ => new RunAgentInput
+                {
+                    ThreadId = _thread.ThreadId,
+                    State = JsonSerializer.SerializeToElement(_agent.State.Value, _jsonOptions),
+                },
+                Tools =
+                [
+                    AIFunctionFactory.Create(
+                        WriteDocument,
+                        name: "write_document_local",
+                        description: "Write the full document in Markdown format."),
+                ],
+            };
+            options.StateMapper = context =>
+            {
+                if (context.Update.Contents
+                    .OfType<FunctionCallContent>()
+                    .Any(call => call.Name == "confirm_changes"))
+                {
+                    _candidateComplete = true;
+                    _ = InvokeAsync(StateHasChanged);
+                }
+
+                if (context.Update.RawRepresentation is not StateSnapshotEvent snapshot)
+                {
+                    return false;
+                }
+
+                var state = snapshot.Snapshot.Deserialize<DocumentState>(_jsonOptions);
+                if (state is null)
+                {
+                    return false;
+                }
+
+                context.SetPredictiveState(state);
+                return true;
+            };
+            options.RegisterUIAction(AIFunctionFactory.Create(
+                ConfirmChanges,
+                name: "confirm_changes",
+                description: "Confirm the document changes with the user."));
+        }, LoggerFactory, initialState);
+    }
+
+    private static string WriteDocument(string document) => "Document written.";
+
+    private string ConfirmChanges(bool accepted = true)
+    {
+        if (accepted)
+        {
+            _agent.State.AcceptPredictiveState();
+        }
+        else
+        {
+            _agent.State.RejectPredictiveState();
+        }
+
+        _showDiff = false;
+        return accepted
+            ? "The user confirmed the changes."
+            : "The user rejected the changes.";
+    }
+
+    private void Reset()
+    {
+        if (_runActive)
+        {
+            return;
+        }
+
+        var nextAgent = CreateAgent(new DocumentState());
+        _stateChangedRegistration?.Dispose();
+        _agent?.Dispose();
+        _agent = nextAgent;
+        _runStartDocument = "";
+        _showDiff = false;
+        _candidateComplete = false;
+        _stateChangedRegistration = _agent.State.OnChanged(
+            () => _ = InvokeAsync(StateHasChanged));
+    }
+
+    private void UpdateDocument(string document)
+    {
+        if (!_runActive)
+        {
+            _agent.State.Value = new DocumentState { Document = document };
+        }
+    }
+
+    private void HandleConversationStatusChanged(ConversationStatus status)
+    {
+        if (status == ConversationStatus.Streaming && !_runActive)
+        {
+            _runStartDocument = _agent.State.Value.Document;
+            _runActive = true;
+            _showDiff = true;
+            _candidateComplete = false;
+        }
+        else if (status is ConversationStatus.Idle or ConversationStatus.Error)
+        {
+            _runActive = false;
+            _showDiff = false;
+            _candidateComplete = false;
+            _runStartDocument = _agent.State.Value.Document;
+        }
+
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        _stateChangedRegistration?.Dispose();
+        _agent?.Dispose();
+    }
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/PredictiveStateUpdatesScenario.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/PredictiveStateUpdatesScenario.razor
@@ -105,17 +105,16 @@
 
                 if (context.Update.RawRepresentation is not StateSnapshotEvent snapshot)
                 {
-                    return false;
+                    return;
                 }
 
                 var state = snapshot.Snapshot.Deserialize<DocumentState>(_jsonOptions);
                 if (state is null)
                 {
-                    return false;
+                    return;
                 }
 
                 context.SetPredictiveState(state);
-                return true;
             };
             options.RegisterUIAction(AIFunctionFactory.Create(
                 ConfirmChanges,

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/PredictiveStateUpdatesScenario.razor.css
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/PredictiveStateUpdates/PredictiveStateUpdatesScenario.razor.css
@@ -1,0 +1,58 @@
+.predictive-state-updates {
+    height: 100vh;
+}
+
+.predictive-layout {
+    display: flex;
+    height: 100%;
+    min-height: 0;
+    min-width: 0;
+}
+
+.document-panel {
+    background: #fff;
+    flex: 1;
+    min-height: 0;
+    min-width: 0;
+    overflow-y: auto;
+    padding: 24px 32px;
+}
+
+.document-panel--streaming {
+    border-right: 3px solid #6366f1;
+}
+
+.predictive-chat {
+    background: #fff;
+    border-left: 1px solid #e5e7eb;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    min-width: 360px;
+    width: 360px;
+}
+
+.predictive-chat__header {
+    align-items: center;
+    border-bottom: 1px solid #e5e7eb;
+    display: flex;
+    justify-content: space-between;
+    padding: 12px 16px;
+}
+
+.predictive-chat__header h1 {
+    font-size: 1.125rem;
+    margin: 0;
+}
+
+.predictive-chat__header button {
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+    font-size: 1.5rem;
+}
+
+.predictive-chat__header button:disabled {
+    cursor: wait;
+    opacity: 0.45;
+}

--- a/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/SharedStateScenario.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/Scenarios/SharedState/SharedStateScenario.razor
@@ -72,7 +72,7 @@
 
     private readonly HashSet<string> _changedSections = new(StringComparer.Ordinal);
     private UIAgent<RecipeState> _agent = default!;
-    private SharedStateConversationThread _thread = default!;
+    private DojoConversationThread _thread = default!;
     private IDisposable? _stateChangedRegistration;
     private Recipe _lastRecipe = default!;
     private bool _isApplyingLocalState;
@@ -86,7 +86,7 @@
 
     private UIAgent<RecipeState> CreateAgent(RecipeState initialState)
     {
-        _thread = new SharedStateConversationThread(Guid.NewGuid().ToString("N"));
+        _thread = new DojoConversationThread(Guid.NewGuid().ToString("N"));
 
         return new UIAgent<RecipeState>(ChatClient, options =>
         {

--- a/src/Components/AI/testassets/DojoClient/Components/_Imports.razor
+++ b/src/Components/AI/testassets/DojoClient/Components/_Imports.razor
@@ -14,4 +14,5 @@
 @using DojoClient.Components.Scenarios.ToolBasedGenerativeUI
 @using DojoClient.Components.Scenarios.AgenticGenerativeUI
 @using DojoClient.Components.Scenarios.SharedState
+@using DojoClient.Components.Scenarios.PredictiveStateUpdates
 @using DojoClient.Components.Layout

--- a/src/Components/AI/testassets/DojoClient/DojoScenarios.cs
+++ b/src/Components/AI/testassets/DojoClient/DojoScenarios.cs
@@ -19,4 +19,6 @@ internal static class DojoScenarios
     internal const string AgenticGenerativeUIEndpoint = "/agentic_generative_ui";
 
     internal const string SharedStateEndpoint = "/shared_state";
+
+    internal const string PredictiveStateUpdatesEndpoint = "/predictive_state_updates";
 }

--- a/src/Components/AI/testassets/DojoClient/Program.cs
+++ b/src/Components/AI/testassets/DojoClient/Program.cs
@@ -40,6 +40,9 @@ builder.Services.AddKeyedScoped<IChatClient>(
 builder.Services.AddKeyedScoped<IChatClient>(
     DojoScenarios.SharedStateEndpoint,
     (sp, _) => CreateChatClient(sp, DojoScenarios.SharedStateEndpoint));
+builder.Services.AddKeyedScoped<IChatClient>(
+    DojoScenarios.PredictiveStateUpdatesEndpoint,
+    (sp, _) => CreateChatClient(sp, DojoScenarios.PredictiveStateUpdatesEndpoint));
 
 var app = builder.Build();
 

--- a/src/Components/AI/testassets/DojoClient/Shared/DojoConversationThread.cs
+++ b/src/Components/AI/testassets/DojoClient/Shared/DojoConversationThread.cs
@@ -4,14 +4,14 @@
 using Microsoft.AspNetCore.Components.AI;
 using Microsoft.Extensions.AI;
 
-namespace DojoClient.Components.Scenarios.SharedState;
+namespace DojoClient;
 
-internal sealed class SharedStateConversationThread : IConversationThread
+internal sealed class DojoConversationThread : IConversationThread
 {
     private readonly List<ChatResponseUpdate> _updates = [];
     private List<ChatResponseUpdate>? _currentTurn;
 
-    internal SharedStateConversationThread(string threadId)
+    internal DojoConversationThread(string threadId)
     {
         ArgumentException.ThrowIfNullOrEmpty(threadId);
         ThreadId = threadId;


### PR DESCRIPTION
## Overview

Adds transactional predictive state to `Microsoft.AspNetCore.Components.AI` and demonstrates it in the document-edit dojo. Streamed edits are visible before confirmation, explicit acceptance commits them, and rejection or an unconfirmed terminal path restores the prior committed value.

This PR is position 9 in native stack #68340 and depends directly on #68334. The shipping API remains provider-neutral while the sample and E2E test continue through the real `DojoClient` to AG-UI HTTP and SSE boundary.

## Design

`StateMapperContext.SetPredictiveState` marks mapped state as provisional. `AgentState<T>` captures one baseline for the predictive transaction, replaces only the visible candidate as snapshots arrive, and exposes explicit accept and reject operations.

`AgentContext` rejects pending predictive state on normal completion without confirmation, cancellation, failure, and disposal. Restore also rejects persisted predictive snapshots before committing restored state because the conversation thread does not currently record whether the user accepted them. Persistence of accepted predictive decisions is tracked in #68227.

The predictive API mapping expands document writes into incremental state snapshots and one confirmation action for the request. Multiple writes update the same latest predictive value and do not create competing confirmations.

## Review updates

- Makes the read-only document textbox keyboard-focusable and marks it as multiline.
- Prevents concurrent confirmation responses and disables both controls while the first response runs.
- Rejects restored predictive state so rejected or unconfirmed snapshots cannot return as pending.
- Emits one confirmation for multiple document writes in the same predictive transaction.

No visual layout changes are included.

## Validation

- `PredictiveStateTests` passed with 6 of 6 tests.
- `PredictiveStateUpdatesScenarioTests` passed with 1 of 1 tests through the dual-host AG-UI path.
- The focused E2E project builds with zero warnings and zero errors.
