### PR TITLE
Fix duplicate schema component for nullable unions in OpenAPI

### DIFF
--- a/src/OpenApi/sample/Endpoints/MapUnionsEndpoints.cs
+++ b/src/OpenApi/sample/Endpoints/MapUnionsEndpoints.cs
@@ -44,6 +44,9 @@ public static class UnionsEndpoints
         // used directly elsewhere registers as a separate component schema.
         unions.MapGet("/kitten-standalone", () => new Kitten("Whiskers", 9));
 
+        // Container record whose property is a *nullable* union with a polymorphic case type.
+        unions.MapGet("/beasts", () => new BeastEnvelope(new OneOrManyBeast(new Dachshund("Chili"))));
+
         return endpointRouteBuilder;
     }
 }

--- a/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
@@ -476,7 +476,17 @@ internal static class JsonNodeSchemaExtensions
         {
             schema[OpenApiConstants.SchemaId] = schemaReferenceId;
         }
-        if (context.TypeInfo.Kind == JsonTypeInfoKind.Union)
+
+        // C# union types are value types, so in case of Nullable<Union> JsonTypeInfoKind is None.
+        // We need to unpack it to properly detect the union: see https://github.com/dotnet/aspnetcore/issues/68653.
+        var unionTypeInfo = context.TypeInfo;
+        if (Nullable.GetUnderlyingType(unionTypeInfo.Type) is { } underlyingType
+            && unionTypeInfo.Options.TryGetTypeInfo(underlyingType, out var underlyingTypeInfo))
+        {
+            unionTypeInfo = underlyingTypeInfo;
+        }
+
+        if (unionTypeInfo.Kind == JsonTypeInfoKind.Union)
         {
             schema[OpenApiConstants.SchemaIsUnion] = true;
         }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=unions.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_0/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=unions.verified.txt
@@ -202,10 +202,105 @@
           }
         }
       }
+    },
+    "/unions/beasts": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeastEnvelope"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
     "schemas": {
+      "Beast": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/BeastLion"
+          },
+          {
+            "$ref": "#/components/schemas/BeastDachshund"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "lion": "#/components/schemas/BeastLion",
+            "dachshund": "#/components/schemas/BeastDachshund"
+          }
+        }
+      },
+      "BeastDachshund": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "dachshund"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "BeastEnvelope": {
+        "required": [
+          "beasts"
+        ],
+        "type": "object",
+        "properties": {
+          "beasts": {
+            "oneOf": [
+              {
+                "enum": [
+                  null
+                ],
+                "nullable": true
+              },
+              {
+                "$ref": "#/components/schemas/OneOrManyBeast"
+              }
+            ]
+          }
+        }
+      },
+      "BeastLion": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "lion"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
       "Clinic": {
         "required": [
           "address",
@@ -236,6 +331,19 @@
             "format": "int32"
           }
         }
+      },
+      "OneOrManyBeast": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/Beast"
+          },
+          {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Beast"
+            }
+          }
+        ]
       },
       "Puppy": {
         "required": [

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=unions.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_1/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=unions.verified.txt
@@ -202,10 +202,102 @@
           }
         }
       }
+    },
+    "/unions/beasts": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeastEnvelope"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
     "schemas": {
+      "Beast": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/BeastLion"
+          },
+          {
+            "$ref": "#/components/schemas/BeastDachshund"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "lion": "#/components/schemas/BeastLion",
+            "dachshund": "#/components/schemas/BeastDachshund"
+          }
+        }
+      },
+      "BeastDachshund": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "dachshund"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "BeastEnvelope": {
+        "required": [
+          "beasts"
+        ],
+        "type": "object",
+        "properties": {
+          "beasts": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/OneOrManyBeast"
+              }
+            ]
+          }
+        }
+      },
+      "BeastLion": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "lion"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
       "Clinic": {
         "required": [
           "address",
@@ -236,6 +328,19 @@
             "format": "int32"
           }
         }
+      },
+      "OneOrManyBeast": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/Beast"
+          },
+          {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Beast"
+            }
+          }
+        ]
       },
       "Puppy": {
         "required": [

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=unions.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApi3_2/OpenApiDocumentIntegrationTests.VerifyOpenApiDocument_documentName=unions.verified.txt
@@ -202,10 +202,102 @@
           }
         }
       }
