### PR TITLE
Reject duplicate SignalR upload stream IDs

### DIFF
--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -829,39 +829,52 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
 
         var streamPointer = 0;
         var hubInvocationArgumentPointer = 0;
-        for (var parameterPointer = 0; parameterPointer < arguments.Length; parameterPointer++)
+        var argumentsReplaced = false;
+        try
         {
-            // populate the synthetic arguments first
-            if (descriptor.IsServiceArgument(parameterPointer))
+            for (var parameterPointer = 0; parameterPointer < arguments.Length; parameterPointer++)
             {
-                arguments[parameterPointer] = descriptor.GetService(scope.ServiceProvider, parameterPointer, descriptor.OriginalParameterTypes[parameterPointer]);
-            }
-            else if (descriptor.OriginalParameterTypes[parameterPointer] == typeof(CancellationToken))
-            {
-                cts = CancellationTokenSource.CreateLinkedTokenSource(connection.ConnectionAborted);
-                arguments[parameterPointer] = cts.Token;
-            }
-            else if (isStreamCall && ReflectionHelper.IsStreamingType(descriptor.OriginalParameterTypes[parameterPointer], mustBeDirectType: true))
-            {
-                Log.StartingParameterStream(_logger, hubMethodInvocationMessage.StreamIds![streamPointer]);
-                var itemType = descriptor.StreamingParameters![streamPointer];
-                arguments[parameterPointer] = connection.StreamTracker.AddStream(hubMethodInvocationMessage.StreamIds[streamPointer],
-                    itemType, descriptor.OriginalParameterTypes[parameterPointer], streamOwner ??= connection.StreamTracker.GetNextStreamOwner());
+                // populate the synthetic arguments first
+                if (descriptor.IsServiceArgument(parameterPointer))
+                {
+                    arguments[parameterPointer] = descriptor.GetService(scope.ServiceProvider, parameterPointer, descriptor.OriginalParameterTypes[parameterPointer]);
+                }
+                else if (descriptor.OriginalParameterTypes[parameterPointer] == typeof(CancellationToken))
+                {
+                    cts = CancellationTokenSource.CreateLinkedTokenSource(connection.ConnectionAborted);
+                    arguments[parameterPointer] = cts.Token;
+                }
+                else if (isStreamCall && ReflectionHelper.IsStreamingType(descriptor.OriginalParameterTypes[parameterPointer], mustBeDirectType: true))
+                {
+                    Log.StartingParameterStream(_logger, hubMethodInvocationMessage.StreamIds![streamPointer]);
+                    var itemType = descriptor.StreamingParameters![streamPointer];
+                    arguments[parameterPointer] = connection.StreamTracker.AddStream(hubMethodInvocationMessage.StreamIds[streamPointer],
+                        itemType, descriptor.OriginalParameterTypes[parameterPointer], streamOwner ??= connection.StreamTracker.GetNextStreamOwner());
 
-                streamPointer++;
+                    streamPointer++;
+                }
+                else if (hubMethodInvocationMessage.Arguments?.Length > hubInvocationArgumentPointer &&
+                    (hubMethodInvocationMessage.Arguments[hubInvocationArgumentPointer] == null ||
+                    descriptor.OriginalParameterTypes[parameterPointer].IsAssignableFrom(hubMethodInvocationMessage.Arguments[hubInvocationArgumentPointer]?.GetType())))
+                {
+                    // The types match so it isn't a synthetic argument, just copy it into the arguments array
+                    arguments[parameterPointer] = hubMethodInvocationMessage.Arguments[hubInvocationArgumentPointer];
+                    hubInvocationArgumentPointer++;
+                }
+                else
+                {
+                    // This should never happen
+                    Debug.Assert(false, $"Failed to bind argument of type '{descriptor.OriginalParameterTypes[parameterPointer].Name}' for hub method '{descriptor.MethodExecutor.MethodInfo.Name}'.");
+                }
             }
-           else if (hubMethodInvocationMessage.Arguments?.Length > hubInvocationArgumentPointer &&
-                (hubMethodInvocationMessage.Arguments[hubInvocationArgumentPointer] == null ||
-                descriptor.OriginalParameterTypes[parameterPointer].IsAssignableFrom(hubMethodInvocationMessage.Arguments[hubInvocationArgumentPointer]?.GetType())))
+
+            argumentsReplaced = true;
+        }
+        finally
+        {
+            if (!argumentsReplaced)
             {
-                // The types match so it isn't a synthetic argument, just copy it into the arguments array
-                arguments[parameterPointer] = hubMethodInvocationMessage.Arguments[hubInvocationArgumentPointer];
-                hubInvocationArgumentPointer++;
-            }
-            else
-            {
-                // This should never happen
-                Debug.Assert(false, $"Failed to bind argument of type '{descriptor.OriginalParameterTypes[parameterPointer].Name}' for hub method '{descriptor.MethodExecutor.MethodInfo.Name}'.");
+                cts?.Dispose();
             }
         }
     }

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -370,6 +370,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
         var scope = _serviceScopeFactory.CreateAsyncScope();
         IHubActivator<THub>? hubActivator = null;
         THub? hub = null;
+        List<StreamTracker.StreamRegistration>? streamRegistrations = null;
         try
         {
             hubActivator = scope.ServiceProvider.GetRequiredService<IHubActivator<THub>>();
@@ -409,7 +410,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                 CancellationTokenSource? cts = null;
                 if (descriptor.HasSyntheticArguments)
                 {
-                    ReplaceArguments(descriptor, hubMethodInvocationMessage, isStreamCall, connection, scope, ref arguments, out cts);
+                    ReplaceArguments(descriptor, hubMethodInvocationMessage, isStreamCall, connection, scope, ref arguments, ref streamRegistrations, out cts);
                 }
 
                 if (isStreamCall || isStreamResponse)
@@ -424,7 +425,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                 if (isStreamResponse)
                 {
                     _ = StreamAsync(hubMethodInvocationMessage.InvocationId!, connection, hubCallerContext,
-                        arguments, scope, hubActivator, hub, cts, hubMethodInvocationMessage, descriptor);
+                        arguments, scope, hubActivator, hub, cts, hubMethodInvocationMessage, descriptor, streamRegistrations);
                 }
                 else
                 {
@@ -439,7 +440,8 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                                                         HubCallerContext hubCallerContext,
                                                         HubMethodInvocationMessage hubMethodInvocationMessage,
                                                         bool isStreamCall,
-                                                        CancellationTokenSource? cts)
+                                                        CancellationTokenSource? cts,
+                                                        List<StreamTracker.StreamRegistration>? streamRegistrations)
                     {
                         var logger = dispatcher._logger;
                         var enableDetailedErrors = dispatcher._enableDetailedErrors;
@@ -509,7 +511,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                             // And normal invocations handle cleanup below in the finally
                             if (isStreamCall)
                             {
-                                await CleanupInvocation(connection, hubMethodInvocationMessage, hubActivator, hub, scope);
+                                await CleanupInvocation(connection, streamRegistrations, hubActivator, hub, scope);
                             }
                         }
 
