### PR TITLE
Don't apply the CSRF verdict to remote authentication callbacks

### DIFF
--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/RemoteAuthenticationCsrfTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/RemoteAuthenticationCsrfTests.cs
@@ -1,0 +1,144 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Net;
+using System.Net.Http;
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.AspNetCore.Tests;
+
+// A remote provider's callback (e.g. OpenID Connect response_mode=form_post) is a cross-site form POST by
+// protocol design. When the callback path also matches a routed endpoint that requires antiforgery
+// validation, the auto-injected CSRF middleware records an invalid verdict for it, and the handler used to
+// fail while reading its own callback body - before any of its events could run.
+public class RemoteAuthenticationCsrfTests
+{
+    [Fact]
+    public async Task RemoteCallback_CrossSiteFormPost_CanReadCallbackForm()
+    {
+        using var app = await CreateApp();
+
+        var response = await app.GetTestClient().SendAsync(CreateCallbackRequest());
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("handled:2", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task RemoteCallback_WhenHandlerSkipsRequest_RestoresAntiforgeryVerdict()
+    {
+        using var app = await CreateApp(skipRequest: true);
+
+        var response = await app.GetTestClient().SendAsync(CreateCallbackRequest());
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("protected", await response.Content.ReadAsStringAsync());
+    }
+
+    private static HttpRequestMessage CreateCallbackRequest()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/signin-oidc")
+        {
+            Content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["state"] = "fakestate",
+                ["code"] = "fakecode",
+            })
+        };
+        request.Headers.Add("Sec-Fetch-Site", "cross-site");
+        return request;
+    }
+
+    private static async Task<WebApplication> CreateApp(bool skipRequest = false)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Services.AddAuthentication("signin")
+            .AddScheme<AuthenticationSchemeOptions, NoOpHandler>("signin", _ => { })
+            .AddScheme<FakeRemoteOptions, FakeRemoteHandler>("remote", o =>
+            {
+                o.CallbackPath = "/signin-oidc";
+                o.SignInScheme = "signin";
+                o.SkipRequest = skipRequest;
+            });
+        builder.Services.AddAuthorization();
+        builder.Services.AddAntiforgery();
+
+        var app = builder.Build();
+        app.UseAuthentication();
+        app.UseAuthorization();
+        app.UseAntiforgery();
+
+        // Stands in for a catch-all server-rendered page: it makes routing match the remote callback path,
+        // which is what causes the CSRF middleware to record a verdict for the callback request.
+        app.MapPost("/{**slug}", EnforceCsrf).WithMetadata(new RequiresValidationMetadata());
+
+        await app.StartAsync();
+        return app;
+    }
+
+    private static string EnforceCsrf(HttpContext context)
+    {
+        var feature = context.Features.Get<IAntiforgeryValidationFeature>();
+        if (feature is null)
+        {
+            return "passthrough";
+        }
+
+        if (!feature.IsValid)
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return "protected";
+        }
+
+        return "allowed";
+    }
+
+    private sealed class RequiresValidationMetadata : IAntiforgeryMetadata
+    {
+        public bool RequiresValidation => true;
+    }
+
+    private sealed class NoOpHandler(IOptionsMonitor<AuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder)
+        : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+    {
+        protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+            => Task.FromResult(AuthenticateResult.NoResult());
+    }
+
+    private sealed class FakeRemoteOptions : RemoteAuthenticationOptions
+    {
+        public bool SkipRequest { get; set; }
+    }
+
+    private sealed class FakeRemoteHandler(IOptionsMonitor<FakeRemoteOptions> options, ILoggerFactory logger, UrlEncoder encoder)
+        : RemoteAuthenticationHandler<FakeRemoteOptions>(options, logger, encoder)
+    {
+        protected override async Task<HandleRequestResult> HandleRemoteAuthenticateAsync()
+        {
+            // Mirrors OpenIdConnectHandler.HandleRemoteAuthenticateAsync: the form_post callback body is read
+            // before the handler raises any of its events.
+            var form = await Request.ReadFormAsync(Context.RequestAborted);
+
+            if (Options.SkipRequest)
+            {
+                return HandleRequestResult.SkipHandler();
+            }
+
+            Response.StatusCode = StatusCodes.Status200OK;
+            await Response.WriteAsync($"handled:{form.Count}");
+            return HandleRequestResult.Handle();
+        }
+    }
+}

--- a/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/RemoteAuthenticationCsrfTests.cs
+++ b/src/DefaultBuilder/test/Microsoft.AspNetCore.Tests/RemoteAuthenticationCsrfTests.cs
@@ -27,7 +27,7 @@ public class RemoteAuthenticationCsrfTests
     [Fact]
     public async Task RemoteCallback_CrossSiteFormPost_CanReadCallbackForm()
     {
-        using var app = await CreateApp();
+        using var app = await CreateAppWithTokenAntiforgery();
 
         var response = await app.GetTestClient().SendAsync(CreateCallbackRequest());
 
@@ -36,9 +36,20 @@ public class RemoteAuthenticationCsrfTests
     }
 
     [Fact]
