### PR TITLE
Fix ANCM app_offline.htm notification match using QueryCCH

### DIFF
--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/CommonLibTests.vcxproj
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/CommonLibTests.vcxproj
@@ -34,6 +34,7 @@
     <ClCompile Include="StandardOutputRedirectionTest.cpp" />
     <ClCompile Include="BindingInformationTest.cpp" />
     <ClCompile Include="utility_tests.cpp" />
+    <ClCompile Include="filewatcher_tests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AspNetCore\AspNetCore.vcxproj">

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/fakeclasses.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/fakeclasses.h
@@ -6,6 +6,7 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "InProcessOptions.h"
+#include "AppOfflineTrackingApplication.h"
 
 class MockProperty : public IAppHostProperty
 {
@@ -185,6 +186,26 @@ public:
         CreateConfig()
     {
         return new MockInProcessOptions;
+    }
+};
+
+class MockAppOfflineTrackingApplication : public AppOfflineTrackingApplication
+{
+public:
+    MockAppOfflineTrackingApplication(const IHttpApplication& application)
+        : AppOfflineTrackingApplication(application)
+    {
+    }
+
+    VOID StopInternal(bool fServerInitiated) override {}
+    VOID OnAppOffline() override {}
+
+    HRESULT CreateHandler(
+        _In_ IHttpContext *pHttpContext,
+        _Outptr_opt_ IREQUEST_HANDLER **pRequestHandler) override
+    {
+        *pRequestHandler = nullptr;
+        return E_NOTIMPL;
     }
 };
 

