### PR TITLE
Follow links when the interactive router is disconnected

### DIFF
--- a/src/Components/Web.JS/src/Boot.Server.Common.ts
+++ b/src/Components/Web.JS/src/Boot.Server.Common.ts
@@ -13,6 +13,7 @@ import { fetchAndInvokeInitializers } from './JSInitializers/JSInitializers.Serv
 import { RootComponentManager } from './Services/RootComponentManager';
 import { WebRendererId } from './Rendering/WebRendererId';
 import { addDispatchEventMiddleware } from './Rendering/WebRendererInteropMethods';
+import { setInteractiveRouterConnectionChecker } from './Services/NavigationUtils';
 
 let initializersPromise: Promise<void> | undefined;
 let appState: string;
@@ -105,6 +106,10 @@ async function startServerCore(components: RootComponentManager<ServerComponentD
   }, (callId: number, uri: string, state: string | undefined, intercepted: boolean): Promise<void> => {
     return circuit.sendLocationChanging(callId, uri, state, intercepted);
   });
+
+  // Navigations can only be routed through the circuit while it is connected. This reads the
+  // module-level 'circuit', so it keeps reporting the current one after a reconnection replaces it.
+  setInteractiveRouterConnectionChecker(() => circuit.isConnected());
 
   Blazor._internal.forceCloseConnection = () => circuit.disconnect();
   Blazor._internal.sendJSDataStream = (data: ArrayBufferView | Blob, streamId: number, chunkSize: number) => circuit.sendJsDataStream(data, streamId, chunkSize);

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
@@ -616,6 +616,10 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     return this._disposePromise !== undefined;
   }
 
