### PR TITLE
Honor all sign-in confirmation requirements after registration

### DIFF
--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ExternalLogin.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ExternalLogin.cshtml.cs
@@ -207,8 +207,8 @@ internal sealed class ExternalLoginModel<TUser> : ExternalLoginModel where TUser
 
                     await _emailSender.SendConfirmationLinkAsync(user, Input.Email, HtmlEncoder.Default.Encode(callbackUrl));
 
-                    // If account confirmation is required, we need to show the link if we don't have a real email sender
-                    if (_userManager.Options.SignIn.RequireConfirmedAccount)
+                    // If confirmation is required, we need to show the link if we don't have a real email sender
+                    if (!await _signInManager.CanSignInAsync(user))
                     {
                         return RedirectToPage("./RegisterConfirmation", new { Email = Input.Email });
                     }

--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Register.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/Register.cshtml.cs
@@ -147,7 +147,7 @@ internal sealed class RegisterModel<TUser> : RegisterModel where TUser : class
 
                 await _emailSender.SendConfirmationLinkAsync(user, Input.Email, HtmlEncoder.Default.Encode(callbackUrl));
 
-                if (_userManager.Options.SignIn.RequireConfirmedAccount)
+                if (!await _signInManager.CanSignInAsync(user))
                 {
                     return RedirectToPage("RegisterConfirmation", new { email = Input.Email, returnUrl = returnUrl });
                 }

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ExternalLogin.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ExternalLogin.cshtml.cs
@@ -207,8 +207,8 @@ internal sealed class ExternalLoginModel<TUser> : ExternalLoginModel where TUser
 
                     await _emailSender.SendConfirmationLinkAsync(user, Input.Email, HtmlEncoder.Default.Encode(callbackUrl));
 
-                    // If account confirmation is required, we need to show the link if we don't have a real email sender
-                    if (_userManager.Options.SignIn.RequireConfirmedAccount)
+                    // If confirmation is required, we need to show the link if we don't have a real email sender
+                    if (!await _signInManager.CanSignInAsync(user))
                     {
                         return RedirectToPage("./RegisterConfirmation", new { Email = Input.Email });
                     }

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Register.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/Register.cshtml.cs
@@ -147,7 +147,7 @@ internal sealed class RegisterModel<TUser> : RegisterModel where TUser : class
 
                 await _emailSender.SendConfirmationLinkAsync(user, Input.Email, HtmlEncoder.Default.Encode(callbackUrl));
 
-                if (_userManager.Options.SignIn.RequireConfirmedAccount)
+                if (!await _signInManager.CanSignInAsync(user))
                 {
                     return RedirectToPage("RegisterConfirmation", new { email = Input.Email, returnUrl = returnUrl });
                 }

--- a/src/Identity/samples/IdentitySample.DefaultUI/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/src/Identity/samples/IdentitySample.DefaultUI/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -101,7 +101,7 @@ public class RegisterModel : PageModel
 
                 await _emailSender.SendConfirmationLinkAsync(user, Input.Email, HtmlEncoder.Default.Encode(callbackUrl));
 
-                if (_userManager.Options.SignIn.RequireConfirmedAccount)
+                if (!await _signInManager.CanSignInAsync(user))
                 {
                     return RedirectToPage("RegisterConfirmation", new { email = Input.Email });
                 }

--- a/src/Identity/test/Identity.FunctionalTests/LoginTests.cs
+++ b/src/Identity/test/Identity.FunctionalTests/LoginTests.cs
@@ -406,6 +406,6 @@ public abstract class LoginTests<TStartup, TContext> : IClassFixture<ServerFacto
         await UserStories.ConfirmEmailAsync(registrationEmail, client);
 
         // Act & Assert
-        await UserStories.LoginFailsWithWrongPasswordAsync(newClient, userName, wrongPassword);
+        await UserStories.LoginFailsAsync(newClient, userName, wrongPassword);
     }
 }

--- a/src/Identity/test/Identity.FunctionalTests/LoginTests.cs
+++ b/src/Identity/test/Identity.FunctionalTests/LoginTests.cs
@@ -167,7 +167,7 @@ public abstract class LoginTests<TStartup, TContext> : IClassFixture<ServerFacto
         var userName = $"{Guid.NewGuid()}@example.com";
         var password = $"[PLACEHOLDER]-1a";
 
