### PR TITLE
Don't cache truncated/aborted responses in OutputCacheMiddleware

### DIFF
--- a/src/Middleware/OutputCaching/src/OutputCacheMiddleware.cs
+++ b/src/Middleware/OutputCaching/src/OutputCacheMiddleware.cs
@@ -167,6 +167,8 @@ internal sealed class OutputCacheMiddleware
                         // Hook up to listen to the response stream
                         ShimResponseStream(context);
 
+                        var isResponseCached = false;
+
                         try
                         {
                             await _next(httpContext);
@@ -181,7 +183,7 @@ internal sealed class OutputCacheMiddleware
                             StartResponse(context);
 
                             // Finalize the cache entry
-                            await FinalizeCacheBodyAsync(context);
+                            isResponseCached = await FinalizeCacheBodyAsync(context);
 
                             executed = true;
                         }
@@ -190,9 +192,8 @@ internal sealed class OutputCacheMiddleware
                             UnshimResponseStream(context);
                         }
 
-                        // If the policies prevented this response from being cached we can't reuse it for other
-                        // pending requests
-                        if (!context.AllowCacheStorage)
+                        // If the response wasn't cached, we can't reuse it for other pending requests
+                        if (!isResponseCached)
                         {
                             context.ReleaseCachedResponse();
                         }
@@ -412,12 +413,15 @@ internal sealed class OutputCacheMiddleware
     }
 
     /// <summary>
-    /// Stores the response body
+    /// Attempts to store the response body.
     /// </summary>
-    internal async ValueTask FinalizeCacheBodyAsync(OutputCacheContext context)
+    /// <param name="context">The <see cref="OutputCacheContext"/>.</param>
+    /// <returns><c>true</c> if the response was cached; otherwise <c>false</c>.</returns>
+    internal async ValueTask<bool> FinalizeCacheBodyAsync(OutputCacheContext context)
     {
         if (context.AllowCacheStorage && context.OutputCacheStream.BufferingEnabled
-            && context.CachedResponse is not null)
+            && context.CachedResponse is not null
+            && !context.HttpContext.RequestAborted.IsCancellationRequested)
         {
             // If AllowCacheLookup is false, the cache key was not created
             CreateCacheKey(context);
@@ -442,6 +446,8 @@ internal sealed class OutputCacheMiddleware
 
                     await OutputCacheEntryFormatter.StoreAsync(context.CacheKey, context.CachedResponse, context.Tags, context.CachedResponseValidFor,
                         _store, _logger, context.HttpContext.RequestAborted);
+
+                    return true;
                 }
             }
             else
@@ -453,6 +459,8 @@ internal sealed class OutputCacheMiddleware
         {
             _logger.ResponseNotCached();
         }
+
+        return false;
     }
 
     /// <summary>

--- a/src/Middleware/OutputCaching/test/OutputCacheMiddlewareTests.cs
+++ b/src/Middleware/OutputCaching/test/OutputCacheMiddlewareTests.cs
@@ -851,6 +851,33 @@ public abstract class OutputCacheMiddlewareTests
     }
 
     [Fact]
+    public async Task FinalizeCacheBody_DoNotCache_IfRequestAborted()
+    {
+        var cache = GetStore();
+        var sink = new TestSink();
+        var middleware = TestUtils.CreateTestMiddleware(testSink: sink, cache: cache);
+        var context = TestUtils.CreateTestContext(cache: cache);
+
+        middleware.ShimResponseStream(context);
+        await context.HttpContext.Response.WriteAsync(new string('0', 10));
+
+        using var entry = new OutputCacheEntry(DateTimeOffset.UtcNow, StatusCodes.Status200OK);
+        context.CachedResponse = entry;
+        context.CacheKey = "BaseKey";
+        context.CachedResponseValidFor = TimeSpan.FromSeconds(10);
+
+        context.HttpContext.RequestAborted = new CancellationToken(canceled: true);
+
+        var isResponseCached = await middleware.FinalizeCacheBodyAsync(context);
+
+        Assert.Equal(0, cache.SetCount);
+        Assert.False(isResponseCached);
+        TestUtils.AssertLoggedMessages(
+            sink.Writes,
+            LoggedMessage.ResponseNotCached);
+    }
+
+    [Fact]
     public async Task FinalizeCacheBody_DoNotCache_IfSizeTooBig()
     {
         var sink = new TestSink();
@@ -1009,6 +1036,69 @@ public abstract class OutputCacheMiddlewareTests
     }
 
     [Fact]
