### PR TITLE
[Blazor] Keep Virtualize spacer callbacks programmatic while an alignment is pending

### DIFF
--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -891,7 +891,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     });
 
     if (intersectingEntries.length === 0) {
-      if (source === ScrollSource.AlignToItem) {
+      if (canEndAlignActivity(source)) {
         scrollActivity.clear();
       }
       return;
@@ -934,9 +934,18 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       dotNetHelper.invokeMethodAsync(methodName, spacerSize, spacerSeparation, containerSize, reason);
     });
 
-    if (source === ScrollSource.AlignToItem) {
+    if (canEndAlignActivity(source)) {
       scrollActivity.clear();
     }
+  }
+
+  // An alignment that could not measure its target yet stays pending until a later render
+  // retries it, and until then scrollTop has not moved. Ending the align activity early would
+  // downgrade the spacer callbacks from ProgrammaticScroll (ignored by C#) to ViewportFill,
+  // letting C# redistribute the window out from under the alignment and strand it at the
+  // pre-alignment scroll position.
+  function canEndAlignActivity(source: ScrollSource): boolean {
+    return source === ScrollSource.AlignToItem && pendingAlignLocalIndex === null;
   }
 
   function isValidTableElement(element: HTMLElement | null): boolean {

--- a/src/Components/Web.JS/test/VirtualizePendingAlign.test.ts
+++ b/src/Components/Web.JS/test/VirtualizePendingAlign.test.ts
@@ -1,0 +1,171 @@
+import { expect, test, describe, beforeEach, afterEach, jest } from '@jest/globals';
+import { Virtualize } from '../src/Virtualize';
+
+const SpacerVisibilityReason = {
+  UserScroll: 0,
+  ProgrammaticScroll: 1,
+  ViewportFill: 2,
+  RenderedContentMeasurement: 3,
+};
+
+let intersectionCallback: (entries: any[]) => void;
+
+function rect(top: number, height: number) {
+  return {
+    top, height, bottom: top + height, left: 0, right: 0, width: 100, x: 0, y: top,
+    toJSON() { return this; },
+  };
+}
+
+function stubGlobals() {
+  (global as any).CSS = { supports: () => true };
+
+  (global as any).IntersectionObserver = class {
+    constructor(cb: (entries: any[]) => void) {
+      intersectionCallback = cb;
+    }
+    observe() { /* no-op */ }
+    unobserve() { /* no-op */ }
+    disconnect() { /* no-op */ }
+    takeRecords() { return []; }
+  };
+
+  (global as any).ResizeObserver = class {
+    observe() { /* no-op */ }
+    unobserve() { /* no-op */ }
+    disconnect() { /* no-op */ }
+  };
+
+  // jsdom has no layout, so Range reports no geometry.
+  (global as any).Range.prototype.getBoundingClientRect = () => rect(127588, 390);
+  (global as any).Range.prototype.getClientRects = () => [];
+
+  // jsdom's computed style does not reflect inline overflow-y, which is what
+  // findClosestScrollContainer relies on to locate the scroll container.
+  (global as any).getComputedStyle = (el: Element) => ({
+    overflowY: (el as HTMLElement).style.overflowY || 'visible',
+  });
+}
+
+// Mirrors the near-end InitialItemIndex layout: a tall before-spacer covering the whole
+// viewport, a few rendered items far below it, and an empty after-spacer.
+function buildDom() {
+  document.body.innerHTML = '';
+  const container = document.createElement('div');
+  container.id = 'scroll-container';
+  container.style.overflowY = 'auto';
+
+  const before = document.createElement('div');
+  const after = document.createElement('div');
+  container.appendChild(before);
+
+  const items: HTMLElement[] = [];
+  for (let i = 0; i < 3; i++) {
+    const item = document.createElement('div');
+    item.className = 'item';
+    container.appendChild(item);
+    items.push(item);
+  }
+  container.appendChild(after);
+  document.body.appendChild(container);
+
+  Object.defineProperty(before, 'offsetHeight', { value: 127588, configurable: true });
+  Object.defineProperty(after, 'offsetHeight', { value: 0, configurable: true });
+  before.getBoundingClientRect = () => rect(0, 127588) as any;
+  after.getBoundingClientRect = () => rect(127588, 0) as any;
+  items.forEach((item, i) => {
+    item.getBoundingClientRect = () => rect(127588 + i * 130, 130) as any;
+  });
+  container.getBoundingClientRect = () => rect(0, 2000) as any;
+  Object.defineProperty(container, 'clientHeight', { value: 2000, configurable: true });
+  Object.defineProperty(container, 'scrollHeight', { value: 130000, configurable: true });
+  Object.defineProperty(container, 'clientTop', { value: 0, configurable: true });
+  container.scrollTo = () => { /* jsdom has no scrolling */ };
+
+  return { container, before, after };
+}
+
+function ioEntry(target: Element, isIntersecting: boolean) {
+  return {
+    target,
+    isIntersecting,
+    intersectionRect: rect(0, isIntersecting ? 2000 : 0),
+    boundingClientRect: target.getBoundingClientRect(),
+    rootBounds: rect(0, 2000),
+  };
+}
+
+function createHelper() {
+  return {
+    _id: 1,
+    _callDispatcher: {},
+    invokeMethodAsync: jest.fn(() => Promise.resolve()),
+  } as any;
+}
+
+function spacerReasons(helper: any): number[] {
+  return helper.invokeMethodAsync.mock.calls
+    .filter((c: any[]) => c[0] === 'OnSpacerBeforeVisible' || c[0] === 'OnSpacerAfterVisible')
+    .map((c: any[]) => c[4] as number);
+}
+
+function raiseSpacerIntersection(before: Element, after: Element) {
+  intersectionCallback([ioEntry(before, true), ioEntry(after, false)]);
+  jest.advanceTimersByTime(100);
+}
+
+describe('Virtualize programmatic alignment', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    stubGlobals();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('spacer callbacks stay ProgrammaticScroll while an alignment is pending', () => {
+    const { container, before, after } = buildDom();
+    const helper = createHelper();
+
+    Virtualize.init(helper, before, after);
+    Virtualize.beginProgrammaticScroll(helper);
+
+    // The target is outside the committed window, so the alignment defers to a later render
+    // and scrollTop has not moved.
+    expect(Virtualize.alignToItem(helper, 950) ?? null).toBeNull();
+    expect(container.scrollTop).toBe(0);
+
+    raiseSpacerIntersection(before, after);
+    helper.invokeMethodAsync.mockClear();
+
+    container.dispatchEvent(new Event('scroll'));
+    raiseSpacerIntersection(before, after);
+
+    // ViewportFill and UserScroll both cause C# to move the window or abandon the initial
+    // index, which would strand the list at the pre-alignment scroll position.
+    const reasons = spacerReasons(helper);
+    expect(reasons).not.toContain(SpacerVisibilityReason.ViewportFill);
+    expect(reasons).not.toContain(SpacerVisibilityReason.UserScroll);
+    expect(reasons).toContain(SpacerVisibilityReason.ProgrammaticScroll);
+  });
+
+  test('spacer callbacks resume ViewportFill once the alignment has landed', () => {
+    const { before, after } = buildDom();
+    const helper = createHelper();
+
+    Virtualize.init(helper, before, after);
+    Virtualize.beginProgrammaticScroll(helper);
+
+    // The target is inside the committed window, so the alignment completes immediately.
+    expect(Virtualize.alignToItem(helper, 0)).not.toBeNull();
+
+    raiseSpacerIntersection(before, after);
+    helper.invokeMethodAsync.mockClear();
+
+    raiseSpacerIntersection(before, after);
+
+    // A completed alignment must still hand control back so viewport-fill can top up the window.
+    expect(spacerReasons(helper)).toContain(SpacerVisibilityReason.ViewportFill);
+  });
+});