-        var loggedIn = await UserStories.RegisterNewUserAsync(client, userName, password);
+        await UserStories.RegisterNewUserAsyncWithConfirmation(client, userName, password, hasRealEmailSender: true);
 
         // Act & Assert
         // Use a new client to simulate a new browser session.
@@ -192,7 +192,7 @@ public abstract class LoginTests<TStartup, TContext> : IClassFixture<ServerFacto
         var userName = $"{Guid.NewGuid()}@example.com";
         var password = $"[PLACEHOLDER]-1a";
 
-        var loggedIn = await UserStories.RegisterNewUserAsync(client, userName, password);
+        await UserStories.RegisterNewUserAsyncWithConfirmation(client, userName, password, hasRealEmailSender: true);
 
         // Act & Assert
         // Use a new client to simulate a new browser session.
@@ -216,7 +216,7 @@ public abstract class LoginTests<TStartup, TContext> : IClassFixture<ServerFacto
         var userName = $"{Guid.NewGuid()}@example.com";
         var password = $"[PLACEHOLDER]-1a";
 
-        var loggedIn = await UserStories.RegisterNewUserAsync(client, userName, password);
+        await UserStories.RegisterNewUserAsyncWithConfirmation(client, userName, password, hasRealEmailSender: true);
 
         // Act & Assert
         // Use a new client to simulate a new browser session.
@@ -243,7 +243,7 @@ public abstract class LoginTests<TStartup, TContext> : IClassFixture<ServerFacto
         var userName = $"{Guid.NewGuid()}@example.com";
         var password = $"[PLACEHOLDER]-1a";
 
-        var loggedIn = await UserStories.RegisterNewUserAsync(client, userName, password);
+        await UserStories.RegisterNewUserAsyncWithConfirmation(client, userName, password, hasRealEmailSender: true);
 
         // Act & Assert
         // Use a new client to simulate a new browser session.
@@ -271,7 +271,7 @@ public abstract class LoginTests<TStartup, TContext> : IClassFixture<ServerFacto
         var userName = $"{Guid.NewGuid()}@example.com";
         var password = $"[PLACEHOLDER]-1a";
 
-        var loggedIn = await UserStories.RegisterNewUserAsync(client, userName, password);
+        await UserStories.RegisterNewUserAsyncWithConfirmation(client, userName, password, hasRealEmailSender: true);
 
         // Act & Assert
         // Use a new client to simulate a new browser session.

--- a/src/Identity/test/Identity.FunctionalTests/ManagementTests.cs
+++ b/src/Identity/test/Identity.FunctionalTests/ManagementTests.cs
@@ -104,7 +104,7 @@ public abstract class ManagementTests<TStartup, TContext> : IClassFixture<Server
 
         // Verify can login with new email, fails with old
         await UserStories.LoginExistingUserAsync(newClient, newEmail, password);
-        await UserStories.LoginFailsWithWrongPasswordAsync(failedClient, userName, password);
+        await UserStories.LoginFailsAsync(failedClient, userName, password);
 
     }
 

--- a/src/Identity/test/Identity.FunctionalTests/Pages/Account/Login.cs
+++ b/src/Identity/test/Identity.FunctionalTests/Pages/Account/Login.cs
@@ -73,7 +73,7 @@ public class Login : DefaultUIPage
             Context.WithAuthenticatedUser().WithPasswordLogin());
     }
 
-    public async Task LoginWrongPasswordAsync(string userName, string password)
+    public async Task LoginFailsAsync(string userName, string password)
     {
         var failedLogin = await SendLoginForm(userName, password);
 

--- a/src/Identity/test/Identity.FunctionalTests/RegistrationTests.cs
+++ b/src/Identity/test/Identity.FunctionalTests/RegistrationTests.cs
@@ -60,6 +60,25 @@ public abstract class RegistrationTests<TStartup, TContext> : IClassFixture<Serv
         await UserStories.LoginExistingUserAsync(client, userName, password);
     }
 
