### PR TITLE
Call TransformOutbound for optional route parameters

### DIFF
--- a/src/Components/Components/src/Microsoft.AspNetCore.Components.Routing.targets
+++ b/src/Components/Components/src/Microsoft.AspNetCore.Components.Routing.targets
@@ -33,6 +33,7 @@
   <Compile Include="$(RoutingSourceRoot)Constraints\**\*.cs" LinkBase="Routing\Constraints" />
 
   <Compile Remove="$(RoutingSourceRoot)Constraints\HttpMethodRouteConstraint.cs" />
+  <Compile Remove="$(RoutingSourceRoot)Constraints\OptionalOutboundParameterTransformerRouteConstraint.cs" />
   <Compile Remove="$(RoutingSourceRoot)Constraints\RequiredRouteConstraint.cs" />
   <Compile Remove="$(RoutingSourceRoot)Constraints\StringRouteConstraint.cs" />
 </ItemGroup>

--- a/src/Http/Routing/src/Constraints/OptionalOutboundParameterTransformerRouteConstraint.cs
+++ b/src/Http/Routing/src/Constraints/OptionalOutboundParameterTransformerRouteConstraint.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Routing.Constraints;
+
+/// <summary>
+/// An <see cref="OptionalRouteConstraint"/> that preserves the <see cref="IOutboundParameterTransformer"/>
+/// implemented by its inner constraint. Wrapping a constraint for an optional parameter would otherwise hide
+/// the transformer from URL generation, so <c>TransformOutbound</c> would never be called for that parameter.
+/// </summary>
+internal sealed class OptionalOutboundParameterTransformerRouteConstraint : OptionalRouteConstraint, IOutboundParameterTransformer
+{
+    public OptionalOutboundParameterTransformerRouteConstraint(IRouteConstraint innerConstraint)
+        : base(innerConstraint)
+    {
+        Debug.Assert(
+            innerConstraint is IOutboundParameterTransformer,
+            $"{nameof(innerConstraint)} must implement {nameof(IOutboundParameterTransformer)}.");
+    }
+
+    /// <inheritdoc />
+    public string? TransformOutbound(object? value)
+    {
+        return ((IOutboundParameterTransformer)InnerConstraint).TransformOutbound(value);
+    }
+}

--- a/src/Http/Routing/src/DefaultParameterPolicyFactory.cs
+++ b/src/Http/Routing/src/DefaultParameterPolicyFactory.cs
@@ -64,7 +64,11 @@ internal sealed class DefaultParameterPolicyFactory : ParameterPolicyFactory
     {
         if (optional)
         {
-            routeConstraint = new OptionalRouteConstraint(routeConstraint);
+            // Wrapping the constraint must not hide an IOutboundParameterTransformer it implements,
+            // otherwise TransformOutbound is never called when generating a URL for this parameter.
+            routeConstraint = routeConstraint is IOutboundParameterTransformer
+                ? new OptionalOutboundParameterTransformerRouteConstraint(routeConstraint)
+                : new OptionalRouteConstraint(routeConstraint);
         }
 
         return routeConstraint;

--- a/src/Http/Routing/test/UnitTests/DefaultParameterPolicyFactoryTest.cs
+++ b/src/Http/Routing/test/UnitTests/DefaultParameterPolicyFactoryTest.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing.Constraints;
 using Microsoft.AspNetCore.Routing.Patterns;
+using Microsoft.AspNetCore.Routing.TestObjects;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -125,6 +126,29 @@ public class DefaultParameterPolicyFactoryTest
         // Assert
         var optionalConstraint = Assert.IsType<OptionalRouteConstraint>(parameterPolicy);
         Assert.IsType<IntRouteConstraint>(optionalConstraint.InnerConstraint);
+    }
+
+    [Fact]
+    public void Create_CreatesParameterPolicy_FromRoutePattern_Constraint_Optional_PreservesOutboundParameterTransformer()
+    {
+        // Arrange
+        var factory = GetParameterPolicyFactory();
+
+        var parameter = RoutePatternFactory.ParameterPart(
+            "id",
+            @default: null,
+            parameterKind: RoutePatternParameterKind.Optional,
+            parameterPolicies: new[] { RoutePatternFactory.ParameterPolicy(new UpperCaseTransformingRouteConstraint()), });
+
+        // Act
+        var parameterPolicy = factory.Create(parameter, parameter.ParameterPolicies[0]);
+
+        // Assert
+        var optionalConstraint = Assert.IsAssignableFrom<OptionalRouteConstraint>(parameterPolicy);
+        Assert.IsType<UpperCaseTransformingRouteConstraint>(optionalConstraint.InnerConstraint);
+
+        var transformer = Assert.IsAssignableFrom<IOutboundParameterTransformer>(parameterPolicy);
+        Assert.Equal("VALUE", transformer.TransformOutbound("value"));
     }
 
     [Fact]

--- a/src/Http/Routing/test/UnitTests/Template/TemplateBinderTests.cs
+++ b/src/Http/Routing/test/UnitTests/Template/TemplateBinderTests.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Routing.Constraints;
 using Microsoft.AspNetCore.Routing.Patterns;
 using Microsoft.AspNetCore.Routing.TestObjects;
 using Microsoft.Extensions.ObjectPool;
+using Microsoft.Extensions.Options;
 
 namespace Microsoft.AspNetCore.Routing.Template.Tests;
 
@@ -1303,6 +1304,44 @@ public class TemplateBinderTests
             defaults,
             requiredKeys: defaults.Keys,
             parameterPolicies: new (string, IParameterPolicy)[] { ("param", new LengthRouteConstraint(500)), ("param", new SlugifyParameterTransformer()), });
