### PR TITLE
Avoid duplicate framework builds from Components E2E publishes

### DIFF
--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -20,6 +20,14 @@
     </ProjectReference>
   </ItemDefinitionGroup>
 
+  <!-- PrepareE2EApps supplies these properties to the app itself. Preserve them on that edge,
+       then remove them when the app traverses its own project references. -->
+  <ItemGroup Condition="'$(IsTestAssetProject)' == 'true'">
+    <ProjectReference Update="@(ProjectReference->WithMetadataValue('E2EApp', 'true'))">
+      <UndefineProperties />
+    </ProjectReference>
+  </ItemGroup>
+
   <!-- After ResolveReferences.targets (imported above) converts Reference to ProjectReference
        at evaluation time (which drops all custom metadata), re-apply metadata at evaluation
        time so it is always in effect for every build phase (Build, Publish, Razor, etc.):

--- a/src/Components/Directory.Build.targets
+++ b/src/Components/Directory.Build.targets
@@ -11,6 +11,15 @@
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.targets))\Directory.Build.targets" />
 
+  <!-- E2E app publishes use app-specific global properties while their framework dependencies
+       share the repository's normal build outputs. Do not create property-distinct dependency
+       builds that can concurrently rewrite those shared outputs. -->
+  <ItemDefinitionGroup Condition="'$(IsTestAssetProject)' == 'true'">
+    <ProjectReference>
+      <UndefineProperties>%(UndefineProperties);E2ECompileTestHarness;E2EAppMode;PublishDir;_E2EIsPublishing</UndefineProperties>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+
   <!-- After ResolveReferences.targets (imported above) converts Reference to ProjectReference
        at evaluation time (which drops all custom metadata), re-apply metadata at evaluation
        time so it is always in effect for every build phase (Build, Publish, Razor, etc.):

--- a/src/Components/Testing/eng/targets/Microsoft.AspNetCore.Components.Testing.targets
+++ b/src/Components/Testing/eng/targets/Microsoft.AspNetCore.Components.Testing.targets
@@ -103,6 +103,10 @@
       <_E2EAppProjects Condition="'%(_E2EAppProjects.E2EAppMode)' == ''">
         <E2EAppMode>$(E2EAppMode)</E2EAppMode>
       </_E2EAppProjects>
+      <!-- These properties control test-host packaging and must not distinguish the app build. -->
+      <_E2EAppProjects>
+        <UndefineProperties>%(_E2EAppProjects.UndefineProperties);_E2EIsPublishing;E2EAppMode</UndefineProperties>
+      </_E2EAppProjects>
       <_E2ESourceAppProjects Include="@(_E2EAppProjects)" Condition="'%(_E2EAppProjects.E2EAppMode)' == 'build' or '%(_E2EAppProjects.E2EAppMode)' == 'all'" />
       <_E2EPublishPrimaryAppProjects Include="@(_E2EAppProjects)" Condition="'%(_E2EAppProjects.E2EAppMode)' == 'publish'" />
       <_E2EPublishSecondaryAppProjects Include="@(_E2EAppProjects)" Condition="'%(_E2EAppProjects.E2EAppMode)' == 'all' and '%(_E2EAppProjects.E2ENativeAot)' != 'true'" />

--- a/src/Components/Testing/eng/targets/Microsoft.AspNetCore.Components.Testing.targets
+++ b/src/Components/Testing/eng/targets/Microsoft.AspNetCore.Components.Testing.targets
@@ -103,10 +103,6 @@
       <_E2EAppProjects Condition="'%(_E2EAppProjects.E2EAppMode)' == ''">
         <E2EAppMode>$(E2EAppMode)</E2EAppMode>
       </_E2EAppProjects>
-      <!-- These properties control test-host packaging and must not distinguish the app build. -->
-      <_E2EAppProjects>
-        <UndefineProperties>%(_E2EAppProjects.UndefineProperties);_E2EIsPublishing;E2EAppMode</UndefineProperties>
-      </_E2EAppProjects>
       <_E2ESourceAppProjects Include="@(_E2EAppProjects)" Condition="'%(_E2EAppProjects.E2EAppMode)' == 'build' or '%(_E2EAppProjects.E2EAppMode)' == 'all'" />
       <_E2EPublishPrimaryAppProjects Include="@(_E2EAppProjects)" Condition="'%(_E2EAppProjects.E2EAppMode)' == 'publish'" />
       <_E2EPublishSecondaryAppProjects Include="@(_E2EAppProjects)" Condition="'%(_E2EAppProjects.E2EAppMode)' == 'all' and '%(_E2EAppProjects.E2ENativeAot)' != 'true'" />


### PR DESCRIPTION
## Summary

Prevent Components test-asset publishes from flowing app-specific global properties into framework project references that share the repository's normal build outputs.

The workaround is intentionally limited to `src/Components/Directory.Build.targets`, which is repository build configuration and is not included in the `Microsoft.AspNetCore.Components.Testing` package.

## Root cause

[Windows build 1558435](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1558435) failed while `Negotiate.Server` compiled against `Microsoft.AspNetCore.Components.dll`.

The binlog shows `NativeAotTestApp.E2E.Tests` publishing `NativeAotTestApp` with `E2ECompileTestHarness=true` and an app-specific `PublishDir`. Those globals flowed into `Microsoft.AspNetCore.Components.csproj`, creating a second MSBuild project configuration even though its output and intermediate paths were unchanged.

That second configuration recompiled Components and ran `CopyRefAssembly` against the shared reference assembly at 23:56:16.559. `Negotiate.Server` attempted to open the same file at 23:56:16.577 and failed with CS0009.

The recent fixes in #68463 and #68501 cover overlapping static-web-asset publish work, but not this property-distinct framework build from the Native AOT E2E harness.

## Fix

Components test assets append these app/host-only globals to `ProjectReference.UndefineProperties`:

- `E2ECompileTestHarness`
- `E2EAppMode`
- `PublishDir`
- `_E2EIsPublishing`

The `E2EApp=true` reference from a test harness to its app is explicitly exempted. This preserves the properties that select the app's publish mode, destination, and Native AOT behavior. The properties are removed only from the harness's other dependencies and when the app traverses its own project references.

`UndefineProperties` is honored by ordinary MSBuild project-reference calls and static-web-assets build/publish traversals. Framework dependencies therefore reuse configurations without E2E-specific globals instead of rebuilding into shared outputs. `BuildProjectReferences` remains unchanged, so clean and standalone builds can still build missing dependencies.

## Validation

- Native AOT and managed harness evaluations preserve an empty `UndefineProperties` value on their `E2EApp=true` references.
- The same apps apply the four-property removal list to generated framework and analyzer project references.
- A standard project-reference traversal evaluates `Microsoft.AspNetCore.Components.csproj` without the E2E globals.
- `ResolveReferencedProjectsStaticWebAssetsConfiguration` evaluates Components without the app-specific globals.
- A `PrepareE2EApps` publish using the unchanged packaged targets preserves the app-specific `PublishDir` and E2E mode on the root app, while no Components evaluation carries any of the four E2E globals.
