### PR TITLE
Fail pending server JS interop calls when circuits disconnect

### DIFF
--- a/src/Components/Server/src/Circuits/CircuitRegistry.cs
+++ b/src/Components/Server/src/Circuits/CircuitRegistry.cs
@@ -108,6 +108,12 @@ internal partial class CircuitRegistry
             }
         }
 
+        if (!circuitHost.Client.Connected &&
+            string.Equals(circuitHost.Client.ConnectionId, connectionId, StringComparison.Ordinal))
+        {
+            circuitHost.JSRuntime.MarkDisconnected();
+        }
+
         return circuitHandlerTask;
     }
 
@@ -214,6 +220,11 @@ internal partial class CircuitRegistry
 
         try
         {
+            if (previouslyConnected)
+            {
+                circuitHost.JSRuntime.MarkDisconnected();
+            }
+
             await circuitHandlerTask;
             Log.ReconnectionSucceeded(_logger, circuitHost.CircuitId);
             return circuitHost;
@@ -251,6 +262,7 @@ internal partial class CircuitRegistry
             DisconnectedCircuits.Remove(circuitId.Secret);
             ConnectedCircuits.TryAdd(circuitId, disconnectedEntry.CircuitHost);
 
+            disconnectedEntry.CircuitHost.JSRuntime.MarkDisconnected();
             disconnectedEntry.CircuitHost.Client.Transfer(clientProxy, connectionId);
             return (disconnectedEntry.CircuitHost, false);
         }

--- a/src/Components/Server/src/Circuits/CircuitRegistry.cs
+++ b/src/Components/Server/src/Circuits/CircuitRegistry.cs
@@ -92,10 +92,12 @@ internal partial class CircuitRegistry
         Log.CircuitDisconnectStarted(_logger, circuitHost.CircuitId, connectionId);
 
         Task circuitHandlerTask;
+        Action completePendingTasks;
         lock (CircuitRegistryLock)
         {
             if (DisconnectCore(circuitHost, connectionId))
             {
+                completePendingTasks = circuitHost.JSRuntime.CapturePendingTasksForDisconnect();
                 circuitHandlerTask = circuitHost.Renderer.Dispatcher.InvokeAsync(() => circuitHost.OnConnectionDownAsync(default));
             }
             else
@@ -108,11 +110,7 @@ internal partial class CircuitRegistry
             }
         }
 
-        if (!circuitHost.Client.Connected &&
-            string.Equals(circuitHost.Client.ConnectionId, connectionId, StringComparison.Ordinal))
-        {
-            circuitHost.JSRuntime.MarkDisconnected();
-        }
+        completePendingTasks();
 
         return circuitHandlerTask;
     }
@@ -181,6 +179,7 @@ internal partial class CircuitRegistry
 
         CircuitHost circuitHost;
         bool previouslyConnected;
+        Action completePendingTasks;
 
         Task circuitHandlerTask;
 
@@ -190,7 +189,7 @@ internal partial class CircuitRegistry
             // Transition the host from disconnected to connected if it's available. In this critical section, we return
             // an existing host if it's currently considered connected or transition a disconnected host to connected.
             // Transferring also wires up the client to the new set.
-            (circuitHost, previouslyConnected) = ConnectCore(circuitId, clientProxy, connectionId);
+            (circuitHost, previouslyConnected, completePendingTasks) = ConnectCore(circuitId, clientProxy, connectionId);
 
             if (circuitHost == null)
             {
@@ -220,11 +219,7 @@ internal partial class CircuitRegistry
 
         try
         {
-            if (previouslyConnected)
-            {
-                circuitHost.JSRuntime.MarkDisconnected();
-            }
-
+            completePendingTasks();
             await circuitHandlerTask;
             Log.ReconnectionSucceeded(_logger, circuitHost.CircuitId);
             return circuitHost;
@@ -239,7 +234,7 @@ internal partial class CircuitRegistry
         }
     }
 