-    public async Task RemoteCallback_WhenHandlerSkipsRequest_RestoresAntiforgeryVerdict()
+    public async Task RemoteCallback_WhenHandlerSkipsRequest_WithTokenAntiforgery_ProtectsDownstreamEndpoint()
     {
-        using var app = await CreateApp(skipRequest: true);
+        using var app = await CreateAppWithTokenAntiforgery(skipRequest: true);
+
+        var response = await app.GetTestClient().SendAsync(CreateCallbackRequest());
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("protected", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task RemoteCallback_WhenHandlerSkipsRequest_RestoresAutoCsrfVerdict()
+    {
+        using var app = await CreateAppWithAutoCsrfOnly(skipRequest: true);
 
         var response = await app.GetTestClient().SendAsync(CreateCallbackRequest());
 
@@ -60,7 +71,13 @@ public class RemoteAuthenticationCsrfTests
         return request;
     }
 
-    private static async Task<WebApplication> CreateApp(bool skipRequest = false)
+    private static Task<WebApplication> CreateAppWithTokenAntiforgery(bool skipRequest = false)
+        => CreateApp(skipRequest, useTokenAntiforgery: true);
+
+    private static Task<WebApplication> CreateAppWithAutoCsrfOnly(bool skipRequest = false)
+        => CreateApp(skipRequest, useTokenAntiforgery: false);
+
+    private static async Task<WebApplication> CreateApp(bool skipRequest, bool useTokenAntiforgery)
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -73,12 +90,18 @@ public class RemoteAuthenticationCsrfTests
                 o.SkipRequest = skipRequest;
             });
         builder.Services.AddAuthorization();
-        builder.Services.AddAntiforgery();
+        if (useTokenAntiforgery)
+        {
+            builder.Services.AddAntiforgery();
+        }
 
         var app = builder.Build();
         app.UseAuthentication();
         app.UseAuthorization();
-        app.UseAntiforgery();
+        if (useTokenAntiforgery)
+        {
+            app.UseAntiforgery();
+        }
 
         // Stands in for a catch-all server-rendered page: it makes routing match the remote callback path,
         // which is what causes the CSRF middleware to record a verdict for the callback request.

--- a/src/Security/Authentication/Core/src/Microsoft.AspNetCore.Authentication.csproj
+++ b/src/Security/Authentication/Core/src/Microsoft.AspNetCore.Authentication.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)SecurityHelper\**\*.cs" />
+    <Compile Include="$(SharedSourceRoot)RemoteAuthenticationAntiforgery.cs" LinkBase="Shared" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Security/Authentication/Core/src/RemoteAuthenticationHandler.cs
+++ b/src/Security/Authentication/Core/src/RemoteAuthenticationHandler.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -79,6 +80,11 @@ public abstract class RemoteAuthenticationHandler<TOptions> : AuthenticationHand
             return false;
         }
 
