### PR TITLE
Fix BL0012 false positive on await foreach and await using

### DIFF
--- a/src/Components/Analyzers/src/StateHasChangedAnalyzer.cs
+++ b/src/Components/Analyzers/src/StateHasChangedAnalyzer.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Text;
 
 #nullable enable
 
@@ -103,7 +104,24 @@ public sealed class StateHasChangedAnalyzer : DiagnosticAnalyzer
                     return;
                 }
 
-                var awaitExpressions = body.DescendantNodes(static node => !IsNestedFunctionLike(node)).OfType<AwaitExpressionSyntax>().OrderBy(n => n.SpanStart).ToList();
+                var suspensionStart = int.MaxValue;
+                var suspensionEnd = int.MinValue;
+                foreach (var node in body.DescendantNodes(static node => !IsNestedFunctionLike(node)))
+                {
+                    if (TryGetSuspensionSpan(node, out var suspension))
+                    {
+                        if (suspension.Start < suspensionStart)
+                        {
+                            suspensionStart = suspension.Start;
+                        }
+
+                        if (suspension.End > suspensionEnd)
+                        {
+                            suspensionEnd = suspension.End;
+                        }
+                    }
+                }
+
                 var stateCalls = body.DescendantNodes(static node => !IsNestedFunctionLike(node)).OfType<InvocationExpressionSyntax>()
                     .Where(invocation => IsStateHasChangedCall(syntaxContext.SemanticModel, invocation))
                     .OrderBy(invocation => invocation.SpanStart)
@@ -115,9 +133,9 @@ public sealed class StateHasChangedAnalyzer : DiagnosticAnalyzer
                 }
 
                 var callLocations = new Dictionary<int, Location>();
-                if (awaitExpressions.Count == 0)
+                if (suspensionStart > suspensionEnd)
                 {
-                    // no await expressions, all calls are potentially redundant
+                    // no awaits, all calls are potentially redundant
                     foreach (var stateCall in stateCalls)
                     {
                         AddCallLocation(callLocations, stateCall);
@@ -125,11 +143,9 @@ public sealed class StateHasChangedAnalyzer : DiagnosticAnalyzer
                 }
                 else
                 {
-                    var firstAwaitStart = awaitExpressions[0].SpanStart;
-                    var lastAwaitStart = awaitExpressions[awaitExpressions.Count - 1].SpanStart;
                     foreach (var stateCall in stateCalls)
                     {
-                        if (stateCall.SpanStart < firstAwaitStart || stateCall.SpanStart > lastAwaitStart)
+                        if (stateCall.SpanStart < suspensionStart || stateCall.SpanStart > suspensionEnd)
                         {
                             // any calls before the first await or after the last one are redundant, because ComponentBase calls StateHasChanged afterwards.
                             AddCallLocation(callLocations, stateCall);
@@ -213,6 +229,39 @@ public sealed class StateHasChangedAnalyzer : DiagnosticAnalyzer
     private static bool IsNestedFunctionLike(SyntaxNode node)
     {
         return node is LocalFunctionStatementSyntax or AnonymousFunctionExpressionSyntax;
+    }
+
+    private static bool TryGetSuspensionSpan(SyntaxNode node, out TextSpan span)
+    {
+        switch (node)
+        {
+            case AwaitExpressionSyntax awaitExpression:
+                span = awaitExpression.Span;
+                return true;
+
+            case CommonForEachStatementSyntax forEachStatement when IsAwaitKeyword(forEachStatement.AwaitKeyword):
+                span = forEachStatement.Span;
+                return true;
+
+            case UsingStatementSyntax usingStatement when IsAwaitKeyword(usingStatement.AwaitKeyword):
+                span = usingStatement.Span;
+                return true;
+
+            case LocalDeclarationStatementSyntax declaration when IsAwaitKeyword(declaration.AwaitKeyword):
+                span = TextSpan.FromBounds(
+                    declaration.SpanStart,
+                    declaration.Parent is BlockSyntax enclosingBlock ? enclosingBlock.Span.End : declaration.Span.End);
+                return true;
+
+            default:
+                span = default;
+                return false;
+        }
+    }
+
+    private static bool IsAwaitKeyword(SyntaxToken token)
+    {
+        return token.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.AwaitKeyword);
     }
 
     private static IMethodSymbol? TryGetMethodFromOperation(IOperation operation)

--- a/src/Components/Analyzers/src/StateHasChangedAnalyzer.cs
+++ b/src/Components/Analyzers/src/StateHasChangedAnalyzer.cs
@@ -244,13 +244,12 @@ public sealed class StateHasChangedAnalyzer : DiagnosticAnalyzer
                 return true;
 
             case UsingStatementSyntax usingStatement when IsAwaitKeyword(usingStatement.AwaitKeyword):
-                span = usingStatement.Span;
+                span = TextSpan.FromBounds(usingStatement.Span.End, usingStatement.Span.End);
                 return true;
 
             case LocalDeclarationStatementSyntax declaration when IsAwaitKeyword(declaration.AwaitKeyword):
-                span = TextSpan.FromBounds(
-                    declaration.SpanStart,
-                    declaration.Parent is BlockSyntax enclosingBlock ? enclosingBlock.Span.End : declaration.Span.End);
+                var disposalPoint = declaration.Parent is BlockSyntax enclosingBlock ? enclosingBlock.Span.End : declaration.Span.End;
+                span = TextSpan.FromBounds(disposalPoint, disposalPoint);
                 return true;
 
             default:

--- a/src/Components/Analyzers/test/StateHasChangedAnalyzerTest.cs
+++ b/src/Components/Analyzers/test/StateHasChangedAnalyzerTest.cs
@@ -620,7 +620,7 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
     }
 
     [Fact]
-    public void StateHasChangedInsideAwaitUsingBlock_DoesNotReportDiagnostic()
+    public void StateHasChangedInsideAwaitUsingBlock_ReportsDiagnostic()
     {
         var test = @"
     namespace ConsoleApplication1
@@ -646,11 +646,51 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
         }
     }" + ComponentDeclarations;
 
+        VerifyCSharpDiagnostic(
+            test,
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary in method 'OnInitializedAsync' and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 14, 21) }
+            });
+    }
+
+    [Fact]
+    public void StateHasChangedInsideAwaitUsingBlockAfterAwait_DoesNotReportDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+        using System;
+        using System.Threading.Tasks;
+
+        class TestComponent : ComponentBase
+        {
+            protected override async Task OnInitializedAsync()
+            {
+                await Task.Delay(1);
+
+                await using (var scope = new Scope())
+                {
+                    StateHasChanged();
+                }
+            }
+
+            private sealed class Scope : IAsyncDisposable
+            {
+                public ValueTask DisposeAsync() => default;
+            }
+        }
+    }" + ComponentDeclarations;
+
         VerifyCSharpDiagnostic(test);
     }
 
     [Fact]
