### PR TITLE
Derive Helix tool versions from dotnet-tools.json

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -228,9 +228,7 @@
     <AGUIClientVersion>$(AGUIVersion)</AGUIClientVersion>
     <AGUIFormattingVersion>$(AGUIVersion)</AGUIFormattingVersion>
     <AGUIServerVersion>$(AGUIVersion)</AGUIServerVersion>
-    <!-- dotnet tool versions (see also auto-updated DotnetEfVersion property). -->
-    <DotnetDumpVersion>6.0.408101</DotnetDumpVersion>
-    <DotnetServeVersion>1.10.194</DotnetServeVersion>
+    <!-- Playwright CLI version -->
     <MicrosoftPlaywrightCLIVersion>1.2.3</MicrosoftPlaywrightCLIVersion>
   </PropertyGroup>
 

--- a/eng/helix/helix.proj
+++ b/eng/helix/helix.proj
@@ -96,12 +96,19 @@
   <Target Name="RestoreDotnetTools" BeforeTargets="IncludeAspNetRuntime">
     <Exec Command="dotnet tool restore" WorkingDirectory="$(RepoRoot)" IgnoreExitCode="true" />
     <ItemGroup>
-      <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-dump\$(DotnetDumpVersion)\dotnet-dump.$(DotnetDumpVersion).nupkg" AsArchive="false" />
-      <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-ef\$(DotnetEfVersion)\dotnet-ef.$(DotnetEfVersion).nupkg" AsArchive="false" />
-      <HelixCorrelationPayload Include="$(NUGET_PACKAGES)\dotnet-serve\$(DotnetServeVersion)\dotnet-serve.$(DotnetServeVersion).nupkg" AsArchive="false" />
+      <_HelixTestRunnerTool Include="dotnet-dump;dotnet-ef;dotnet-serve" />
     </ItemGroup>
-    <Warning Text="dotnet-ef nupkg not found at '$(NUGET_PACKAGES)\dotnet-ef\$(DotnetEfVersion)\dotnet-ef.$(DotnetEfVersion).nupkg'. Helix template tests may install an incompatible version."
-        Condition="!Exists('$(NUGET_PACKAGES)\dotnet-ef\$(DotnetEfVersion)\dotnet-ef.$(DotnetEfVersion).nupkg')" />
+    <ResolveDotnetToolPackagePaths
+        ToolManifestPath="$([MSBuild]::NormalizePath('$(RepoRoot)', '.config', 'dotnet-tools.json'))"
+        NuGetPackageRoot="$(NUGET_PACKAGES)"
+        PackageIds="@(_HelixTestRunnerTool)">
+      <Output TaskParameter="ToolPackages" ItemName="_HelixTestRunnerToolPackage" />
+    </ResolveDotnetToolPackagePaths>
+    <ItemGroup>
+      <HelixCorrelationPayload Include="@(_HelixTestRunnerToolPackage)" AsArchive="false" />
+    </ItemGroup>
+    <Warning Text="%(_HelixTestRunnerToolPackage.PackageId) nupkg not found at '%(_HelixTestRunnerToolPackage.Identity)'. HelixTestRunner cannot install the tool."
+        Condition="!Exists('%(_HelixTestRunnerToolPackage.Identity)')" />
   </Target>
 
   <Choose>

--- a/eng/tools/RepoTasks/RepoTasks.tasks
+++ b/eng/tools/RepoTasks/RepoTasks.tasks
@@ -7,4 +7,5 @@
   <UsingTask TaskName="RepoTasks.GenerateGuid" AssemblyFile="$(_RepoTaskAssembly)" TaskFactory="TaskHostFactory" Runtime="NET" />
   <UsingTask TaskName="RepoTasks.GenerateTestDevCert" AssemblyFile="$(_RepoTaskAssembly)" TaskFactory="TaskHostFactory" Runtime="NET" />
   <UsingTask TaskName="RepoTasks.BatchHelixWorkItems" AssemblyFile="$(_RepoTaskAssembly)" TaskFactory="TaskHostFactory" Runtime="NET" />
+  <UsingTask TaskName="RepoTasks.ResolveDotnetToolPackagePaths" AssemblyFile="$(_RepoTaskAssembly)" TaskFactory="TaskHostFactory" Runtime="NET" />
 </Project>

