### PR TITLE
Clarify that default passkey origin validation enforces same-origin

### DIFF
--- a/src/Identity/Core/src/PasskeyHandler.cs
+++ b/src/Identity/Core/src/PasskeyHandler.cs
@@ -666,6 +666,9 @@ public sealed class PasskeyHandler<TUser> : IPasskeyHandler<TUser>
             });
         }
 
+        // Default (no IdentityPasskeyOptions.ValidateOrigin override): reject cross-origin requests outright,
+        // then require the client data's origin to exactly match the actual request's Origin header. This is
+        // the same-origin allow-list behavior; there is no separate opt-in allow-list to configure.
         if (string.IsNullOrEmpty(clientData.Origin) ||
             clientData.CrossOrigin == true ||
             !Uri.TryCreate(clientData.Origin, UriKind.Absolute, out var originUri))

--- a/src/Identity/Core/src/PasskeyHandler.cs
+++ b/src/Identity/Core/src/PasskeyHandler.cs
@@ -666,9 +666,9 @@ public sealed class PasskeyHandler<TUser> : IPasskeyHandler<TUser>
             });
         }
 
-        // Default (no IdentityPasskeyOptions.ValidateOrigin override): reject cross-origin requests outright,
-        // then require the client data's origin to exactly match the actual request's Origin header. This is
-        // the same-origin allow-list behavior; there is no separate opt-in allow-list to configure.
+        // Default (no IdentityPasskeyOptions.ValidateOrigin override): reject requests marked as cross-origin,
+        // then require the origin in the WebAuthn client data to match the actual request's Origin header.
+        // This is a same-origin check; there is no separate allow-list unless ValidateOrigin is overridden.
         if (string.IsNullOrEmpty(clientData.Origin) ||
             clientData.CrossOrigin == true ||
             !Uri.TryCreate(clientData.Origin, UriKind.Absolute, out var originUri))


### PR DESCRIPTION
## Context

PasskeyHandler.ValidateOriginAsync has a default (no IdentityPasskeyOptions.ValidateOrigin override) code path whose safety isn't obvious from a quick read: it silently falls through to origin comparison logic a few lines down. This PR adds an inline comment at that code path spelling out the intended behavior (reject cross-origin, require exact match against the request's Origin header), matching the existing XML doc on the options property.

## Change

Comment-only change in PasskeyHandler.ValidateOriginAsync; no behavior change.