### PR TITLE
Update Helix Job Monitor to preserve failures

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -27,7 +27,7 @@
       ]
     },
     "microsoft.dotnet.helix.jobmonitor": {
-      "version": "11.0.0-beta.26412.2",
+      "version": "11.0.0-beta.26412.5",
       "commands": [
         "dotnet-helix-job-monitor"
       ]

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -14,7 +14,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftDotNetBuildTasksArchivesPackageVersion>11.0.0-beta.26410.101</MicrosoftDotNetBuildTasksArchivesPackageVersion>
     <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26410.101</MicrosoftDotNetBuildTasksInstallersPackageVersion>
     <MicrosoftDotNetBuildTasksTemplatingPackageVersion>11.0.0-beta.26410.101</MicrosoftDotNetBuildTasksTemplatingPackageVersion>
-    <MicrosoftDotNetHelixJobMonitorPackageVersion>11.0.0-beta.26412.2</MicrosoftDotNetHelixJobMonitorPackageVersion>
+    <MicrosoftDotNetHelixJobMonitorPackageVersion>11.0.0-beta.26412.5</MicrosoftDotNetHelixJobMonitorPackageVersion>
     <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26410.101</MicrosoftDotNetHelixSdkPackageVersion>
     <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26410.101</MicrosoftDotNetRemoteExecutorPackageVersion>
     <MicrosoftDotNetSharedFrameworkSdkPackageVersion>11.0.0-beta.26410.101</MicrosoftDotNetSharedFrameworkSdkPackageVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -386,9 +386,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>64a29867c5c5c8e0babc9e31313cf3b6e50f0193</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.JobMonitor" Version="11.0.0-beta.26412.2">
+    <Dependency Name="Microsoft.DotNet.Helix.JobMonitor" Version="11.0.0-beta.26412.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>2a4b873dc15423d356c0509a7ac9663276f39664</Sha>
+      <Sha>4e948e7c5bbfab4e87a02fc9b27bfaa068d0d4b3</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26410.101">
       <Uri>https://github.com/dotnet/dotnet</Uri>


### PR DESCRIPTION
Updates `Microsoft.DotNet.Helix.JobMonitor` from `11.0.0-beta.26412.2` to `11.0.0-beta.26412.5`.

The older monitor used the AzDO submitter and Helix queue as the work-item outcome key. Independent subset jobs on the same queue could therefore overwrite a failed work item with a later passing work item of the same name. This caused [build 1553410](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1553410) for dotnet/aspnetcore#68517 to report success despite three real test failures.

The updated package is built from dotnet/arcade@4e948e7c5bbfab4e87a02fc9b27bfaa068d0d4b3, which contains the root-Helix-job lineage fix and regression coverage from dotnet/arcade#17325.

Fixes dotnet/arcade#17346.

cc @wtgodbe