### PR TITLE
Resolve NuGet Audit warnings

### DIFF
--- a/eng/tools/RepoTasks/RepoTasks.csproj
+++ b/eng/tools/RepoTasks/RepoTasks.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <TargetFramework>$(BundledNETCoreAppTargetFramework)</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <Optimize>false</Optimize>
-    <DebugType>embedded</DebugType>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!-- Need to build this project in source build -->
     <ExcludeFromSourceOnlyBuild>false</ExcludeFromSourceOnlyBuild>
@@ -12,15 +10,9 @@
     <TargetLatestDotNetRuntime>false</TargetLatestDotNetRuntime>
     <!-- No need to track public APIs of these MSBuild tasks. -->
     <AddPublicApiAnalyzers>false</AddPublicApiAnalyzers>
-    <!-- Suppress NuGet vulnerability audit warnings for transitive dependencies in this build-time tool.
-         Uses NoWarn instead of WarningsNotAsErrors because NuGet restore promotes audit warnings to errors
-         via its own mechanism that WarningsNotAsErrors does not override. -->
-    <NoWarn>$(NoWarn);NU1901;NU1902;NU1903;NU1904</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildFrameworkVersion)" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildUtilitiesCoreVersion)" ExcludeAssets="runtime" />
   </ItemGroup>
 


### PR DESCRIPTION
Removed optimization and debug type settings, and the suppressed NuGet vulnerability audit warnings.

Remove unnecessary package references which avoids the NuGet Audit warnings in the first place.

Extracted from https://github.com/dotnet/aspnetcore/pull/68489
Contributes to https://github.com/dotnet/dotnet/issues/8303