### PR TITLE
Preserve BadHttpRequestException status codes

### DIFF
--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddlewareImpl.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddlewareImpl.cs
@@ -164,7 +164,8 @@ internal sealed class ExceptionHandlerMiddlewareImpl
 
             context.Features.Set<IExceptionHandlerFeature>(exceptionHandlerFeature);
             context.Features.Set<IExceptionHandlerPathFeature>(exceptionHandlerFeature);
-            var isBadHttpRequestException = edi.SourceException is BadHttpRequestException;
+            var is404FromBadHttpRequestException = edi.SourceException is
+                BadHttpRequestException { StatusCode: StatusCodes.Status404NotFound };
             context.Response.StatusCode = _options.StatusCodeSelector?.Invoke(edi.SourceException)
                 ?? (edi.SourceException switch
                 {
@@ -221,7 +222,7 @@ internal sealed class ExceptionHandlerMiddlewareImpl
                 }
             }
 
-            if (result != ExceptionHandledType.Unhandled || _options.StatusCodeSelector is not null || isBadHttpRequestException || context.Response.StatusCode != StatusCodes.Status404NotFound || _options.AllowStatusCode404Response)
+            if (result != ExceptionHandledType.Unhandled || _options.StatusCodeSelector is not null || is404FromBadHttpRequestException || context.Response.StatusCode != StatusCodes.Status404NotFound || _options.AllowStatusCode404Response)
             {
                 var suppressDiagnostics = false;
 

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddlewareImpl.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerMiddlewareImpl.cs
@@ -164,7 +164,13 @@ internal sealed class ExceptionHandlerMiddlewareImpl
 
             context.Features.Set<IExceptionHandlerFeature>(exceptionHandlerFeature);
             context.Features.Set<IExceptionHandlerPathFeature>(exceptionHandlerFeature);
-            context.Response.StatusCode = _options.StatusCodeSelector?.Invoke(edi.SourceException) ?? DefaultStatusCode;
+            var isBadHttpRequestException = edi.SourceException is BadHttpRequestException;
+            context.Response.StatusCode = _options.StatusCodeSelector?.Invoke(edi.SourceException)
+                ?? (edi.SourceException switch
+                {
+                    BadHttpRequestException badHttpRequestException => badHttpRequestException.StatusCode,
+                    _ => DefaultStatusCode,
+                });
             context.Response.OnStarting(_clearCacheHeadersDelegate, context.Response);
 
             string? handlerTag = null;
@@ -215,7 +221,7 @@ internal sealed class ExceptionHandlerMiddlewareImpl
                 }
             }
 
