### PR TITLE
Merge test result files before publishing

### DIFF
--- a/.azure/pipelines/jobs/default-build.yml
+++ b/.azure/pipelines/jobs/default-build.yml
@@ -305,6 +305,22 @@ jobs:
           displayName: Upload cores
 
       - ${{ if and(eq(parameters.isAzDOTestingJob, true), ne(parameters.enablePublishTestResults, false)) }}:
+        - pwsh: |
+            ./eng/scripts/MergeTestResults.ps1 `
+              -Format XUnit `
+              -SearchPath '$(System.DefaultWorkingDirectory)/artifacts/TestResults/$(_BuildConfig)' `
+              -Filter '*.xml' `
+              -OutputPath '$(System.DefaultWorkingDirectory)/artifacts/TestResults/$(_BuildConfig)/merged-xunit.xml' `
+              -RemoveSourceFiles
+            ./eng/scripts/MergeTestResults.ps1 `
+              -Format JUnit `
+              -SearchPath '$(System.DefaultWorkingDirectory)' `
+              -Filter '*.junit.xml' `
+              -OutputPath '$(System.DefaultWorkingDirectory)/artifacts/log/merged-js.junit.xml' `
+              -Recurse `
+              -RemoveSourceFiles
+          displayName: Merge test result files
+          condition: always()
         - task: PublishTestResults@2
           displayName: Publish js test results
           condition: always()
@@ -568,6 +584,22 @@ jobs:
           displayName: Upload cores
 
       - ${{ if and(eq(parameters.isAzDOTestingJob, true), ne(parameters.enablePublishTestResults, false)) }}:
+        - pwsh: |
+            ./eng/scripts/MergeTestResults.ps1 `
+              -Format XUnit `
+              -SearchPath '$(System.DefaultWorkingDirectory)/artifacts/TestResults/$(_BuildConfig)' `
+              -Filter '*.xml' `
+              -OutputPath '$(System.DefaultWorkingDirectory)/artifacts/TestResults/$(_BuildConfig)/merged-xunit.xml' `
+              -RemoveSourceFiles
+            ./eng/scripts/MergeTestResults.ps1 `
+              -Format JUnit `
+              -SearchPath '$(System.DefaultWorkingDirectory)' `
+              -Filter '*.junit.xml' `
+              -OutputPath '$(System.DefaultWorkingDirectory)/artifacts/log/merged-js.junit.xml' `
+              -Recurse `
+              -RemoveSourceFiles
+          displayName: Merge test result files
+          condition: always()
         - task: PublishTestResults@2
           displayName: Publish js test results
           condition: always()