+        return await RemoteAuthenticationAntiforgery.HandleWithoutAntiforgeryVerdictAsync(Context, HandleRequestCoreAsync);
+    }
+
+    private async Task<bool> HandleRequestCoreAsync()
+    {
         AuthenticationTicket? ticket = null;
         Exception? exception = null;
         AuthenticationProperties? properties = null;

--- a/src/Security/Authentication/OpenIdConnect/src/Microsoft.AspNetCore.Authentication.OpenIdConnect.csproj
+++ b/src/Security/Authentication/OpenIdConnect/src/Microsoft.AspNetCore.Authentication.OpenIdConnect.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <Compile Include="$(SharedSourceRoot)StringHelpers.cs" LinkBase="Shared" />
+    <Compile Include="$(SharedSourceRoot)RemoteAuthenticationAntiforgery.cs" LinkBase="Shared" />
   </ItemGroup>
 
 </Project>

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -11,6 +11,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.WebUtilities;
@@ -88,13 +89,16 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
     /// <inheritdoc />
     public override Task<bool> HandleRequestAsync()
     {
+        // Both paths below are, like the sign-in callback, cross-site requests owned by this handler, and
+        // HandleRemoteSignOutAsync reads a form_post body, so they need the same antiforgery verdict handling
+        // that RemoteAuthenticationHandler applies to CallbackPath.
         if (Options.RemoteSignOutPath.HasValue && Options.RemoteSignOutPath == Request.Path)
         {
-            return HandleRemoteSignOutAsync();
+            return RemoteAuthenticationAntiforgery.HandleWithoutAntiforgeryVerdictAsync(Context, HandleRemoteSignOutAsync);
         }
         else if (Options.SignedOutCallbackPath.HasValue && Options.SignedOutCallbackPath == Request.Path)
         {
-            return HandleSignOutCallbackAsync();
+            return RemoteAuthenticationAntiforgery.HandleWithoutAntiforgeryVerdictAsync(Context, HandleSignOutCallbackAsync);
         }
 
         return base.HandleRequestAsync();

--- a/src/Shared/RemoteAuthenticationAntiforgery.cs
+++ b/src/Shared/RemoteAuthenticationAntiforgery.cs
@@ -1,0 +1,45 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Antiforgery;
+
+// Shared between Microsoft.AspNetCore.Authentication (RemoteAuthenticationHandler) and the remote handlers
+// that own additional callback paths of their own (e.g. Microsoft.AspNetCore.Authentication.OpenIdConnect).
+//
+// A remote provider's callback is a cross-site request by protocol design: OpenID Connect
+// response_mode=form_post and WS-Federation both deliver the response as a top-level form POST from the
+// identity provider's origin. Cross-origin CSRF protection therefore records an invalid
+// IAntiforgeryValidationFeature verdict for it, and the handler then fails on its very first action - reading
+// the callback body - before any of its events can run, so an application has no way to opt out.
+//
+// These callbacks carry their own forgery protection: the state parameter round-trips a protected
+// AuthenticationProperties payload whose correlation id must match the correlation cookie, which the handler
+// validates. The verdict is therefore suppressed while the handler owns the request, and restored when the
+// handler declines it so the rest of the pipeline still sees the original verdict.
+internal static class RemoteAuthenticationAntiforgery
+{
+    public static async Task<bool> HandleWithoutAntiforgeryVerdictAsync(HttpContext context, Func<Task<bool>> handler)
+    {
+        var suppressedVerdict = context.Features.Get<IAntiforgeryValidationFeature>();
+        if (suppressedVerdict is { IsValid: false })
+        {
+            context.Features.Set<IAntiforgeryValidationFeature?>(null);
+        }
+
+        var handled = false;
+        try
+        {
+            handled = await handler();
+            return handled;
+        }
+        finally
+        {
+            if (!handled && suppressedVerdict is { IsValid: false })
+            {
+                context.Features.Set(suppressedVerdict);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #68666.

A Blazor Web App using `AddOpenIdConnect` fails the sign-in callback with `InvalidOperationException: This form is being accessed with a failed antiforgery validation` thrown from `FormFeature.ReadFormAsync`, inside `OpenIdConnectHandler.HandleRemoteAuthenticateAsync`.

### How this worked in .NET 10 with antiforgery

Token antiforgery is per-endpoint: `AntiforgeryMiddleware` only validates when the matched endpoint carries `IAntiforgeryMetadata` with `RequiresValidation: true`, which Blazor attaches to each routable component endpoint in `RazorComponentEndpointFactory`. `/signin-oidc` is not a component endpoint, so it never carried that metadata. More importantly, `UseAntiforgery()` sits after `UseAuthentication()`, and `RemoteAuthenticationHandler` short-circuits the callback as an `IAuthenticationRequestHandler` — so the antiforgery middleware never ran for the callback at all.

### Why CSRF protection triggers now

`CsrfProtectionMiddleware` is auto-injected and runs in the post-routing pipeline, which `EndpointRoutingMiddleware` invokes immediately after matching — i.e. before `UseAuthentication()`, so the auth handler no longer short-circuits ahead of it. It records `IAntiforgeryValidationFeature { IsValid = false }` plus an `HttpContext.Items` marker instead of rejecting the request (#67082), deferring the failure to whoever reads the body. For the callback that consumer is the OIDC handler itself, and it reads the form before `OnMessageReceived` fires, so applications have no way to opt out.

### Why the callback is always a cross-site request

With `response_mode=form_post` the identity provider returns the response as a top-level auto-submitted form POST from its own origin to `CallbackPath`, so the browser always sends `Sec-Fetch-Site: cross-site`. That is the exact shape the Fetch Metadata algorithm classifies as a CSRF attempt, and nothing about a legitimate callback distinguishes it at the HTTP layer. `form_post` is the default for `response_type` values containing `id_token` and is what Entra ID and `Microsoft.Identity.Web` use, so this fails deterministically rather than intermittently. The same applies to WS-Federation and to the OIDC `RemoteSignOutPath`.

### Why suppressing the verdict here is safe

The callback carries its own forgery protection: `state` round-trips a data-protected `AuthenticationProperties` payload whose correlation id must match the `.AspNetCore.Correlation.*` cookie, and `ValidateCorrelationId` rejects the request when it doesn't. Nonce validation for `id_token` and PKCE for the code flow apply on top of that, none of which an attacker can forge. The verdict is suppressed only while the handler owns the request and is restored when it declines (`SkipHandler` / `SkipUnrecognizedRequests` / exception), so anything the handler hands back to the pipeline still sees the original verdict.
