### PR TITLE
Clarify that the certificate validation cache is safely scoped per scheme

### DIFF
--- a/src/Security/Authentication/Certificate/src/CertificateAuthenticationExtensions.cs
+++ b/src/Security/Authentication/Certificate/src/CertificateAuthenticationExtensions.cs
@@ -87,8 +87,8 @@ public static class CertificateAuthenticationAppBuilderExtensions
         this AuthenticationBuilder builder,
         Action<CertificateValidationCacheOptions>? configureOptions = null)
     {
-        // Registered as a single app-wide singleton: safe to share across multiple certificate authentication
-        // schemes because CertificateValidationCache.ComputeKey namespaces every cache entry by scheme name.
+        // Registered as an app-wide singleton shared across certificate authentication schemes: safe because
+        // CertificateValidationCache.ComputeKey namespaces every cache entry by scheme name.
         builder.Services.AddSingleton<ICertificateValidationCache, CertificateValidationCache>();
         if (configureOptions != null)
         {

--- a/src/Security/Authentication/Certificate/src/CertificateAuthenticationExtensions.cs
+++ b/src/Security/Authentication/Certificate/src/CertificateAuthenticationExtensions.cs
@@ -87,6 +87,8 @@ public static class CertificateAuthenticationAppBuilderExtensions
         this AuthenticationBuilder builder,
         Action<CertificateValidationCacheOptions>? configureOptions = null)
     {
+        // Registered as a single app-wide singleton: safe to share across multiple certificate authentication
+        // schemes because CertificateValidationCache.ComputeKey namespaces every cache entry by scheme name.
         builder.Services.AddSingleton<ICertificateValidationCache, CertificateValidationCache>();
         if (configureOptions != null)
         {

--- a/src/Security/Authentication/Certificate/src/CertificateValidationCache.cs
+++ b/src/Security/Authentication/Certificate/src/CertificateValidationCache.cs
@@ -80,6 +80,9 @@ public class CertificateValidationCache : ICertificateValidationCache
         if (context.Items.TryGetValue(CertificateAuthenticationHandler.CertificateSchemeCacheKeyItem, out var schemeObj)
             && schemeObj is string schemeName)
         {
+            // The scheme name prefix namespaces entries per authentication scheme, so registering a single
+            // shared ICertificateValidationCache for multiple certificate authentication schemes cannot let
+            // one scheme's cached result be returned for another scheme's certificate lookup.
             return $"{schemeName}:{certificate.GetCertHashString(HashAlgorithmName.SHA256)}";
         }
         return null;


### PR DESCRIPTION
## Context

CertificateValidationCache is registered once as an app-wide singleton via AddCertificateCache(), which can look surprising at a glance since multiple certificate authentication schemes may share the same instance. This PR adds inline comments at the cache-key computation and at the singleton registration spelling out the intended behavior: ComputeKey already namespaces every entry by authentication scheme name before the certificate thumbprint, so sharing one cache instance across schemes is by design.

## Change

Comment-only change in CertificateValidationCache.ComputeKey and CertificateAuthenticationExtensions.AddCertificateCache; no behavior change.