+
+        // Act
+        var result = binder.GetValues(ambientValues, explicitValues);
+        var boundTemplate = binder.BindValues(result.AcceptedValues);
+
+        // Assert
+        Assert.Equal(expected, boundTemplate);
+    }
+
+    [Fact]
+    public void BindValues_ParameterTransformer_OptionalParameter()
+    {
+        // Arrange
+        var expected = "/ConventionalTransformerRoute/conventional-transformer/Param/MY-VALUE";
+
+        var template = "ConventionalTransformerRoute/conventional-transformer/Param/{param?}";
+        var defaults = new RouteValueDictionary(new { controller = "ConventionalTransformer", action = "Param" });
+        var ambientValues = new RouteValueDictionary(new { controller = "ConventionalTransformer", action = "Param" });
+        var explicitValues = new RouteValueDictionary(new { controller = "ConventionalTransformer", action = "Param", param = "my-value" });
+
+        // The parameter policy is created the same way routing creates it at runtime, so that the
+        // optional parameter is wrapped exactly as DefaultParameterPolicyFactory would wrap it.
+        var parameterPolicyFactory = new DefaultParameterPolicyFactory(Options.Create(new RouteOptions()), new TestServiceProvider());
+        var parameterPolicy = parameterPolicyFactory.Create(
+            RoutePatternFactory.ParameterPart("param", @default: null, RoutePatternParameterKind.Optional),
+            new UpperCaseTransformingRouteConstraint());
+
+        var binder = new TemplateBinder(
+            UrlEncoder.Default,
+            new DefaultObjectPoolProvider().Create(new UriBuilderContextPooledObjectPolicy()),
+            RoutePatternFactory.Parse(
+                template,
+                defaults,
+                parameterPolicies: null,
+                requiredValues: new { area = (string)null, action = "Param", controller = "ConventionalTransformer", page = (string)null }),
+            defaults,
+            requiredKeys: defaults.Keys,
+            parameterPolicies: new (string, IParameterPolicy)[] { ("param", parameterPolicy), });
 
         // Act
         var result = binder.GetValues(ambientValues, explicitValues);

--- a/src/Http/Routing/test/UnitTests/TestObjects/UpperCaseTransformingRouteConstraint.cs
+++ b/src/Http/Routing/test/UnitTests/TestObjects/UpperCaseTransformingRouteConstraint.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Routing.TestObjects;
+
+public class UpperCaseTransformingRouteConstraint : IRouteConstraint, IOutboundParameterTransformer
+{
+    public bool Match(
+        HttpContext httpContext,
+        IRouter route,
+        string routeKey,
+        RouteValueDictionary values,
+        RouteDirection routeDirection)
+    {
+        return true;
+    }
+
+    public string TransformOutbound(object value)
+    {
+        return value?.ToString()?.ToUpperInvariant();
+    }
+}


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Call TransformOutbound for optional route parameters

## Description

`DefaultParameterPolicyFactory.InitializeRouteConstraint` wraps an optional parameter's constraint in `OptionalRouteConstraint`, which implements only `IRouteConstraint`. `TemplateBinder.Initialize` discovers transformers with a separate `is IOutboundParameterTransformer` test, and the wrapper fails that test — so when the inner constraint also implements `IOutboundParameterTransformer`, the transformer is silently dropped and `TransformOutbound` is never called during URL generation.

The visible effect is that a transforming constraint applies to a required segment but not to an optional one:

| Route template | Outbound value today | Expected |
| --- | --- | --- |
| `{id:myconstraint}` | transformed | transformed |
| `{id:myconstraint?}` | **not transformed** | transformed |

### Approach

Optional constraints that also implement `IOutboundParameterTransformer` are now wrapped in a new `internal sealed` subclass of `OptionalRouteConstraint` that additionally implements `IOutboundParameterTransformer` and forwards to the inner constraint. Matching behaviour is inherited unchanged.

Constraints that are not transformers keep using `OptionalRouteConstraint` exactly as before, so the wrapper type callers already observe is unchanged for every existing case.

The public `OptionalRouteConstraint` type is untouched, so there is no public API change and no `PublicAPI.Unshipped.txt` entry.

### Note on the Components build

`src/Http/Routing/src/Constraints/**/*.cs` is compiled into `Microsoft.AspNetCore.Components` via `Microsoft.AspNetCore.Components.Routing.targets`, and `IOutboundParameterTransformer` is not part of that source set. The new file is excluded with a `Compile Remove` entry, alongside the three constraints already excluded there. Verified that `Microsoft.AspNetCore.Components` still builds clean.

### Behaviour change

URLs generated for an optional segment with a transforming constraint now contain the transformed value where they previously contained the raw value. That is the fix, but it is an observable output change for anyone relying on the current behaviour — happy to gate it if you would prefer that.

### Tests

- `DefaultParameterPolicyFactoryTest.Create_CreatesParameterPolicy_FromRoutePattern_Constraint_Optional_PreservesOutboundParameterTransformer` — the policy returned for an optional transforming constraint still surfaces `IOutboundParameterTransformer` and forwards `TransformOutbound`.
- `TemplateBinderTests.BindValues_ParameterTransformer_OptionalParameter` — end-to-end URL generation applies the transform, using a policy built through `DefaultParameterPolicyFactory` so the parameter is wrapped exactly as it is at runtime.

Both fail without the change. Full `Microsoft.AspNetCore.Routing.Tests` suite passes (3480 tests).

Fixes #23063
