### PR TITLE
Propagate `ScrollToItemAsync` cancellation to pending item-provider work  

### DIFF
--- a/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
+++ b/src/Components/QuickGrid/Microsoft.AspNetCore.Components.QuickGrid/src/QuickGrid.razor.cs
@@ -560,7 +560,7 @@ public partial class QuickGrid<TGridItem> : IAsyncDisposable
         // Debounce the requests. This eliminates a lot of redundant queries at the cost of slight lag after interactions.
         // TODO: Consider making this configurable, or smarter (e.g., doesn't delay on first call in a batch, then the amount
         // of delay increases if you rapidly issue repeated requests, such as when scrolling a long way)
-        await Task.Delay(100);
+        await Task.Delay(100, request.CancellationToken);
         if (request.CancellationToken.IsCancellationRequested)
         {
             return default;

--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -332,7 +332,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
 
         if (refetchRequired)
         {
-            await RefreshDataCoreAsync(renderOnSuccess: true);
+            await RefreshDataCoreAsync(renderOnSuccess: true, token);
             token.ThrowIfCancellationRequested();
         }
         else
@@ -861,9 +861,13 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
         }
     }
 
-    private async ValueTask RefreshDataCoreAsync(bool renderOnSuccess)
+    private ValueTask RefreshDataCoreAsync(bool renderOnSuccess)
+        => RefreshDataCoreAsync(renderOnSuccess, CancellationToken.None);
+
+    private async ValueTask RefreshDataCoreAsync(bool renderOnSuccess, CancellationToken ownerCancellationToken)
     {
         _refreshCts?.Cancel();
+        CancellationTokenSource? refreshCts = null;
         CancellationToken cancellationToken;
 
         if (_itemsProvider == DefaultItemsProvider)
@@ -872,12 +876,15 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
             // Items collection) we know it will complete synchronously, and there's no point
             // instantiating a new CancellationTokenSource
             _refreshCts = null;
-            cancellationToken = CancellationToken.None;
+            cancellationToken = ownerCancellationToken;
         }
         else
         {
-            _refreshCts = new CancellationTokenSource();
-            cancellationToken = _refreshCts.Token;
+            refreshCts = ownerCancellationToken.CanBeCanceled
+                ? CancellationTokenSource.CreateLinkedTokenSource(ownerCancellationToken)
+                : new CancellationTokenSource();
+            _refreshCts = refreshCts;
+            cancellationToken = refreshCts.Token;
             _loading = true;
         }
 
@@ -996,6 +1003,18 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
                 // Re-render the component to throw the exception.
                 StateHasChanged();
             }
+        }
+        finally
+        {
+            if (refreshCts is not null && ReferenceEquals(_refreshCts, refreshCts))
+            {
+                _refreshCts = null;
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    _loading = false;
+                }
+            }
+            refreshCts?.Dispose();
         }
     }
 

--- a/src/Components/Web/test/Virtualization/VirtualizeTest.cs
+++ b/src/Components/Web/test/Virtualization/VirtualizeTest.cs
@@ -1052,6 +1052,46 @@ public class VirtualizeTest
     }
 
     [Fact]
+    public async Task ScrollToIndexAsync_CancellationCancelsProviderRequest()
+    {
+        var blockProvider = false;
+        var requestStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var requestCanceled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        async ValueTask<ItemsProviderResult<int>> provider(ItemsProviderRequest request)
+        {
+            if (!blockProvider)
+            {
+                return new ItemsProviderResult<int>(
+                    Enumerable.Range(request.StartIndex, Math.Min(request.Count, 100 - request.StartIndex)),
+                    100);
+            }
+
+            requestStarted.TrySetResult();
+            using var registration = request.CancellationToken.Register(requestCanceled.SetResult);
+            await Task.Delay(Timeout.InfiniteTimeSpan, request.CancellationToken);
+            return default;
+        }
+
+        var (virtualize, renderer) = await CreateRenderedVirtualize(
+            itemSize: 50f, totalItems: 100, customProvider: provider);
+        var callbacks = (IVirtualizeJsCallbacks)virtualize;
+        await renderer.Dispatcher.InvokeAsync(() =>
+            callbacks.OnAfterSpacerVisible(0f, 500f, 500f, SpacerVisibilityReason.ViewportFill));
+
+        blockProvider = true;
+        using var cts = new CancellationTokenSource();
+        Task task = null;
+        await renderer.Dispatcher.InvokeAsync(() => { task = virtualize.ScrollToItemAsync(90, cts.Token); });
+        await requestStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task.WaitAsync(TimeSpan.FromSeconds(5)));
+        await requestCanceled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
     public async Task ScrollToIndexAsync_SecondCallDoesNotFaultFirstTask()
     {
         var (virtualize, renderer) = await CreateRenderedVirtualize(itemSize: 50f, totalItems: 1000);

--- a/src/Components/test/testassets/BasicTestApp/QuickGridTest/QuickGridScrollComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/QuickGridTest/QuickGridScrollComponent.razor
@@ -143,7 +143,7 @@
         await Task.Yield();
         if (useProviderDelay)
         {
-            await Task.Delay(150);
+            await Task.Delay(150, request.CancellationToken);
         }
 
         var count = request.Count ?? rows.Count;

--- a/src/Components/test/testassets/BasicTestApp/VirtualizationAnchorMode.razor
+++ b/src/Components/test/testassets/BasicTestApp/VirtualizationAnchorMode.razor
@@ -363,7 +363,7 @@
         await Task.Yield();
         if (useProviderDelay)
         {
-            await Task.Delay(500);
+            await Task.Delay(500, request.CancellationToken);
         }
         if (useProviderGate)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/68475.

Propagates `ScrollToItemAsync` cancellation to the underlying `ItemsProvider` request. This prevents canceled scrolls from waiting for or applying stale provider results. QuickGrid's debounce now also observes request cancellation. Adds regression unit test.