@@ -521,7 +523,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                         }
                     }
 
-                    invocation = ExecuteInvocation(this, methodExecutor, hub, arguments, scope, hubActivator, connection, hubCallerContext, hubMethodInvocationMessage, isStreamCall, cts);
+                    invocation = ExecuteInvocation(this, methodExecutor, hub, arguments, scope, hubActivator, connection, hubCallerContext, hubMethodInvocationMessage, isStreamCall, cts, streamRegistrations);
                 }
 
                 if (isStreamCall || isStreamResponse)
@@ -557,21 +559,21 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                 {
                     wasSemaphoreReleased = !hubCallerClients.TrySetSemaphoreReleased();
                 }
-                await CleanupInvocation(connection, hubMethodInvocationMessage, hubActivator, hub, scope);
+                await CleanupInvocation(connection, streamRegistrations, hubActivator, hub, scope);
             }
         }
 
         return !wasSemaphoreReleased;
     }
 
-    private static ValueTask CleanupInvocation(HubConnectionContext connection, HubMethodInvocationMessage hubMessage, IHubActivator<THub>? hubActivator,
+    private static ValueTask CleanupInvocation(HubConnectionContext connection, List<StreamTracker.StreamRegistration>? streamRegistrations, IHubActivator<THub>? hubActivator,
         THub? hub, AsyncServiceScope scope)
     {
-        if (hubMessage.StreamIds != null)
+        if (streamRegistrations is not null)
         {
-            foreach (var stream in hubMessage.StreamIds)
+            foreach (var streamRegistration in streamRegistrations)
             {
-                connection.StreamTracker.TryComplete(CompletionMessage.Empty(stream));
+                connection.StreamTracker.TryComplete(streamRegistration);
             }
         }
 
@@ -584,7 +586,8 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
     }
 
     private async Task StreamAsync(string invocationId, HubConnectionContext connection, HubCallerContext hubCallerContext, object?[] arguments, AsyncServiceScope scope,
-        IHubActivator<THub> hubActivator, THub hub, CancellationTokenSource? streamCts, HubMethodInvocationMessage hubMethodInvocationMessage, HubMethodDescriptor descriptor)
+        IHubActivator<THub> hubActivator, THub hub, CancellationTokenSource? streamCts, HubMethodInvocationMessage hubMethodInvocationMessage,
+        HubMethodDescriptor descriptor, List<StreamTracker.StreamRegistration>? streamRegistrations)
     {
         string? error = null;
 
@@ -671,7 +674,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                 Activity.Current = previousActivity;
             }
 
-            await CleanupInvocation(connection, hubMethodInvocationMessage, hubActivator, hub, scope);
+            await CleanupInvocation(connection, streamRegistrations, hubActivator, hub, scope);
 
             // Only remove/dispose the CTS if we successfully registered it, otherwise we'd evict
             // another invocation's CTS on ID collision.
@@ -817,7 +820,8 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
     }
 
     private void ReplaceArguments(HubMethodDescriptor descriptor, HubMethodInvocationMessage hubMethodInvocationMessage, bool isStreamCall,
-        HubConnectionContext connection, AsyncServiceScope scope, ref object?[] arguments, out CancellationTokenSource? cts)
+        HubConnectionContext connection, AsyncServiceScope scope, ref object?[] arguments,
+        ref List<StreamTracker.StreamRegistration>? streamRegistrations, out CancellationTokenSource? cts)
     {
         cts = null;
         // In order to add the synthetic arguments we need a new array because the invocation array is too small (it doesn't know about synthetic arguments)
@@ -842,7 +846,8 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                 Log.StartingParameterStream(_logger, hubMethodInvocationMessage.StreamIds![streamPointer]);
                 var itemType = descriptor.StreamingParameters![streamPointer];
                 arguments[parameterPointer] = connection.StreamTracker.AddStream(hubMethodInvocationMessage.StreamIds[streamPointer],
-                    itemType, descriptor.OriginalParameterTypes[parameterPointer]);
+                    itemType, descriptor.OriginalParameterTypes[parameterPointer], out var streamRegistration);
+                (streamRegistrations ??= []).Add(streamRegistration);
 
                 streamPointer++;
             }

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -370,7 +370,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
         var scope = _serviceScopeFactory.CreateAsyncScope();
         IHubActivator<THub>? hubActivator = null;
         THub? hub = null;
