### PR TITLE
Fix BL0013 highlighting unrelated locations in Razor files

### DIFF
--- a/src/Components/Analyzers/src/AuthenticationStateProviderAnalyzer.cs
+++ b/src/Components/Analyzers/src/AuthenticationStateProviderAnalyzer.cs
@@ -45,7 +45,7 @@ public sealed class AuthenticationStateProviderAnalyzer : DiagnosticAnalyzer
                     return;
                 }
 
-                var hasGetAuthStateCall = false;
+                Location? getAuthStateInvocationLocation = null;
                 var hasAuthStateChangedSubscription = false;
 
                 context.RegisterOperationAction(operationContext =>
@@ -55,7 +55,7 @@ public sealed class AuthenticationStateProviderAnalyzer : DiagnosticAnalyzer
                         IsAuthenticationStateProviderType(invocation.Instance.Type, authStateProviderType) &&
                         invocation.TargetMethod.Name == ComponentsApi.AuthenticationStateProvider.GetAuthenticationStateAsync)
                     {
-                        hasGetAuthStateCall = true;
+                        getAuthStateInvocationLocation ??= invocation.Syntax.GetLocation();
                     }
                 }, OperationKind.Invocation);
 
@@ -73,11 +73,11 @@ public sealed class AuthenticationStateProviderAnalyzer : DiagnosticAnalyzer
 
                 context.RegisterSymbolEndAction(endContext =>
                 {
-                    if (hasGetAuthStateCall && !hasAuthStateChangedSubscription)
+                    if (getAuthStateInvocationLocation is not null && !hasAuthStateChangedSubscription)
                     {
                         endContext.ReportDiagnostic(Diagnostic.Create(
                             DiagnosticDescriptors.AuthenticationStateProviderCachedWithoutSubscription,
-                            namedType.Locations.FirstOrDefault(),
+                            getAuthStateInvocationLocation,
                             namedType.Name));
                     }
                 });
@@ -121,7 +121,7 @@ public sealed class AuthenticationStateProviderAnalyzer : DiagnosticAnalyzer
                     return SymbolEqualityComparer.Default.Equals(currentType, type) || field.DeclaredAccessibility != Accessibility.Private;
                 }
             }
-        }    
+        }
 
         return false;
     }

--- a/src/Components/Analyzers/test/AuthenticationStateProviderAnalyzerTest.cs
+++ b/src/Components/Analyzers/test/AuthenticationStateProviderAnalyzerTest.cs
@@ -127,7 +127,7 @@ public class AuthenticationStateProviderAnalyzerTest : DiagnosticVerifier
                 Id = "BL0013",
                 Message = "'MyComponent' calls GetAuthenticationStateAsync on AuthenticationStateProvider without subscribing to the AuthenticationStateChanged event. This may result in using stale authentication state.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 7, 15) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 18, 35) }
             });
     }
 
@@ -178,14 +178,14 @@ public class AuthenticationStateProviderAnalyzerTest : DiagnosticVerifier
                 Message = "'MyCustomProvider' calls GetAuthenticationStateAsync on AuthenticationStateProvider without subscribing to the AuthenticationStateChanged event. This may result in using stale authentication state.",
 
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 7, 15) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 18, 32) }
             },
             new DiagnosticResult
             {
                 Id = "BL0013",
                 Message = "'ConsumerComponent' calls GetAuthenticationStateAsync on AuthenticationStateProvider without subscribing to the AuthenticationStateChanged event. This may result in using stale authentication state.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 22, 15) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 33, 35) }
             });
     }
 
@@ -230,7 +230,7 @@ public class AuthenticationStateProviderAnalyzerTest : DiagnosticVerifier
                 Message = "'MyComponent' calls GetAuthenticationStateAsync on AuthenticationStateProvider without subscribing to the AuthenticationStateChanged event. This may result in using stale authentication state.",
 
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 7, 15) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 22, 35) }
             });
     }
 
