### PR TITLE
Fix OpenAPI nullability for ignored setters

### DIFF
--- a/src/OpenApi/src/Extensions/TypeExtensions.cs
+++ b/src/OpenApi/src/Extensions/TypeExtensions.cs
@@ -112,6 +112,10 @@ internal static class TypeExtensions
 
         var nullabilityInfoContext = new NullabilityInfoContext();
         var nullabilityInfo = nullabilityInfoContext.Create(propertyInfo);
-        return nullabilityInfo.WriteState == NullabilityState.Nullable || nullabilityInfo.ReadState == NullabilityState.Nullable;
+
+        // Reflection reports a nullable write state for [AllowNull] properties whose setters
+        // System.Text.Json ignores. The type-keyword path works around the same issue in dotnet/runtime#131602.
+        return nullabilityInfo.ReadState == NullabilityState.Nullable ||
+            (jsonPropertyInfo.Set is not null && nullabilityInfo.WriteState == NullabilityState.Nullable);
     }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.PropertySchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.PropertySchemas.cs
@@ -3,7 +3,11 @@
 
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -701,6 +705,62 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
         });
     }
 
+    [Fact]
+    public async Task GetOpenApiSchema_DoesNotMarkAllowNullPropertyWithIgnoredSetterAsNullable()
+    {
+        var jsonPropertyInfo = GetValueProperty<AllowNullPrivateSetterModel>();
+        Assert.Null(jsonPropertyInfo.Set);
+        await AssertAllowNullComponentProperty<AllowNullPrivateSetterModel>(expectNullable: false);
+    }
+
+    [Fact]
+    public async Task GetOpenApiSchema_MarksAllowNullPropertyWithPublicSetterAsNullable()
+    {
+        var jsonPropertyInfo = GetValueProperty<AllowNullPublicSetterModel>();
+        Assert.NotNull(jsonPropertyInfo.Set);
+        await AssertAllowNullComponentProperty<AllowNullPublicSetterModel>(expectNullable: true);
+    }
+
+    [Fact]
+    public async Task GetOpenApiSchema_MarksAllowNullPropertyWithJsonIncludeSetterAsNullable()
+    {
+        var jsonPropertyInfo = GetValueProperty<AllowNullJsonIncludeSetterModel>();
+        Assert.NotNull(jsonPropertyInfo.Set);
+        await AssertAllowNullComponentProperty<AllowNullJsonIncludeSetterModel>(expectNullable: true);
+    }
+
+    private static JsonPropertyInfo GetValueProperty<TModel>()
+        => Assert.Single(
+            JsonSerializerOptions.Default.GetTypeInfo(typeof(TModel)).Properties,
+            propertyInfo => propertyInfo.Name == "Value");
+
+    private static async Task AssertAllowNullComponentProperty<TModel>(bool expectNullable)
+    {
+        var builder = CreateBuilder();
+        builder.MapPost("/api", (TModel model) => { });
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/api"].Operations[HttpMethod.Post];
+            var content = Assert.Single(operation.RequestBody.Content);
+            var valueProperty = content.Value.Schema.Properties["value"];
+
+            if (expectNullable)
+            {
+                Assert.NotNull(valueProperty.OneOf);
+                Assert.Equal(2, valueProperty.OneOf.Count);
+                Assert.Collection(valueProperty.OneOf,
+                    item => Assert.Equal(JsonSchemaType.Null, item.Type),
+                    item => Assert.Equal("Todo", ((OpenApiSchemaReference)item).Reference.Id));
+            }
+            else
+            {
+                Assert.Null(valueProperty.OneOf);
+                Assert.Equal("Todo", ((OpenApiSchemaReference)valueProperty).Reference.Id);
+            }
+        });
+    }
+
 #nullable enable
     private class NullablePropertiesTestModel
     {
@@ -723,6 +783,37 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
         public ConstructorBoundPropertyModel(Todo? value) => Value = value;
         public Todo? Value { get; }
         public IEnumerable<string> Values => [];
+    }
+
+    private class AllowNullPrivateSetterModel
+    {
+        private Todo? _value;
+
+        [AllowNull]
+        public Todo Value
+        {
+            get => _value ?? new Todo(0, string.Empty, false, default);
+            private set => _value = value;
+        }
+    }
+
+    private class AllowNullPublicSetterModel
+    {
+        [AllowNull]
+        public Todo Value { get; set; } = new Todo(0, string.Empty, false, default);
+    }
+
+    private class AllowNullJsonIncludeSetterModel
+    {
+        private Todo? _value;
+
+        [AllowNull]
+        [JsonInclude]
+        public Todo Value
+        {
+            get => _value ?? new Todo(0, string.Empty, false, default);
+            private set => _value = value;
+        }
     }
 
     private class NullableCollectionPropertiesModel


### PR DESCRIPTION
## What this fixes

This is a follow-up to dotnet/aspnetcore#68116 and the System.Text.Json behavior tracked by dotnet/runtime#131602.

PR #68116 fixed nullable get-only and constructor-bound properties, but it left one componentized-schema case inconsistent. Consider a non-nullable property with an `[AllowNull]` private setter:

```csharp
private Todo? _value;

[AllowNull]
public Todo Value
{
    get => _value ?? new Todo(0, string.Empty, false, default);
    private set => _value = value;
}
```

System.Text.Json ignores that private setter unless `[JsonInclude]` is present, so `JsonPropertyInfo.Set` is `null`. Reflection still sees `[AllowNull]` and reports a nullable write state. The componentized OpenAPI path trusted the reflection result and generated `oneOf: [null, $ref]`, even though the effective JSON contract cannot write `null` through that setter.

## What changed

Nullable read state is still honored unconditionally. That preserves nullable get-only and constructor-bound properties.

Nullable write state is now honored only when System.Text.Json exposes an effective setter:

```csharp
return nullabilityInfo.ReadState == NullabilityState.Nullable ||
    (jsonPropertyInfo.Set is not null && nullabilityInfo.WriteState == NullabilityState.Nullable);
```

The tests cover all three setter behaviors that matter here:

- an ignored private setter stays non-nullable
- a public setter with `[AllowNull]` stays nullable
- a private setter with `[JsonInclude]` stays nullable

## How this was verified

This came out of a historical regression review against the exact merged head of dotnet/aspnetcore#68116.

- The trimmed regression suite was red on the frozen PR head: 2 passed, 1 failed. Only the ignored-private-setter case failed.
- The same suite passed 3/3 with this change.
- An 18-case constructor/accessor matrix across OpenAPI 3.0, 3.1, and 3.2 went from 15/18 on the frozen code to 18/18 with this change.
- The focused `GetOpenApiSchema_` subset passes 22/22 on this branch.
- The full `Microsoft.AspNetCore.OpenApi.Tests` project passes with 1,028 passed, 5 skipped, and 0 failed.

The matrix also confirmed that setter-less constructor-bound properties report `WriteState == Unknown`. Their nullable behavior comes from `ReadState`, so this gate does not remove constructor-bound nullability.
