### PR TITLE
Harden Response/Output cache

### DIFF
--- a/src/Middleware/OutputCaching/src/OutputCacheKeyProvider.cs
+++ b/src/Middleware/OutputCaching/src/OutputCacheKeyProvider.cs
@@ -30,7 +30,7 @@ internal sealed class OutputCacheKeyProvider : IOutputCacheKeyProvider
     }
 
     // <VaryByKeyPrefix><delimiter>
-    // GET<delimiter>SCHEME<delimiter>HOST:PORT/PATHBASE/PATH<delimiter>
+    // GET<delimiter>SCHEME<delimiter>HOST:PORT/PATHBASE<delimiter>/PATH<delimiter>
     // H<delimiter>HeaderName=HeaderValue1<subdelimiter>HeaderValue2<delimiter>
     // Q<delimiter>QueryName=QueryValue1<subdelimiter>QueryValue2<delimiter>
     // R<delimiter>RouteName1=RouteValue1<delimiter>RouteName2=RouteValue2
@@ -90,7 +90,7 @@ internal sealed class OutputCacheKeyProvider : IOutputCacheKeyProvider
         return true;
     }
 
-    // GET<delimiter>SCHEME<delimiter>HOST:PORT/PATHBASE/PATH
+    // GET<delimiter>SCHEME<delimiter>HOST:PORT/PATHBASE<delimiter>/PATH
     public bool TryAppendBaseKey(OutputCacheContext context, StringBuilder builder)
     {
         var request = context.HttpContext.Request;
@@ -121,12 +121,14 @@ internal sealed class OutputCacheKeyProvider : IOutputCacheKeyProvider
         {
             builder
                 .Append(request.PathBase.Value)
+                .Append(KeyDelimiter)
                 .Append(request.Path.Value);
         }
         else
         {
             builder
                 .AppendUpperInvariant(request.PathBase.Value)
+                .Append(KeyDelimiter)
                 .AppendUpperInvariant(request.Path.Value);
         }
 

--- a/src/Middleware/OutputCaching/test/OutputCacheKeyProviderTests.cs
+++ b/src/Middleware/OutputCaching/test/OutputCacheKeyProviderTests.cs
@@ -10,7 +10,7 @@ public class OutputCacheKeyProviderTests
 {
     private const char KeyDelimiter = '\x1e';
     private const char KeySubDelimiter = '\x1f';
-    private static readonly string EmptyBaseKey = $"{KeyDelimiter}{KeyDelimiter}";
+    private static readonly string EmptyBaseKey = $"{KeyDelimiter}{KeyDelimiter}{KeyDelimiter}";
 
     [Fact]
     public void OutputCachingKeyProvider_CreateStorageKey_IncludesOnlyNormalizedMethodSchemeHostPortAndPath()
@@ -24,7 +24,7 @@ public class OutputCacheKeyProviderTests
         context.HttpContext.Request.PathBase = "/pathBase";
         context.HttpContext.Request.QueryString = new QueryString("?query.Key=a&query.Value=b");
 
-        Assert.Equal($"HEAD{KeyDelimiter}HTTPS{KeyDelimiter}EXAMPLE.COM:80/PATHBASE/PATH/SUBPATH", cacheKeyProvider.CreateStorageKey(context));
+        Assert.Equal($"HEAD{KeyDelimiter}HTTPS{KeyDelimiter}EXAMPLE.COM:80/PATHBASE{KeyDelimiter}/PATH/SUBPATH", cacheKeyProvider.CreateStorageKey(context));
     }
 
     [Fact]
@@ -41,7 +41,7 @@ public class OutputCacheKeyProviderTests
         context.HttpContext.Request.PathBase = "/pathBase";
         context.HttpContext.Request.QueryString = new QueryString("?query.Key=a&query.Value=b");
 
-        Assert.Equal($"HEAD{KeyDelimiter}HTTPS{KeyDelimiter}*:*/PATHBASE/PATH/SUBPATH", cacheKeyProvider.CreateStorageKey(context));
+        Assert.Equal($"HEAD{KeyDelimiter}HTTPS{KeyDelimiter}*:*/PATHBASE{KeyDelimiter}/PATH/SUBPATH", cacheKeyProvider.CreateStorageKey(context));
     }
 
     [Fact]
