### PR TITLE
OutputCaching: Avoid locking request with invalid cache key when another request is in-flight

### DIFF
--- a/src/Middleware/OutputCaching/src/OutputCacheMiddleware.cs
+++ b/src/Middleware/OutputCaching/src/OutputCacheMiddleware.cs
@@ -140,7 +140,7 @@ internal sealed class OutputCacheMiddleware
 
                     var executed = false;
 
-                    if (context.AllowLocking)
+                    if (context.AllowLocking && !string.IsNullOrEmpty(context.CacheKey))
                     {
                         var cacheEntry = await _requestDispatcher.ScheduleAsync(context.CacheKey, key => ExecuteResponseAsync());
 

--- a/src/Middleware/OutputCaching/test/OutputCacheMiddlewareTests.cs
+++ b/src/Middleware/OutputCaching/test/OutputCacheMiddlewareTests.cs
@@ -1056,6 +1056,54 @@ public abstract class OutputCacheMiddlewareTests
     }
 
     [Fact]
+    public async Task Locking_InvalidCacheKey_DoesNotCoalesceRequests()
+    {
+        var responseCounter = 0;
+
+        var blocker1 = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var blocker2 = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var options = new OutputCacheOptions();
+        options.AddBasePolicy(build => build.Cache());
+
+        var middleware = TestUtils.CreateTestMiddleware(
+            options: options,
+            keyProvider: new TestResponseCachingKeyProvider(string.Empty),
+            next: async c =>
+            {
+                var index = Interlocked.Increment(ref responseCounter);
+                if (index == 1)
+                {
+                    blocker1.SetResult(true);
+                    await blocker2.Task;
+                }
+                else if (index == 2)
+                {
+                    blocker2.SetResult(true);
+                }
+            });
+
+        var context1 = TestUtils.CreateTestContext();
+        context1.HttpContext.Request.Method = "GET";
+        context1.HttpContext.Request.Path = "/a";
+
+        var context2 = TestUtils.CreateTestContext();
+        context2.HttpContext.Request.Method = "GET";
+        context2.HttpContext.Request.Path = "/b";
+
+        var task1 = Task.Run(() => middleware.Invoke(context1.HttpContext));
+
+        // Wait for the first request to enter the pipeline.
+        await blocker1.Task;
+
+        var task2 = Task.Run(() => middleware.Invoke(context2.HttpContext));
+
+        await Task.WhenAll(task1, task2);
+
+        Assert.Equal(2, responseCounter);
+    }
+
+    [Fact]
     public async Task EmptyCacheKey_IsNotCached()
     {
         var cache = GetStore();


### PR DESCRIPTION
Fixes #67763

Previously, an invalid cache key (surfaced as string.Empty) would let two concurrent requests to serve the same response (`var cacheEntry = await _requestDispatcher.ScheduleAsync(context.CacheKey, key => ExecuteResponseAsync());`)

We shouldn't call ScheduleAsync with empty CacheKey.