### PR TITLE
Surface SignalR Java WebSocket handshake HTTP errors

### DIFF
--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java
@@ -134,11 +134,19 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
         public void onFailure(WebSocket webSocket, Throwable t, Response response) {
             logger.error("WebSocket closed from an error.", t);
 
+            Throwable error = t;
+            if (response != null && response.code() != 101) {
+                error = new HttpRequestException(String.format(
+                    "Unexpected status code returned from WebSocket handshake: %d %s.",
+                    response.code(), response.message()), response.code());
+                error.initCause(t);
+            }
+
             boolean isOpen = false;
             try {
                 stateLock.lock();
                 if (!closeSubject.hasComplete()) {
-                    closeSubject.onError(new RuntimeException(t));
+                    closeSubject.onError(new RuntimeException(error));
                 }
 
                 isOpen = startSubject.hasComplete();
@@ -150,7 +158,7 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
             if (isOpen) {
                 onClose.invoke(null, t.getMessage());
             }
-            checkStartFailure(t);
+            checkStartFailure(error);
         }
 
         private void checkStartFailure(Throwable t) {
@@ -159,7 +167,11 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
                 // If the start task hasn't completed yet, then we need to complete it
                 // exceptionally.
                 if (!startSubject.hasComplete()) {
-                    startSubject.onError(new RuntimeException("There was an error starting the WebSocket transport.", t));
+                    if (t instanceof HttpRequestException) {
+                        startSubject.onError(t);
+                    } else {
+                        startSubject.onError(new RuntimeException("There was an error starting the WebSocket transport.", t));
+                    }
                 }
             } finally {
                 stateLock.unlock();

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapperTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapperTest.java
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+package com.microsoft.signalr;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+class OkHttpWebSocketWrapperTest {
+    @Test
+    public void nonSwitchingProtocolsResponseThrowsHttpRequestException() throws Exception {
+        try (ServerSocket server = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"))) {
+            CompletableFuture<Void> serverResponse = CompletableFuture.runAsync(() -> respondWithUnauthorized(server));
+
+            HubConnection hubConnection = HubConnectionBuilder
+                .create("http://127.0.0.1:" + server.getLocalPort() + "/hub")
+                .withTransport(TransportEnum.WEBSOCKETS)
+                .shouldSkipNegotiate(true)
+                .build();
+
+            HttpRequestException exception = assertThrows(HttpRequestException.class,
+                () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
+
+            assertEquals("Unexpected status code returned from WebSocket handshake: 401 Unauthorized.", exception.getMessage());
+            assertEquals(401, exception.getStatusCode());
+            serverResponse.get(30, TimeUnit.SECONDS);
+        }
+    }
+
+    private static void respondWithUnauthorized(ServerSocket server) {
+        try (Socket socket = server.accept()) {
+            BufferedReader reader = new BufferedReader(
+                new InputStreamReader(socket.getInputStream(), StandardCharsets.US_ASCII));
+            String requestLine;
+            while ((requestLine = reader.readLine()) != null && !requestLine.isEmpty()) {
+                // Read the complete request before sending the response.
+            }
+
+            byte[] response = "HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                .getBytes(StandardCharsets.US_ASCII);
+            socket.getOutputStream().write(response);
+            socket.getOutputStream().flush();
+        } catch (Exception exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+}


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making.

When negotiation is skipped, OkHttp reports a failed WebSocket upgrade through `onFailure` and includes the HTTP response. The Java client was discarding that response, so callers only saw a generic exception and couldn't handle status codes such as 401.

This surfaces non-101 handshake responses as the existing `HttpRequestException`, including the status code, while keeping the original OkHttp failure as the cause. Failures without an HTTP response keep their current behavior.

I added a regression test that serves a 401 response over a local socket and verifies the status code is available to callers.

Tested with `./gradlew spotlessCheck :test:test --no-daemon`.

Fixes #47597
