### PR TITLE
Avoid PublishTestResults warnings in PR builds

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -94,7 +94,8 @@ jobs:
       ${{ if and(eq(parameters.isAzDOTestingJob, true), ne(parameters.enablePublishTestResults, false)) }}:
         enablePublishTestResults: true
         testResultsFormat: xUnit # Have no vsTest results in any job.
-      mergeTestResults: true
+      # Merging multiple result files causes PublishTestResults to emit a warning for every result after the first file.
+      mergeTestResults: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
       testRunTitle: ${{ parameters.testRunTitle }}
       enableSbom: ${{ parameters.enableSbom }}
       enableTelemetry: true
@@ -312,7 +313,8 @@ jobs:
             testResultsFormat: JUnit
             testResultsFiles: '**/artifacts/log/**/*.junit.xml'
             testRunTitle: $(AgentOsName)-$(BuildConfiguration)-js
-            mergeTestResults: true
+            # See the mergeTestResults comment above.
+            mergeTestResults: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
             buildConfiguration: $(BuildConfiguration)
             buildPlatform: $(AgentOsName)
 
@@ -333,7 +335,8 @@ jobs:
       ${{ if and(eq(parameters.isAzDOTestingJob, true), ne(parameters.enablePublishTestResults, false)) }}:
         enablePublishTestResults: true
         testResultsFormat: xUnit # Have no vsTest results in any job.
-      mergeTestResults: true
+      # Merging multiple result files causes PublishTestResults to emit a warning for every result after the first file.
+      mergeTestResults: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
       testRunTitle: ${{ parameters.testRunTitle }}
       enableSbom: ${{ parameters.enableSbom }}
       enableTelemetry: true
@@ -575,6 +578,7 @@ jobs:
             testResultsFormat: JUnit
             testResultsFiles: '**/artifacts/log/**/*.junit.xml'
             testRunTitle: $(AgentOsName)-$(BuildConfiguration)-js
-            mergeTestResults: true
+            # See the mergeTestResults comment above.
+            mergeTestResults: ${{ ne(variables['Build.Reason'], 'PullRequest') }}
             buildConfiguration: $(BuildConfiguration)
             buildPlatform: $(AgentOsName)


### PR DESCRIPTION
`PublishTestResults@2` emits a warning for every test result after the first result file when `mergeTestResults` is enabled. In a representative successful PR build, that produced 2,088 warnings across the JS and xUnit publishing tasks.

Publish each result file as a separate test run during PR validation. Preserve merged test runs for non-PR builds.

For example, build 1552753 showed:
- Linux JS: 693 results, 31 in the first file, 662 warnings
- Windows JS: 982 results, 289 in the first file, 693 warnings
- Linux/macOS xUnit: 38 results, 15 in the first file, 23 warnings
- Windows xUnit: 40 results, 15 in the first file, 25 warnings

This should remove approximately 2,088 warnings from each `aspnetcore-ci` PR build while retaining all published test results.