-        List<StreamTracker.StreamRegistration>? streamRegistrations = null;
+        object? streamOwner = null;
         try
         {
             hubActivator = scope.ServiceProvider.GetRequiredService<IHubActivator<THub>>();
@@ -410,7 +410,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                 CancellationTokenSource? cts = null;
                 if (descriptor.HasSyntheticArguments)
                 {
-                    ReplaceArguments(descriptor, hubMethodInvocationMessage, isStreamCall, connection, scope, ref arguments, ref streamRegistrations, out cts);
+                    ReplaceArguments(descriptor, hubMethodInvocationMessage, isStreamCall, connection, scope, ref arguments, ref streamOwner, out cts);
                 }
 
                 if (isStreamCall || isStreamResponse)
@@ -425,7 +425,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                 if (isStreamResponse)
                 {
                     _ = StreamAsync(hubMethodInvocationMessage.InvocationId!, connection, hubCallerContext,
-                        arguments, scope, hubActivator, hub, cts, hubMethodInvocationMessage, descriptor, streamRegistrations);
+                        arguments, scope, hubActivator, hub, cts, hubMethodInvocationMessage, descriptor, streamOwner);
                 }
                 else
                 {
@@ -441,7 +441,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                                                         HubMethodInvocationMessage hubMethodInvocationMessage,
                                                         bool isStreamCall,
                                                         CancellationTokenSource? cts,
-                                                        List<StreamTracker.StreamRegistration>? streamRegistrations)
+                                                        object? streamOwner)
                     {
                         var logger = dispatcher._logger;
                         var enableDetailedErrors = dispatcher._enableDetailedErrors;
@@ -511,7 +511,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                             // And normal invocations handle cleanup below in the finally
                             if (isStreamCall)
                             {
-                                await CleanupInvocation(connection, streamRegistrations, hubActivator, hub, scope);
+                                await CleanupInvocation(connection, hubMethodInvocationMessage, streamOwner, hubActivator, hub, scope);
                             }
                         }
 
@@ -523,7 +523,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                         }
                     }
 
-                    invocation = ExecuteInvocation(this, methodExecutor, hub, arguments, scope, hubActivator, connection, hubCallerContext, hubMethodInvocationMessage, isStreamCall, cts, streamRegistrations);
+                    invocation = ExecuteInvocation(this, methodExecutor, hub, arguments, scope, hubActivator, connection, hubCallerContext, hubMethodInvocationMessage, isStreamCall, cts, streamOwner);
                 }
 
                 if (isStreamCall || isStreamResponse)
@@ -559,21 +559,21 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                 {
                     wasSemaphoreReleased = !hubCallerClients.TrySetSemaphoreReleased();
                 }
-                await CleanupInvocation(connection, streamRegistrations, hubActivator, hub, scope);
+                await CleanupInvocation(connection, hubMethodInvocationMessage, streamOwner, hubActivator, hub, scope);
             }
         }
 
         return !wasSemaphoreReleased;
     }
 
-    private static ValueTask CleanupInvocation(HubConnectionContext connection, List<StreamTracker.StreamRegistration>? streamRegistrations, IHubActivator<THub>? hubActivator,
+    private static ValueTask CleanupInvocation(HubConnectionContext connection, HubMethodInvocationMessage hubMessage, object? streamOwner, IHubActivator<THub>? hubActivator,
         THub? hub, AsyncServiceScope scope)
     {
-        if (streamRegistrations is not null)
+        if (streamOwner is not null)
         {
-            foreach (var streamRegistration in streamRegistrations)
+            foreach (var streamId in hubMessage.StreamIds!)
             {
-                connection.StreamTracker.TryComplete(streamRegistration);
+                connection.StreamTracker.TryComplete(streamId, streamOwner);
             }
         }
 
@@ -587,7 +587,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
 
     private async Task StreamAsync(string invocationId, HubConnectionContext connection, HubCallerContext hubCallerContext, object?[] arguments, AsyncServiceScope scope,
         IHubActivator<THub> hubActivator, THub hub, CancellationTokenSource? streamCts, HubMethodInvocationMessage hubMethodInvocationMessage,
-        HubMethodDescriptor descriptor, List<StreamTracker.StreamRegistration>? streamRegistrations)
+        HubMethodDescriptor descriptor, object? streamOwner)
     {
         string? error = null;
 
@@ -674,7 +674,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                 Activity.Current = previousActivity;
             }
 
-            await CleanupInvocation(connection, streamRegistrations, hubActivator, hub, scope);
+            await CleanupInvocation(connection, hubMethodInvocationMessage, streamOwner, hubActivator, hub, scope);
 
             // Only remove/dispose the CTS if we successfully registered it, otherwise we'd evict
             // another invocation's CTS on ID collision.
@@ -821,7 +821,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
 
     private void ReplaceArguments(HubMethodDescriptor descriptor, HubMethodInvocationMessage hubMethodInvocationMessage, bool isStreamCall,
         HubConnectionContext connection, AsyncServiceScope scope, ref object?[] arguments,
-        ref List<StreamTracker.StreamRegistration>? streamRegistrations, out CancellationTokenSource? cts)
+        ref object? streamOwner, out CancellationTokenSource? cts)
     {
         cts = null;
         // In order to add the synthetic arguments we need a new array because the invocation array is too small (it doesn't know about synthetic arguments)
@@ -846,8 +846,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                 Log.StartingParameterStream(_logger, hubMethodInvocationMessage.StreamIds![streamPointer]);
                 var itemType = descriptor.StreamingParameters![streamPointer];
                 arguments[parameterPointer] = connection.StreamTracker.AddStream(hubMethodInvocationMessage.StreamIds[streamPointer],
-                    itemType, descriptor.OriginalParameterTypes[parameterPointer], out var streamRegistration);
-                (streamRegistrations ??= []).Add(streamRegistration);
+                    itemType, descriptor.OriginalParameterTypes[parameterPointer], streamOwner ??= new object());
 
                 streamPointer++;
             }

--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -370,7 +370,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
         var scope = _serviceScopeFactory.CreateAsyncScope();
         IHubActivator<THub>? hubActivator = null;
         THub? hub = null;
-        object? streamOwner = null;
+        long? streamOwner = null;
         try
         {
             hubActivator = scope.ServiceProvider.GetRequiredService<IHubActivator<THub>>();
@@ -441,7 +441,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                                                         HubMethodInvocationMessage hubMethodInvocationMessage,
                                                         bool isStreamCall,
                                                         CancellationTokenSource? cts,
-                                                        object? streamOwner)
+                                                        long? streamOwner)
                     {
                         var logger = dispatcher._logger;
                         var enableDetailedErrors = dispatcher._enableDetailedErrors;
@@ -566,14 +566,14 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
         return !wasSemaphoreReleased;
     }
 
