### PR TITLE
Fix OneLoc GitHub App installation selection

### DIFF
--- a/eng/common/Get-GitHubAppToken.ps1
+++ b/eng/common/Get-GitHubAppToken.ps1
@@ -113,10 +113,13 @@ try {
     $installations = @()
     $page = 1
     do {
-        $pageInstallations = @(Invoke-RestMethod `
+        # Assign the response before wrapping it in @(). PowerShell otherwise
+        # preserves a top-level JSON array as one nested pipeline object.
+        $pageResponse = Invoke-RestMethod `
             -Uri "https://api.github.com/app/installations?per_page=100&page=$page" `
             -Headers $headers `
-            -Method Get)
+            -Method Get
+        $pageInstallations = @($pageResponse)
         $installations += $pageInstallations
         $page++
     } while ($pageInstallations.Count -eq 100)
@@ -125,12 +128,19 @@ catch {
     Write-PipelineTelemetryError -Category 'Build' -Message "Failed to list GitHub App installations: $_. The signed JWT may be invalid or the App's Client ID ('$AppClientId') may be incorrect."
     exit 1
 }
-$installation = $installations | Where-Object { $_.account.login -ieq $InstallationOwner } | Select-Object -First 1
-if (-not $installation) {
+$matchingInstallations = @($installations | Where-Object { $_.account.login -ieq $InstallationOwner })
+if ($matchingInstallations.Count -eq 0) {
     $found = ($installations | ForEach-Object { $_.account.login }) -join ', '
     Write-PipelineTelemetryError -Category 'Build' -Message "No installation found for '$InstallationOwner'. App is installed on: $found"
     exit 1
 }
+if ($matchingInstallations.Count -ne 1) {
+    $matchingIds = ($matchingInstallations | ForEach-Object { $_.id }) -join ', '
+    Write-PipelineTelemetryError -Category 'Build' -Message "Found multiple installations for '$InstallationOwner': $matchingIds"
+    exit 1
+}
+$installation = $matchingInstallations[0]
+Write-Host "Using installation $($installation.id) for '$($installation.account.login)'."
 
 try {
     $tokenResponse = Invoke-RestMethod `


### PR DESCRIPTION
OneLoc currently receives a token for the first GitHub App installation (microsoft) instead of selecting the requested dotnet installation. That causes 403 Resource not accessible by integration when localization tries to create locfiles/* branches or update PRs.

This syncs the focused installation-selection fix already merged in dotnet/arcade#17312 and propagated to dotnet/dotnet main. It flattens the installations response before filtering, requires exactly one owner match, and logs the selected installation.

Evidence:
- The App-token step succeeds, but OneLoc branch/PR writes fail with 403.
- Replaying the same operation with the correctly selected dotnet installation token succeeds.
- The change is limited to ng/common/Get-GitHubAppToken.ps1 (14 insertions, 4 deletions).