-    protected virtual (CircuitHost circuitHost, bool previouslyConnected) ConnectCore(CircuitId circuitId, ISingleClientProxy clientProxy, string connectionId)
+    protected virtual (CircuitHost circuitHost, bool previouslyConnected, Action completePendingTasks) ConnectCore(CircuitId circuitId, ISingleClientProxy clientProxy, string connectionId)
     {
         if (ConnectedCircuits.TryGetValue(circuitId, out var connectedCircuitHost))
         {
@@ -247,8 +242,11 @@ internal partial class CircuitRegistry
 
             // The host is still active i.e. the server hasn't detected the client disconnect.
             // However the client reconnected establishing a new connection.
+            // Stop new calls from using the old connection while its pending calls are captured.
+            connectedCircuitHost.Client.SetDisconnected();
+            var completePendingTasks = connectedCircuitHost.JSRuntime.CapturePendingTasksForDisconnect();
             connectedCircuitHost.Client.Transfer(clientProxy, connectionId);
-            return (connectedCircuitHost, true);
+            return (connectedCircuitHost, true, completePendingTasks);
         }
 
         if (DisconnectedCircuits.TryGetValue(circuitId.Secret, out DisconnectedCircuitEntry disconnectedEntry))
@@ -262,9 +260,9 @@ internal partial class CircuitRegistry
             DisconnectedCircuits.Remove(circuitId.Secret);
             ConnectedCircuits.TryAdd(circuitId, disconnectedEntry.CircuitHost);
 
-            disconnectedEntry.CircuitHost.JSRuntime.MarkDisconnected();
+            var completePendingTasks = disconnectedEntry.CircuitHost.JSRuntime.CapturePendingTasksForDisconnect();
             disconnectedEntry.CircuitHost.Client.Transfer(clientProxy, connectionId);
-            return (disconnectedEntry.CircuitHost, false);
+            return (disconnectedEntry.CircuitHost, false, completePendingTasks);
         }
 
         return default;

--- a/src/Components/Server/src/Circuits/RemoteJSDataStream.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSDataStream.cs
@@ -51,8 +51,16 @@ internal sealed class RemoteJSDataStream : Stream
 
         var streamId = runtime.RemoteJSDataStreamNextInstanceId++;
         var remoteJSDataStream = new RemoteJSDataStream(runtime, streamId, totalLength, chunkSize, jsInteropDefaultCallTimeout, cancellationToken);
-        await runtime.InvokeVoidAsync("Blazor._internal.sendJSDataStream", jsStreamReference, streamId, chunkSize);
-        return remoteJSDataStream;
+        try
+        {
+            await runtime.InvokeVoidAsync("Blazor._internal.sendJSDataStream", jsStreamReference, streamId, chunkSize);
+            return remoteJSDataStream;
+        }
+        catch
+        {
+            remoteJSDataStream.Dispose();
+            throw;
+        }
     }
 
     private RemoteJSDataStream(

--- a/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
@@ -144,6 +144,13 @@ internal partial class RemoteJSRuntime : JSRuntime
             }
         }
 