+    },
+    "/unions/beasts": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeastEnvelope"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
     "schemas": {
+      "Beast": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/BeastLion"
+          },
+          {
+            "$ref": "#/components/schemas/BeastDachshund"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "lion": "#/components/schemas/BeastLion",
+            "dachshund": "#/components/schemas/BeastDachshund"
+          }
+        }
+      },
+      "BeastDachshund": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "dachshund"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "BeastEnvelope": {
+        "required": [
+          "beasts"
+        ],
+        "type": "object",
+        "properties": {
+          "beasts": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/OneOrManyBeast"
+              }
+            ]
+          }
+        }
+      },
+      "BeastLion": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "lion"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
       "Clinic": {
         "required": [
           "address",
@@ -236,6 +328,19 @@
             "format": "int32"
           }
         }
+      },
+      "OneOrManyBeast": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/Beast"
+          },
+          {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Beast"
+            }
+          }
+        ]
       },
       "Puppy": {
         "required": [

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Integration/snapshots/OpenApiDocumentLocalizationTests.VerifyOpenApiDocumentIsInvariant.verified.txt
@@ -2297,6 +2297,25 @@
         }
       }
     },
+    "/unions/beasts": {
+      "get": {
+        "tags": [
+          "Sample"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BeastEnvelope"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/obsolete/deprecated": {
       "post": {
         "tags": [
@@ -2780,6 +2799,79 @@
         "properties": {
           "relatedLocation": {
             "$ref": "#/components/schemas/LocationDto"
+          }
+        }
+      },
+      "Beast": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/BeastLion"
+          },
+          {
+            "$ref": "#/components/schemas/BeastDachshund"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "lion": "#/components/schemas/BeastLion",
+            "dachshund": "#/components/schemas/BeastDachshund"
+          }
+        }
+      },
+      "BeastDachshund": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "dachshund"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "BeastEnvelope": {
+        "required": [
+          "beasts"
+        ],
+        "type": "object",
+        "properties": {
+          "beasts": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/OneOrManyBeast"
+              }
+            ]
+          }
+        }
+      },
+      "BeastLion": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "type": {
+            "enum": [
+              "lion"
+            ],
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
           }
         }
       },
@@ -3385,6 +3477,19 @@
           }
         },
         "deprecated": true
+      },
+      "OneOrManyBeast": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/Beast"
+          },
+          {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Beast"
+            }
+          }
+        ]
       },
       "ParentObject": {
         "type": "object",

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.UnionSchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.UnionSchemas.cs
@@ -146,4 +146,98 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
             Assert.Equal(2, unionComponent.AnyOf.Count);
         });
     }
