### PR TITLE
Require red/green proof before claiming a bug fix is verified

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,6 +32,8 @@
 ## Running tests
 
 * To build and run tests in the repo, use the `build.sh` script that is located in each subdirectory within the `src` folder. For example, to run the build with tests in the `src/Http` directory, run `./src/Http/build.sh -test`.
+* Before claiming a bug fix is verified, confirm that the relevant test or check fails for the expected reason without the fix and passes with it. Reading the source or seeing a test pass on its own is not proof that the bug is fixed.
+* If that red/green verification isn't practical, say so explicitly and state what you did verify rather than describing the fix as verified.
 
 ## .NET Environment
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,7 +33,7 @@
 
 * To build and run tests in the repo, use the `build.sh` script that is located in each subdirectory within the `src` folder. For example, to run the build with tests in the `src/Http` directory, run `./src/Http/build.sh -test`.
 * Before claiming a bug fix is verified, confirm that the relevant test or check fails for the expected reason without the fix and passes with it. Reading the source or seeing a test pass on its own is not proof that the bug is fixed.
-* If that red/green verification isn't practical, say so explicitly and state what you did verify rather than describing the fix as verified.
+* If that red/green verification isn't practical, explain why, state what you did verify, and don't describe the fix as verified.
 
 ## .NET Environment
 


### PR DESCRIPTION
Adds two bullets to the `## Running tests` section of `.github/copilot-instructions.md`.

## Problem

The repo-wide pre-prompt currently says nothing about what counts as proof that a bug is actually fixed. The common failure mode is an agent that reads the source, reasons that the change looks correct, adds a test that passes on the first run, and then reports the fix as "verified." A test that was never observed failing proves nothing about the bug — it may assert on the wrong thing, exercise a path that never regressed, or pass identically before and after the change. That produces confident but unfounded verification claims in PRs, which reviewers then have to catch by hand.

## Change

```
* Before claiming a bug fix is verified, confirm that the relevant test or check fails for the expected reason without the fix and passes with it. Reading the source or seeing a test pass on its own is not proof that the bug is fixed.
* If that red/green verification isn't practical, say so explicitly and state what you did verify rather than describing the fix as verified.
```

Notes on the wording:

- **"test or check"** rather than "assertion" so it covers this repo's E2E, Playwright, and browser-based verification, not just unit tests.
- **"fails for the expected reason"** closes the loophole where a pre-fix run fails for an unrelated reason (a compile error, an unrelated failure) and gets counted as red.
- **The second bullet is deliberately an escape hatch, not a blocker.** Red/green isn't always achievable — crashes and hangs, build-infra fixes, timing-dependent bugs, or fixes whose removal prevents compilation. Requiring the agent to state what it *did* verify keeps the exception honest rather than silent, and mirrors the existing allowance in `CONTRIBUTING.md` that "if there is a scenario that is far too hard to test there does not need to be a test for it."

## Why here

Follows the convention established by #62046 and #62129, both of which made small, targeted additions to this file in reaction to observed agent behavior. Placed in `## Running tests` because the rule is about executing tests and the standard of evidence drawn from them, rather than test-authoring style (`### Testing`, which is nested under `## Formatting` and holds only conventions like xUnit/Moq/naming).

This is not duplicative of `src/Components/AGENTS.md`. That guidance applies only to `src/Components/**` and asks for interactive browser reproduction in a sample app before starting a fix; this is repo-wide and concerns the evidence required before *claiming* the fix works.

Markdown-only change.