+        if (!_clientProxy.Connected)
+        {
+            throw new JSDisconnectedException(
+                "JavaScript interop calls cannot be issued at this time. This is because the circuit is disconnected " +
+                "and is attempting to reconnect.");
+        }
+
         Log.BeginInvokeJS(_logger, invocationInfo.AsyncHandle, invocationInfo.Identifier);
 
         _clientProxy.SendAsync(
@@ -225,8 +232,15 @@ internal partial class RemoteJSRuntime : JSRuntime
 
     public void MarkPermanentlyDisconnected()
     {
+        MarkDisconnected();
         _permanentlyDisconnected = true;
         _clientProxy = null;
+    }
+
+    public void MarkDisconnected()
+    {
+        FailPendingTasks(new JSDisconnectedException(
+            "JavaScript interop calls cannot complete because the circuit disconnected."));
     }
 
     protected override async Task<Stream> ReadJSDataAsStreamAsync(IJSStreamReference jsStreamReference, long totalLength, CancellationToken cancellationToken = default)

--- a/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
+++ b/src/Components/Server/src/Circuits/RemoteJSRuntime.cs
@@ -232,14 +232,21 @@ internal partial class RemoteJSRuntime : JSRuntime
 
     public void MarkPermanentlyDisconnected()
     {
-        MarkDisconnected();
         _permanentlyDisconnected = true;
         _clientProxy = null;
+        var completePendingTasks = CapturePendingTasksForDisconnect();
+        completePendingTasks();
     }
 
     public void MarkDisconnected()
     {
-        FailPendingTasks(new JSDisconnectedException(
+        var completePendingTasks = CapturePendingTasksForDisconnect();
+        completePendingTasks();
+    }
+
+    public Action CapturePendingTasksForDisconnect()
+    {
+        return CapturePendingTasks(new JSDisconnectedException(
             "JavaScript interop calls cannot complete because the circuit disconnected."));
     }
 

--- a/src/Components/Server/test/Circuits/CircuitRegistryJSInteropTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitRegistryJSInteropTest.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Infrastructure;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Microsoft.JSInterop;
+using Moq;
+
+namespace Microsoft.AspNetCore.Components.Server.Circuits;
+
+public class CircuitRegistryJSInteropTest
+{
+    [Fact]
+    public async Task DisconnectAsync_FailsPendingJSInteropCalls()
+    {
+        var registry = CreateRegistry();
+        var client = Mock.Of<ISingleClientProxy>(
+            c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()) == Task.CompletedTask);
+        var circuitHost = TestCircuitHost.Create(clientProxy: new CircuitClientProxy(client, "connection"));
+        registry.Register(circuitHost);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var pendingInteropCall = circuitHost.JSRuntime.InvokeAsync<string>("test", cts.Token, Array.Empty<object>());
+
+        await registry.DisconnectAsync(circuitHost, circuitHost.Client.ConnectionId);
+
+        await Assert.ThrowsAsync<JSDisconnectedException>(async () => await pendingInteropCall);
+    }
+
+    private static CircuitRegistry CreateRegistry()
+    {
+        return new CircuitRegistry(
+            Options.Create(new CircuitOptions()),
+            NullLogger<CircuitRegistry>.Instance,
+            TestCircuitIdFactory.CreateTestFactory(),
+            CreatePersistenceManager());
+    }
+
+    private static CircuitPersistenceManager CreatePersistenceManager()
+    {
+        return new CircuitPersistenceManager(
+            Options.Create(new CircuitOptions()),
+            new Endpoints.ServerComponentSerializer(new EphemeralDataProtectionProvider()),
+            new TestCircuitPersistenceProvider(),
+            new EphemeralDataProtectionProvider());
+    }
+
+    private class TestCircuitPersistenceProvider : ICircuitPersistenceProvider
+    {
+        public Task PersistCircuitAsync(CircuitId circuitId, PersistedCircuitState persistedCircuitState, CancellationToken cancellation = default)
+            => Task.CompletedTask;
+
+        public Task<PersistedCircuitState> RestoreCircuitAsync(CircuitId circuitId, CancellationToken cancellation = default)
+            => throw new NotImplementedException();
+    }
+}

--- a/src/Components/Server/test/Circuits/CircuitRegistryJSInteropTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitRegistryJSInteropTest.cs
@@ -20,6 +20,7 @@ public class CircuitRegistryJSInteropTest
         var client = Mock.Of<ISingleClientProxy>(
             c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()) == Task.CompletedTask);
         var circuitHost = TestCircuitHost.Create(clientProxy: new CircuitClientProxy(client, "connection"));
+        circuitHost.JSRuntime.Initialize(circuitHost.Client);
         registry.Register(circuitHost);
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var pendingInteropCall = circuitHost.JSRuntime.InvokeAsync<string>("test", cts.Token, Array.Empty<object>());

--- a/src/Components/Server/test/Circuits/CircuitRegistryJSInteropTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitRegistryJSInteropTest.cs
@@ -30,6 +30,42 @@ public class CircuitRegistryJSInteropTest
         await Assert.ThrowsAsync<JSDisconnectedException>(async () => await pendingInteropCall);
     }
 
