### PR TITLE
Added DotNetBuild=true target in NativeAotTestApp project

### DIFF
--- a/src/Components/Testing/testassets/NativeAotTestApp/NativeAotTestApp.csproj
+++ b/src/Components/Testing/testassets/NativeAotTestApp/NativeAotTestApp.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseAspNetCoreSharedRuntime>false</UseAspNetCoreSharedRuntime>
+    <RuntimeIdentifier Condition="'$(DotNetBuild)' == 'true'">$(TargetRuntimeIdentifier)</RuntimeIdentifier>
     <DoNotApplyWorkaroundsToMicrosoftAspNetCoreApp>false</DoNotApplyWorkaroundsToMicrosoftAspNetCoreApp>
     <RuntimeIdentifiers>$(TargetRuntimeIdentifier)</RuntimeIdentifiers>
     <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>


### PR DESCRIPTION
## Description
The Asp.Net Core build fails on linux-ppc64le with NU1101 errors for `Microsoft.NETCore.App.Runtime.linux-ppc64le` and `Microsoft.NETCore.App.Host.linux-ppc64le` in project `src/Components/Testing/testassets/NativeAotTestApp/NativeAotTestApp.csproj.` The issue occurs when building Asp.Net Core on linux-ppc64le with .NET SDK 11.0.100-rc.1.26413.103

As Native AOT is not supported on Power Mono Runtime, we are using` /p:PublishAot=false` and `/p:EnableAotAnalyzer=false` properties with the build command. These properties should skip the Native AOT related build steps, but the project is still being built and fails during the build.

Error as below

```
/root/jenkins-scripts/ci/aspnetcore/src/Components/Testing/testassets/NativeAotTestApp/NativeAotTestApp.csproj : error NU1101: Unable to find package Microsoft.NETCore.App.Runtime.linux-ppc64le. No packages exist with this id in source(s): darc-pub-dotnet-extensions-ccb356f, dotnet-eng, dotnet-public, dotnet-tools, dotnet10, dotnet10-transport, dotnet11, dotnet11-transport, dotnet8, dotnet8-transport, dotnet9, dotnet9-transport, source L3Jvb3QvYXNodXRvc2gvcG9ydC9ncnBjL2FydGlmYWN0cwo=
/root/jenkins-scripts/ci/aspnetcore/src/Components/Testing/testassets/NativeAotTestApp/NativeAotTestApp.csproj : error NU1101: Unable to find package Microsoft.NETCore.App.Host.linux-ppc64le. No packages exist with this id in source(s): darc-pub-dotnet-extensions-ccb356f, dotnet-eng, dotnet-public, dotnet-tools, dotnet10, dotnet10-transport, dotnet11, dotnet11-transport, dotnet8, dotnet8-transport, dotnet9, dotnet9-transport, source L3Jvb3QvYXNodXRvc2gvcG9ydC9ncnBjL2FydGlmYWN0cwo=
```


If we add `$(DotNetBuild) == 'true'` to the project file, the build is successful.

Similar issue: -  https://github.com/dotnet/aspnetcore/pull/66383

CC @omajid @tmds 