+
+    [Fact]
+    public async Task GetOpenApiResponse_UnionWithPolymorphicCase_ReturnedDirectly_BranchesRefPolymorphicBase()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/api/beasts", () => new OneOrManyBeast(new Dachshund("Chili")));
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            Assert.True(document.Components.Schemas.TryGetValue(nameof(OneOrManyBeast), out var unionComponent));
+            Assert.NotNull(unionComponent.AnyOf);
+            Assert.Equal(2, unionComponent.AnyOf.Count);
+
+            var objectBranch = Assert.IsType<OpenApiSchemaReference>(unionComponent.AnyOf[0]);
+            Assert.Equal(nameof(Beast), objectBranch.Reference.Id);
+
+            var arrayItems = Assert.IsType<OpenApiSchemaReference>(unionComponent.AnyOf[1].Items);
+            Assert.Equal(nameof(Beast), arrayItems.Reference.Id);
+
+            Assert.DoesNotContain(nameof(OneOrManyBeast) + nameof(Beast), document.Components.Schemas.Keys);
+        });
+    }
+
+    [Fact]
+    public async Task GetOpenApiResponse_NestedUnionWithPolymorphicCase_DoesNotDuplicatePolymorphicComponent()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/api/beasts", () => new BeastEnvelope(new OneOrManyBeast(new Dachshund("Chili"))));
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            Assert.True(document.Components.Schemas.TryGetValue(nameof(OneOrManyBeast), out var unionComponent));
+            Assert.NotNull(unionComponent.AnyOf);
+            Assert.Equal(2, unionComponent.AnyOf.Count);
+
+            // Both branches must reference the polymorphic base component `Beast`; the object
+            // case must not be lifted into a duplicate `OneOrManyBeastBeast` component.
+            var objectBranch = Assert.IsType<OpenApiSchemaReference>(unionComponent.AnyOf[0]);
+            Assert.Equal(nameof(Beast), objectBranch.Reference.Id);
+
+            var arrayItems = Assert.IsType<OpenApiSchemaReference>(unionComponent.AnyOf[1].Items);
+            Assert.Equal(nameof(Beast), arrayItems.Reference.Id);
+
+            Assert.DoesNotContain(nameof(OneOrManyBeast) + nameof(Beast), document.Components.Schemas.Keys);
+        });
+    }
+
+    [Fact]
+    public async Task GetOpenApiResponse_NestedNonNullableUnionWithPolymorphicCase_DoesNotDuplicatePolymorphicComponent()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/api/beasts", () => new BeastContainer(new OneOrManyBeast(new Dachshund("Chili"))));
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            Assert.True(document.Components.Schemas.TryGetValue(nameof(OneOrManyBeast), out var unionComponent));
+            Assert.NotNull(unionComponent.AnyOf);
+            Assert.Equal(2, unionComponent.AnyOf.Count);
+
+            var objectBranch = Assert.IsType<OpenApiSchemaReference>(unionComponent.AnyOf[0]);
+            Assert.Equal(nameof(Beast), objectBranch.Reference.Id);
+
+            var arrayItems = Assert.IsType<OpenApiSchemaReference>(unionComponent.AnyOf[1].Items);
+            Assert.Equal(nameof(Beast), arrayItems.Reference.Id);
+
+            Assert.DoesNotContain(nameof(OneOrManyBeast) + nameof(Beast), document.Components.Schemas.Keys);
+        });
+    }
+
+    [Fact]
+    public async Task GetOpenApiResponse_TopLevelNullableUnionWithPolymorphicCase_DoesNotDuplicatePolymorphicComponent()
+    {
+        var builder = CreateBuilder();
+
+        builder.MapGet("/api/beasts", OneOrManyBeast? () => new OneOrManyBeast(new Dachshund("Chili")));
+
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            Assert.True(document.Components.Schemas.TryGetValue(nameof(OneOrManyBeast), out var unionComponent));
+            Assert.NotNull(unionComponent.AnyOf);
+            Assert.Equal(2, unionComponent.AnyOf.Count);
+
+            var objectBranch = Assert.IsType<OpenApiSchemaReference>(unionComponent.AnyOf[0]);
+            Assert.Equal(nameof(Beast), objectBranch.Reference.Id);
+
+            var arrayItems = Assert.IsType<OpenApiSchemaReference>(unionComponent.AnyOf[1].Items);
+            Assert.Equal(nameof(Beast), arrayItems.Reference.Id);
+
+            Assert.DoesNotContain(nameof(OneOrManyBeast) + nameof(Beast), document.Components.Schemas.Keys);
+        });
+    }
 }

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Shared/SharedTypes.Unions.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Shared/SharedTypes.Unions.cs
@@ -6,6 +6,8 @@
 // primitive-paired and object-cased unions, plus a container record that references a union
 // to validate component schema reuse.
 
+using System.Text.Json.Serialization;
+
 internal record Kitten(string Name, int Lives);
 
 internal record Puppy(string Name, string Breed);
@@ -15,3 +17,19 @@ internal union UnionPet(Kitten, Puppy);
 internal union UnionIntString(int, string);
 
 internal record Clinic(string Address, UnionPet Patient);
+
+// Union with a polymorphic case type plus a collection of the same polymorphic type.
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
+[JsonDerivedType(typeof(Lion), "lion")]
+[JsonDerivedType(typeof(Dachshund), "dachshund")]
+internal abstract record Beast(string Name);
+
+internal sealed record Lion(string Name) : Beast(Name);
+
+internal sealed record Dachshund(string Name) : Beast(Name);
+
+internal union OneOrManyBeast(Beast, IReadOnlyList<Beast>);
+
+internal sealed record BeastEnvelope(OneOrManyBeast? Beasts);
+
+internal sealed record BeastContainer(OneOrManyBeast Beasts);


### PR DESCRIPTION
## Problem

A nullable union property duplicated its case type component — `OneOrManyBeast` referenced `OneOrManyBeastBeast` instead of `Beast`, even though the array branch referenced `Beast` correctly:

```json
"OneOrManyBeast": {
  "anyOf": [
    { "$ref": "#/components/schemas/OneOrManyBeastBeast" },
    { "type": "array", "items": { "$ref": "#/components/schemas/Beast" } }
  ]
},
"OneOrManyBeastBeast": { ... identical to Beast ... }
```

## Cause

Unions are value types, so `MyUnion?` surfaces as `Nullable<MyUnion>` whose `JsonTypeInfo.Kind` is `None`, not `Union`. The `x-schema-is-union` marker was never written, so the existing union carve-out in `ResolveReferenceForSchema` didn't apply.

The problem was nullability of the union type.

## Fix

Unwrap `Nullable<>` before the `Kind` check, mirroring `GetSchemaReferenceId`. Uses `TryGetTypeInfo` so a resolver missing the underlying type degrades instead of throwing.

Fixes #68653