### PR TITLE
Fix TryServeFromCacheAsync_ReturnsFalse_IfVaryByKeyContainsDelimiters failure

### DIFF
--- a/src/Middleware/ResponseCaching/test/ResponseCachingMiddlewareTests.cs
+++ b/src/Middleware/ResponseCaching/test/ResponseCachingMiddlewareTests.cs
@@ -949,7 +949,7 @@ public class ResponseCachingMiddlewareTests
 
         // Pre-set a base key so CreateBaseKey succeeds, then set up vary rules in cache
         // so the middleware will call CreateLookupVaryByKeys -> CreateStorageVaryByKey
-        var baseKey = $"GET{(char)0x1e}{(char)0x1e}";
+        var baseKey = $"GET{(char)0x1e}{(char)0x1e}{(char)0x1e}";
         context.BaseKey = baseKey;
         var varyByRules = new CachedVaryByRules()
         {


### PR DESCRIPTION
I broke this test in https://github.com/dotnet/aspnetcore/pull/68517.

The test was already failing in CI in that PR, but the CI was green due to Helix Monitor bug (filed in dotnet/arcade#17346).

This PR fixes the failing test.