### PR TITLE
Remove misleading debug log message from AuthenticationService.ts

### DIFF
--- a/src/Components/WebAssembly/Authentication.Msal/src/Interop/AuthenticationService.ts
+++ b/src/Components/WebAssembly/Authentication.Msal/src/Interop/AuthenticationService.ts
@@ -288,7 +288,6 @@ class MsalAuthorizeService implements AuthorizeService {
         } catch (e) {
             // If the user explicitly cancelled the pop-up, avoid performing a redirect.
             if (this.isMsalError(e) && e.errorCode !== Msal.BrowserAuthErrorCodes.userCancelled) {
-                this.debug('User canceled sign-in pop-up');
                 this.signInWithRedirect(request);
             } else {
                 this.debug(`Sign-in pop-up failed: '${(e as Error).message}'.`);


### PR DESCRIPTION
Uncovered by Copilot review comment in https://github.com/dotnet/aspnetcore/pull/66236#discussion_r3054837960.

The message got refactored a couple times but was originally intended to be logged when the user canceled sign-in.
