### PR TITLE
Use model display names in Blazor input parsing errors

### DIFF
--- a/src/Components/Web/src/Forms/ExpressionMemberAccessor.cs
+++ b/src/Components/Web/src/Forms/ExpressionMemberAccessor.cs
@@ -4,6 +4,7 @@
 using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -31,24 +32,35 @@ internal static class ExpressionMemberAccessor
         return _memberInfoCache.GetOrAdd(accessor, static expr =>
         {
             var lambdaExpression = (LambdaExpression)expr;
-            var accessorBody = lambdaExpression.Body;
-
-            if (accessorBody is UnaryExpression unaryExpression
-                && unaryExpression.NodeType == ExpressionType.Convert
-                && unaryExpression.Type == typeof(object))
-            {
-                accessorBody = unaryExpression.Operand;
-            }
-
-            if (accessorBody is not MemberExpression memberExpression)
+            var member = GetMemberInfo(lambdaExpression.Body, out var accessorBody);
+            if (member is null)
             {
                 throw new ArgumentException(
                     $"The provided expression contains a {accessorBody.GetType().Name} which is not supported. " +
                     $"Only simple member accessors (fields, properties) of an object are supported.");
             }
 
-            return memberExpression.Member;
+            return member;
         });
+    }
+
+    private static MemberInfo? GetMemberInfo(Expression accessorBody, out Expression normalizedAccessorBody)
+    {
+        normalizedAccessorBody = accessorBody;
+
+        if (normalizedAccessorBody is UnaryExpression
+            {
+                NodeType: ExpressionType.Convert,
+                Type: var type
+            } unaryExpression &&
+            type == typeof(object))
+        {
+            normalizedAccessorBody = unaryExpression.Operand;
+        }
+
+        return normalizedAccessorBody is MemberExpression memberExpression
+            ? memberExpression.Member
+            : null;
     }
 
     public static string GetDisplayName(MemberInfo member)
@@ -82,6 +94,23 @@ internal static class ExpressionMemberAccessor
         ArgumentNullException.ThrowIfNull(accessor);
         var member = GetMemberInfo(accessor);
         return GetDisplayName(member);
+    }
+
+    public static bool TryGetDisplayName<TValue>(
+        Expression<Func<TValue>> accessor,
+        [NotNullWhen(true)] out string? displayName)
+    {
+        ArgumentNullException.ThrowIfNull(accessor);
+
+        var member = GetMemberInfo(accessor.Body, out _);
+        if (member is null)
+        {
+            displayName = null;
+            return false;
+        }
+
+        displayName = GetDisplayName(member);
+        return true;
     }
 
     private static void ClearCache()

--- a/src/Components/Web/src/Forms/InputBase.cs
+++ b/src/Components/Web/src/Forms/InputBase.cs
@@ -60,6 +60,25 @@ public abstract class InputBase<TValue> : ComponentBase, IDisposable
     /// </summary>
     [Parameter] public string? DisplayName { get; set; }
 
+    internal string GetDisplayName()
+    {
+        if (DisplayName is not null)
+        {
+            return DisplayName;
+        }
+
+        var accessorBody = ValueExpression!.Body;
+        if (accessorBody is UnaryExpression { NodeType: ExpressionType.Convert, Type: var type } unaryExpression &&
+            type == typeof(object))
+        {
+            accessorBody = unaryExpression.Operand;
+        }
+
+        return accessorBody is MemberExpression memberExpression
+            ? ExpressionMemberAccessor.GetDisplayName(memberExpression.Member)
+            : FieldIdentifier.FieldName;
+    }
+
     /// <summary>
     /// Gets the associated <see cref="Forms.EditContext"/>.
     /// This property is uninitialized if the input does not have a parent <see cref="EditForm"/>.

--- a/src/Components/Web/src/Forms/InputBase.cs
+++ b/src/Components/Web/src/Forms/InputBase.cs
@@ -67,15 +67,8 @@ public abstract class InputBase<TValue> : ComponentBase, IDisposable
             return DisplayName;
         }
 
-        var accessorBody = ValueExpression!.Body;
-        if (accessorBody is UnaryExpression { NodeType: ExpressionType.Convert, Type: var type } unaryExpression &&
-            type == typeof(object))
-        {
-            accessorBody = unaryExpression.Operand;
-        }
-
-        return accessorBody is MemberExpression memberExpression
-            ? ExpressionMemberAccessor.GetDisplayName(memberExpression.Member)
+        return ExpressionMemberAccessor.TryGetDisplayName(ValueExpression!, out var displayName)
+            ? displayName
             : FieldIdentifier.FieldName;
     }
 

