### PR TITLE
Serialize trimmed app publishes to avoid static asset lock races

### DIFF
--- a/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
+++ b/src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj
@@ -36,6 +36,8 @@
 
     <TestTrimmedApps Condition="'$(ContinuousIntegrationBuild)' == 'true'">true</TestTrimmedApps>
     <TestTrimmedApps Condition="'$(Configuration)' == 'Release'">true</TestTrimmedApps>
+    <!-- The trimmed app publishes share project intermediate outputs, so their project references cannot run concurrently. -->
+    <BuildInParallel Condition="'$(TestTrimmedApps)' == 'true'">false</BuildInParallel>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Serialize the Components E2E trimmed app project-reference traversal so concurrent publishes cannot write the same static web asset compression intermediate.

## Root cause

[Build 1552169](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1552169) failed in Windows local development validation while `GlobalizationWasmApp` and `Wasm.Performance.TestApp` publishes overlapped. Both traversed `Microsoft.AspNetCore.Components.WebAssembly.csproj` and ran `GeneratePublishCompressedStaticWebAssets` for the same logical `_framework/blazor.webassembly.js.map` asset. The SDK derives the compressed output identity from the shared asset metadata, so both invocations targeted:

```text
artifacts\obj\Microsoft.AspNetCore.Components.WebAssembly\Release\net11.0\compressed\publish\jpsg8p4gww-{0}-n92mzkaipp-n92mzkaipp.br
```

The Brotli tool opens outputs with `FileMode.Create` and has no cross-invocation lock. [Current-main build 1552404](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1552404) reproduced the identical lock after #68463 merged, confirming that the prior `Components.TestServer`-specific mitigation did not cover the direct trimmed app references.

## Correction

Set `BuildInParallel=false` only when `TestTrimmedApps=true`. This serializes the Release/CI E2E project references that own the colliding publish traversal while preserving normal Debug/local parallelism.

## Validation

- Release/CI evaluation: `TestTrimmedApps=true`, `BuildInParallel=false`
- Debug/local evaluation: `TestTrimmedApps` unset, `BuildInParallel=true`
- Release E2E project build succeeded: 117 projects, 0 errors
- Release binlog confirms the E2E `ResolveProjectReferences` MSBuild task runs with `BuildInParallel=False`
- Four-model adversarial review selected this fix over per-publish intermediate isolation and skip/re-publish alternatives because those approaches had unproven property propagation or asset-preservation risks

## Limitations

Local validation ran on macOS, so it cannot reproduce the Windows file-sharing exception. The correction is validated structurally through evaluated properties and the MSBuild task parameter; Windows CI remains the behavioral confirmation. This repository workaround addresses the proven E2E ownership boundary but is not a systemic SDK fix for arbitrary concurrent publishes.