+  public isConnected(): boolean {
+    return this._connection?.state === HubConnectionState.Connected;
+  }
+
   public sendDisconnectBeacon() {
     if (this._disposed) {
       return;

--- a/src/Components/Web.JS/src/Services/NavigationManager.ts
+++ b/src/Components/Web.JS/src/Services/NavigationManager.ts
@@ -4,7 +4,7 @@
 import '@microsoft/dotnet-js-interop';
 import { scheduleScrollReset, ScrollResetSchedule } from '../Rendering/Renderer';
 import { EventDelegator } from '../Rendering/Events/EventDelegator';
-import { attachEnhancedNavigationListener, getInteractiveRouterRendererId, handleClickForNavigationInterception, hasInteractiveRouter, hasProgrammaticEnhancedNavigationHandler, isForSamePath, isSamePageWithHash, isWithinBaseUriSpace, performProgrammaticEnhancedNavigation, performScrollToElementOnTheSamePage, scrollToElement, setHasInteractiveRouter, toAbsoluteUri } from './NavigationUtils';
+import { attachEnhancedNavigationListener, getInteractiveRouterRendererId, handleClickForNavigationInterception, hasInteractiveRouter, hasProgrammaticEnhancedNavigationHandler, isForSamePath, isInteractiveRouterConnected, isSamePageWithHash, isWithinBaseUriSpace, performProgrammaticEnhancedNavigation, performScrollToElementOnTheSamePage, scrollToElement, setHasInteractiveRouter, toAbsoluteUri } from './NavigationUtils';
 import { WebRendererId } from '../Rendering/WebRendererId';
 import { isRendererAttached } from '../Rendering/WebRendererInteropMethods';
 import { IBlazor } from '../GlobalExports';
@@ -78,6 +78,14 @@ export function attachToEventDelegator(eventDelegator: EventDelegator): void {
   // So instead of registering our own native event, register using the EventDelegator.
   eventDelegator.notifyAfterClick(event => {
     if (!hasInteractiveRouter()) {
+      return;
+    }
+
+    if (!isInteractiveRouterConnected()) {
+      // The interactive router can't be reached (e.g., the circuit was lost), so leave the click
+      // alone. The browser then performs a normal page load, which both follows the link and gives
+      // the app a chance to establish a new connection. Intercepting it here would instead fail
+      // with 'Cannot send data if the connection is not in the "Connected" State'.
       return;
     }
 
@@ -288,7 +296,9 @@ function getInteractiveRouterNavigationCallbacks(): NavigationCallbacks | undefi
 
 function currentPageLoadMechanism(): PageLoadMechanism {
   if (hasInteractiveRouter()) {
-    return 'clientside-router';
+    // While the interactive router is unreachable, routing client-side would fail, so fall back to
+    // a full page load. That performs the navigation and lets the app reconnect on the new page.
+    return isInteractiveRouterConnected() ? 'clientside-router' : 'serverside-fullpageload';
   } else if (hasProgrammaticEnhancedNavigationHandler()) {
     return 'serverside-enhanced';
   } else {

--- a/src/Components/Web.JS/src/Services/NavigationUtils.ts
+++ b/src/Components/Web.JS/src/Services/NavigationUtils.ts
@@ -6,6 +6,7 @@ import { WebRendererId } from '../Rendering/WebRendererId';
 let interactiveRouterRendererId: WebRendererId | undefined = undefined;
 let programmaticEnhancedNavigationHandler: typeof performProgrammaticEnhancedNavigation | undefined;
 let enhancedNavigationListener: typeof notifyEnhancedNavigationListeners | undefined;
+let interactiveRouterConnectionChecker: (() => boolean) | undefined;
 
 /**
  * Checks if a click event corresponds to an <a> tag referencing a URL within the base href, and that interception
@@ -155,4 +156,20 @@ export function setHasInteractiveRouter(rendererId: WebRendererId) {
   }
 
   interactiveRouterRendererId = rendererId;
+}
+
+/**
+ * Registers a callback reporting whether the interactive router can currently reach the runtime
+ * that owns it. Rendering modes whose router can lose its connection (i.e., Server) use this so
+ * that navigations can fall back to a full page load while disconnected.
+ * @param checker A callback returning true while the interactive router is reachable.
+ */
+export function setInteractiveRouterConnectionChecker(checker: (() => boolean) | undefined): void {
+  interactiveRouterConnectionChecker = checker;
+}
+
+export function isInteractiveRouterConnected(): boolean {
+  // Rendering modes that can't lose their connection (i.e., WebAssembly) never register a checker,
+  // so in their absence the interactive router is always considered reachable.
+  return interactiveRouterConnectionChecker?.() ?? true;
 }

--- a/src/Components/Web.JS/test/NavigationManager.test.ts
+++ b/src/Components/Web.JS/test/NavigationManager.test.ts
@@ -1,0 +1,98 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+import { expect, test, describe, beforeEach, afterEach } from '@jest/globals';
+import { attachToEventDelegator } from '../src/Services/NavigationManager';
+import { isInteractiveRouterConnected, setHasInteractiveRouter, setInteractiveRouterConnectionChecker } from '../src/Services/NavigationUtils';
+import { EventDelegator } from '../src/Rendering/Events/EventDelegator';
+import { WebRendererId } from '../src/Rendering/WebRendererId';
+
+// Captures the click handler that NavigationManager registers, so tests can invoke it directly
+// instead of standing up a real EventDelegator.
+function captureAfterClickHandler(): (event: MouseEvent) => void {
+  let handler: ((event: MouseEvent) => void) | undefined;
+  const eventDelegator = {
+    notifyAfterClick: (callback: (event: MouseEvent) => void) => {
+      handler = callback;
+    },
+  };
+
+  attachToEventDelegator(eventDelegator as unknown as EventDelegator);
+
+  if (!handler) {
+    throw new Error('attachToEventDelegator did not register an after-click handler');
+  }
+
+  return handler;
+}
+
+// A left-click on an internal <a>, shaped like the events handleClickForNavigationInterception reads.
+function createInternalLinkClick(href: string): MouseEvent {
+  const anchor = document.createElement('a');
+  anchor.setAttribute('href', href);
+  document.body.appendChild(anchor);
+
+  let defaultPrevented = false;
+
+  return {
+    button: 0,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    get defaultPrevented() {
+      return defaultPrevented;
+    },
+    preventDefault() {
+      defaultPrevented = true;
+    },
+    composedPath: () => [anchor],
+  } as unknown as MouseEvent;
+}
+
+describe('Issue #9964 - follow links when the interactive router is disconnected', () => {
+  beforeEach(() => {
+    setHasInteractiveRouter(WebRendererId.Server);
+  });
+
+  afterEach(() => {
+    setInteractiveRouterConnectionChecker(undefined);
+    document.body.innerHTML = '';
+  });
+
+  test('reports connected when no checker is registered', () => {
+    expect(isInteractiveRouterConnected()).toBe(true);
+  });
+
+  test('reports whatever the registered checker returns', () => {
+    let connected = true;
+    setInteractiveRouterConnectionChecker(() => connected);
+
+    expect(isInteractiveRouterConnected()).toBe(true);
+
+    connected = false;
+    expect(isInteractiveRouterConnected()).toBe(false);
+  });
+
+  test('intercepts link clicks while connected', () => {
+    setInteractiveRouterConnectionChecker(() => true);
+    const notifyAfterClick = captureAfterClickHandler();
+
+    const event = createInternalLinkClick('/some-page');
+    notifyAfterClick(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test('leaves link clicks to the browser while disconnected', () => {
+    setInteractiveRouterConnectionChecker(() => false);
+    const notifyAfterClick = captureAfterClickHandler();
+
+    const event = createInternalLinkClick('/some-page');
+    notifyAfterClick(event);
+
+    // Not calling preventDefault is what lets the browser perform a full page load, which follows
+    // the link and gives the app a chance to establish a new connection.
+    expect(event.defaultPrevented).toBe(false);
+  });
+});


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making.

Fall back to a full page load when the interactive router is disconnected.

> **Opened as a draft on purpose.** The contributor guide asks for a positive acknowledgement of
> the approach before investing in an implementation, and this issue has an open design question
> (see *Design question* below). The code is here so the proposal is concrete rather than
> hypothetical — I'll move it out of draft if the approach is acceptable, or rework it if not.

## Description

Link clicks are intercepted whenever an interactive router is registered, without considering
whether that router can actually be reached:

```ts
eventDelegator.notifyAfterClick(event => {
  if (!hasInteractiveRouter()) {
    return;
  }

  handleClickForNavigationInterception(event, absoluteInternalHref => {
    performInternalNavigation(absoluteInternalHref, /* interceptedLink */ true, /* replace */ false);
  });
});
```

With the Blazor Server circuit down, `performInternalNavigation` ends in `notifyLocationChanged`,
which dispatches to .NET over the circuit and fails with
`Cannot send data if the connection is not in the 'Connected' State`. Because
`handleClickForNavigationInterception` has already called `preventDefault()`, the browser's own
navigation is suppressed too, so the user is left on the page with nothing but a console error.

This change lets navigations fall back to a full page load while the interactive router is
unreachable, which follows the link and gives the app a chance to establish a new circuit. The
mechanism for that already exists — `currentPageLoadMechanism()` can return
`'serverside-fullpageload'`, and `navigateToCore` routes that to `performExternalNavigation` — so
this mostly widens the condition that selects it.

### Changes

- **`NavigationUtils`** — adds an optional connection checker, following the same registration
  pattern as `attachProgrammaticEnhancedNavigationHandler`. Rendering modes that never register one
  (i.e. WebAssembly) report as connected, so their behavior is unchanged.
- **`NavigationManager`** — skips click interception *without* calling `preventDefault()`, so the
  browser performs the navigation itself; and returns `'serverside-fullpageload'` from
  `currentPageLoadMechanism()` so programmatic `Blazor.navigateTo` is covered too.
- **`CircuitManager`** — exposes `isConnected()`, the public form of a `HubConnectionState` check
  already made in four places in the class.
- **`Boot.Server.Common`** — registers the checker. It reads the module-level `circuit`, so it keeps
  reporting the current one after a reconnection replaces the instance.

38 lines of product code across 4 files. No public API change.

## Design question

A full page load discards circuit state, which is what the reconnection UI exists to avoid. My
reasoning for accepting that here: this path is only reached *after* the user clicked a link to
another page, so the current page's state is being left behind either way — and today the
alternative isn't "state is preserved", it's a swallowed navigation plus an unhandled error.

If you'd rather this were opt-in, or gated on the reconnection attempts having been exhausted
rather than on the connection simply not being `Connected` right now, I'm happy to rework it.

## Scope

Deliberately limited to link clicks and programmatic navigation. Back/forward (`onPopState`) reaches
the same interop call while disconnected, but the right behavior there is less obvious, so I left it
for a separate change.

## Testing

- Added `src/Components/Web.JS/test/NavigationManager.test.ts`, covering both directions: clicks are
  intercepted while connected, and left to the browser while disconnected. Reverting the fix fails
  only the disconnected case.
- Full `Web.JS` suite passes (12 suites, 251 tests).
- `npm run build:debug` succeeds for all four bundles, including `Boot.WebAssembly`.
- ESLint reports no new errors against the `main` baseline for the touched files.

Not yet covered: an E2E test, and manual verification against a real disconnected circuit.

Fixes #9964