--- a/src/Components/Web/src/Forms/InputDate.cs
+++ b/src/Components/Web/src/Forms/InputDate.cs
@@ -118,7 +118,7 @@ public class InputDate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
         }
         else
         {
-            validationErrorMessage = string.Format(CultureInfo.InvariantCulture, _parsingErrorMessage, DisplayName ?? FieldIdentifier.FieldName);
+            validationErrorMessage = string.Format(CultureInfo.InvariantCulture, _parsingErrorMessage, GetDisplayName());
             return false;
         }
     }

--- a/src/Components/Web/src/Forms/InputExtensions.cs
+++ b/src/Components/Web/src/Forms/InputExtensions.cs
@@ -40,7 +40,7 @@ internal static class InputExtensions
             }
 
             result = default;
-            validationErrorMessage = $"The {input.DisplayName ?? input.FieldIdentifier.FieldName} field is not valid.";
+            validationErrorMessage = $"The {input.GetDisplayName()} field is not valid.";
             return false;
         }
         catch (InvalidOperationException ex)

--- a/src/Components/Web/src/Forms/InputNumber.cs
+++ b/src/Components/Web/src/Forms/InputNumber.cs
@@ -75,7 +75,7 @@ public class InputNumber<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
         }
         else
         {
-            validationErrorMessage = string.Format(CultureInfo.InvariantCulture, ParsingErrorMessage, DisplayName ?? FieldIdentifier.FieldName);
+            validationErrorMessage = string.Format(CultureInfo.InvariantCulture, ParsingErrorMessage, GetDisplayName());
             return false;
         }
     }

--- a/src/Components/Web/test/Forms/InputDateTest.cs
+++ b/src/Components/Web/test/Forms/InputDateTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.AspNetCore.Components.Test.Helpers;
 
@@ -11,7 +12,7 @@ public class InputDateTest
     private readonly TestRenderer _testRenderer = new TestRenderer();
 
     [Fact]
-    public async Task ValidationErrorUsesDisplayAttributeName()
+    public async Task ValidationErrorUsesExplicitDisplayName()
     {
         // Arrange
         var model = new TestModel();
@@ -34,6 +35,24 @@ public class InputDateTest
         var validationMessages = rootComponent.EditContext.GetValidationMessages(fieldIdentifier);
         Assert.NotEmpty(validationMessages);
         Assert.Contains("The Date property field must be a date.", validationMessages);
+    }
+
+    [Fact]
+    public async Task ValidationErrorUsesDisplayAttributeOnModel()
+    {
+        var model = new TestModel();
+        var rootComponent = new TestInputHostComponent<DateTime, TestInputDateComponent>
+        {
+            EditContext = new EditContext(model),
+            ValueExpression = () => model.DateProperty,
+        };
+        var fieldIdentifier = FieldIdentifier.Create(() => model.DateProperty);
+        var inputComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
+
+        await inputComponent.SetCurrentValueAsStringAsync("invalidDate");
+
+        var validationMessages = rootComponent.EditContext.GetValidationMessages(fieldIdentifier);
+        Assert.Contains("The Date from attribute field must be a date.", validationMessages);
     }
 
     [Fact]
@@ -99,6 +118,7 @@ public class InputDateTest
 
     private class TestModel
     {
+        [Display(Name = "Date from attribute")]
         public DateTime DateProperty { get; set; }
     }
 

--- a/src/Components/Web/test/Forms/InputNumberTest.cs
+++ b/src/Components/Web/test/Forms/InputNumberTest.cs
@@ -24,20 +24,20 @@ public class InputNumberTest
     }
 
     [Fact]