-            if (result != ExceptionHandledType.Unhandled || _options.StatusCodeSelector != null || context.Response.StatusCode != StatusCodes.Status404NotFound || _options.AllowStatusCode404Response)
+            if (result != ExceptionHandledType.Unhandled || _options.StatusCodeSelector is not null || isBadHttpRequestException || context.Response.StatusCode != StatusCodes.Status404NotFound || _options.AllowStatusCode404Response)
             {
                 var suppressDiagnostics = false;
 

--- a/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerOptions.cs
+++ b/src/Middleware/Diagnostics/src/ExceptionHandler/ExceptionHandlerOptions.cs
@@ -45,7 +45,8 @@ public class ExceptionHandlerOptions
     /// Gets or sets a delegate used to map an exception to an HTTP status code.
     /// </summary>
     /// <remarks>
-    /// If <see cref="StatusCodeSelector"/> is <c>null</c>, the default exception status code 500 is used.
+    /// If <see cref="StatusCodeSelector"/> is <c>null</c>, the default exception status code is 500. If the exception
+    /// is a <see cref="BadHttpRequestException"/>, its <see cref="BadHttpRequestException.StatusCode"/> is used instead.
     /// </remarks>
     public Func<Exception, int>? StatusCodeSelector { get; set; }
 

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerMiddlewareTest.cs
@@ -115,7 +115,7 @@ public class ExceptionHandlerMiddlewareTest : LoggedTest
 
     [Theory]
     [InlineData(StatusCodes.Status400BadRequest)]
-    [InlineData(StatusCodes.Status404NotFound)]
+    [InlineData(StatusCodes.Status404NotFound)] // Does not require AllowStatusCode404Response.
     [InlineData(StatusCodes.Status418ImATeapot)]
     public async Task Invoke_BadHttpRequestException_PreservesStatusCode(int statusCode)
     {
@@ -161,22 +161,21 @@ public class ExceptionHandlerMiddlewareTest : LoggedTest
     }
 
     [Fact]
-    public async Task Invoke_BadHttpRequestException_IExceptionHandlerCanOverrideStatusCode()
+    public async Task Invoke_BadHttpRequestException_Non404StatusDoesNotBypass404ResponseGuard()
     {
         var httpContext = CreateHttpContext();
-        var optionsAccessor = CreateOptionsAccessor();
-        var exceptionHandlers = new[]
+        var optionsAccessor = CreateOptionsAccessor(exceptionHandler: context =>
         {
-            new TestExceptionHandler(true, "handler", StatusCodes.Status422UnprocessableEntity),
-        };
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Task.CompletedTask;
+        });
         var middleware = CreateMiddleware(
-            _ => throw new BadHttpRequestException("Bad request.", StatusCodes.Status418ImATeapot),
-            optionsAccessor,
-            exceptionHandlers);
+            _ => throw new BadHttpRequestException("Bad request.", StatusCodes.Status400BadRequest),
+            optionsAccessor);
 
-        await middleware.Invoke(httpContext);
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => middleware.Invoke(httpContext));
 
-        Assert.Equal(StatusCodes.Status422UnprocessableEntity, httpContext.Response.StatusCode);
+        Assert.IsType<BadHttpRequestException>(exception.InnerException);
     }
 
     [Theory]
@@ -703,23 +702,16 @@ public class ExceptionHandlerMiddlewareTest : LoggedTest
     {
         private readonly bool _handle;
         private readonly string _name;
-        private readonly int? _statusCode;
 
-        public TestExceptionHandler(bool handle, string name, int? statusCode = null)
+        public TestExceptionHandler(bool handle, string name)
         {
             _handle = handle;
             _name = name;
-            _statusCode = statusCode;
         }
 
         public ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
         {
             httpContext.Items[_name] = true;
-            if (_statusCode is { } statusCode)
-            {
-                httpContext.Response.StatusCode = statusCode;
-            }
-
             return ValueTask.FromResult(_handle);
         }
     }

--- a/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerMiddlewareTest.cs
+++ b/src/Middleware/Diagnostics/test/UnitTests/ExceptionHandlerMiddlewareTest.cs
@@ -114,6 +114,72 @@ public class ExceptionHandlerMiddlewareTest : LoggedTest
     }
 
     [Theory]
