### PR TITLE
Don't trim trailing whitespace in resx files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,9 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.resx]
+trim_trailing_whitespace = false
+
 [*.cs]
 indent_size = 4
 dotnet_sort_system_directives_first = true


### PR DESCRIPTION
The RESX generator in Visual Studio produces extra trailing whitespaces in resx files. Manual edits to the resx files could lead editors to try to trim these whitespaces, then a next developer editing resx by Visual Studio will get those whitespaces back again, etc.
It's best to instruct editors to not touch the whitespaces in this case.