### PR TITLE
Document framework assembly access rule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,8 +8,8 @@
 
 ## Framework assembly boundaries
 
-* Do not use `InternalsVisibleTo` or `UnsafeAccessor` to access non-public members across ASP.NET Core framework assemblies.
-* If framework code in one assembly needs an API from another, design an explicit public API and follow the repository API-review and baseline process. Existing uses are not precedent for adding another cross-assembly bridge.
+* In shipping framework code, do not add `InternalsVisibleTo` or use `[UnsafeAccessor]` to access non-public members in another framework assembly. Existing uses of these mechanisms are not precedent for new uses.
+* Redesign the assembly boundary instead. If that requires a public API, follow the repository API-review and baseline process.
 
 ## Formatting
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,11 @@
 * Never change package.json or package-lock.json files unless explicitly asked to.
 * Never change NuGet.config files unless explicitly asked to.
 
+## Framework assembly boundaries
+
+* Do not use `InternalsVisibleTo` or `UnsafeAccessor` to access non-public members across ASP.NET Core framework assemblies.
+* If framework code in one assembly needs an API from another, design an explicit public API and follow the repository API-review and baseline process. Existing uses are not precedent for adding another cross-assembly bridge.
+
 ## Formatting
 
 * Apply code-formatting style defined in `.editorconfig`.


### PR DESCRIPTION
Documents the framework-wide rule against adding `InternalsVisibleTo` or `[UnsafeAccessor]` in shipping framework code to reach non-public members in another framework assembly. The assembly boundary should be redesigned instead; if that requires a public API, the repository API-review and baseline process applies.

This makes the guidance from https://github.com/dotnet/aspnetcore/pull/68365#discussion_r3764666966 durable for future contributors and coding agents, while clarifying that existing uses are not precedent for new ones.