### PR TITLE
Revert "Use 1es ubuntu for Linux x64 job"

### DIFF
--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -344,7 +344,6 @@ extends:
           jobName: Linux_x64_build
           jobDisplayName: "Build: Linux x64"
           agentOs: Linux
-          use1ESUbuntu: true
           buildArgs:
             --arch x64
             --pack


### PR DESCRIPTION
Reverts dotnet/aspnetcore#66054, fixes https://github.com/dotnet/aspnetcore/issues/66076