@@ -56,7 +56,7 @@ public class OutputCacheKeyProviderTests
         context.HttpContext.Request.Method = HttpMethods.Get;
         context.HttpContext.Request.Path = "/Path";
 
-        Assert.Equal($"{HttpMethods.Get}{KeyDelimiter}{KeyDelimiter}/PATH", cacheKeyProvider.CreateStorageKey(context));
+        Assert.Equal($"{HttpMethods.Get}{KeyDelimiter}{KeyDelimiter}{KeyDelimiter}/PATH", cacheKeyProvider.CreateStorageKey(context));
     }
 
     [Fact]
@@ -70,7 +70,31 @@ public class OutputCacheKeyProviderTests
         context.HttpContext.Request.Method = HttpMethods.Get;
         context.HttpContext.Request.Path = "/Path";
 
-        Assert.Equal($"{HttpMethods.Get}{KeyDelimiter}{KeyDelimiter}/Path", cacheKeyProvider.CreateStorageKey(context));
+        Assert.Equal($"{HttpMethods.Get}{KeyDelimiter}{KeyDelimiter}{KeyDelimiter}/Path", cacheKeyProvider.CreateStorageKey(context));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void OutputCachingKeyProvider_CreateStorageKey_PathBaseAndPathBoundaryIsInjective(bool useCaseSensitivePaths)
+    {
+        var cacheKeyProvider = TestUtils.CreateTestKeyProvider(new OutputCacheOptions()
+        {
+            UseCaseSensitivePaths = useCaseSensitivePaths
+        });
+
+        // Distinct (PathBase, Path) pairs whose concatenations are equal must not collide.
+        var contextA = TestUtils.CreateTestContext();
+        contextA.HttpContext.Request.Method = HttpMethods.Get;
+        contextA.HttpContext.Request.PathBase = "/a";
+        contextA.HttpContext.Request.Path = "/b";
+
+        var contextB = TestUtils.CreateTestContext();
+        contextB.HttpContext.Request.Method = HttpMethods.Get;
+        contextB.HttpContext.Request.PathBase = "/a/b";
+        contextB.HttpContext.Request.Path = PathString.Empty;
+
+        Assert.NotEqual(cacheKeyProvider.CreateStorageKey(contextA), cacheKeyProvider.CreateStorageKey(contextB));
     }
 
     [Fact]

--- a/src/Middleware/OutputCaching/test/OutputCacheKeyProviderTests.cs
+++ b/src/Middleware/OutputCaching/test/OutputCacheKeyProviderTests.cs
@@ -95,6 +95,13 @@ public class OutputCacheKeyProviderTests
         contextB.HttpContext.Request.Path = PathString.Empty;
 
         Assert.NotEqual(cacheKeyProvider.CreateStorageKey(contextA), cacheKeyProvider.CreateStorageKey(contextB));
+
+        var contextC = TestUtils.CreateTestContext();
+        contextC.HttpContext.Request.Method = HttpMethods.Get;
+        contextC.HttpContext.Request.PathBase = PathString.Empty;
+        contextC.HttpContext.Request.Path = "/a/b";
+
+        Assert.NotEqual(cacheKeyProvider.CreateStorageKey(contextC), cacheKeyProvider.CreateStorageKey(contextB));
     }
 
     [Fact]

--- a/src/Middleware/ResponseCaching/src/ResponseCachingKeyProvider.cs
+++ b/src/Middleware/ResponseCaching/src/ResponseCachingKeyProvider.cs
@@ -36,7 +36,7 @@ internal sealed class ResponseCachingKeyProvider : IResponseCachingKeyProvider
         return new string[] { CreateStorageVaryByKey(context) };
     }
 
-    // GET<delimiter>SCHEME<delimiter>HOST:PORT/PATHBASE/PATH
+    // GET<delimiter>SCHEME<delimiter>HOST:PORT/PATHBASE<delimiter>/PATH
     public string CreateBaseKey(ResponseCachingContext context)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -61,12 +61,14 @@ internal sealed class ResponseCachingKeyProvider : IResponseCachingKeyProvider
             {
                 builder
                     .Append(request.PathBase.Value)
+                    .Append(KeyDelimiter)
                     .Append(request.Path.Value);
             }
             else
             {
                 builder
                     .AppendUpperInvariant(request.PathBase.Value)
+                    .Append(KeyDelimiter)
                     .AppendUpperInvariant(request.Path.Value);
             }
 