+    public async Task Locking_IgnoresTruncatedResponses()
+    {
+        var responseCounter = 0;
+        var cache = GetStore();
+
+        var blocker1 = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var blocker2 = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var memoryStream1 = new MemoryStream();
+        var memoryStream2 = new MemoryStream();
+
+        var options = new OutputCacheOptions();
+        options.AddBasePolicy(build => build.Cache());
+
+        var middleware = TestUtils.CreateTestMiddleware(options: options, cache: cache, next: async c =>
+        {
+            responseCounter++;
+
+            if (responseCounter == 1)
+            {
+                blocker1.SetResult(true);
+
+                // Announce more bytes than are written so the response is truncated
+                c.Response.ContentLength = 1000;
+            }
+
+            c.Response.Write("Hello" + responseCounter);
+
+            await blocker2.Task;
+        });
+
+        var context1 = TestUtils.CreateTestContext(cache: cache);
+        context1.HttpContext.Request.Method = "GET";
+        context1.HttpContext.Request.Path = "/";
+        context1.HttpContext.Response.Body = memoryStream1;
+
+        var context2 = TestUtils.CreateTestContext(cache: cache);
+        context2.HttpContext.Request.Method = "GET";
+        context2.HttpContext.Request.Path = "/";
+        context2.HttpContext.Response.Body = memoryStream2;
+
+        var task1 = Task.Run(() => middleware.Invoke(context1.HttpContext));
+
+        // Wait for context1 to be processed
+        await blocker1.Task;
+
+        // Start context2 and let it run until it is blocked by the locking feature
+        var task2 = middleware.Invoke(context2.HttpContext);
+        Assert.False(task2.IsCompleted);
+
+        // Unblock context1
+        blocker2.SetResult(true);
+
+        await Task.WhenAll(task1, task2);
+
+        Assert.Equal(2, responseCounter);
+
+        // Ensure the truncated response was not returned from cache
+        Assert.Equal("Hello1", Encoding.UTF8.GetString(memoryStream1.ToArray()));
+        Assert.Equal("Hello2", Encoding.UTF8.GetString(memoryStream2.ToArray()));
+    }
+
+    [Fact]
     public async Task Locking_ExecuteAllRequestsWhenDisabled()
     {
         var responseCounter = 0;
@@ -1101,6 +1191,89 @@ public abstract class OutputCacheMiddlewareTests
         await Task.WhenAll(task1, task2);
 
         Assert.Equal(2, responseCounter);
+    }
+
+    [Fact]
+    public async Task AbortedRequest_DoesNotReExecuteRequest()
+    {
+        var responseCounter = 0;
+        var cache = GetStore();
+
+        var options = new OutputCacheOptions();
+        options.AddBasePolicy(build => build.Cache());
+
+        var middleware = TestUtils.CreateTestMiddleware(options: options, cache: cache, next: c =>
+        {
+            responseCounter++;
+
+            c.Response.Write("Hello" + responseCounter);
+
+            // Simulates an action result that aborts after a canceled write
+            c.RequestAborted = new CancellationToken(canceled: true);
+
+            return Task.CompletedTask;
+        });
+
+        var memoryStream = new MemoryStream();
+
+        var context = TestUtils.CreateTestContext(cache: cache);
+        context.HttpContext.Request.Method = "GET";
+        context.HttpContext.Request.Path = "/";
+        context.HttpContext.Response.Body = memoryStream;
+
+        await middleware.Invoke(context.HttpContext);
+
+        // The aborted request must not run the pipeline a second time
+        Assert.Equal(1, responseCounter);
+        Assert.Equal(0, cache.SetCount);
+        Assert.Equal("Hello1", Encoding.UTF8.GetString(memoryStream.ToArray()));
+    }
+
+    [Fact]
+    public async Task AbortedRequest_IsNotServedToSubsequentRequests()
+    {
+        var responseCounter = 0;
+        var cache = GetStore();
+
+        var options = new OutputCacheOptions();
+        options.AddBasePolicy(build => build.Cache());
+
+        var middleware = TestUtils.CreateTestMiddleware(options: options, cache: cache, next: c =>
+        {
+            responseCounter++;
+
+            c.Response.Write("Hello" + responseCounter);
+
+            if (responseCounter == 1)
+            {
+                c.RequestAborted = new CancellationToken(canceled: true);
+            }
+
+            return Task.CompletedTask;
+        });
+
+        var memoryStream1 = new MemoryStream();
+
+        var context1 = TestUtils.CreateTestContext(cache: cache);
+        context1.HttpContext.Request.Method = "GET";
+        context1.HttpContext.Request.Path = "/";
+        context1.HttpContext.Response.Body = memoryStream1;
+
+        await middleware.Invoke(context1.HttpContext);
+
+        var memoryStream2 = new MemoryStream();
+
+        var context2 = TestUtils.CreateTestContext(cache: cache);
+        context2.HttpContext.Request.Method = "GET";
+        context2.HttpContext.Request.Path = "/";
+        context2.HttpContext.Response.Body = memoryStream2;
+
+        await middleware.Invoke(context2.HttpContext);
+
+        // The later request runs its own delegate, not the aborted response
+        Assert.Equal(2, responseCounter);
+        Assert.Equal("Hello1", Encoding.UTF8.GetString(memoryStream1.ToArray()));
+        Assert.Equal("Hello2", Encoding.UTF8.GetString(memoryStream2.ToArray()));
     }
 
     [Fact]


### PR DESCRIPTION
# Don't cache truncated/aborted responses in OutputCacheMiddleware

Fixes #66877
Fixes #56427

## Issue

When a request is aborted, `OutputCacheMiddleware` can still store the partial response and serve it to subsequent clients until the entry expires.

Two safeguards are meant to prevent this, and neither is reliable:
- The byte count is compared against `Content-Length`. With no `Content-Length` set there is nothing to compare against, and the check passes.
- `OutputCacheStream` disables buffering on a write failure, but only sees failures raised at its own layer. When another stream is layered above it, the exception is thrown before the write ever reaches `OutputCacheStream`.

Locking makes this worse. With `SetLocking(true)`, requests waiting on an in-flight response are handed it directly, **without the cacheability checks running at all**. On that path, even a response carrying a `Content-Length` can be shared truncated.

## Fix
1. Don't cache a response when `httpContext.RequestAborted` is canceled.
2. Only share a response with waiting requests when it actually passed the cacheability checks and was cached.

`FinalizeCacheBodyAsync` now reports whether the response was stored, and the caller releases the pending entry if it wasn't, forcing waiters to execute the pipeline themselves instead of receiving the incomplete entry.

The release condition is just `!isResponseCached`. The previous `!context.AllowCacheStorage` check is now redundant, since `FinalizeCacheBodyAsync` will return `false` when storage is disabled.

## Tests

Validates scenarios: an aborted response isn't stored, isn't served to later requests, and isn't handed to a request waiting on the locking path. Also ensures the aborted request itself still runs the pipeline exactly once.