--- a/src/Components/Web.JS/test/VirtualizePendingAlign.test.ts
+++ b/src/Components/Web.JS/test/VirtualizePendingAlign.test.ts
@@ -111,7 +111,9 @@ function spacerReasons(helper: any): number[] {
 
 function raiseSpacerIntersection(before: Element, after: Element) {
   intersectionCallback([ioEntry(before, true), ioEntry(after, false)]);
-  jest.advanceTimersByTime(100);
+  // Virtualize throttles its intersection callbacks behind a single setTimeout, so flush
+  // whatever is pending rather than coupling the test to the throttle duration.
+  jest.runOnlyPendingTimers();
 }
 
 describe('Virtualize programmatic alignment', () => {


### PR DESCRIPTION
Fixes #68708

## Problem

`VirtualizationTest.QuickGrid_InitialIndex_TallContainer_NearEnd_FillsViewportWithoutUserScroll` has been failing intermittently on `main` and on unrelated PRs since #67936 merged, on both the Mono and CoreCLR E2E legs, in both the WebAssembly and Interactive Server variants, and for both `useProvider` cases.

```
Item 950 should remain aligned with the viewport top once the last item has loaded,
but top rendered index was -1, scrollTop=0.
```

The DOM captured at failure time explains the `-1`: the before-spacer is `127588px`, the rendered window is items 977–999, and `scrollTop` is `0`. The viewport is entirely covered by the before-spacer, so no item intersects it.

## Root cause

1. `InitialItemIndex = 950` puts the component in `InitialIndexPhase.Pending` and calls JS `alignToItem`.
2. `alignToItemAt` finds the target is not in the committed window yet, so it records `pendingAlignLocalIndex` and **returns without scrolling**. `scrollTop` is still `0`.
3. Because it returns immediately, `ScrollToItemAsyncCore`'s `finally` clears `_currentScrollCts` while the alignment is still pending in JS.
4. #67936 made `processIntersectionEntries` call `scrollActivity.clear()` whenever `source === AlignToItem` — including when the alignment is merely *deferred*. That resets the source to `None`, so the following spacer callbacks are classified `ViewportFill` instead of `ProgrammaticScroll`.
5. #67936 also removed the `|| _initialIndex.Phase == InitialIndexPhase.Pending` clause from the C# `ViewportFill` early-return. With `_currentScrollCts` already null, C# now acts on those callbacks during `Pending` and runs `UpdateWindowFromViewport`.
6. The pending alignment is abandoned with `scrollTop` never applied. The ordinary end-of-list fill then sets `itemsBefore = _itemCount - visibleItemCapacity` = `1000 - 23` = `977`, reproducing the captured DOM exactly.

It is intermittent because it depends on an IntersectionObserver callback landing between the deferred alignment and its retry. The Interactive Server variant fails most often, since SignalR round-trips widen that window.

## Fix

Only end the align scroll activity once the alignment has actually landed:

```ts
function canEndAlignActivity(source: ScrollSource): boolean {
  return source === ScrollSource.AlignToItem && pendingAlignLocalIndex === null;
}
```

While an alignment is pending, spacer callbacks stay `ProgrammaticScroll`, which C# ignores, so the window is not redistributed out from under it. C# already re-drives `AlignToTargetAsync` on every render while the phase is `Pending`, so the alignment converges once the DOM catches up.

This deliberately does not restore the C# `Pending` guard removed in #67936 — that guard is what enables the viewport-underfill growth that PR added. Keeping the callbacks classified as programmatic addresses the race without giving up that behavior.

## Testing

`src/Components/Web.JS/test/Virtualize.test.ts` was a 13-line export smoke test, so none of this state machine was covered. Added `VirtualizePendingAlign.test.ts`, which drives `init` / `beginProgrammaticScroll` / `alignToItem` against a stubbed IntersectionObserver and a DOM mirroring the near-end layout:

- **`spacer callbacks stay ProgrammaticScroll while an alignment is pending`** — fails without the fix, passes with it.
- **`spacer callbacks resume ViewportFill once the alignment has landed`** — passes both with and without the fix, so the first test is not vacuous and #67936's intended behavior is still exercised.

Verified red/green:

| Virtualize.ts | pending-align test | landed-align test |
|---|---|---|
| `fde48e9521^` (pre-#67936) | pass | pass |
| `main` (post-#67936) | **fail** | pass |
| this PR | pass | pass |

Full `Web.JS` jest suite: 208 passing, up from 206 at baseline. The 5 failing suites are pre-existing `Cannot find module '@microsoft/signalr'` resolution errors, identical with and without this change. `eslint` reports no new problems in the edited region.

## Follow-up

`src/Components/Web/test/Virtualization/VirtualizeTest.cs` still has no `InitialItemIndex` coverage at all. Worth adding separately.