--- a/eng/tools/RepoTasks/ResolveDotnetToolPackagePaths.cs
+++ b/eng/tools/RepoTasks/ResolveDotnetToolPackagePaths.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace RepoTasks;
+
+public class ResolveDotnetToolPackagePaths : Microsoft.Build.Utilities.Task
+{
+    [Required]
+    public string ToolManifestPath { get; set; }
+
+    [Required]
+    public string NuGetPackageRoot { get; set; }
+
+    [Required]
+    public ITaskItem[] PackageIds { get; set; }
+
+    [Output]
+    public ITaskItem[] ToolPackages { get; private set; }
+
+    public override bool Execute()
+    {
+        try
+        {
+            using var stream = File.OpenRead(ToolManifestPath);
+            using var document = JsonDocument.Parse(stream);
+
+            if (!document.RootElement.TryGetProperty("tools", out var tools))
+            {
+                Log.LogError($"The dotnet tool manifest '{ToolManifestPath}' does not contain a 'tools' object.");
+                return false;
+            }
+
+            var toolPackages = new List<ITaskItem>();
+            foreach (var package in PackageIds)
+            {
+                var packageId = package.ItemSpec;
+                if (!tools.TryGetProperty(packageId, out var tool) ||
+                    !tool.TryGetProperty("version", out var versionElement))
+                {
+                    Log.LogError($"The dotnet tool manifest '{ToolManifestPath}' does not contain a version for '{packageId}'.");
+                    continue;
+                }
+
+                var version = versionElement.GetString();
+                if (string.IsNullOrEmpty(version))
+                {
+                    Log.LogError($"The dotnet tool manifest '{ToolManifestPath}' contains an empty version for '{packageId}'.");
+                    continue;
+                }
+
+                var normalizedPackageId = packageId.ToLowerInvariant();
+                var packagePath = Path.Combine(
+                    NuGetPackageRoot,
+                    normalizedPackageId,
+                    version,
+                    $"{normalizedPackageId}.{version}.nupkg");
+                var toolPackage = new TaskItem(packagePath);
+                toolPackage.SetMetadata("PackageId", packageId);
+                toolPackage.SetMetadata("Version", version);
+                toolPackages.Add(toolPackage);
+            }
+
+            ToolPackages = toolPackages.ToArray();
+        }
+        catch (Exception exception)
+        {
+            Log.LogErrorFromException(exception);
+        }
+
+        return !Log.HasLoggedErrors;
+    }
+}

--- a/eng/tools/RepoTasks/ResolveDotnetToolPackagePaths.cs
+++ b/eng/tools/RepoTasks/ResolveDotnetToolPackagePaths.cs
@@ -31,9 +31,35 @@ public class ResolveDotnetToolPackagePaths : Microsoft.Build.Utilities.Task
             using var stream = File.OpenRead(ToolManifestPath);
             using var document = JsonDocument.Parse(stream);
 
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                Log.LogError($"The dotnet tool manifest '{ToolManifestPath}' must contain a JSON object.");
+                return false;
+            }
+
             if (!document.RootElement.TryGetProperty("tools", out var tools))
             {
                 Log.LogError($"The dotnet tool manifest '{ToolManifestPath}' does not contain a 'tools' object.");
+                return false;
+            }
+
+            if (tools.ValueKind != JsonValueKind.Object)
+            {
+                Log.LogError($"The 'tools' value in dotnet tool manifest '{ToolManifestPath}' must be a JSON object.");
+                return false;
+            }
+
+            var toolsByPackageId = new Dictionary<string, JsonElement>(StringComparer.OrdinalIgnoreCase);
+            foreach (var tool in tools.EnumerateObject())
+            {
+                if (!toolsByPackageId.TryAdd(tool.Name, tool.Value))
+                {
+                    Log.LogError($"The dotnet tool manifest '{ToolManifestPath}' contains duplicate package ID '{tool.Name}' under case-insensitive comparison.");
+                }
+            }
+
+            if (Log.HasLoggedErrors)
+            {
                 return false;
             }
 
@@ -41,10 +67,27 @@ public class ResolveDotnetToolPackagePaths : Microsoft.Build.Utilities.Task
             foreach (var package in PackageIds)
             {
                 var packageId = package.ItemSpec;
-                if (!tools.TryGetProperty(packageId, out var tool) ||
-                    !tool.TryGetProperty("version", out var versionElement))
+                if (!toolsByPackageId.TryGetValue(packageId, out var tool))
                 {
-                    Log.LogError($"The dotnet tool manifest '{ToolManifestPath}' does not contain a version for '{packageId}'.");
+                    Log.LogError($"The dotnet tool manifest '{ToolManifestPath}' does not contain tool '{packageId}'.");
+                    continue;
+                }
+
+                if (tool.ValueKind != JsonValueKind.Object)
+                {
+                    Log.LogError($"Tool '{packageId}' in dotnet tool manifest '{ToolManifestPath}' must be a JSON object.");
+                    continue;
+                }
+
+                if (!tool.TryGetProperty("version", out var versionElement))
+                {
+                    Log.LogError($"Tool '{packageId}' in dotnet tool manifest '{ToolManifestPath}' does not contain a version.");
+                    continue;
+                }
+
+                if (versionElement.ValueKind != JsonValueKind.String)
+                {
+                    Log.LogError($"The version for tool '{packageId}' in dotnet tool manifest '{ToolManifestPath}' must be a string.");
                     continue;
                 }
 


### PR DESCRIPTION
Use `.config/dotnet-tools.json` as the source of truth for the tool nupkg paths included in the Helix correlation payload.

This removes the duplicate `DotnetDumpVersion` and `DotnetServeVersion` properties from `eng/Versions.props`, so Maestro tool-manifest updates such as #68489 do not require manually synchronizing those properties. `DotnetEfVersion` remains because the project template infrastructure also consumes it.