### PR TITLE
Exclude WiX SDK from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -163,7 +163,7 @@ updates:
   - dependency-name: "Microsoft.NETCore.BrowserDebugHost.Transport"
   - dependency-name: "Microsoft.NETCore.Platforms"
   - dependency-name: "Microsoft.Web.Xdt"
-  - dependency-name: "Microsoft.WixToolset.Sdk"
+  - dependency-name: "Microsoft.Wix*"
   - dependency-name: "NuGet.Frameworks"
   - dependency-name: "NuGet.Packaging"
   - dependency-name: "NuGet.Versioning"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -163,6 +163,7 @@ updates:
   - dependency-name: "Microsoft.NETCore.BrowserDebugHost.Transport"
   - dependency-name: "Microsoft.NETCore.Platforms"
   - dependency-name: "Microsoft.Web.Xdt"
+  - dependency-name: "Microsoft.WixToolset.Sdk"
   - dependency-name: "NuGet.Frameworks"
   - dependency-name: "NuGet.Packaging"
   - dependency-name: "NuGet.Versioning"


### PR DESCRIPTION
The WiX versions in `global.json` and the installer package references are managed by Arcade and flow through dotnet/dotnet. Ignore the `Microsoft.Wix*` package family so updates only arrive through codeflow.

This covers `Microsoft.WixToolset.Sdk`, `Microsoft.Wix`, and the WiX extension/tool packages that share `$(MicrosoftWixToolsetSdkVersion)`. It supersedes #68587.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>