### PR TITLE
Avoid duplicate WebAssembly publish asset compression

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
+++ b/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
@@ -20,6 +20,14 @@
     <NoWarn>$(NoWarn);CA1416</NoWarn>
   </PropertyGroup>
 
+  <!-- Components.TestServer publishes multiple referenced WebAssembly apps that all traverse this
+       project. Skip the redundant traversal on that publish path to avoid concurrent compression. -->
+  <PropertyGroup Condition="'$(_SkipReferencedProjectPublishAssets)' == 'true'">
+    <StaticWebAssetsGetPublishAssetsTargets>_SkipGetPublishAssetsForTrimmedBuild</StaticWebAssetsGetPublishAssetsTargets>
+  </PropertyGroup>
+
+  <Target Name="_SkipGetPublishAssetsForTrimmedBuild" />
+
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.Components.Web" />
     <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />


### PR DESCRIPTION
`Components.TestServer` publishes multiple referenced WebAssembly apps that all traverse `Microsoft.AspNetCore.Components.WebAssembly`. Those traversals can run concurrently and compress the same static web asset output, causing the file-lock failure seen in [build 1550669](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1550669&view=results).

Extend the `_SkipReferencedProjectPublishAssets` pattern from #68085 to the shared WebAssembly project so the redundant nested traversal is skipped.

Related to #61178.