+    [InlineData(StatusCodes.Status400BadRequest)]
+    [InlineData(StatusCodes.Status404NotFound)]
+    [InlineData(StatusCodes.Status418ImATeapot)]
+    public async Task Invoke_BadHttpRequestException_PreservesStatusCode(int statusCode)
+    {
+        var httpContext = CreateHttpContext();
+        var optionsAccessor = CreateOptionsAccessor();
+        var middleware = CreateMiddleware(_ => throw new BadHttpRequestException("Bad request.", statusCode), optionsAccessor);
+
+        await middleware.Invoke(httpContext);
+
+        Assert.Equal(statusCode, httpContext.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Invoke_BadHttpRequestException_StatusCodeSelectorTakesPrecedence()
+    {
+        var httpContext = CreateHttpContext();
+        var optionsAccessor = CreateOptionsAccessor(statusCodeSelector: _ => StatusCodes.Status409Conflict);
+        var middleware = CreateMiddleware(
+            _ => throw new BadHttpRequestException("Bad request.", StatusCodes.Status418ImATeapot),
+            optionsAccessor);
+
+        await middleware.Invoke(httpContext);
+
+        Assert.Equal(StatusCodes.Status409Conflict, httpContext.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Invoke_BadHttpRequestException_ExceptionHandlerDelegateCanOverrideStatusCode()
+    {
+        var httpContext = CreateHttpContext();
+        var optionsAccessor = CreateOptionsAccessor(exceptionHandler: context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status422UnprocessableEntity;
+            return Task.CompletedTask;
+        });
+        var middleware = CreateMiddleware(
+            _ => throw new BadHttpRequestException("Bad request.", StatusCodes.Status418ImATeapot),
+            optionsAccessor);
+
+        await middleware.Invoke(httpContext);
+
+        Assert.Equal(StatusCodes.Status422UnprocessableEntity, httpContext.Response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Invoke_BadHttpRequestException_IExceptionHandlerCanOverrideStatusCode()
+    {
+        var httpContext = CreateHttpContext();
+        var optionsAccessor = CreateOptionsAccessor();
+        var exceptionHandlers = new[]
+        {
+            new TestExceptionHandler(true, "handler", StatusCodes.Status422UnprocessableEntity),
+        };
+        var middleware = CreateMiddleware(
+            _ => throw new BadHttpRequestException("Bad request.", StatusCodes.Status418ImATeapot),
+            optionsAccessor,
+            exceptionHandlers);
+
+        await middleware.Invoke(httpContext);
+
+        Assert.Equal(StatusCodes.Status422UnprocessableEntity, httpContext.Response.StatusCode);
+    }
+
+    [Theory]
     [InlineData(ExceptionHandledType.ExceptionHandlerDelegate, false)]
     [InlineData(ExceptionHandledType.ProblemDetailsService, true)]
     public async Task Invoke_HasExceptionHandler_SuppressDiagnostics_CallbackRun(ExceptionHandledType suppressResult, bool logged)
@@ -637,16 +703,23 @@ public class ExceptionHandlerMiddlewareTest : LoggedTest
     {
         private readonly bool _handle;
         private readonly string _name;
+        private readonly int? _statusCode;
 
-        public TestExceptionHandler(bool handle, string name)
+        public TestExceptionHandler(bool handle, string name, int? statusCode = null)
         {
             _handle = handle;
             _name = name;
+            _statusCode = statusCode;
         }
 
         public ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
         {
             httpContext.Items[_name] = true;
+            if (_statusCode is { } statusCode)
+            {
+                httpContext.Response.StatusCode = statusCode;
+            }
+
             return ValueTask.FromResult(_handle);
         }
     }
@@ -664,13 +737,15 @@ public class ExceptionHandlerMiddlewareTest : LoggedTest
     private IOptions<ExceptionHandlerOptions> CreateOptionsAccessor(
         RequestDelegate exceptionHandler = null,
         string exceptionHandlingPath = null,
-        Func<ExceptionHandlerSuppressDiagnosticsContext, bool> suppressDiagnosticsCallback = null)
+        Func<ExceptionHandlerSuppressDiagnosticsContext, bool> suppressDiagnosticsCallback = null,
+        Func<Exception, int> statusCodeSelector = null)
     {
         exceptionHandler ??= c => Task.CompletedTask;
         var options = new ExceptionHandlerOptions()
         {
             ExceptionHandler = exceptionHandler,
             ExceptionHandlingPath = exceptionHandlingPath,
+            StatusCodeSelector = statusCodeSelector,
         };
         if (suppressDiagnosticsCallback != null)
         {


### PR DESCRIPTION
`ExceptionHandlerMiddleware` currently converts `BadHttpRequestException` responses to 500, masking client errors such as invalid or incomplete request bodies. This change uses `BadHttpRequestException.StatusCode` by default, while retaining 500 as the default exception status code for all other exceptions.

A configured `StatusCodeSelector` still takes precedence, and custom `ExceptionHandler` delegates and `IExceptionHandler` services can continue overriding the selected status code. Status code 404 carried by `BadHttpRequestException` is treated as intentional rather than as a misconfigured exception handler response.

Fixes: #43831