### PR TITLE
[Blazor] Cover AllowUpdates state on enhanced navigation

### DIFF
--- a/src/Components/test/E2ETest/Tests/StatePersistenceTest.cs
+++ b/src/Components/test/E2ETest/Tests/StatePersistenceTest.cs
@@ -311,6 +311,35 @@ public class StatePersistenceTest : ServerTestBase<BasicTestAppServerSiteFixture
             stateValue: "other");
     }
 
+    // Regression test for https://github.com/dotnet/aspnetcore/issues/63996
+    // Declarative state with AllowUpdates enabled must be available during initialization each time
+    // enhanced navigation reactivates a component on an already-running interactive runtime.
+    [Theory]
+    [InlineData("server", typeof(InteractiveServerRenderMode))]
+    [InlineData("wasm", typeof(InteractiveWebAssemblyRenderMode))]
+    public void DeclarativeStateAllowingUpdatesIsRestoredOnSubsequentEnhancedNavigations(string mode, Type renderMode)
+    {
+        Navigate($"subdir/persistent-state/page-no-components?render-mode={mode}");
+        ((IJavaScriptExecutor)Browser).ExecuteScript("sessionStorage.setItem('keep-circuit-alive', 'true')");
+        Navigate($"subdir/persistent-state/page-no-components?render-mode={mode}");
+
+        Browser.Click(By.Id("page-with-components-link-and-declarative-state"));
+        AssertStateIsRestored();
+
+        Browser.Click(By.Id("page-no-components-link"));
+        Browser.Click(By.Id("page-with-components-link-and-declarative-state"));
+        AssertStateIsRestored();
+
+        void AssertStateIsRestored()
+        {
+            AssertDeclarativePageState(
+                mode: mode,
+                renderMode: renderMode.Name,
+                interactive: true,
+                stateValue: "other");
+        }
+    }
+
     // Same regression as above, but with streaming rendering, where the persisted state only reaches
     // the document on a streaming update at the end of the response, after the interactive components
     // have already been discovered.


### PR DESCRIPTION
Related to #63996

## Summary

- Adds focused E2E coverage for declarative `[PersistentState(AllowUpdates = true)]` state across repeated enhanced navigations.
- Covers both Interactive WebAssembly and Interactive Server on an already-running runtime.
- Verifies the state is restored during component initialization after navigating away and back.

The runtime issue was already fixed by #68088. This test covers the non-streaming declarative scenario reported in #63996 and prevents that behavior from regressing.

## Validation

- The exact two-page Interactive WebAssembly scenario from #63996 passes on current `main` with enhanced navigation and no browser or network errors.
- The new test passes for both Server and WebAssembly with the current runtime fix.
- Both rows fail when the pre-#68088 root-component state discovery ordering is restored.