### PR TITLE
Make HostMatcherPolicy DFA edges case-insensitive

### DIFF
--- a/src/Http/Routing/src/Matching/HostMatcherPolicy.cs
+++ b/src/Http/Routing/src/Matching/HostMatcherPolicy.cs
@@ -432,7 +432,7 @@ public sealed class HostMatcherPolicy : MatcherPolicy, IEndpointComparerPolicy, 
 
         public int CompareTo(EdgeKey other)
         {
-            var result = Comparer<string>.Default.Compare(Host, other.Host);
+            var result = string.Compare(Host, other.Host, StringComparison.OrdinalIgnoreCase);
             if (result != 0)
             {
                 return result;
@@ -448,7 +448,7 @@ public sealed class HostMatcherPolicy : MatcherPolicy, IEndpointComparerPolicy, 
 
         public bool Equals(EdgeKey other)
         {
-            return string.Equals(Host, other.Host, StringComparison.Ordinal) && Port == other.Port;
+            return string.Equals(Host, other.Host, StringComparison.OrdinalIgnoreCase) && Port == other.Port;
         }
 
         public bool MatchHost(string host)
@@ -479,7 +479,11 @@ public sealed class HostMatcherPolicy : MatcherPolicy, IEndpointComparerPolicy, 
 
         public override int GetHashCode()
         {
-            return (Host?.GetHashCode() ?? 0) ^ (Port?.GetHashCode() ?? 0);
+            var hash = new HashCode();
+            hash.Add(Host, StringComparer.OrdinalIgnoreCase);
+            hash.Add(Port);
+
+            return hash.ToHashCode();
         }
 
         public override bool Equals(object? obj)

--- a/src/Http/Routing/test/UnitTests/Matching/HostMatcherPolicyIntegrationTestBase.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/HostMatcherPolicyIntegrationTestBase.cs
@@ -225,6 +225,30 @@ public abstract class HostMatcherPolicyIntegrationTestBase
         MatcherAssert.AssertMatch(httpContext, endpoint);
     }
 
+    [Theory]
+    [InlineData("contoso.com", "CONTOSO.COM", "contoso.com")]
+    [InlineData("contoso.com:5000", "CONTOSO.COM:5000", "contoso.com:5000")]
+    [InlineData("*.contoso.com", "*.CONTOSO.COM", "www.contoso.com")]
+    [InlineData("*.contoso.com:5000", "*.CONTOSO.COM:5000", "www.contoso.com:5000")]
+    public async Task Match_EquivalentHostsWithDifferentCasing_PreservesCandidatesForLaterPolicies(
+        string firstHost,
+        string secondHost,
+        string requestHost)
+    {
+        var encodedEndpoint = CreateEndpoint(
+            "/hello",
+            hosts: new[] { firstHost },
+            contentEncoding: "gzip");
+        var fallbackEndpoint = CreateEndpoint("/hello", hosts: new[] { secondHost });
+
+        var matcher = CreateMatcher(encodedEndpoint, fallbackEndpoint);
+        var httpContext = CreateContext("/hello", requestHost);
+
+        await matcher.MatchAsync(httpContext);
+
+        MatcherAssert.AssertMatch(httpContext, fallbackEndpoint);
+    }
+
     [Fact]
     public async Task Match_HostWithPort_InferHttpPort()
     {
@@ -423,12 +447,18 @@ public abstract class HostMatcherPolicyIntegrationTestBase
         object defaults = null,
         object constraints = null,
         int order = 0,
-        string[] hosts = null)
+        string[] hosts = null,
+        string contentEncoding = null)
     {
         var metadata = new List<object>();
         if (hosts != null)
         {
             metadata.Add(new HostAttribute(hosts ?? Array.Empty<string>()));
+        }
+
+        if (contentEncoding != null)
+        {
+            metadata.Add(new ContentEncodingMetadata(contentEncoding, quality: 1.0));
         }
 
         if (HasDynamicMetadata)

--- a/src/Http/Routing/test/UnitTests/Matching/HostMatcherPolicyTest.cs
+++ b/src/Http/Routing/test/UnitTests/Matching/HostMatcherPolicyTest.cs
@@ -255,6 +255,62 @@ public class HostMatcherPolicyTest
             });
     }
 
+    [Theory]
+    [InlineData("contoso.com", "CONTOSO.COM")]
+    [InlineData("contoso.com", "CONTOSO.COM:*")]
+    [InlineData("contoso.com:5000", "CONTOSO.COM:5000")]
+    [InlineData("æon.contoso.com", "ÆON.CONTOSO.COM")]
+    [InlineData("*.contoso.com", "*.CONTOSO.COM")]
+    [InlineData("*.contoso.com", "*.CONTOSO.COM:*")]
+    [InlineData("*.contoso.com:5000", "*.CONTOSO.COM:5000")]
+    public void GetEdges_GroupsHostsCaseInsensitively(string firstHost, string secondHost)
+    {
+        var endpoints = new[]
+        {
+            CreateEndpoint("/", new HostAttribute(firstHost)),
+            CreateEndpoint("/", new HostAttribute(secondHost)),
+        };
+
+        var policy = CreatePolicy();
+
+        var edge = Assert.Single(policy.GetEdges(endpoints));
+
+        Assert.Equal(endpoints, edge.Endpoints);
+    }
+
+    [Fact]
+    public void GetEdges_DoesNotDuplicateEndpointWithEquivalentHosts()
+    {
+        var endpoint = CreateEndpoint(
+            "/",
+            new HostAttribute("contoso.com", "CONTOSO.COM:*"));
+
+        var policy = CreatePolicy();
+
+        var edge = Assert.Single(policy.GetEdges(new[] { endpoint }));
+
+        Assert.Equal(endpoint, Assert.Single(edge.Endpoints));
+    }
+
+    [Fact]
+    public void GetEdges_DoesNotGroupHostsWithDifferentPorts()
+    {
+        var endpoints = new[]
+        {
+            CreateEndpoint("/", new HostAttribute("contoso.com:5000")),
+            CreateEndpoint("/", new HostAttribute("CONTOSO.COM:5001")),
+        };
+
+        var policy = CreatePolicy();
+
+        var edges = policy.GetEdges(endpoints);
+
+        Assert.Collection(
+            edges.OrderBy(e => e.State),
+            e => Assert.Equal(endpoints[0], Assert.Single(e.Endpoints)),
+            e => Assert.Equal(endpoints[1], Assert.Single(e.Endpoints)));
+    }
+
     private static RouteEndpoint CreateEndpoint(string template, IHostMetadata hostMetadata, params object[] more)
     {
         var metadata = new List<object>();


### PR DESCRIPTION
Host matching is ordinal-ignore-case at request time, but `HostMatcherPolicy.EdgeKey` previously used case-sensitive equality, hashing, and ordering. Equivalent host metadata could therefore be placed in separate DFA branches, removing valid fallback endpoints before later matcher policies ran.

This aligns edge identity with runtime matching while keeping ports exact and preserving the original host spelling. Regression coverage includes exact and wildcard hosts, fixed and wildcard ports, Unicode casing, duplicate suppression, endpoint ordering, and downstream policy selection through both static DFA and dynamic endpoint-selector paths.

Fixes: #68349