### PR TITLE
Fix nullref in Identity on netfx/netstandard

### DIFF
--- a/src/Identity/Extensions.Core/src/Rfc6238AuthenticationService.cs
+++ b/src/Identity/Extensions.Core/src/Rfc6238AuthenticationService.cs
@@ -53,7 +53,15 @@ internal static class Rfc6238AuthenticationService
         Debug.Assert(res);
         Debug.Assert(written == hash.Length);
 #else
-        var hash = hashAlgorithm.ComputeHash(ApplyModifier(timestepAsBytes, modifierBytes));
+        byte[] hash;
+        if (modifierBytes is null)
+        {
+            hash = hashAlgorithm.ComputeHash(timestepAsBytes);
+        }
+        else
+        {
+            hash = hashAlgorithm.ComputeHash(ApplyModifier(timestepAsBytes, modifierBytes));
+        }
 #endif
 
         // Generate DT string
@@ -67,7 +75,7 @@ internal static class Rfc6238AuthenticationService
         return binaryCode % Mod;
     }
 
-    private static byte[] ApplyModifier(Span<byte> input, byte[] modifierBytes)
+    private static byte[] ApplyModifier(ReadOnlySpan<byte> input, byte[] modifierBytes)
     {
         var combined = new byte[checked(input.Length + modifierBytes.Length)];
         input.CopyTo(combined);


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/54634
I don't think null analysis runs on netstandard/netfx so this was missed in https://github.com/dotnet/aspnetcore/pull/44557/
Specifically, https://github.com/dotnet/aspnetcore/pull/44557/changes#diff-fbad76b3623a1dfa54927dc4b3509ef75bfeb5425852e5640e9a035643ac3275L70 where we used to return the input array but now nullref.