### PR TITLE
Align authentication-state revalidation with authorization semantics

### DIFF
--- a/src/Components/Server/src/Circuits/RevalidatingServerAuthenticationStateProvider.cs
+++ b/src/Components/Server/src/Circuits/RevalidatingServerAuthenticationStateProvider.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.Extensions.Logging;
@@ -61,7 +62,7 @@ public abstract class RevalidatingServerAuthenticationStateProvider
         try
         {
             var authenticationState = await authenticationStateTask;
-            if (authenticationState.User.Identity?.IsAuthenticated == true)
+            if (authenticationState.User.Identities.Any(static i => i.IsAuthenticated))
             {
                 while (!cancellationToken.IsCancellationRequested)
                 {


### PR DESCRIPTION
This improves authentication-state revalidation by starting the loop when any identity on the principal is authenticated, rather than only the selected primary identity. This aligns the provider with framework authorization behavior for principals containing multiple identities.