### PR TITLE
Enable CFG for ARM64X ANCM forwarders

### DIFF
--- a/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/build.cmd
+++ b/src/Installers/Windows/AspNetCoreModule-Setup/Forwarders/build.cmd
@@ -2,18 +2,18 @@ SET objDir=%1
 SET binDir=%2
 SET configuration=%3
 
-cl /nologo /c /Fo%objDir%\aspnetcorev2_arm64.obj empty.cpp
-cl /nologo /c /arm64EC /Fo%objDir%\aspnetcorev2_x64.obj empty.cpp
+cl /nologo /guard:cf /Qspectre /c /Fo%objDir%\aspnetcorev2_arm64.obj empty.cpp
+cl /nologo /guard:cf /Qspectre /c /arm64EC /Fo%objDir%\aspnetcorev2_x64.obj empty.cpp
 
 link /lib /nologo /machine:arm64 /def:aspnetcorev2_arm64.def /out:%objDir%\aspnetcorev2_arm64.lib
 link /lib /nologo /machine:x64 /def:aspnetcorev2_x64.def /out:%objDir%\aspnetcorev2_x64.lib
 
-link /dll /nologo /noentry /machine:arm64x /defArm64Native:aspnetcorev2_arm64.def /def:aspnetcorev2_x64.def %objDir%\aspnetcorev2_arm64.obj %objDir%\aspnetcorev2_x64.obj %objDir%\..\AspNetCoreModuleShim\x64\%configuration%\aspnetcoremodule.res /out:%binDir%\aspnetcorev2.dll %objDir%\aspnetcorev2_arm64.lib %objDir%\aspnetcorev2_x64.lib
+link /dll /nologo /noentry /guard:cf /dynamicbase /machine:arm64x /defArm64Native:aspnetcorev2_arm64.def /def:aspnetcorev2_x64.def %objDir%\aspnetcorev2_arm64.obj %objDir%\aspnetcorev2_x64.obj %objDir%\..\AspNetCoreModuleShim\x64\%configuration%\aspnetcoremodule.res /out:%binDir%\aspnetcorev2.dll %objDir%\aspnetcorev2_arm64.lib %objDir%\aspnetcorev2_x64.lib
 
-cl /nologo /nologo /c /Fo%objDir%\aspnetcorev2_outofprocess_arm64.obj empty.cpp
-cl /nologo /nologo /c /arm64EC /Fo%objDir%\aspnetcorev2_outofprocess_x64.obj empty.cpp
+cl /nologo /guard:cf /Qspectre /c /Fo%objDir%\aspnetcorev2_outofprocess_arm64.obj empty.cpp
+cl /nologo /guard:cf /Qspectre /c /arm64EC /Fo%objDir%\aspnetcorev2_outofprocess_x64.obj empty.cpp
 
 link /lib /nologo /machine:arm64 /def:aspnetcorev2_outofprocess_arm64.def /out:%objDir%\aspnetcorev2_outofprocess_arm64.lib
 link /lib /nologo /machine:x64 /def:aspnetcorev2_outofprocess_x64.def /out:%objDir%\aspnetcorev2_outofprocess_x64.lib
 
-link /dll /nologo /noentry /machine:arm64x /defArm64Native:aspnetcorev2_outofprocess_arm64.def /def:aspnetcorev2_outofprocess_x64.def %objDir%\aspnetcorev2_outofprocess_arm64.obj %objDir%\aspnetcorev2_outofprocess_x64.obj %objDir%\..\OutOfProcessRequestHandler\x64\%configuration%\outofprocessrequesthandler.res /out:%binDir%\aspnetcorev2_outofprocess.dll %objDir%\aspnetcorev2_outofprocess_arm64.lib %objDir%\aspnetcorev2_outofprocess_x64.lib
+link /dll /nologo /noentry /guard:cf /dynamicbase /machine:arm64x /defArm64Native:aspnetcorev2_outofprocess_arm64.def /def:aspnetcorev2_outofprocess_x64.def %objDir%\aspnetcorev2_outofprocess_arm64.obj %objDir%\aspnetcorev2_outofprocess_x64.obj %objDir%\..\OutOfProcessRequestHandler\x64\%configuration%\outofprocessrequesthandler.res /out:%binDir%\aspnetcorev2_outofprocess.dll %objDir%\aspnetcorev2_outofprocess_arm64.lib %objDir%\aspnetcorev2_outofprocess_x64.lib


### PR DESCRIPTION
## Description

The ARM64X ANCM forwarders are built using direct `cl` and `link` invocations, so the native mitigation settings imported by `build.proj` are not applied to them. This was missed in https://github.com/dotnet/aspnetcore/pull/63437 / https://github.com/dotnet/aspnetcore/pull/63725

Pass `/guard:cf` and `/Qspectre` to the ARM64 and ARM64EC compiler invocations, and pass `/guard:cf` and `/dynamicbase` to the final ARM64X linker invocations. This enables Control Flow Guard on both forwarder DLLs.

Validated with the VS 18 ARM64 toolchain. `dumpbin /headers /loadconfig` reports the `Control Flow Guard` DLL characteristic, `CF instrumented`, and an FID table containing two targets for both generated forwarders.

Addresses https://github.com/dotnet/dotnet/issues/8565.