-    public async Task ValidationErrorUsesDisplayAttributeName()
+    public async Task ValidationErrorUsesExplicitDisplayName()
     {
         // Arrange
         var model = new TestModel();
         var rootComponent = new TestInputHostComponent<int, TestInputNumberComponent>
         {
             EditContext = new EditContext(model),
-            ValueExpression = () => model.SomeNumber,
+            ValueExpression = () => model.NumberWithDisplayAttribute,
             AdditionalAttributes = new Dictionary<string, object>
                 {
                     { "DisplayName", "Some number" }
                 }
         };
-        var fieldIdentifier = FieldIdentifier.Create(() => model.SomeNumber);
+        var fieldIdentifier = FieldIdentifier.Create(() => model.NumberWithDisplayAttribute);
         var inputComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
 
         // Act

--- a/src/Components/Web/test/Forms/InputNumberTest.cs
+++ b/src/Components/Web/test/Forms/InputNumberTest.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.Linq.Expressions;
 using Microsoft.AspNetCore.Components.Forms.Mapping;
 using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.RenderTree;
@@ -44,6 +47,26 @@ public class InputNumberTest
         var validationMessages = rootComponent.EditContext.GetValidationMessages(fieldIdentifier);
         Assert.NotEmpty(validationMessages);
         Assert.Contains("The Some number field must be a number.", validationMessages);
+    }
+
+    [Fact]
+    public Task ValidationErrorUsesDisplayAttributeOnModel()
+    {
+        var model = new TestModel();
+
+        return AssertValidationErrorUsesDisplayName(
+            () => model.NumberWithDisplayAttribute,
+            "The Display attribute number field must be a number.");
+    }
+
+    [Fact]
+    public Task ValidationErrorUsesDisplayNameAttributeName()
+    {
+        var model = new TestModel();
+
+        return AssertValidationErrorUsesDisplayName(
+            () => model.NumberWithDisplayNameAttribute,
+            "The DisplayName attribute number field must be a number.");
     }
 
     [Fact]
@@ -128,6 +151,24 @@ public class InputNumberTest
         Assert.Equal("custom-number-id", idAttribute.AttributeValue);
     }
 
+    private static async Task AssertValidationErrorUsesDisplayName(
+        Expression<Func<int>> valueExpression,
+        string expectedValidationMessage)
+    {
+        var fieldIdentifier = FieldIdentifier.Create(valueExpression);
+        var rootComponent = new TestInputHostComponent<int, TestInputNumberComponent>
+        {
+            EditContext = new EditContext(fieldIdentifier.Model),
+            ValueExpression = valueExpression,
+        };
+        var inputComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
+
+        await inputComponent.SetCurrentValueAsStringAsync("notANumber");
+
+        var validationMessages = rootComponent.EditContext.GetValidationMessages(fieldIdentifier);
+        Assert.Contains(expectedValidationMessage, validationMessages);
+    }
+
     private async Task<int> RenderAndGetTestInputNumberComponentIdAsync(TestInputHostComponent<int, TestInputNumberComponent> hostComponent)
     {
         var hostComponentId = _testRenderer.AssignRootComponentId(hostComponent);
@@ -139,6 +180,12 @@ public class InputNumberTest
     private class TestModel
     {
         public int SomeNumber { get; set; }
+
+        [Display(Name = "Display attribute number")]
+        public int NumberWithDisplayAttribute { get; set; }
+
+        [DisplayName("DisplayName attribute number")]
+        public int NumberWithDisplayNameAttribute { get; set; }
     }
 
     private class TestInputNumberComponent : InputNumber<int>

--- a/src/Components/Web/test/Forms/InputRadioTest.cs
+++ b/src/Components/Web/test/Forms/InputRadioTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.RenderTree;
@@ -73,6 +74,24 @@ public class InputRadioTest
         Assert.All(inputRadioComponents, inputRadio => Assert.NotNull(inputRadio.Element));
     }
 
+    [Fact]
+    public async Task ValidationErrorUsesDisplayAttributeOnModel()
+    {
+        var model = new TestModel();
+        var rootComponent = new TestInputHostComponent<TestEnum, TestInputRadioGroup>
+        {
+            EditContext = new EditContext(model),
+            ValueExpression = () => model.TestEnum,
+        };
+        var fieldIdentifier = FieldIdentifier.Create(() => model.TestEnum);
+        var inputRadioGroup = await InputRenderer.RenderAndGetComponent(rootComponent);
+
+        await inputRadioGroup.SetCurrentValueAsStringAsync("invalidValue");
+
+        var validationMessages = rootComponent.EditContext.GetValidationMessages(fieldIdentifier);
+        Assert.Contains("The Radio choice field is not valid.", validationMessages);
+    }
+
     private static RenderFragment RadioButtonsWithoutGroup(string name) => (builder) =>
     {
         foreach (var selectedValue in (TestEnum[])Enum.GetValues(typeof(TestEnum)))
@@ -125,7 +144,16 @@ public class InputRadioTest
 
     private class TestModel
     {
+        [Display(Name = "Radio choice")]
         public TestEnum TestEnum { get; set; }
+    }
+
+    private class TestInputRadioGroup : InputRadioGroup<TestEnum>
+    {
+        public async Task SetCurrentValueAsStringAsync(string value)
+        {
+            await InvokeAsync(() => { base.CurrentValueAsString = value; });
+        }
     }
 
     private class TestInputRadio : InputRadio<TestEnum>

--- a/src/Components/Web/test/Forms/InputSelectTest.cs
+++ b/src/Components/Web/test/Forms/InputSelectTest.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.AspNetCore.Components.Test.Helpers;
 
@@ -169,7 +170,7 @@ public class InputSelectTest
     }
 
     [Fact]
