### PR TITLE
Fix ApiExplorer to include FromQuery(Name) prefix in parameter names

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.AspNetCore.Http.Metadata;
@@ -637,7 +638,7 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
             var newContainerName = containerName;
             if (modelMetadata.ContainerType != null || !string.IsNullOrEmpty(bindingContext.BinderModelName))
             {
-                newContainerName = GetName(containerName, bindingContext);
+                newContainerName = GetName(containerName, bindingContext, source);
             }
 
             var metadataProperties = modelMetadata.Properties;
@@ -674,7 +675,7 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
             return new ApiParameterDescription()
             {
                 ModelMetadata = bindingContext.ModelMetadata,
-                Name = GetName(containerName, bindingContext),
+                Name = GetName(containerName, bindingContext, source),
                 Source = source,
                 Type = GetModelType(bindingContext.ModelMetadata),
                 ParameterDescriptor = Parameter,
@@ -693,10 +694,14 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
             return metadata.ModelType;
         }
 
-        private static string GetName(string containerName, ApiParameterDescriptionContext metadata)
+        private static string GetName(string containerName, ApiParameterDescriptionContext metadata, BindingSource? source)
         {
             var propertyName = !string.IsNullOrEmpty(metadata.BinderModelName) ? metadata.BinderModelName : metadata.PropertyName;
-            return ModelNames.CreatePropertyModelName(containerName, propertyName);
+            Debug.Assert(propertyName is not null);
+
+            return source == BindingSource.Header
+                ? propertyName
+                : ModelNames.CreatePropertyModelName(containerName, propertyName);
         }
 
         private readonly struct PropertyKey

--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -633,7 +633,7 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
             //  Order - source: Body
             //
 
-            // We don't want to append the **parameter** name when building a model name.
+            // Append the property name when building a model name, or the parameter name when it was explicitly provided via IModelNameProvider.
             var newContainerName = containerName;
             if (modelMetadata.ContainerType != null || !string.IsNullOrEmpty(bindingContext.BinderModelName))
             {

--- a/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
+++ b/src/Mvc/Mvc.ApiExplorer/src/DefaultApiDescriptionProvider.cs
@@ -635,7 +635,7 @@ public class DefaultApiDescriptionProvider : IApiDescriptionProvider
 
             // We don't want to append the **parameter** name when building a model name.
             var newContainerName = containerName;
-            if (modelMetadata.ContainerType != null)
+            if (modelMetadata.ContainerType != null || !string.IsNullOrEmpty(bindingContext.BinderModelName))
             {
                 newContainerName = GetName(containerName, bindingContext);
             }

--- a/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
@@ -1624,7 +1624,7 @@ public class DefaultApiDescriptionProviderTest
         var description = Assert.Single(descriptions);
         Assert.Single(description.ParameterDescriptions);
 
-        var id = Assert.Single(description.ParameterDescriptions, p => p.Name == "Name");
+        var id = Assert.Single(description.ParameterDescriptions, p => p.Name == "employee.Name");
         Assert.Same(BindingSource.Query, id.Source);
         Assert.Equal(typeof(string), id.Type);
     }

--- a/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
@@ -1642,7 +1642,7 @@ public class DefaultApiDescriptionProviderTest
         var description = Assert.Single(descriptions);
         Assert.Equal(2, description.ParameterDescriptions.Count);
 
-        var header = Assert.Single(description.ParameterDescriptions, p => p.Name == "employee.X-MyCustomHeader");
+        var header = Assert.Single(description.ParameterDescriptions, p => p.Name == "X-MyCustomHeader");
         Assert.Same(BindingSource.Header, header.Source);
         Assert.Equal(typeof(string), header.Type);
 

--- a/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/DefaultApiDescriptionProviderTest.cs
@@ -1630,6 +1630,28 @@ public class DefaultApiDescriptionProviderTest
     }
 
     [Fact]
+    public void GetApiDescription_ParameterDescription_FromQueryEmployee_WithCustomPropertyBindingNames()
+    {
+        // Arrange
+        var action = CreateActionDescriptor(nameof(AcceptsEmployeeWithCustomPropertyNames));
+
+        // Act
+        var descriptions = GetApiDescriptions(action);
+
+        // Assert
+        var description = Assert.Single(descriptions);
+        Assert.Equal(2, description.ParameterDescriptions.Count);
+
+        var header = Assert.Single(description.ParameterDescriptions, p => p.Name == "employee.X-MyCustomHeader");
+        Assert.Same(BindingSource.Header, header.Source);
+        Assert.Equal(typeof(string), header.Type);
+
+        var route = Assert.Single(description.ParameterDescriptions, p => p.Name == "employee.employeeid");
+        Assert.Same(BindingSource.Path, route.Source);
+        Assert.Equal(typeof(string), route.Type);
+    }
+
+    [Fact]
     public void GetApiDescription_ParameterDescription_ParsablePrimitiveType()
     {
         // Arrange
@@ -2542,6 +2564,10 @@ public class DefaultApiDescriptionProviderTest
     {
     }
 
+    private void AcceptsEmployeeWithCustomPropertyNames([FromQuery(Name = "employee")] EmployeeWithCustomPropertyNames dto)
+    {
+    }
+
     private void AcceptsTryParsablePrimitiveType([FromQuery] Guid id)
     {
     }
@@ -2693,6 +2719,15 @@ public class DefaultApiDescriptionProviderTest
     private class Employee
     {
         public string Name { get; set; }
+    }
+
+    private class EmployeeWithCustomPropertyNames
+    {
+        [FromHeader(Name = "X-MyCustomHeader")]
+        public string HeaderName { get; set; }
+
+        [FromRoute(Name = "employeeid")]
+        public string EmployeeId { get; set; }
     }
 
     [TypeConverter(typeof(EmployeeConverter))]


### PR DESCRIPTION
When using `[FromQuery(Name = "prefix")]` on complex types, ApiExplorer was incorrectly omitting the prefix from parameter names in Swagger/OpenAPI documentation. This caused a mismatch between the documented parameter names and the actual query parameter names that ASP.NET Core's model binder expects.

For example, with `[FromQuery(Name = "custom")] CustomType customType`, the actual query parameter is `custom.Input`, but Swagger docs were showing just `Input`.

This fix ensures ApiExplorer includes the `FromQuery(Name)` prefix when generating parameter names, so Swagger documentation accurately reflects the actual binding behavior.

Fixes #43464