-    private static ValueTask CleanupInvocation(HubConnectionContext connection, HubMethodInvocationMessage hubMessage, object? streamOwner, IHubActivator<THub>? hubActivator,
+    private static ValueTask CleanupInvocation(HubConnectionContext connection, HubMethodInvocationMessage hubMessage, long? streamOwner, IHubActivator<THub>? hubActivator,
         THub? hub, AsyncServiceScope scope)
     {
         if (streamOwner is not null)
         {
             foreach (var streamId in hubMessage.StreamIds!)
             {
-                connection.StreamTracker.TryComplete(streamId, streamOwner);
+                connection.StreamTracker.TryComplete(streamId, streamOwner.Value);
             }
         }
 
@@ -587,7 +587,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
 
     private async Task StreamAsync(string invocationId, HubConnectionContext connection, HubCallerContext hubCallerContext, object?[] arguments, AsyncServiceScope scope,
         IHubActivator<THub> hubActivator, THub hub, CancellationTokenSource? streamCts, HubMethodInvocationMessage hubMethodInvocationMessage,
-        HubMethodDescriptor descriptor, object? streamOwner)
+        HubMethodDescriptor descriptor, long? streamOwner)
     {
         string? error = null;
 
@@ -821,7 +821,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
 
     private void ReplaceArguments(HubMethodDescriptor descriptor, HubMethodInvocationMessage hubMethodInvocationMessage, bool isStreamCall,
         HubConnectionContext connection, AsyncServiceScope scope, ref object?[] arguments,
-        ref object? streamOwner, out CancellationTokenSource? cts)
+        ref long? streamOwner, out CancellationTokenSource? cts)
     {
         cts = null;
         // In order to add the synthetic arguments we need a new array because the invocation array is too small (it doesn't know about synthetic arguments)
@@ -846,7 +846,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                 Log.StartingParameterStream(_logger, hubMethodInvocationMessage.StreamIds![streamPointer]);
                 var itemType = descriptor.StreamingParameters![streamPointer];
                 arguments[parameterPointer] = connection.StreamTracker.AddStream(hubMethodInvocationMessage.StreamIds[streamPointer],
-                    itemType, descriptor.OriginalParameterTypes[parameterPointer], streamOwner ??= new object());
+                    itemType, descriptor.OriginalParameterTypes[parameterPointer], streamOwner ??= connection.StreamTracker.GetNextStreamOwner());
 
                 streamPointer++;
             }

--- a/src/SignalR/server/Core/src/StreamTracker.cs
+++ b/src/SignalR/server/Core/src/StreamTracker.cs
@@ -17,10 +17,16 @@ internal sealed class StreamTracker
     private static readonly MethodInfo _buildConverterMethod = typeof(StreamTracker).GetMethods(BindingFlags.NonPublic | BindingFlags.Static).Single(m => m.Name.Equals(nameof(BuildStream)));
     private readonly object[] _streamConverterArgs;
     private readonly ConcurrentDictionary<string, StreamRegistration> _lookup = new ConcurrentDictionary<string, StreamRegistration>();
+    private long _nextStreamOwner;
 
     public StreamTracker(int streamBufferCapacity)
     {
         _streamConverterArgs = new object[] { streamBufferCapacity };
+    }
+
+    public long GetNextStreamOwner()
+    {
+        return Interlocked.Increment(ref _nextStreamOwner);
     }
 
     /// <summary>
@@ -30,7 +36,7 @@ internal sealed class StreamTracker
         Justification = "BuildStream doesn't have trimming annotations.")]
     [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
         Justification = "HubMethodDescriptor checks for ValueType streaming item types when PublishAot=true. Developers will get an exception in this situation before publishing.")]
-    public object AddStream(string streamId, Type itemType, Type targetType, object streamOwner)
+    public object AddStream(string streamId, Type itemType, Type targetType, long streamOwner)
     {
         Debug.Assert(RuntimeFeature.IsDynamicCodeSupported || !itemType.IsValueType, "HubMethodDescriptor ensures itemType is not a ValueType when PublishAot=true.");
 
@@ -44,7 +50,7 @@ internal sealed class StreamTracker
         return reader;
     }
 