--- a/src/Middleware/ResponseCaching/test/ResponseCachingKeyProviderTests.cs
+++ b/src/Middleware/ResponseCaching/test/ResponseCachingKeyProviderTests.cs
@@ -23,7 +23,7 @@ public class ResponseCachingKeyProviderTests
         context.HttpContext.Request.PathBase = "/pathBase";
         context.HttpContext.Request.QueryString = new QueryString("?query.Key=a&query.Value=b");
 
-        Assert.Equal($"HEAD{KeyDelimiter}HTTPS{KeyDelimiter}EXAMPLE.COM:80/PATHBASE/PATH/SUBPATH", cacheKeyProvider.CreateBaseKey(context));
+        Assert.Equal($"HEAD{KeyDelimiter}HTTPS{KeyDelimiter}EXAMPLE.COM:80/PATHBASE{KeyDelimiter}/PATH/SUBPATH", cacheKeyProvider.CreateBaseKey(context));
     }
 
     [Fact]
@@ -37,7 +37,7 @@ public class ResponseCachingKeyProviderTests
         context.HttpContext.Request.Method = HttpMethods.Get;
         context.HttpContext.Request.Path = "/Path";
 
-        Assert.Equal($"{HttpMethods.Get}{KeyDelimiter}{KeyDelimiter}/PATH", cacheKeyProvider.CreateBaseKey(context));
+        Assert.Equal($"{HttpMethods.Get}{KeyDelimiter}{KeyDelimiter}{KeyDelimiter}/PATH", cacheKeyProvider.CreateBaseKey(context));
     }
 
     [Fact]
@@ -51,7 +51,31 @@ public class ResponseCachingKeyProviderTests
         context.HttpContext.Request.Method = HttpMethods.Get;
         context.HttpContext.Request.Path = "/Path";
 
-        Assert.Equal($"{HttpMethods.Get}{KeyDelimiter}{KeyDelimiter}/Path", cacheKeyProvider.CreateBaseKey(context));
+        Assert.Equal($"{HttpMethods.Get}{KeyDelimiter}{KeyDelimiter}{KeyDelimiter}/Path", cacheKeyProvider.CreateBaseKey(context));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ResponseCachingKeyProvider_CreateStorageBaseKey_PathBaseAndPathBoundaryIsInjective(bool useCaseSensitivePaths)
+    {
+        var cacheKeyProvider = TestUtils.CreateTestKeyProvider(new ResponseCachingOptions()
+        {
+            UseCaseSensitivePaths = useCaseSensitivePaths
+        });
+
+        // Distinct (PathBase, Path) pairs whose concatenations are equal must not collide.
+        var contextA = TestUtils.CreateTestContext();
+        contextA.HttpContext.Request.Method = HttpMethods.Get;
+        contextA.HttpContext.Request.PathBase = "/a";
+        contextA.HttpContext.Request.Path = "/b";
+
+        var contextB = TestUtils.CreateTestContext();
+        contextB.HttpContext.Request.Method = HttpMethods.Get;
+        contextB.HttpContext.Request.PathBase = "/a/b";
+        contextB.HttpContext.Request.Path = PathString.Empty;
+
+        Assert.NotEqual(cacheKeyProvider.CreateBaseKey(contextA), cacheKeyProvider.CreateBaseKey(contextB));
     }
 
     [Fact]

--- a/src/Middleware/ResponseCaching/test/ResponseCachingKeyProviderTests.cs
+++ b/src/Middleware/ResponseCaching/test/ResponseCachingKeyProviderTests.cs
@@ -76,6 +76,13 @@ public class ResponseCachingKeyProviderTests
         contextB.HttpContext.Request.Path = PathString.Empty;
 
         Assert.NotEqual(cacheKeyProvider.CreateBaseKey(contextA), cacheKeyProvider.CreateBaseKey(contextB));
+
+        var contextC = TestUtils.CreateTestContext();
+        contextC.HttpContext.Request.Method = HttpMethods.Get;
+        contextC.HttpContext.Request.PathBase = PathString.Empty;
+        contextC.HttpContext.Request.Path = "/a/b";
+
+        Assert.NotEqual(cacheKeyProvider.CreateBaseKey(contextC), cacheKeyProvider.CreateBaseKey(contextB));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/67907

This separates path base and path via key delimiter