### PR TITLE
[test-quarantine] Stabilize and Unquarantine VirtualizationTest.AnchorMode_WindowScroll_HomeKeyJumpsToTop

### DIFF
--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -4794,7 +4794,6 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     [InlineData("0")]
     [InlineData("1")]
     [InlineData("2")]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/68225")]
     public void AnchorMode_WindowScroll_HomeKeyJumpsToTop(string anchorMode)
     {
         MountWindowScrollAnchorModeComponent(anchorMode);

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -4505,9 +4505,10 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
 
     private void WindowScrollMidListAndWaitForRender(IJavaScriptExecutor js)
     {
-        js.ExecuteScript("window.scrollTo(0, 5000)");
         Browser.True(() =>
         {
+            js.ExecuteScript("window.scrollTo(0, 5000)");
+
             var scrollY = (long)js.ExecuteScript("return Math.round(window.scrollY)");
             return scrollY > 4000;
         }, TimeSpan.FromSeconds(5));


### PR DESCRIPTION
## Stabilize and Unquarantine VirtualizationTest.AnchorMode_WindowScroll_HomeKeyJumpsToTop

### Description

This PR addresses flakiness in

`VirtualizationTest.AnchorMode_WindowScroll_HomeKeyJumpsToTop`.

The test was previously quarantined due to intermittent failures in CI. Based on the stack trace, the failure occurs inside `WindowScrollMidListAndWaitForRender(...)`, before the Home key assertion is reached.

The helper previously called `window.scrollTo(0, 5000)` once and then used `Browser.True(...)` only to retry checking whether `window.scrollY > 4000`. In CI/VM environments, Virtualize/layout can adjust or delay the window scroll after the initial scroll request, so the single scroll attempt may not leave the page at the expected mid-list position.

To make the test more resilient, the scroll request has been moved inside the retryable assertion delegate. This allows the test framework to retry both the scroll action and the scroll-position validation within the existing timeout, instead of retrying only the assertion.

### Validation / Investigation

As part of the investigation:
- The failure was observed in Linux CI artifacts.
- The stack trace from the Linux run shows the failure occurs in
  `WindowScrollMidListAndWaitForRender(...)`, before the Home key assertion.
- The fix is based on that stack trace and targets the mid-list scroll setup,
  not the Home key behavior.

### Changes

- Moved `window.scrollTo(0, 5000)` inside the `Browser.True(...)` retry loop.
- Ensured the test retries the scroll action until `window.scrollY > 4000`.
- Kept the existing timeout unchanged.
- Removed `[QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/68225")]`.

### Test Output
After implementing the fix, I tested it with 100 iterations on Windows, and all test runs passed successfully. I also confirmed that the fix does not introduce any regressions or breaking changes on Windows.

<img width="1440" height="318" alt="image" src="https://github.com/user-attachments/assets/0e5baaf2-cf37-4845-992a-358fb6cb5af9" />


Fixes #68225