### PR TITLE
Clarify AllowUpdates property summary comment

### DIFF
--- a/src/Components/Components/src/PersistentStateAttribute.cs
+++ b/src/Components/Components/src/PersistentStateAttribute.cs
@@ -23,9 +23,9 @@ public sealed class PersistentStateAttribute : CascadingParameterAttributeBase
     public RestoreBehavior RestoreBehavior { get; set; } = RestoreBehavior.Default;
 
     /// <summary>
-    /// Gets or sets a value whether the component wants to receive updates to the parameter
-    /// beyond the initial value provided during initialization when supplied during enhanced 
-    /// navigation.
+    /// Gets or sets a value indicating whether the component wants to receive updates to the
+    /// parameter beyond the initial value provided during initialization when the updates are
+    /// supplied during enhanced navigation.
     /// </summary>
     public bool AllowUpdates { get; set; }
 }

--- a/src/Components/Components/src/PersistentStateAttribute.cs
+++ b/src/Components/Components/src/PersistentStateAttribute.cs
@@ -24,7 +24,8 @@ public sealed class PersistentStateAttribute : CascadingParameterAttributeBase
 
     /// <summary>
     /// Gets or sets a value whether the component wants to receive updates to the parameter
-    /// beyond the initial value provided during initialization.
+    /// beyond the initial value provided during initialization when supplied during enhanced 
+    /// navigation.
     /// </summary>
     public bool AllowUpdates { get; set; }
 }


### PR DESCRIPTION
# Clarify AllowUpdates property summary comment

Updated summary comment for AllowUpdates property to clarify its behavior during enhanced navigation.

## Description

Per @danroth27's suggestion on the docs issue ...

> The `PersistentStateAttribute.AllowUpdates` API documentation currently says that the property controls whether a component receives updates "beyond the initial value provided during initialization." The Blazor [prerendered-state documentation](https://learn.microsoft.com/aspnet/core/blazor/state-management/prerendered-state-persistence?view=aspnetcore-10.0#interactive-routing-and-prerendering) explains that this means updates supplied during enhanced navigation, but that scope isn't clear from the API text itself.
>
> Suggested changes:
>
> * Update the API summary to mention enhanced-navigation updates explicitly.
> * ... pertains to article changes handled by a separate docs PR ...
> * ... pertains to article changes handled by a separate docs PR ...

Addresses https://github.com/dotnet/AspNetCore.Docs/issues/37483