-    public void StateHasChangedAfterAwaitUsingDeclaration_DoesNotReportDiagnostic()
+    public void StateHasChangedAfterAwaitUsingDeclaration_ReportsDiagnostic()
     {
         var test = @"
     namespace ConsoleApplication1
@@ -664,6 +704,45 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
             protected override async Task OnInitializedAsync()
             {
                 await using var scope = new Scope();
+
+                StateHasChanged();
+            }
+
+            private sealed class Scope : IAsyncDisposable
+            {
+                public ValueTask DisposeAsync() => default;
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(
+            test,
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary in method 'OnInitializedAsync' and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 14, 17) }
+            });
+    }
+
+    [Fact]
+    public void StateHasChangedBetweenAwaitAndUsingDeclarationDisposal_DoesNotReportDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+        using System;
+        using System.Threading.Tasks;
+
+        class TestComponent : ComponentBase
+        {
+            protected override async Task OnInitializedAsync()
+            {
+                await using var scope = new Scope();
+
+                await Task.Delay(1);
 
                 StateHasChanged();
             }

--- a/src/Components/Analyzers/test/StateHasChangedAnalyzerTest.cs
+++ b/src/Components/Analyzers/test/StateHasChangedAnalyzerTest.cs
@@ -509,6 +509,176 @@ public class StateHasChangedAnalyzerTest : DiagnosticVerifier
     }
 
     [Fact]