--- a/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/filewatcher_tests.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/CommonLibTests/filewatcher_tests.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+#include "stdafx.h"
+#include "filewatcher.h"
+#include "AppOfflineTrackingApplication.h"
+#include "fakeclasses.h"
+
+class FileWatcherTests : public testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        EXPECT_CALL(m_mockHttpApplication, GetApplicationPhysicalPath())
+            .WillRepeatedly(testing::Return(m_applicationPath.c_str()));
+        EXPECT_CALL(m_mockHttpApplication, GetApplicationId())
+            .WillRepeatedly(testing::Return(L"/TestApp"));
+        EXPECT_CALL(m_mockHttpApplication, GetAppConfigPath())
+            .WillRepeatedly(testing::Return(L"/TestApp/web.config"));
+    }
+
+    void SetupFileChangeNotification(
+        FILE_WATCHER& watcher,
+        AppOfflineTrackingApplication* pApplication,
+        PCWSTR pszWatchedFileName,
+        PCWSTR pszNotificationFileName,
+        DWORD& outSize)
+    {
+        watcher._pApplication = ReferenceApplication(pApplication);
+
+        HRESULT hr = watcher._strFileName.Copy(pszWatchedFileName);
+        ASSERT_TRUE(SUCCEEDED(hr));
+
+        const DWORD fileNameLength = static_cast<DWORD>(wcslen(pszNotificationFileName) * sizeof(WCHAR));
+        outSize = FIELD_OFFSET(FILE_NOTIFY_INFORMATION, FileName) + fileNameLength;
+
+        ASSERT_TRUE(watcher._buffDirectoryChanges.Resize(outSize));
+
+        auto pNotificationInfo = reinterpret_cast<FILE_NOTIFY_INFORMATION*>(watcher._buffDirectoryChanges.QueryPtr());
+        memset(pNotificationInfo, 0, outSize);
+        pNotificationInfo->NextEntryOffset = 0;
+        pNotificationInfo->Action = FILE_ACTION_MODIFIED;
+        pNotificationInfo->FileNameLength = fileNameLength;
+        memcpy(pNotificationInfo->FileName, pszNotificationFileName, fileNameLength);
+    }
+
+    MockHttpApplication m_mockHttpApplication;
+    std::wstring m_applicationPath = L"C:\\TestApp";
+};
+
+TEST_F(FileWatcherTests, HandleChangeCompletion_AppOfflineExactMatch_IsDetected)
+{
+    AppOfflineTrackingApplication* pApplication = new MockAppOfflineTrackingApplication(m_mockHttpApplication);
+    FILE_WATCHER watcher;
+
+    DWORD notifySize = 0;
+    SetupFileChangeNotification(watcher, pApplication, L"app_offline.htm", L"app_offline.htm", notifySize);
+
+    HRESULT hr = watcher.HandleChangeCompletion(notifySize);
+    ASSERT_TRUE(SUCCEEDED(hr));
+
+    EXPECT_TRUE(pApplication->m_detectedAppOffline);
+
+    pApplication->DereferenceApplication();
+}
+
+TEST_F(FileWatcherTests, HandleChangeCompletion_AppOfflinePrefix_IsIgnored)
+{
+    AppOfflineTrackingApplication* pApplication = new MockAppOfflineTrackingApplication(m_mockHttpApplication);
+    FILE_WATCHER watcher;
+
+    DWORD notifySize = 0;
+    SetupFileChangeNotification(watcher, pApplication, L"app_offline.htm", L"app_o", notifySize);
+
+    HRESULT hr = watcher.HandleChangeCompletion(notifySize);
+    ASSERT_TRUE(SUCCEEDED(hr));
+
+    EXPECT_FALSE(pApplication->m_detectedAppOffline);
+
+    pApplication->DereferenceApplication();
+}
+
+TEST_F(FileWatcherTests, HandleChangeCompletion_AppOfflineSuffix_IsIgnored)
+{
+    AppOfflineTrackingApplication* pApplication = new MockAppOfflineTrackingApplication(m_mockHttpApplication);
+    FILE_WATCHER watcher;
+
+    DWORD notifySize = 0;
+    SetupFileChangeNotification(watcher, pApplication, L"app_offline.htm", L"app_offline.htmx", notifySize);
+
+    HRESULT hr = watcher.HandleChangeCompletion(notifySize);
+    ASSERT_TRUE(SUCCEEDED(hr));
+
+    EXPECT_FALSE(pApplication->m_detectedAppOffline);
+
+    pApplication->DereferenceApplication();
+}

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.cpp
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.cpp
@@ -165,7 +165,7 @@ Win32 error
 --*/
 {
     FILE_WATCHER* pFileMonitor = (FILE_WATCHER*)pvArg;
-    
+
     LOG_INFO(L"Starting file watcher thread");
     DBG_ASSERT(pFileMonitor != nullptr);
 
@@ -294,7 +294,7 @@ HRESULT
             //
             // check whether the monitored file got changed
             //
-            if (_strFileName.QuerySizeCCH() == (pNotificationInfo->FileNameLength / sizeof(WCHAR))
+            if (_strFileName.QueryCCH() == (pNotificationInfo->FileNameLength / sizeof(WCHAR))
                 && _wcsnicmp(pNotificationInfo->FileName,
                 _strFileName.QueryStr(),
                 pNotificationInfo->FileNameLength / sizeof(WCHAR)) == 0)

--- a/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.h
+++ b/src/Servers/IIS/AspNetCoreModuleV2/RequestHandlerLib/filewatcher.h
@@ -76,4 +76,5 @@ private:
     OVERLAPPED              _overlapped;
     std::unique_ptr<AppOfflineTrackingApplication, IAPPLICATION_DELETER> _pApplication;
     bool                    m_fRudeThreadTermination;
+    friend class FileWatcherTests;
 };


### PR DESCRIPTION
# Fix ANCM app_offline.htm notification match using QueryCCH

## Description
Fixes an issue in file watcher where `FILE_WATCHER::HandleChangeCompletion` compared the buffer capacity (`QuerySizeCCH()`) instead of the actual string length (`QueryCCH()`) against the notified filename length. This made the notification-driven `app_offline.htm` match path unreachable, causing the application to rely solely on the fallback existence check.

## Changes
- Replaced `_strFileName.QuerySizeCCH()` with `_strFileName.QueryCCH()` in `filewatcher.cpp`.
- Added friend class `FileWatcherTests` in `filewatcher.h`.
- Added `MockAppOfflineTrackingApplication` in `FakeClasses.cpp`.
- Added native unit tests covering exact matches and prefix rejections in `filewatcher_tests.cpp`.
- include `filewatcher_tests.cpp` in `CommonLibTests.vcxproj`.

Fixes #68283