--- a/eng/scripts/MergeTestResults.ps1
+++ b/eng/scripts/MergeTestResults.ps1
@@ -1,0 +1,145 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('JUnit', 'XUnit')]
+    [string]$Format,
+
+    [Parameter(Mandatory = $true)]
+    [string]$SearchPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Filter,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputPath,
+
+    [switch]$Recurse,
+
+    [switch]$RemoveSourceFiles
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 2
+
+if (-not (Test-Path -LiteralPath $SearchPath)) {
+    Write-Host "Test result search path '$SearchPath' does not exist."
+    return
+}
+
+$outputFullPath = [System.IO.Path]::GetFullPath($OutputPath)
+$files = @(
+    Get-ChildItem -LiteralPath $SearchPath -Filter $Filter -File -Recurse:$Recurse |
+        Where-Object { $_.FullName -ne $outputFullPath } |
+        Sort-Object FullName
+)
+
+if ($files.Count -eq 0) {
+    Write-Host "No $Format test result files matching '$Filter' were found under '$SearchPath'."
+    return
+}
+
+if ($files.Count -eq 1) {
+    if (Test-Path -LiteralPath $outputFullPath) {
+        Remove-Item -LiteralPath $outputFullPath -Force
+    }
+
+    Write-Host "A single $Format test result file was found; no merge is needed."
+    return
+}
+
+function Get-IntegerAttribute([System.Xml.Linq.XElement]$Element, [string]$Name) {
+    $attribute = $Element.Attribute([System.Xml.Linq.XName]::Get($Name))
+    if ($null -eq $attribute) {
+        return 0L
+    }
+
+    return [long]::Parse($attribute.Value, [System.Globalization.CultureInfo]::InvariantCulture)
+}
+
+function Get-DoubleAttribute([System.Xml.Linq.XElement]$Element, [string]$Name) {
+    $attribute = $Element.Attribute([System.Xml.Linq.XName]::Get($Name))
+    if ($null -eq $attribute) {
+        return 0.0
+    }
+
+    return [double]::Parse($attribute.Value, [System.Globalization.CultureInfo]::InvariantCulture)
+}
+
+$documents = @($files | ForEach-Object { [System.Xml.Linq.XDocument]::Load($_.FullName) })
+
+if ($Format -eq 'XUnit') {
+    $mergedRoot = [System.Xml.Linq.XElement]::new([System.Xml.Linq.XName]::Get('assemblies'))
+
+    for ($documentIndex = 0; $documentIndex -lt $documents.Count; $documentIndex++) {
+        $document = $documents[$documentIndex]
+        if ($document.Root.Name.LocalName -ne 'assemblies') {
+            throw "Expected an xUnit 'assemblies' root element in a $Format result file."
+        }
+
+        if ($documentIndex -eq 0) {
+            foreach ($attribute in $document.Root.Attributes()) {
+                $mergedRoot.SetAttributeValue($attribute.Name, $attribute.Value)
+            }
+        }
+
+        foreach ($assembly in $document.Root.Elements()) {
+            if ($assembly.Name.LocalName -eq 'assembly') {
+                $mergedRoot.Add([System.Xml.Linq.XElement]::new($assembly))
+            }
+        }
+    }
+}
+else {
+    $mergedRoot = [System.Xml.Linq.XElement]::new([System.Xml.Linq.XName]::Get('testsuites'))
+    $totals = @{
+        tests = 0L
+        failures = 0L
+        errors = 0L
+        skipped = 0L
+        time = 0.0
+    }
+
+    foreach ($document in $documents) {
+        if ($document.Root.Name.LocalName -eq 'testsuite') {
+            $testSuites = @($document.Root)
+        }
+        elseif ($document.Root.Name.LocalName -eq 'testsuites') {
+            $testSuites = @($document.Root.Elements() | Where-Object { $_.Name.LocalName -eq 'testsuite' })
+        }
+        else {
+            throw "Expected a JUnit 'testsuite' or 'testsuites' root element in a $Format result file."
+        }
+
+        foreach ($testSuite in $testSuites) {
+            $mergedRoot.Add([System.Xml.Linq.XElement]::new($testSuite))
+            $totals.tests += Get-IntegerAttribute $testSuite 'tests'
+            $totals.failures += Get-IntegerAttribute $testSuite 'failures'
+            $totals.errors += Get-IntegerAttribute $testSuite 'errors'
+            $totals.skipped += Get-IntegerAttribute $testSuite 'skipped'
+            $totals.time += Get-DoubleAttribute $testSuite 'time'
+        }
+    }
+
+    $mergedRoot.SetAttributeValue([System.Xml.Linq.XName]::Get('name'), 'Merged test results')
+    foreach ($name in @('tests', 'failures', 'errors', 'skipped')) {
+        $mergedRoot.SetAttributeValue(
+            [System.Xml.Linq.XName]::Get($name),
+            $totals[$name].ToString([System.Globalization.CultureInfo]::InvariantCulture))
+    }
+    $mergedRoot.SetAttributeValue(
+        [System.Xml.Linq.XName]::Get('time'),
+        $totals.time.ToString('0.################', [System.Globalization.CultureInfo]::InvariantCulture))
+}
+
+$outputDirectory = Split-Path -Parent $outputFullPath
+New-Item -ItemType Directory -Path $outputDirectory -Force | Out-Null
+
+$mergedDocument = [System.Xml.Linq.XDocument]::new(
+    [System.Xml.Linq.XDeclaration]::new('1.0', 'utf-8', $null),
+    $mergedRoot)
+$mergedDocument.Save($outputFullPath)
+
+if ($RemoveSourceFiles) {
+    $files | Remove-Item -Force
+}
+
+Write-Host "Merged $($files.Count) $Format test result files into '$outputFullPath'."


### PR DESCRIPTION
`PublishTestResults@2` emits one warning for every result after the first result file when Azure merges multiple files into a single run. A representative successful PR build emitted 2,088 of these warnings.

Merge the xUnit and JUnit XML files locally after the original files have been uploaded as build artifacts. The publisher then receives one file per framework, preserving the existing consolidated test-run reporting without using its noisy multi-file merge path.

The merger was exercised against the Linux result artifacts from build 1552753:
- 5 xUnit files became one document containing all 5 assemblies
- 4 JUnit files became one document containing all 34 suites and 693 test cases
- zero-file and single-file jobs retain their existing behavior

Supersedes the reporting-changing approach in #68505.