@@ -327,7 +327,7 @@ public class AuthenticationStateProviderAnalyzerTest : DiagnosticVerifier
                 Id = "BL0013",
                 Message = "'Consumer2Component' calls GetAuthenticationStateAsync on AuthenticationStateProvider without subscribing to the AuthenticationStateChanged event. This may result in using stale authentication state.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 17, 15) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 23, 35) }
             });
     }
 
@@ -407,7 +407,7 @@ public class AuthenticationStateProviderAnalyzerTest : DiagnosticVerifier
                 Id = "BL0013",
                 Message = "'Consumer2Component' calls GetAuthenticationStateAsync on AuthenticationStateProvider without subscribing to the AuthenticationStateChanged event. This may result in using stale authentication state.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 19, 15) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 25, 35) }
             });
     }
 
@@ -491,7 +491,7 @@ public class AuthenticationStateProviderAnalyzerTest : DiagnosticVerifier
                 Id = "BL0013",
                 Message = "'Consumer2Component' calls GetAuthenticationStateAsync on AuthenticationStateProvider without subscribing to the AuthenticationStateChanged event. This may result in using stale authentication state.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 21, 15) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 27, 35) }
             });
     }
 
@@ -586,7 +586,7 @@ public class AuthenticationStateProviderAnalyzerTest : DiagnosticVerifier
                 Id = "BL0013",
                 Message = "'Consumer2Component' calls GetAuthenticationStateAsync on AuthenticationStateProvider without subscribing to the AuthenticationStateChanged event. This may result in using stale authentication state.",
                 Severity = DiagnosticSeverity.Warning,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 30, 15) }
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 36, 35) }
             });
     }
 


### PR DESCRIPTION
# Fix BL0013 Diagnostic Location in Razor Components 

## Description

The BL0013 analyzer (`AuthenticationStateProvider` used without subscribing to `AuthenticationStateChanged`) was reporting diagnostics at incorrect locations in Razor files. Instead of highlighting the actual `GetAuthenticationStateAsync()` invocation that triggered the diagnostic, it was pointing to unrelated code directives (`@using`, `@inject`, etc.) at the top of generated Razor components.

**Root Cause:** Analyzer used `namedType.Locations.FirstOrDefault()` (class declaration location) instead of the invocation location. For generated Razor components, the class location in the `.g.cs` file doesn't map back to the original `.razor` source.

**Solution:** Capture and report the diagnostic at the actual `GetAuthenticationStateAsync()` invocation location using `invocation.Syntax.GetLocation()`.

## Changes

- Changed `hasGetAuthStateCall` (bool) to `getAuthStateInvocationLocation` (Location?)
- Extract and store the invocation location at the point of detection using `invocation.Syntax.GetLocation()`
- Use null-coalescing assignment `??=` to capture only the first invocation
- Report diagnostic at the invocation location instead of class declaration
- Diagnostic now correctly maps to the `.razor` source, providing actionable error location

## Before

Developers see BL0013 on the wrong line in their `.razor` file:

```razor
@page "/analyzers"
@rendermode InteractiveServer
@using Microsoft.AspNetCore.Components.Authorization          ← ❌ ERROR HERE (confusing!)

@code {
    [Inject]
    private AuthenticationStateProvider AuthProvider { get; set; } = default!;

    protected override async Task OnInitializedAsync()
    {
        var state = await AuthProvider.GetAuthenticationStateAsync();  ← Actual problem is here
    }
}
```

## After

Developers see BL0013 on the correct line:

```razor
@page "/analyzers"
@rendermode InteractiveServer
@using Microsoft.AspNetCore.Components.Authorization

@code {
    [Inject]
    private AuthenticationStateProvider AuthProvider { get; set; } = default!;

    protected override async Task OnInitializedAsync()
    {
        var state = await AuthProvider.GetAuthenticationStateAsync();  ← ✅ ERROR HERE (correct!)
    }
}
```

Fixes [#68339](https://github.com/dotnet/aspnetcore/issues/68339)