### PR TITLE
Add eng/common Copilot review instructions

### DIFF
--- a/.github/instructions/eng-common.instructions.md
+++ b/.github/instructions/eng-common.instructions.md
@@ -1,0 +1,18 @@
+---
+description: Instructions for Arcade-owned files under eng/common
+applyTo: "eng/common/**"
+---
+
+Files under `eng/common` come from
+[dotnet/arcade](https://github.com/dotnet/arcade) and are synchronized into this
+repository. Read `eng/common/AGENTS.md` and `eng/common/README.md` for the
+authoritative ownership guidance.
+
+When reviewing a change authored directly in this repository, report that the
+local edit will be overwritten and that the durable change must be made in
+Arcade and flowed back to ASP.NET Core.
+
+Do not report this for upstream dependency, source, mirror, or inter-branch
+flows, or when the pull request provenance is unclear. Keep the finding about
+ownership and durability; do not invent a defect in the changed code merely
+because the file is under `eng/common/**`.


### PR DESCRIPTION
## Summary

- add path-specific Copilot review guidance for Arcade-owned `eng/common/**` files
- preserve `eng/common/AGENTS.md` as the authoritative ownership fact while making the ASP.NET Core review behavior and false-positive guards explicit
- account for current GitHub support for nested `AGENTS.md` files and nearest-file precedence

## Evaluation

An isolated private fork-only CCR A/B used byte-identical one-line `eng/common/tools.sh` fixture patches (SHA-256 `0bb1e1e64dd1d5ee80d6419be7ad33ec67229f6dd77c51c0554e3c23c42ae1b7`) and this exact instruction (SHA-256 `9759f3961682b7f7bc4d04c6bd0bf10a07506006bffaab52f08ecd2554e557cb`). The completed control produced no ownership finding, two completed treatments produced the intended Arcade ownership finding, and a completed source-flow case abstained.

This is targeted evidence from a private fork evaluation, not broad production proof. No private repository URLs are included.

## Validation

No build run; this is a documentation-only custom instruction and the repository has no specific validator for it.