-    private bool TryGetRegistration(string streamId, [NotNullWhen(true)] out StreamRegistration? registration)
+    private bool TryGetRegistration(string streamId, out StreamRegistration registration)
     {
         if (_lookup.TryGetValue(streamId, out registration))
         {
@@ -78,8 +84,7 @@ internal sealed class StreamTracker
 
     public bool TryComplete(CompletionMessage message)
     {
-        _lookup.TryRemove(message.InvocationId!, out var registration);
-        if (registration is null)
+        if (!_lookup.TryRemove(message.InvocationId!, out var registration))
         {
             return false;
         }
@@ -87,10 +92,10 @@ internal sealed class StreamTracker
         return true;
     }
 
-    public bool TryComplete(string streamId, object streamOwner)
+    public bool TryComplete(string streamId, long streamOwner)
     {
         if (_lookup.TryGetValue(streamId, out var registration) &&
-            ReferenceEquals(registration.Owner, streamOwner) &&
+            registration.Owner == streamOwner &&
             ((ICollection<KeyValuePair<string, StreamRegistration>>)_lookup).Remove(new KeyValuePair<string, StreamRegistration>(streamId, registration)))
         {
             registration.Converter.TryComplete(null);
@@ -113,15 +118,15 @@ internal sealed class StreamTracker
         return new ChannelConverter<T>(streamBufferCapacity);
     }
 
-    private sealed class StreamRegistration
+    private readonly struct StreamRegistration
     {
-        public StreamRegistration(object owner, IStreamConverter converter)
+        public StreamRegistration(long owner, IStreamConverter converter)
         {
             Owner = owner;
             Converter = converter;
         }
 
-        public object Owner { get; }
+        public long Owner { get; }
 
         public IStreamConverter Converter { get; }
     }

--- a/src/SignalR/server/Core/src/StreamTracker.cs
+++ b/src/SignalR/server/Core/src/StreamTracker.cs
@@ -16,7 +16,7 @@ internal sealed class StreamTracker
 {
     private static readonly MethodInfo _buildConverterMethod = typeof(StreamTracker).GetMethods(BindingFlags.NonPublic | BindingFlags.Static).Single(m => m.Name.Equals(nameof(BuildStream)));
     private readonly object[] _streamConverterArgs;
-    private readonly ConcurrentDictionary<string, StreamRegistration> _lookup = new ConcurrentDictionary<string, StreamRegistration>();
+    private readonly ConcurrentDictionary<string, (long Owner, IStreamConverter Converter)> _lookup = new();
     private long _nextStreamOwner;
 
     public StreamTracker(int streamBufferCapacity)
@@ -42,7 +42,7 @@ internal sealed class StreamTracker
 
         var newConverter = (IStreamConverter)_buildConverterMethod.MakeGenericMethod(itemType).Invoke(null, _streamConverterArgs)!;
         var reader = newConverter.GetReaderAsObject(targetType);
-        if (!_lookup.TryAdd(streamId, new StreamRegistration(streamOwner, newConverter)))
+        if (!_lookup.TryAdd(streamId, (streamOwner, newConverter)))
         {
             throw new HubException($"Stream ID '{streamId}' is already in use.");
         }
@@ -50,7 +50,7 @@ internal sealed class StreamTracker
         return reader;
     }
 
-    private bool TryGetRegistration(string streamId, out StreamRegistration registration)
+    private bool TryGetRegistration(string streamId, out (long Owner, IStreamConverter Converter) registration)
     {
         if (_lookup.TryGetValue(streamId, out registration))
         {
@@ -94,15 +94,18 @@ internal sealed class StreamTracker
 
     public bool TryComplete(string streamId, long streamOwner)
     {
-        if (_lookup.TryGetValue(streamId, out var registration) &&
-            registration.Owner == streamOwner &&
-            ((ICollection<KeyValuePair<string, StreamRegistration>>)_lookup).Remove(new KeyValuePair<string, StreamRegistration>(streamId, registration)))
+        if (!_lookup.TryGetValue(streamId, out var registration) || registration.Owner != streamOwner)
         {
-            registration.Converter.TryComplete(null);
-            return true;
+            return false;
         }
 
-        return false;
+        if (!_lookup.TryRemove(KeyValuePair.Create(streamId, registration)))
+        {
+            return false;
+        }
+
+        registration.Converter.TryComplete(null);
+        return true;
     }
 
     public void CompleteAll(Exception ex)
@@ -116,19 +119,6 @@ internal sealed class StreamTracker
     private static IStreamConverter BuildStream<T>(int streamBufferCapacity)
     {
         return new ChannelConverter<T>(streamBufferCapacity);
-    }
-
-    private readonly struct StreamRegistration
-    {
-        public StreamRegistration(long owner, IStreamConverter converter)
-        {
-            Owner = owner;
-            Converter = converter;
-        }
-
-        public long Owner { get; }
-
-        public IStreamConverter Converter { get; }
     }
 
     private interface IStreamConverter

--- a/src/SignalR/server/Core/src/StreamTracker.cs
+++ b/src/SignalR/server/Core/src/StreamTracker.cs
@@ -24,19 +24,25 @@ internal sealed class StreamTracker
     }
 
     /// <summary>
-    /// Creates a new stream and returns the ChannelReader for it as an object.
+    /// Creates a new stream and returns the ChannelReader for it as an object and a registration used for cleanup.
     /// </summary>
     [UnconditionalSuppressMessage("Trimming", "IL2060:MakeGenericMethod",
         Justification = "BuildStream doesn't have trimming annotations.")]
     [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
         Justification = "HubMethodDescriptor checks for ValueType streaming item types when PublishAot=true. Developers will get an exception in this situation before publishing.")]
-    public object AddStream(string streamId, Type itemType, Type targetType)
+    public object AddStream(string streamId, Type itemType, Type targetType, out StreamRegistration streamRegistration)
     {
         Debug.Assert(RuntimeFeature.IsDynamicCodeSupported || !itemType.IsValueType, "HubMethodDescriptor ensures itemType is not a ValueType when PublishAot=true.");
 
         var newConverter = (IStreamConverter)_buildConverterMethod.MakeGenericMethod(itemType).Invoke(null, _streamConverterArgs)!;
-        _lookup[streamId] = newConverter;
-        return newConverter.GetReaderAsObject(targetType);
+        var reader = newConverter.GetReaderAsObject(targetType);
+        if (!_lookup.TryAdd(streamId, newConverter))
+        {
+            throw new HubException($"Stream ID '{streamId}' is already in use.");
+        }
+
+        streamRegistration = new StreamRegistration(streamId, newConverter);
+        return reader;
     }
 
     private bool TryGetConverter(string streamId, [NotNullWhen(true)] out IStreamConverter? converter)
@@ -74,12 +80,24 @@ internal sealed class StreamTracker
     public bool TryComplete(CompletionMessage message)
     {
         _lookup.TryRemove(message.InvocationId!, out var converter);
-        if (converter == null)
+        if (converter is null)
         {
             return false;
         }
         converter.TryComplete(message.HasResult || message.Error == null ? null : new HubException(message.Error));
         return true;
+    }
+
+    public bool TryComplete(StreamRegistration streamRegistration)
+    {
+        var stream = new KeyValuePair<string, IStreamConverter>(streamRegistration.StreamId, streamRegistration.Converter);
+        if (((ICollection<KeyValuePair<string, IStreamConverter>>)_lookup).Remove(stream))
+        {
+            streamRegistration.Converter.TryComplete(null);
+            return true;
+        }
+
+        return false;
     }
 
     public void CompleteAll(Exception ex)
@@ -95,7 +113,20 @@ internal sealed class StreamTracker
         return new ChannelConverter<T>(streamBufferCapacity);
     }
 
-    private interface IStreamConverter
+    public readonly struct StreamRegistration
+    {
+        internal StreamRegistration(string streamId, IStreamConverter converter)
+        {
+            StreamId = streamId;
+            Converter = converter;
+        }
+
+        internal string StreamId { get; }
+
+        internal IStreamConverter Converter { get; }
+    }
+
+    internal interface IStreamConverter
     {
         Type GetItemType();
         object GetReaderAsObject(Type type);

--- a/src/SignalR/server/Core/src/StreamTracker.cs
+++ b/src/SignalR/server/Core/src/StreamTracker.cs
@@ -16,7 +16,7 @@ internal sealed class StreamTracker
 {
     private static readonly MethodInfo _buildConverterMethod = typeof(StreamTracker).GetMethods(BindingFlags.NonPublic | BindingFlags.Static).Single(m => m.Name.Equals(nameof(BuildStream)));
     private readonly object[] _streamConverterArgs;
-    private readonly ConcurrentDictionary<string, IStreamConverter> _lookup = new ConcurrentDictionary<string, IStreamConverter>();
+    private readonly ConcurrentDictionary<string, StreamRegistration> _lookup = new ConcurrentDictionary<string, StreamRegistration>();
 
     public StreamTracker(int streamBufferCapacity)
     {
@@ -24,30 +24,29 @@ internal sealed class StreamTracker
     }
 
     /// <summary>
-    /// Creates a new stream and returns the ChannelReader for it as an object and a registration used for cleanup.
+    /// Creates a new stream and returns the ChannelReader for it as an object.
     /// </summary>
     [UnconditionalSuppressMessage("Trimming", "IL2060:MakeGenericMethod",
         Justification = "BuildStream doesn't have trimming annotations.")]
     [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode",
         Justification = "HubMethodDescriptor checks for ValueType streaming item types when PublishAot=true. Developers will get an exception in this situation before publishing.")]
-    public object AddStream(string streamId, Type itemType, Type targetType, out StreamRegistration streamRegistration)
+    public object AddStream(string streamId, Type itemType, Type targetType, object streamOwner)
     {
         Debug.Assert(RuntimeFeature.IsDynamicCodeSupported || !itemType.IsValueType, "HubMethodDescriptor ensures itemType is not a ValueType when PublishAot=true.");
 
         var newConverter = (IStreamConverter)_buildConverterMethod.MakeGenericMethod(itemType).Invoke(null, _streamConverterArgs)!;
         var reader = newConverter.GetReaderAsObject(targetType);
-        if (!_lookup.TryAdd(streamId, newConverter))
+        if (!_lookup.TryAdd(streamId, new StreamRegistration(streamOwner, newConverter)))
         {
             throw new HubException($"Stream ID '{streamId}' is already in use.");
         }
 
-        streamRegistration = new StreamRegistration(streamId, newConverter);
         return reader;
     }
 
-    private bool TryGetConverter(string streamId, [NotNullWhen(true)] out IStreamConverter? converter)
+    private bool TryGetRegistration(string streamId, [NotNullWhen(true)] out StreamRegistration? registration)
     {
-        if (_lookup.TryGetValue(streamId, out converter))
+        if (_lookup.TryGetValue(streamId, out registration))
         {
             return true;
         }
@@ -57,9 +56,9 @@ internal sealed class StreamTracker
 
     public bool TryProcessItem(StreamItemMessage message, [NotNullWhen(true)] out Task? task)
     {
-        if (TryGetConverter(message.InvocationId!, out var converter))
+        if (TryGetRegistration(message.InvocationId!, out var registration))
         {
-            task = converter.WriteToStream(message.Item);
+            task = registration.Converter.WriteToStream(message.Item);
             return true;
         }
 
@@ -69,9 +68,9 @@ internal sealed class StreamTracker
 
     public Type GetStreamItemType(string streamId)
     {
-        if (TryGetConverter(streamId, out var converter))
+        if (TryGetRegistration(streamId, out var registration))
         {
-            return converter.GetItemType();
+            return registration.Converter.GetItemType();
         }
 
         throw new KeyNotFoundException($"No stream with id '{streamId}' could be found.");
@@ -79,21 +78,22 @@ internal sealed class StreamTracker
 
     public bool TryComplete(CompletionMessage message)
     {
-        _lookup.TryRemove(message.InvocationId!, out var converter);
-        if (converter is null)
+        _lookup.TryRemove(message.InvocationId!, out var registration);
+        if (registration is null)
         {
             return false;
         }
-        converter.TryComplete(message.HasResult || message.Error == null ? null : new HubException(message.Error));
+        registration.Converter.TryComplete(message.HasResult || message.Error == null ? null : new HubException(message.Error));
         return true;
     }
 
-    public bool TryComplete(StreamRegistration streamRegistration)
+    public bool TryComplete(string streamId, object streamOwner)
     {
-        var stream = new KeyValuePair<string, IStreamConverter>(streamRegistration.StreamId, streamRegistration.Converter);
-        if (((ICollection<KeyValuePair<string, IStreamConverter>>)_lookup).Remove(stream))
+        if (_lookup.TryGetValue(streamId, out var registration) &&
+            ReferenceEquals(registration.Owner, streamOwner) &&
+            ((ICollection<KeyValuePair<string, StreamRegistration>>)_lookup).Remove(new KeyValuePair<string, StreamRegistration>(streamId, registration)))
         {
-            streamRegistration.Converter.TryComplete(null);
+            registration.Converter.TryComplete(null);
             return true;
         }
 
@@ -104,7 +104,7 @@ internal sealed class StreamTracker
     {
         foreach (var converter in _lookup)
         {
-            converter.Value.TryComplete(ex);
+            converter.Value.Converter.TryComplete(ex);
         }
     }
 
@@ -113,20 +113,20 @@ internal sealed class StreamTracker
         return new ChannelConverter<T>(streamBufferCapacity);
     }
 
-    public readonly struct StreamRegistration
+    private sealed class StreamRegistration
     {
-        internal StreamRegistration(string streamId, IStreamConverter converter)
+        public StreamRegistration(object owner, IStreamConverter converter)
         {
-            StreamId = streamId;
+            Owner = owner;
             Converter = converter;
         }
 
-        internal string StreamId { get; }
+        public object Owner { get; }
 
-        internal IStreamConverter Converter { get; }
+        public IStreamConverter Converter { get; }
     }
 
-    internal interface IStreamConverter
+    private interface IStreamConverter
     {
         Type GetItemType();
         object GetReaderAsObject(Type type);

--- a/src/SignalR/server/Core/src/StreamTracker.cs
+++ b/src/SignalR/server/Core/src/StreamTracker.cs
@@ -41,13 +41,12 @@ internal sealed class StreamTracker
         Debug.Assert(RuntimeFeature.IsDynamicCodeSupported || !itemType.IsValueType, "HubMethodDescriptor ensures itemType is not a ValueType when PublishAot=true.");
 
         var newConverter = (IStreamConverter)_buildConverterMethod.MakeGenericMethod(itemType).Invoke(null, _streamConverterArgs)!;
-        var reader = newConverter.GetReaderAsObject(targetType);
         if (!_lookup.TryAdd(streamId, (streamOwner, newConverter)))
         {
             throw new HubException($"Stream ID '{streamId}' is already in use.");
         }
 
-        return reader;
+        return newConverter.GetReaderAsObject(targetType);
     }
 
     private bool TryGetRegistration(string streamId, out (long Owner, IStreamConverter Converter) registration)

--- a/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTestUtils/Hubs.cs
@@ -223,6 +223,25 @@ public class MethodHub : TestHub
         return sb.ToString();
     }
 
+    public async Task<string> StreamingConcatTwoStreams(ChannelReader<string> first, ChannelReader<string> second)
+    {
+        return await ReadStream(first) + await ReadStream(second);
+
+        static async Task<string> ReadStream(ChannelReader<string> source)
+        {
+            var result = new StringBuilder();
+            while (await source.WaitToReadAsync())
+            {
+                while (source.TryRead(out var item))
+                {
+                    result.Append(item);
+                }
+            }
+
+            return result.ToString();
+        }
+    }
+
     public async Task StreamDontRead(ChannelReader<string> source)
     {
         while (await source.WaitToReadAsync())

--- a/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTestUtils/Hubs.cs
@@ -225,21 +225,7 @@ public class MethodHub : TestHub
 
     public async Task<string> StreamingConcatTwoStreams(ChannelReader<string> first, ChannelReader<string> second)
     {
-        return await ReadStream(first) + await ReadStream(second);
-
-        static async Task<string> ReadStream(ChannelReader<string> source)
-        {
-            var result = new StringBuilder();
-            while (await source.WaitToReadAsync())
-            {
-                while (source.TryRead(out var item))
-                {
-                    result.Append(item);
-                }
-            }
-
-            return result.ToString();
-        }
+        return await StreamingConcat(first) + await StreamingConcat(second);
     }
 
     public async Task StreamDontRead(ChannelReader<string> source)

--- a/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
@@ -3697,6 +3697,88 @@ public partial class HubConnectionHandlerTests : VerifiableLoggedTest
     }
 
     [Fact]
+    public async Task UploadStreamWithDuplicateIdsFailsAndConnectionContinues()
+    {
+        var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(services =>
+        {
+            services.AddSignalR(options =>
+            {
+                options.EnableDetailedErrors = true;
+                options.StreamBufferCapacity = 1;
+            });
+        });
+        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
+
+        using (var client = new TestClient())
+        {
+            var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+            await client.BeginUploadStreamAsync("duplicate", nameof(MethodHub.StreamingConcatTwoStreams), new[] { "id", "id" }, Array.Empty<object>()).DefaultTimeout();
+            await client.SendHubMessageAsync(new StreamItemMessage("id", "first")).DefaultTimeout();
+            await client.SendHubMessageAsync(new StreamItemMessage("id", "second")).DefaultTimeout();
+            await client.SendInvocationAsync(nameof(MethodHub.Echo), "test").DefaultTimeout();
+
+            var duplicateCompletion = Assert.IsType<CompletionMessage>(await client.ReadAsync().DefaultTimeout());
+            Assert.Equal("An unexpected error occurred invoking 'StreamingConcatTwoStreams' on the server. HubException: Stream ID 'id' is already in use.", duplicateCompletion.Error);
+
+            var echoCompletion = Assert.IsType<CompletionMessage>(await client.ReadAsync().DefaultTimeout());
+            Assert.Equal("test", echoCompletion.Result);
+        }
+    }
+
+    [Fact]
+    public async Task ActiveUploadStreamCannotBeReplacedAndIdCanBeReusedAfterCompletion()
+    {
+        var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(services =>
+        {
+            services.AddSignalR(options => options.EnableDetailedErrors = true);
+        });
+        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
+
+        using (var client = new TestClient())
+        {
+            var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+            await client.BeginUploadStreamAsync("original", nameof(MethodHub.StreamingConcat), new[] { "id" }, Array.Empty<object>()).DefaultTimeout();
+            await client.BeginUploadStreamAsync("duplicate", nameof(MethodHub.StreamingConcat), new[] { "id" }, Array.Empty<object>()).DefaultTimeout();
+
+            var duplicateCompletion = Assert.IsType<CompletionMessage>(await client.ReadAsync().DefaultTimeout());
+            Assert.Equal("An unexpected error occurred invoking 'StreamingConcat' on the server. HubException: Stream ID 'id' is already in use.", duplicateCompletion.Error);
+
+            await client.SendHubMessageAsync(new StreamItemMessage("id", "original")).DefaultTimeout();
+            await client.SendHubMessageAsync(CompletionMessage.Empty("id")).DefaultTimeout();
+
+            var originalCompletion = Assert.IsType<CompletionMessage>(await client.ReadAsync().DefaultTimeout());
+            Assert.Equal("original", originalCompletion.Result);
+
+            await client.BeginUploadStreamAsync("reused", nameof(MethodHub.StreamingConcat), new[] { "id" }, Array.Empty<object>()).DefaultTimeout();
+            await client.SendHubMessageAsync(new StreamItemMessage("id", "reused")).DefaultTimeout();
+            await client.SendHubMessageAsync(CompletionMessage.Empty("id")).DefaultTimeout();
+
+            var reusedCompletion = Assert.IsType<CompletionMessage>(await client.ReadAsync().DefaultTimeout());
+            Assert.Equal("reused", reusedCompletion.Result);
+        }
+    }
+
+    [Fact]
+    public async Task UploadMultipleStreamsWithUniqueIds()
+    {
+        var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider();
+        var connectionHandler = serviceProvider.GetService<HubConnectionHandler<MethodHub>>();
+
+        using (var client = new TestClient())
+        {
+            var connectionHandlerTask = await client.ConnectAsync(connectionHandler).DefaultTimeout();
+            await client.BeginUploadStreamAsync("invocation", nameof(MethodHub.StreamingConcatTwoStreams), new[] { "first", "second" }, Array.Empty<object>()).DefaultTimeout();
+            await client.SendHubMessageAsync(new StreamItemMessage("first", "hello ")).DefaultTimeout();
+            await client.SendHubMessageAsync(CompletionMessage.Empty("first")).DefaultTimeout();
+            await client.SendHubMessageAsync(new StreamItemMessage("second", "world")).DefaultTimeout();
+            await client.SendHubMessageAsync(CompletionMessage.Empty("second")).DefaultTimeout();
+
+            var completion = Assert.IsType<CompletionMessage>(await client.ReadAsync().DefaultTimeout());
+            Assert.Equal("hello world", completion.Result);
+        }
+    }
+
+    [Fact]
     public async Task UploadStreamedObjects()
     {
         var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider();


### PR DESCRIPTION
Fixes #68301

## Overview

SignalR upload streams were registered with dictionary assignment, so a protocol-invalid duplicate stream ID replaced the active channel and could leave the displaced hub argument permanently unreachable. This change makes registration atomic and rejects an active duplicate immediately, while preserving valid multi-stream uploads and reuse after completion. The cross-cutting constraint is ownership-safe cleanup: a rejected invocation must roll back streams it registered without completing a stream owned by another invocation.

## Design

There is no public API change. Internally, each upload-stream invocation receives one allocation-free owner ID, and the stream dictionary remains keyed only by the protocol stream ID because `StreamItem` and `Completion` messages contain no owner information. Its value is an allocation-free tuple containing the owner and converter:

```csharp
// src/SignalR/server/Core/src/StreamTracker.cs
// Owner IDs need only be unique within this connection's StreamTracker.
private readonly ConcurrentDictionary<string, (long Owner, IStreamConverter Converter)> _lookup = new();
private long _nextStreamOwner;

public long GetNextStreamOwner()
{
    return Interlocked.Increment(ref _nextStreamOwner);
}
```

Alternatives considered:

- **Use dictionary `Add` instead of assignment:** this detects duplicates, but does not solve cleanup. The rejected invocation's existing `finally` path would still complete the pre-existing stream by ID. `TryAdd` also allows the deterministic `Stream ID '7' is already in use.` protocol error.
- **Use `(streamId, owner)` as the dictionary key:** this would permit duplicate protocol stream IDs under different owners and make item/completion lookup ambiguous because those messages carry only the stream ID.
- **Track every successful registration in a list:** correct, including partial rollback, but adds invocation plumbing and a list allocation. One owner ID lets cleanup use the existing `StreamIds` while proving ownership.
- **Use an object or `Guid` owner:** both work. A connection-local monotonic `long` is allocation-free and cheaper; the tuple dictionary value is also a value type.
- **Return `null` on collision:** possible, but argument binding would need a separate failure-propagation path to prevent invoking the hub with a null stream. Throwing `HubException` reuses the dispatcher's existing invocation-error handling for this rare protocol violation.

## Implementation

Registration now uses `TryAdd`; a collision leaves the current entry untouched and aborts argument binding through the existing error path. Reader conversion occurs only after registration succeeds:

```csharp
// src/SignalR/server/Core/src/StreamTracker.cs
public object AddStream(string streamId, Type itemType, Type targetType, long streamOwner)
{
    var newConverter = CreateConverter(itemType); // reflection details omitted
    if (!_lookup.TryAdd(streamId, (streamOwner, newConverter)))
    {
        throw new HubException($"Stream ID '{streamId}' is already in use.");
    }

    return newConverter.GetReaderAsObject(targetType);
}
```

The dispatcher lazily assigns one numeric owner ID when it encounters the invocation's first streaming argument. All streams from that invocation share it:

```csharp
// src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
arguments[parameterPointer] = connection.StreamTracker.AddStream(
    hubMethodInvocationMessage.StreamIds[streamPointer],
    itemType,
    descriptor.OriginalParameterTypes[parameterPointer],
    streamOwner ??= connection.StreamTracker.GetNextStreamOwner());
```

If argument replacement fails after creating a linked `CancellationTokenSource`, a `finally` disposes it before the exception propagates. Successfully replaced arguments transfer that source to the existing invocation cleanup path.

Cleanup separates lookup, ownership validation, and mutation. `TryRemove(KeyValuePair)` atomically removes only the exact key/value observed; if the stream was completed and its ID reused before older asynchronous cleanup ran, the tuple no longer matches and the newer stream remains intact:

```csharp
// src/SignalR/server/Core/src/StreamTracker.cs
public bool TryComplete(string streamId, long streamOwner)
{
    if (!_lookup.TryGetValue(streamId, out var registration) || registration.Owner != streamOwner)
    {
        return false;
    }

    if (!_lookup.TryRemove(KeyValuePair.Create(streamId, registration)))
    {
        return false;
    }

    registration.Converter.TryComplete(null);
    return true;
}
```

The regression tests cover the distinct behavior classes once each: duplicate IDs within one invocation under a buffer capacity of one while a later invocation still completes; a second invocation attempting to reuse an active ID without disturbing the original; reuse after completion; and multiple unique upload streams continuing to work.

## Outcome

| Behavior | Result |
|---|---|
| Duplicate ID in one invocation | Prompt deterministic completion error; connection continues processing |
| Duplicate ID across active invocations | Existing stream remains registered and receives its items/completion |
| Partial registration failure | Cleanup completes only entries owned by the rejected invocation |
| ID reuse after completion | Supported unchanged |
| Multiple unique upload streams | Supported unchanged |
| Allocation impact | No owner or registration object allocation |

Validation: the complete `Microsoft.AspNetCore.SignalR.Tests` project passes with zero warnings and errors via `eng\build.cmd -nobuildnative -noBuildJava -projects .\src\SignalR\server\SignalR\test\Microsoft.AspNetCore.SignalR.Tests\Microsoft.AspNetCore.SignalR.Tests.csproj -test`.