+    [Fact]
+    public async Task ConnectAsync_FailsOnlyPendingJSInteropCallsFromPreviousConnection()
+    {
+        var registry = CreateRegistry();
+        var handler = new Mock<CircuitHandler> { CallBase = true };
+        var client = Mock.Of<ISingleClientProxy>(
+            c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()) == Task.CompletedTask);
+        var circuitHost = TestCircuitHost.Create(
+            handlers: [handler.Object],
+            clientProxy: new CircuitClientProxy(client, "old-connection"));
+        circuitHost.JSRuntime.Initialize(circuitHost.Client);
+        registry.Register(circuitHost);
+
+        var pendingCallFromPreviousConnection = circuitHost.JSRuntime.InvokeAsync<string>("old-call").AsTask();
+        Task<string> pendingCallFromReplacementConnection = null;
+        handler
+            .Setup(h => h.OnConnectionUpAsync(It.IsAny<Circuit>(), It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                pendingCallFromReplacementConnection = circuitHost.JSRuntime.InvokeAsync<string>("new-call").AsTask();
+                return Task.CompletedTask;
+            });
+
+        var replacementClient = Mock.Of<ISingleClientProxy>(
+            c => c.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()) == Task.CompletedTask);
+        var result = await registry.ConnectAsync(circuitHost.CircuitId, replacementClient, "new-connection", default);
+
+        Assert.Same(circuitHost, result);
+        await Assert.ThrowsAsync<JSDisconnectedException>(() => pendingCallFromPreviousConnection);
+        Assert.NotNull(pendingCallFromReplacementConnection);
+        Assert.False(pendingCallFromReplacementConnection.IsCompleted);
+
+        circuitHost.JSRuntime.MarkDisconnected();
+        await Assert.ThrowsAsync<JSDisconnectedException>(() => pendingCallFromReplacementConnection);
+    }
+
     private static CircuitRegistry CreateRegistry()
     {
         return new CircuitRegistry(

--- a/src/Components/Server/test/Circuits/CircuitRegistryTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitRegistryTest.cs
@@ -609,7 +609,7 @@ public class CircuitRegistryTest
         public Action OnAfterEntryEvicted { get; set; }
         public TaskCompletionSource PauseInvoked { get; internal set; }
 
-        protected override (CircuitHost, bool) ConnectCore(CircuitId circuitId, ISingleClientProxy clientProxy, string connectionId)
+        protected override (CircuitHost, bool, Action) ConnectCore(CircuitId circuitId, ISingleClientProxy clientProxy, string connectionId)
         {
             if (BeforeConnect != null)
             {

--- a/src/Components/Server/test/Circuits/RemoteJSDataStreamTest.cs
+++ b/src/Components/Server/test/Circuits/RemoteJSDataStreamTest.cs
@@ -28,6 +28,31 @@ public class RemoteJSDataStreamTest
     }
 
     [Fact]
+    public async Task CreateRemoteJSDataStreamAsync_RemovesStreamWhenStartupFails()
+    {
+        var expectedException = new InvalidOperationException("Failed to start the stream.");
+        var jsRuntime = new TestRemoteJSRuntime(
+            Options.Create(new CircuitOptions()),
+            Options.Create(new HubOptions<ComponentHub>()),
+            Mock.Of<ILogger<RemoteJSRuntime>>())
+        {
+            InvokeException = expectedException,
+        };
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await RemoteJSDataStream.CreateRemoteJSDataStreamAsync(
+                jsRuntime,
+                Mock.Of<IJSStreamReference>(),
+                totalLength: 100,
+                signalRMaximumIncomingBytes: 10_000,
+                jsInteropDefaultCallTimeout: TimeSpan.FromMinutes(1),
+                cancellationToken: CancellationToken.None));
+
+        Assert.Same(expectedException, exception);
+        Assert.Empty(jsRuntime.RemoteJSDataStreamInstances);
+    }
+
+    [Fact]
     public async Task ReceiveData_DoesNotFindStream()
     {
         // Arrange
@@ -358,9 +383,16 @@ public class RemoteJSDataStreamTest
         {
         }
 
+        public Exception InvokeException { get; init; }
+
         public new ValueTask<TValue> InvokeAsync<TValue>(string identifier, object[] args)
         {
             Assert.Equal("Blazor._internal.sendJSDataStream", identifier);
+            if (InvokeException is not null)
+            {
+                return ValueTask.FromException<TValue>(InvokeException);
+            }
+
             return ValueTask.FromResult<TValue>(default);
         }
     }

--- a/src/Components/Server/test/Circuits/TestCircuitHost.cs
+++ b/src/Components/Server/test/Circuits/TestCircuitHost.cs
@@ -32,6 +32,7 @@ internal class TestCircuitHost : CircuitHost
     {
         clientProxy = clientProxy ?? new CircuitClientProxy(Mock.Of<ISingleClientProxy>(), Guid.NewGuid().ToString());
         var jsRuntime = new RemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Mock.Of<ILogger<RemoteJSRuntime>>());
+        jsRuntime.Initialize(clientProxy);
         var navigationManager = new RemoteNavigationManager(Mock.Of<ILogger<RemoteNavigationManager>>());
         var componentsActivitySource = new ComponentsActivitySource();
         var circuitActivitySource = new CircuitActivitySource();

--- a/src/Components/Server/test/Circuits/TestCircuitHost.cs
+++ b/src/Components/Server/test/Circuits/TestCircuitHost.cs
@@ -32,7 +32,6 @@ internal class TestCircuitHost : CircuitHost
     {
         clientProxy = clientProxy ?? new CircuitClientProxy(Mock.Of<ISingleClientProxy>(), Guid.NewGuid().ToString());
         var jsRuntime = new RemoteJSRuntime(Options.Create(new CircuitOptions()), Options.Create(new HubOptions<ComponentHub>()), Mock.Of<ILogger<RemoteJSRuntime>>());
-        jsRuntime.Initialize(clientProxy);
         var navigationManager = new RemoteNavigationManager(Mock.Of<ILogger<RemoteNavigationManager>>());
         var componentsActivitySource = new ComponentsActivitySource();
         var circuitActivitySource = new CircuitActivitySource();

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
@@ -194,6 +194,28 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
     }
 
     /// <summary>
+    /// Fails all pending asynchronous JavaScript calls with the specified exception.
+    /// </summary>
+    /// <param name="exception">The exception used to complete the pending calls.</param>
+    protected void FailPendingTasks(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+
+        foreach (var taskId in _pendingTasks.Keys)
+        {
+            if (_pendingTasks.TryRemove(taskId, out var pendingCall))
+            {
+                pendingCall.Fail(exception);
+            }
+
+            if (_cancellationRegistrations.TryRemove(taskId, out var registration))
+            {
+                registration.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
     /// Begins an asynchronous function invocation.
     /// </summary>
     /// <param name="taskId">The identifier for the function invocation, or zero if no async callback is required.</param>

--- a/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
+++ b/src/JSInterop/Microsoft.JSInterop/src/JSRuntime.cs
@@ -194,25 +194,41 @@ public abstract partial class JSRuntime : IJSRuntime, IDisposable
     }
 
     /// <summary>
-    /// Fails all pending asynchronous JavaScript calls with the specified exception.
+    /// Captures all pending asynchronous JavaScript calls so they can be failed with the specified exception.
     /// </summary>
     /// <param name="exception">The exception used to complete the pending calls.</param>
-    protected void FailPendingTasks(Exception exception)
+    /// <returns>An action that fails the captured calls.</returns>
+    protected Action CapturePendingTasks(Exception exception)
     {
         ArgumentNullException.ThrowIfNull(exception);
 
+        var pendingCalls = new List<IPendingAsyncCall>();
+        var cancellationRegistrations = new List<CancellationTokenRegistration>();
         foreach (var taskId in _pendingTasks.Keys)
         {
             if (_pendingTasks.TryRemove(taskId, out var pendingCall))
             {
-                pendingCall.Fail(exception);
+                pendingCalls.Add(pendingCall);
             }
 
             if (_cancellationRegistrations.TryRemove(taskId, out var registration))
             {
-                registration.Dispose();
+                cancellationRegistrations.Add(registration);
             }
         }
+
+        return () =>
+        {
+            foreach (var pendingCall in pendingCalls)
+            {
+                pendingCall.Fail(exception);
+            }
+
+            foreach (var registration in cancellationRegistrations)
+            {
+                registration.Dispose();
+            }
+        };
     }
 
     /// <summary>

--- a/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
+++ b/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+Microsoft.JSInterop.JSRuntime.FailPendingTasks(System.Exception! exception) -> void

--- a/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
+++ b/src/JSInterop/Microsoft.JSInterop/src/PublicAPI.Unshipped.txt
@@ -1,2 +1,2 @@
 #nullable enable
-Microsoft.JSInterop.JSRuntime.FailPendingTasks(System.Exception! exception) -> void
+Microsoft.JSInterop.JSRuntime.CapturePendingTasks(System.Exception! exception) -> System.Action!


### PR DESCRIPTION
# Fail pending server JS interop calls when circuits disconnect

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Summary of the changes (Less than 80 chars)
Fail pending server JS interop calls when circuits disconnect

## Description
Server-side JS interop calls are tracked in `JSRuntime` until `EndInvokeJS` receives the client result. If SignalR closes the connection before the result reaches `EndInvokeJSFromDotNet`, such as when the incoming JS interop result exceeds the receive message size limit, the pending call is never completed and only observes caller cancellation or timeout.

This adds a protected `JSRuntime` helper for derived runtimes to fail all pending async JS calls, and has `RemoteJSRuntime` use it when the circuit disconnects or transfers to another connection. It also rejects new JS interop calls while the circuit client is disconnected and attempting to reconnect.

Fixes #67479.

## Testing
- `git diff --check`: passed.
- Not run: narrow local restore/build/test. The repo tooling hit Windows Schannel TLS failures while restoring packages from configured feeds in this environment. CI should be treated as the authoritative validation for the full test matrix.
