### PR TITLE
Remove OS platform check from test setup

### DIFF
--- a/src/Hosting/Hosting/test/StaticWebAssets/StaticWebAssetsFileProviderTests.cs
+++ b/src/Hosting/Hosting/test/StaticWebAssets/StaticWebAssetsFileProviderTests.cs
@@ -164,7 +164,6 @@ namespace Microsoft.AspNetCore.Hosting.StaticWebAssets
         public void GetFileInfo_DoesNotMatch_IncompletePrefixSegments()
         {
             // Arrange
-            var expectedResult = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             var provider = new StaticWebAssetsFileProvider(
                 "_cont",
                 Path.GetDirectoryName(typeof(StaticWebAssetsFileProviderTests).Assembly.Location));


### PR DESCRIPTION
Summary of the changes:
Removed unused OS platform expected result assignment.

Description:
Removed the unused expectedResult assignment for the OS platform check in GetFileInfo_DoesNotMatch_IncompletePrefixSegments. The variable was not used by the test, so this change removes unnecessary code.