### PR TITLE
Fix rewrite map lookups nested in a pattern

### DIFF
--- a/src/Middleware/Rewrite/src/PatternSegments/RewriteMapSegment.cs
+++ b/src/Middleware/Rewrite/src/PatternSegments/RewriteMapSegment.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Text;
 using Microsoft.AspNetCore.Rewrite.IISUrlRewrite;
 
 namespace Microsoft.AspNetCore.Rewrite.PatternSegments;
@@ -18,7 +19,12 @@ internal sealed class RewriteMapSegment : PatternSegment
 
     public override string? Evaluate(RewriteContext context, BackReferenceCollection? ruleBackReferences, BackReferenceCollection? conditionBackReferences)
     {
+        // PERF as we share the string builder across the context, we need to make a new one here to
+        // evaluate the rewrite map key, which may itself contain nested pattern segments.
+        var tempBuilder = context.Builder;
+        context.Builder = new StringBuilder(64);
         var key = _pattern.Evaluate(context, ruleBackReferences, conditionBackReferences).ToLowerInvariant();
+        context.Builder = tempBuilder;
         return _rewriteMap[key];
     }
 }

--- a/src/Middleware/Rewrite/test/IISUrlRewrite/MiddleWareTests.cs
+++ b/src/Middleware/Rewrite/test/IISUrlRewrite/MiddleWareTests.cs
@@ -151,6 +151,51 @@ public class MiddlewareTests
     }
 
     [Fact]
+    // Regression test for https://github.com/dotnet/aspnetcore/issues/24618. A rewrite map lookup
+    // nested inside an action URL (for example {id-map:{C:1}}) must evaluate its key with its own
+    // string builder. Otherwise the key evaluation appends to and clears the shared RewriteContext
+    // builder that the surrounding pattern is still using, so the map lookup misses and the rest of
+    // the action URL is lost.
+    public async Task Invoke_RewriteMapNestedInActionUrlEvaluatesKey()
+    {
+        var options = new RewriteOptions().AddIISUrlRewrite(new StringReader(@"<rewrite>
+                <rules>
+                <rule name=""Rewrite with rewrite map"" stopProcessing=""true"">
+                <match url=""page\.asp$"" />
+                <conditions>
+                <add input=""{QUERY_STRING}"" pattern=""id=([0-9-]+)"" />
+                </conditions>
+                <action type=""Rewrite"" url=""newpage.aspx?id={id-map:{C:1}}"" appendQueryString=""false"" />
+                </rule>
+                </rules>
+                <rewriteMaps>
+                <rewriteMap name=""id-map"" defaultValue="""">
+                <add key=""1234-1234"" value=""abcd-abcd"" />
+                </rewriteMap>
+                </rewriteMaps>
+                </rewrite>"));
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                .UseTestServer()
+                .Configure(app =>
+                {
+                    app.UseRewriter(options);
+                    app.Run(context => context.Response.WriteAsync(context.Request.Path + context.Request.QueryString));
+                });
+            }).Build();
+
+        await host.StartAsync();
+
+        var server = host.GetTestServer();
+
+        var response = await server.CreateClient().GetStringAsync("page.asp?id=1234-1234");
+
+        Assert.Equal("/newpage.aspx?id=abcd-abcd", response);
+    }
+
+    [Fact]
     public async Task Invoke_RedirectToLowerCase()
     {
         var options = new RewriteOptions().AddIISUrlRewrite(new StringReader(@"<rewrite>


### PR DESCRIPTION
### Summary

Fixes #24618. A rewrite map lookup used inside another pattern, such as `{id-map:{C:1}}` in a rule's action URL, does not work: the redirect or rewrite drops the mapped value and the rest of the URL is lost.

`RewriteMapSegment.Evaluate` evaluates its key pattern with the `StringBuilder` shared on `RewriteContext`. Pattern evaluation is recursive in this case, because the map key is itself a pattern, so evaluating the key appends to and then clears the same builder the surrounding pattern is still using. The map lookup then misses, because the computed key is wrong, and the outer pattern's accumulated text is discarded.

`ToLowerSegment`, `UrlDecodeSegment`, and `UrlEncodeSegment` already avoid this by swapping in a fresh builder while they evaluate their inner pattern and restoring it afterward. `RewriteMapSegment` was missing that swap.

### Change

Evaluate the rewrite map key with its own `StringBuilder` and restore the shared one afterward, matching the sibling segments.

### Testing

Added `Invoke_RewriteMapNestedInActionUrlEvaluatesKey` to the IIS URL rewrite middleware tests, using a rewrite map nested in an action URL. It fails without the change (the response is `/?id=1234-1234` instead of `/newpage.aspx?id=abcd-abcd`) and passes with it. The full Rewrite test suite (478 tests) passes on Linux and Windows.
