### PR TITLE
Fix BL0013 diagnostic location for GetAuthenticationStateAsync

### DIFF
--- a/src/Components/Analyzers/src/AuthenticationStateProviderAnalyzer.cs
+++ b/src/Components/Analyzers/src/AuthenticationStateProviderAnalyzer.cs
@@ -47,6 +47,7 @@ public sealed class AuthenticationStateProviderAnalyzer : DiagnosticAnalyzer
 
                 var hasGetAuthStateCall = false;
                 var hasAuthStateChangedSubscription = false;
+                Location? getAuthenticationStateCallLocation = null;
 
                 context.RegisterOperationAction(operationContext =>
                 {
@@ -56,6 +57,7 @@ public sealed class AuthenticationStateProviderAnalyzer : DiagnosticAnalyzer
                         invocation.TargetMethod.Name == ComponentsApi.AuthenticationStateProvider.GetAuthenticationStateAsync)
                     {
                         hasGetAuthStateCall = true;
+                        getAuthenticationStateCallLocation ??= invocation.Syntax.GetLocation();
                     }
                 }, OperationKind.Invocation);
 
@@ -73,11 +75,11 @@ public sealed class AuthenticationStateProviderAnalyzer : DiagnosticAnalyzer
 
                 context.RegisterSymbolEndAction(endContext =>
                 {
-                    if (hasGetAuthStateCall && !hasAuthStateChangedSubscription)
+                    if (hasGetAuthStateCall && !hasAuthStateChangedSubscription && getAuthenticationStateCallLocation is not null)
                     {
                         endContext.ReportDiagnostic(Diagnostic.Create(
                             DiagnosticDescriptors.AuthenticationStateProviderCachedWithoutSubscription,
-                            namedType.Locations.FirstOrDefault(),
+                            getAuthenticationStateCallLocation,
                             namedType.Name));
                     }
                 });

--- a/src/Components/Analyzers/test/AuthenticationStateProviderAnalyzerTest.cs
+++ b/src/Components/Analyzers/test/AuthenticationStateProviderAnalyzerTest.cs
@@ -127,7 +127,7 @@ public class AuthenticationStateProviderAnalyzerTest : DiagnosticVerifier
                 Id = "BL0013",
                 Message = "'MyComponent' calls GetAuthenticationStateAsync on AuthenticationStateProvider without subscribing to the AuthenticationStateChanged event. This may result in using stale authentication state.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 7, 15) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 18, 35) }
             });
     }
 
@@ -178,14 +178,14 @@ public class AuthenticationStateProviderAnalyzerTest : DiagnosticVerifier
                 Message = "'MyCustomProvider' calls GetAuthenticationStateAsync on AuthenticationStateProvider without subscribing to the AuthenticationStateChanged event. This may result in using stale authentication state.",
 
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 7, 15) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 18, 32) }
             },
             new DiagnosticResult
             {
                 Id = "BL0013",
                 Message = "'ConsumerComponent' calls GetAuthenticationStateAsync on AuthenticationStateProvider without subscribing to the AuthenticationStateChanged event. This may result in using stale authentication state.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 22, 15) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 33, 35) }
             });
     }
 
@@ -230,7 +230,7 @@ public class AuthenticationStateProviderAnalyzerTest : DiagnosticVerifier
                 Message = "'MyComponent' calls GetAuthenticationStateAsync on AuthenticationStateProvider without subscribing to the AuthenticationStateChanged event. This may result in using stale authentication state.",
 
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 7, 15) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 22, 35) }
             });
     }
 
@@ -327,7 +327,7 @@ public class AuthenticationStateProviderAnalyzerTest : DiagnosticVerifier
                 Id = "BL0013",
                 Message = "'Consumer2Component' calls GetAuthenticationStateAsync on AuthenticationStateProvider without subscribing to the AuthenticationStateChanged event. This may result in using stale authentication state.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 17, 15) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 23, 35) }
             });
     }
 
@@ -407,7 +407,7 @@ public class AuthenticationStateProviderAnalyzerTest : DiagnosticVerifier
                 Id = "BL0013",
                 Message = "'Consumer2Component' calls GetAuthenticationStateAsync on AuthenticationStateProvider without subscribing to the AuthenticationStateChanged event. This may result in using stale authentication state.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 19, 15) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 25, 35) }
             });
     }
 
@@ -491,7 +491,7 @@ public class AuthenticationStateProviderAnalyzerTest : DiagnosticVerifier
                 Id = "BL0013",
                 Message = "'Consumer2Component' calls GetAuthenticationStateAsync on AuthenticationStateProvider without subscribing to the AuthenticationStateChanged event. This may result in using stale authentication state.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 21, 15) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 27, 35) }
             });
     }
 
@@ -586,7 +586,7 @@ public class AuthenticationStateProviderAnalyzerTest : DiagnosticVerifier
                 Id = "BL0013",
                 Message = "'Consumer2Component' calls GetAuthenticationStateAsync on AuthenticationStateProvider without subscribing to the AuthenticationStateChanged event. This may result in using stale authentication state.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 30, 15) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 36, 35) }
             });
     }
 


### PR DESCRIPTION
## Summary
Fix BL0013 to report the actual GetAuthenticationStateAsync() invocation location instead of the component declaration when analyzing generated Razor code.

## Validation
- dotnet test src\Components\Analyzers\test\Microsoft.AspNetCore.Components.Analyzers.Tests.csproj --filter AuthenticationStateProviderAnalyzerTest

Fixes #68339