+    [Fact]
+    public async Task CanRegisterAUserWithRequiredEmailConfirmation()
+    {
+        void ConfigureTestServices(IServiceCollection services) { services.SetupEmailRequired(); };
+
+        var server = ServerFactory
+                .WithWebHostBuilder(whb => whb.ConfigureServices(ConfigureTestServices));
+        var client = server.CreateClient();
+
+        var userName = $"{Guid.NewGuid()}@example.com";
+        var password = $"[PLACEHOLDER]-1a";
+
+        var register = await UserStories.RegisterNewUserAsyncWithConfirmation(client, userName, password);
+
+        await UserStories.LoginFailsWithWrongPasswordAsync(client, userName, password);
+        await register.ClickConfirmLinkAsync();
+        await UserStories.LoginExistingUserAsync(client, userName, password);
+    }
+
     private class FakeEmailSender : IEmailSender
     {
         public Task SendEmailAsync(string email, string subject, string htmlMessage)
@@ -148,6 +167,25 @@ public abstract class RegistrationTests<TStartup, TContext> : IClassFixture<Serv
         var email = $"{guid}@example.com";
 
         // Act & Assert
+        await UserStories.RegisterNewUserWithSocialLoginWithConfirmationAsync(client, userName, email);
+    }
+
+    [Fact]
+    public async Task CanRegisterWithASocialLoginProviderFromLoginWithRequiredEmailConfirmation()
+    {
+        void ConfigureTestServices(IServiceCollection services) =>
+            services
+                .SetupEmailRequired()
+                .SetupTestThirdPartyLogin();
+
+        var client = ServerFactory
+            .WithWebHostBuilder(whb => whb.ConfigureServices(ConfigureTestServices))
+            .CreateClient();
+
+        var guid = Guid.NewGuid();
+        var userName = $"{guid}";
+        var email = $"{guid}@example.com";
+
         await UserStories.RegisterNewUserWithSocialLoginWithConfirmationAsync(client, userName, email);
     }
 

--- a/src/Identity/test/Identity.FunctionalTests/RegistrationTests.cs
+++ b/src/Identity/test/Identity.FunctionalTests/RegistrationTests.cs
@@ -55,7 +55,7 @@ public abstract class RegistrationTests<TStartup, TContext> : IClassFixture<Serv
         var register = await UserStories.RegisterNewUserAsyncWithConfirmation(client, userName, password);
 
         // Since we aren't confirmed yet, login should fail until we confirm
-        await UserStories.LoginFailsWithWrongPasswordAsync(client, userName, password);
+        await UserStories.LoginFailsAsync(client, userName, password);
         await register.ClickConfirmLinkAsync();
         await UserStories.LoginExistingUserAsync(client, userName, password);
     }
@@ -74,7 +74,7 @@ public abstract class RegistrationTests<TStartup, TContext> : IClassFixture<Serv
 
         var register = await UserStories.RegisterNewUserAsyncWithConfirmation(client, userName, password);
 
-        await UserStories.LoginFailsWithWrongPasswordAsync(client, userName, password);
+        await UserStories.LoginFailsAsync(client, userName, password);
         await register.ClickConfirmLinkAsync();
         await UserStories.LoginExistingUserAsync(client, userName, password);
     }
@@ -107,7 +107,7 @@ public abstract class RegistrationTests<TStartup, TContext> : IClassFixture<Serv
         var register = await UserStories.RegisterNewUserAsyncWithConfirmation(client, userName, password, hasRealEmailSender: true);
 
         // Since we aren't confirmed yet, login should fail until we confirm
-        await UserStories.LoginFailsWithWrongPasswordAsync(client, userName, password);
+        await UserStories.LoginFailsAsync(client, userName, password);
     }
 
     [Fact]

--- a/src/Identity/test/Identity.FunctionalTests/UserStories.cs
+++ b/src/Identity/test/Identity.FunctionalTests/UserStories.cs
@@ -44,13 +44,13 @@ public class UserStories
         return await login.LoginValidUserAsync(userName, password);
     }
 