-    public async Task ValidationErrorUsesDisplayAttributeName()
+    public async Task ValidationErrorUsesExplicitDisplayName()
     {
         // Arrange
         var model = new TestModel();
@@ -192,6 +193,24 @@ public class InputSelectTest
         var validationMessages = rootComponent.EditContext.GetValidationMessages(fieldIdentifier);
         Assert.NotEmpty(validationMessages);
         Assert.Contains("The Some number field is not valid.", validationMessages);
+    }
+
+    [Fact]
+    public async Task ValidationErrorUsesDisplayAttributeOnModel()
+    {
+        var model = new TestModel();
+        var rootComponent = new TestInputHostComponent<int, TestInputSelect<int>>
+        {
+            EditContext = new EditContext(model),
+            ValueExpression = () => model.NotNullableInt,
+        };
+        var fieldIdentifier = FieldIdentifier.Create(() => model.NotNullableInt);
+        var inputSelectComponent = await InputRenderer.RenderAndGetComponent(rootComponent);
+
+        await inputSelectComponent.SetCurrentValueAsStringAsync("invalidNumber");
+
+        var validationMessages = rootComponent.EditContext.GetValidationMessages(fieldIdentifier);
+        Assert.Contains("The Number from attribute field is not valid.", validationMessages);
     }
 
     [Fact]
@@ -273,6 +292,7 @@ public class InputSelectTest
 
         public Guid? NullableGuid { get; set; }
 
+        [Display(Name = "Number from attribute")]
         public int NotNullableInt { get; set; }
 
         public int? NullableInt { get; set; }

--- a/src/Components/test/E2ETest/Tests/FormsTest.cs
+++ b/src/Components/test/E2ETest/Tests/FormsTest.cs
@@ -582,6 +582,18 @@ public class FormsTest : ServerTestBase<ToggleExecutionModeServerFixture<Program
     }
 
     [Fact]
+    public void InputNumberParsingErrorUsesDisplayNameAttribute()
+    {
+        var appElement = Browser.MountTestComponent<DisplayNameComponent>();
+        var priceInput = appElement.FindElement(By.Id("price-input"));
+        var messagesAccessor = CreateValidationMessagesAccessor(appElement);
+        priceInput.SendKeys(Keys.Control + "a");
+        priceInput.SendKeys(Keys.Delete);
+        priceInput.SendKeys(Keys.Tab);
+        Browser.Equal(new[] { "The Unit Price field must be a number." }, messagesAccessor);
+    }
+
+    [Fact]
     public void InputComponentsCauseContainerToRerenderOnChange()
     {
         var appElement = MountTypicalValidationComponent();

--- a/src/Components/test/testassets/BasicTestApp/FormsTest/DisplayNameComponent.razor
+++ b/src/Components/test/testassets/BasicTestApp/FormsTest/DisplayNameComponent.razor
@@ -10,6 +10,11 @@
     <p id="localized-label"><DisplayName For="@(() => _product.LocalizedName)" /></p>
 </div>
 
+<EditForm Model="_product">
+    <InputNumber id="price-input" @bind-Value="_product.Price" />
+    <ValidationMessage For="@(() => _product.Price)" />
+</EditForm>
+
 @code {
     private Product _product = new Product();
 


### PR DESCRIPTION
Fixes #68609

see: https://github.com/dotnet/aspnetcore/issues/68609#issuecomment-5357715905

Blazor input components currently use the CLR property name in parsing validation messages unless their `DisplayName` parameter is explicitly set. This produces inconsistent output when the same field is rendered using `DisplayName` or `Label`.

For example, a property annotated with `[DisplayName("Unit Price")]` renders a `Unit Price` label but an empty `InputNumber` reports:

> The UnitPrice field must be a number.

This change makes input parsing errors use the display name resolved from the bound member's `[Display]` or `[DisplayName]` attribute.

The resolution order is:

1. The explicit `InputBase.DisplayName` parameter
2. The bound member's `[Display]` or `[DisplayName]` metadata
3. The existing CLR field-name fallback

The existing `ExpressionMemberAccessor` is reused, so display-name precedence, localization, and caching remain consistent with the `DisplayName` and `Label` components.

The shared behavior applies to parsing failures from `InputNumber`, `InputDate`, `InputSelect`, and `InputRadioGroup`.