+    public void StateHasChangedInsideAwaitForeach_DoesNotReportDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+        using System.Collections.Generic;
+        using System.Threading.Tasks;
+
+        class TestComponent : ComponentBase
+        {
+            protected override async Task OnInitializedAsync()
+            {
+                await foreach (var item in StreamAsync())
+                {
+                    StateHasChanged();
+                }
+            }
+
+            private static async IAsyncEnumerable<int> StreamAsync()
+            {
+                await Task.Delay(1);
+                yield return 1;
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
+    public void StateHasChangedBeforeAwaitForeach_ReportsDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+        using System.Collections.Generic;
+        using System.Threading.Tasks;
+
+        class TestComponent : ComponentBase
+        {
+            protected override async Task OnInitializedAsync()
+            {
+                StateHasChanged();
+
+                await foreach (var item in StreamAsync())
+                {
+                }
+            }
+
+            private static async IAsyncEnumerable<int> StreamAsync()
+            {
+                await Task.Delay(1);
+                yield return 1;
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(
+            test,
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary in method 'OnInitializedAsync' and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 12, 17) }
+            });
+    }
+
+    [Fact]
+    public void StateHasChangedAfterAwaitForeach_ReportsDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+        using System.Collections.Generic;
+        using System.Threading.Tasks;
+
+        class TestComponent : ComponentBase
+        {
+            protected override async Task OnInitializedAsync()
+            {
+                await foreach (var item in StreamAsync())
+                {
+                }
+
+                StateHasChanged();
+            }
+
+            private static async IAsyncEnumerable<int> StreamAsync()
+            {
+                await Task.Delay(1);
+                yield return 1;
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(
+            test,
+            new DiagnosticResult
+            {
+                Id = DiagnosticDescriptors.UnnecessaryStateHasChangedCall.Id,
+                Message = "StateHasChanged is unnecessary in method 'OnInitializedAsync' and can be removed.",
+                Severity = DiagnosticSeverity.Warning,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 16, 17) }
+            });
+    }
+
+    [Fact]
+    public void StateHasChangedInsideAwaitUsingBlock_DoesNotReportDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+        using System;
+        using System.Threading.Tasks;
+
+        class TestComponent : ComponentBase
+        {
+            protected override async Task OnInitializedAsync()
+            {
+                await using (var scope = new Scope())
+                {
+                    StateHasChanged();
+                }
+            }
+
+            private sealed class Scope : IAsyncDisposable
+            {
+                public ValueTask DisposeAsync() => default;
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
+    public void StateHasChangedAfterAwaitUsingDeclaration_DoesNotReportDiagnostic()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+        using System;
+        using System.Threading.Tasks;
+
+        class TestComponent : ComponentBase
+        {
+            protected override async Task OnInitializedAsync()
+            {
+                await using var scope = new Scope();
+
+                StateHasChanged();
+            }
+
+            private sealed class Scope : IAsyncDisposable
+            {
+                public ValueTask DisposeAsync() => default;
+            }
+        }
+    }" + ComponentDeclarations;
+
+        VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
     public void NonComponentBaseClassWithOnInitialized_DoesNotReportDiagnostic()
     {
         var test = @"


### PR DESCRIPTION
## Problem

`BL0012` reports `StateHasChanged` calls that are required, whenever the enclosing method's only awaits are `await foreach` or `await using`.

```csharp
protected override async Task OnInitializedAsync()
{
    await foreach (var item in LoadAsync())
    {
        _items.Add(item);
        StateHasChanged();   // BL0012: "unnecessary in method 'OnInitializedAsync'"
    }
}
```

The call is what paints each item as it arrives. Accepting the offered code fix removes it, and the list then stays empty until the stream completes and appears in one batch.

## Cause

`StateHasChangedAnalyzer` located the first and last await by collecting `AwaitExpressionSyntax` nodes:

```csharp
var awaitExpressions = body.DescendantNodes(...).OfType<AwaitExpressionSyntax>()
```

Three forms do not produce an `AwaitExpressionSyntax`. They carry their await as a keyword token on the statement instead:

| Form | Token |
|---|---|
| `await foreach (...)` | `CommonForEachStatementSyntax.AwaitKeyword` |
| `await using (...) { }` | `UsingStatementSyntax.AwaitKeyword` |
| `await using var x = ...;` | `LocalDeclarationStatementSyntax.AwaitKeyword` |

A method whose only awaits take one of those forms therefore looked await-free. The analyzer took its `Count == 0` branch, which treats every call in the method as redundant on the grounds that `ComponentBase` renders once the method returns.

## Fix

Track the region the method can suspend in, rather than a set of await positions. Each construct contributes the span over which it can yield:

| Form | Suspends | Contributes |
|---|---|---|
| `await expr` | at the expression | the expression |
| `await foreach (...)` | on each iteration, and when the enumerator is disposed | the statement |
| `await using (...) { }` | when the resource is disposed, at the end of the statement | the statement |
| `await using var x = ...;` | when the enclosing block exits | to the end of that block |

The reporting rule is unchanged: a call is redundant when it sits outside that region, so behaviour for ordinary awaits stays as it was.

The last row is why a call after an `await using` declaration is no longer reported. Its disposal runs at the end of the enclosing block, so the call still has an await after it and `ComponentBase` has not rendered yet.

## Tests

Five added to `StateHasChangedAnalyzerTest`:

- three asserting no diagnostic for a call inside `await foreach`, inside an `await using` block, and after an `await using` declaration
- two asserting a call before or after an `await foreach` is still reported

With the analyzer change reverted the three fail and the two pass.

Found while validating #68484.