-    internal static async Task LoginFailsWithWrongPasswordAsync(HttpClient client, string userName, string password)
+    internal static async Task LoginFailsAsync(HttpClient client, string userName, string password)
     {
         var index = await Index.CreateAsync(client);
 
         var login = await index.ClickLoginLinkAsync();
 
-        await login.LoginWrongPasswordAsync(userName, password);
+        await login.LoginFailsAsync(userName, password);
     }
 
     internal static async Task<DefaultUIPage> LockoutExistingUserAsync(HttpClient client, string userName, string password)

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/ExternalLogin.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/ExternalLogin.razor
@@ -168,8 +168,8 @@
                     new Dictionary<string, object?> { ["userId"] = userId, ["code"] = code });
                 await EmailSender.SendConfirmationLinkAsync(user, Input.Email, HtmlEncoder.Default.Encode(callbackUrl));
 
-                // If account confirmation is required, we need to show the link if we don't have a real email sender
-                if (UserManager.Options.SignIn.RequireConfirmedAccount)
+                // If confirmation is required, we need to show the link if we don't have a real email sender
+                if (!await SignInManager.CanSignInAsync(user))
                 {
                     RedirectManager.RedirectTo("Account/RegisterConfirmation", new() { ["email"] = Input.Email });
                 }

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Register.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Register.razor
@@ -102,7 +102,7 @@
 
         await EmailSender.SendConfirmationLinkAsync(user, Input.Email, HtmlEncoder.Default.Encode(callbackUrl));
 
-        if (UserManager.Options.SignIn.RequireConfirmedAccount)
+        if (!await SignInManager.CanSignInAsync(user))
         {
             RedirectManager.RedirectTo(
                 "Account/RegisterConfirmation",

--- a/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs
@@ -64,6 +64,34 @@ public class BlazorWebTemplateTest(ProjectFactoryFixture projectFactory) : Blazo
         await TestProjectCoreAsync(project, browserKind, pagesToExclude, authenticationFeatures);
     }
 
+    [Theory]
+    [InlineData(BrowserKind.Chromium)]
+    public async Task BlazorWebTemplate_CanRequireConfirmedEmail(BrowserKind browserKind)
+    {
+        var project = await CreateBuildPublishAsync(
+            args: ["-int", "None", "-au", "Individual"],
+            onlyCreate: true);
+
+        var programPath = Path.Combine(project.TemplateOutputDir, "Program.cs");
+        var program = await File.ReadAllTextAsync(programPath);
+        const string requireConfirmedAccount = "options.SignIn.RequireConfirmedAccount = true;";
+        Assert.Contains(requireConfirmedAccount, program);
+        program = program.Replace(
+            requireConfirmedAccount,
+            "options.SignIn.RequireConfirmedEmail = true;",
+            StringComparison.Ordinal);
+        await File.WriteAllTextAsync(programPath, program);
+
+        await project.RunDotNetPublishAsync(noRestore: false);
+        await project.RunDotNetBuildAsync();
+
+        await TestProjectCoreAsync(
+            project,
+            browserKind,
+            BlazorTemplatePages.Counter,
+            AuthenticationFeatures.RegisterAndLogIn);
+    }
+
     private async Task TestProjectCoreAsync(Project project, BrowserKind browserKind, BlazorTemplatePages pagesToExclude, AuthenticationFeatures authenticationFeatures)
     {
         var appName = project.ProjectName;


### PR DESCRIPTION
**Behavior change:** Identity UI and Blazor templates now honor all configured sign-in confirmation requirements after password or external registration. Users requiring confirmed email or phone are redirected to registration confirmation instead of being signed in automatically.

If desired for your application, you can restore automatic sign-in by disabling the relevant requirement(s):

`options.SignIn.RequireConfirmedEmail = false;`
`options.SignIn.RequireConfirmedPhoneNumber = false;`
`options.SignIn.RequireConfirmedAccount = false;`

There is no compatibility switch to keep confirmation required for later sign-ins while bypassing it during registration. That behavior requires scaffolding/customizing the registration pages and explicitly calling `SignInAsync` or changing the check back to `_userManager.Options.SignIn.RequireConfirmedAccount`.