### PR TITLE
[Blazor] Re-derive Virtualize at-bottom state when the anchor mode changes

### DIFF
--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -716,7 +716,18 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
     scrollElement,
     startConvergenceObserving,
     isFollowingBottom: () => bottomTracking.following,
-    setAnchorMode: (mode: number) => { anchorMode = mode; bottomTracking.following = (mode & 2) !== 0; bottomTracking.reached = isViewportAtBottom(); },
+    setAnchorMode: (mode: number) => {
+      anchorMode = mode;
+      // Re-derive the whole at-bottom state from the live viewport. `wasAtBottomLastRender`
+      // is otherwise only refreshed by a render or a user scroll, so a list that was briefly
+      // shorter than its container (an empty first render, or an async ItemsProvider round
+      // trip) leaves it latched. Switching into End mode would then pin the viewport to the
+      // bottom even though the user is parked at the top.
+      const atBottom = isViewportAtBottom();
+      bottomTracking.following = (mode & 2) !== 0;
+      bottomTracking.reached = atBottom;
+      bottomTracking.wasAtBottomLastRender = atBottom;
+    },
     restoreAnchor: restoreAnchorForShift,
     alignToItem: alignToItemAt,
     beginProgrammaticScroll: beginProgrammaticScroll,

--- a/src/Components/Web.JS/test/VirtualizeEndAnchorLatch.test.ts
+++ b/src/Components/Web.JS/test/VirtualizeEndAnchorLatch.test.ts
@@ -1,0 +1,146 @@
+import { expect, test, describe, beforeEach } from '@jest/globals';
+import { Virtualize } from '../src/Virtualize';
+
+// Reproduces the `QuickGrid_AnchorMode_End_PrependAtTop_ViewportStaysStable` E2E failure:
+// switching into AnchorMode.End while the viewport is at the top must not jump to the bottom,
+// even if the list was momentarily shorter than the viewport while an async ItemsProvider
+// was in flight.
+
+function rect(top: number, height: number) {
+  return {
+    top, height, bottom: top + height, left: 0, right: 0, width: 100, x: 0, y: top,
+    toJSON() { return this; },
+  };
+}
+
+function stubGlobals() {
+  (global as any).CSS = { supports: () => true };
+
+  (global as any).IntersectionObserver = class {
+    observe() { /* no-op */ }
+    unobserve() { /* no-op */ }
+    disconnect() { /* no-op */ }
+    takeRecords() { return []; }
+  };
+
+  (global as any).ResizeObserver = class {
+    observe() { /* no-op */ }
+    unobserve() { /* no-op */ }
+    disconnect() { /* no-op */ }
+  };
+
+  (global as any).MutationObserver = class {
+    observe() { /* no-op */ }
+    disconnect() { /* no-op */ }
+    takeRecords() { return []; }
+  };
+
+  (global as any).Range.prototype.getBoundingClientRect = () => rect(0, 0);
+  (global as any).Range.prototype.getClientRects = () => [];
+
+  (global as any).getComputedStyle = (el: Element) => ({
+    overflowY: (el as HTMLElement).style.overflowY || 'visible',
+  });
+}
+
+const CLIENT_HEIGHT = 300;
+const LOADED_SCROLL_HEIGHT = 55078;
+
+function buildDom() {
+  document.body.innerHTML = '';
+
+  const container = document.createElement('div');
+  container.id = 'qg-anchor-container';
+  container.style.overflowY = 'auto';
+
+  const before = document.createElement('div');
+  container.appendChild(before);
+
+  const items: HTMLElement[] = [];
+  for (let i = 0; i < 6; i++) {
+    const item = document.createElement('div');
+    item.className = 'item';
+    container.appendChild(item);
+    items.push(item);
+  }
+
+  const after = document.createElement('div');
+  container.appendChild(after);
+  document.body.appendChild(container);
+
+  // Mutable geometry so the test can model "provider in flight" vs "data loaded".
+  const geometry = { scrollHeight: LOADED_SCROLL_HEIGHT, beforeHeight: 0, afterHeight: 54000 };
+
+  Object.defineProperty(container, 'clientHeight', { get: () => CLIENT_HEIGHT, configurable: true });
+  Object.defineProperty(container, 'scrollHeight', { get: () => geometry.scrollHeight, configurable: true });
+  Object.defineProperty(container, 'clientTop', { value: 0, configurable: true });
+  container.getBoundingClientRect = () => rect(0, CLIENT_HEIGHT) as any;
+
+  Object.defineProperty(before, 'offsetHeight', { get: () => geometry.beforeHeight, configurable: true });
+  Object.defineProperty(after, 'offsetHeight', { get: () => geometry.afterHeight, configurable: true });
+  before.getBoundingClientRect = () => rect(0, geometry.beforeHeight) as any;
+  after.getBoundingClientRect = () => rect(CLIENT_HEIGHT, geometry.afterHeight) as any;
+  items.forEach((item, i) => {
+    item.getBoundingClientRect = () => rect(geometry.beforeHeight + i * 50, 50) as any;
+  });
+
+  return { container, before, after, geometry };
+}
+
+function createDotNetHelper(): any {
+  return { _callDispatcher: {}, _id: 1, invokeMethodAsync: () => Promise.resolve() };
+}
+
+const AnchorMode = { None: 0, Start: 1, End: 2 };
+
+describe('Virtualize End anchor mode', () => {
+  beforeEach(() => {
+    stubGlobals();
+  });
+
+  test('switching into End mode at the top does not jump to the bottom after a transient short list', () => {
+    const { container, before, after, geometry } = buildDom();
+    const helper = createDotNetHelper();
+
+    Virtualize.init(helper, before, after, AnchorMode.None);
+
+    // Data is loaded, user is at the top of a long list.
+    container.scrollTop = 0;
+    Virtualize.refreshObservers(helper, false);
+
+    // An async ItemsProvider round-trip momentarily leaves nothing rendered, so the
+    // container is not scrollable for one render.
+    geometry.scrollHeight = CLIENT_HEIGHT;
+    geometry.afterHeight = 0;
+    Virtualize.refreshObservers(helper, true);
+
+    // The provider resolves; the list is long again and the viewport is still at the top.
+    geometry.scrollHeight = LOADED_SCROLL_HEIGHT;
+    geometry.afterHeight = 54000;
+    container.scrollTop = 0;
+
+    // The user selects AnchorMode.End while parked at the top.
+    Virtualize.setAnchorMode(helper, AnchorMode.End);
+    Virtualize.refreshObservers(helper, false);
+
+    expect(container.scrollTop).toBe(0);
+  });
+
+  test('End mode still follows appends once the viewport has actually reached the bottom', () => {
+    const { container, before, after, geometry } = buildDom();
+    const helper = createDotNetHelper();
+
+    Virtualize.init(helper, before, after, AnchorMode.End);
+
+    // User scrolls to the bottom of the loaded list.
+    container.scrollTop = LOADED_SCROLL_HEIGHT - CLIENT_HEIGHT;
+    container.dispatchEvent(new Event('scroll'));
+    Virtualize.refreshObservers(helper, false);
+
+    // New items are appended.
+    geometry.scrollHeight = LOADED_SCROLL_HEIGHT + 500;
+    Virtualize.refreshObservers(helper, false);
+
+    expect(container.scrollTop).toBe(geometry.scrollHeight);
+  });
+});

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -2332,6 +2332,7 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/68730")]
     public void QuickGrid_AnchorMode_End_PrependAtTop_ViewportStaysStable(bool useItemsProvider)
     {
         MountQuickGridAnchorModeComponent("2", useItemsProvider, delay: useItemsProvider);

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -2332,7 +2332,6 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/68730")]
     public void QuickGrid_AnchorMode_End_PrependAtTop_ViewportStaysStable(bool useItemsProvider)
     {
         MountQuickGridAnchorModeComponent("2", useItemsProvider, delay: useItemsProvider);


### PR DESCRIPTION
**Draft.** This fixes a real state-machine defect, but I can no longer claim it is the cause of the CI flake it was written for. See "What this does not establish" below. The `[QuarantinedTest]` attribute is intentionally left in place.

## Observed failure

`VirtualizationTest.QuickGrid_AnchorMode_End_PrependAtTop_ViewportStaysStable` failed 3 times in ~28 days on `main`, always as `ServerVirtualizationTest` on the Mono E2E leg with `useItemsProvider: True`:

```
Scroll assertion failed: expected QuickGrid should start at the top,
but scrollTop=54778, scrollHeight=55078, clientHeight=300, maxScrollTop=54778
```

`scrollTop == maxScrollTop`, byte-identical across all three failures. The test never scrolls, so something re-pinned the viewport to the bottom.

## The defect this fixes

`isViewportAtBottom()` reports true for any container that is not yet scrollable:

```ts
const isViewportAtBottom = (): boolean =>
  scrollElement.scrollHeight <= scrollElement.clientHeight
  || Math.abs(scrollElement.scrollTop + scrollElement.clientHeight - scrollElement.scrollHeight) < 2;
```

The End re-pin guard in `refreshObservedElements` consumes `bottomTracking.wasAtBottomLastRender`, which is captured by `updateAnchorSnapshot()` at the *end* of the previous render — so the guard always acts on the previous render's geometry:

```ts
if ((anchorModeIs.end || bottomTracking.following) && (bottomTracking.wasAtBottomLastRender || bottomTracking.reached)) {
  scrollElement.scrollTop = scrollElement.scrollHeight;
```

`setAnchorMode` refreshed `following` and `reached` but left `wasAtBottomLastRender` untouched:

```ts
setAnchorMode: (mode) => { anchorMode = mode; bottomTracking.following = (mode & 2) !== 0; bottomTracking.reached = isViewportAtBottom(); },
```

So if the last render before an anchor-mode change happened while the container was not scrollable, switching into End mode re-pins to the bottom on the next render even though the viewport is at the top. This change re-derives all three flags from the live viewport, mirroring what the user-scroll path already does, and matching the existing reasoning in `restoreAnchorForShift` (*"Don't rely on the cached `wasAtBottomLastRender` — it may be stale"*).

## What this does not establish

I originally presented the above as the root cause of the CI failure. That was overstated, and two specific claims in the earlier description were wrong:

1. I wrote that `wasAtBottomLastRender` "is only reset by a user scroll". **That is false.** It is reassigned by `updateAnchorSnapshot()` on every render. The stale window is one render wide, not unbounded.

2. I implied the async `ItemsProvider` round trip leaves the container non-scrollable. `Virtualize.cs` keeps previously loaded items rendered while `_loading` is true and emits placeholders, so the container does not generally collapse after the first load. The mount helper also waits for rendered rows before selecting the anchor mode.

More importantly, this fix does **not** close the general case. I probed two other orderings; both still re-pin to the bottom with this change applied:

- **A** — already in End mode, one non-scrollable render, then a tall render. `setAnchorMode` is never called, so the fix cannot help.
- **B** — `setAnchorMode(End)` first, *then* a non-scrollable render, then a tall render. `updateAnchorSnapshot()` re-latches the flag after the fix has run.

Ordering B is at least as plausible as the one this fixes, since changing the anchor mode itself triggers a re-render. The real fix likely needs `updateAnchorSnapshot()` to stop treating a non-scrollable render as evidence of "at bottom" when the content is incomplete — while still allowing it for a genuinely short, fully-loaded list, where End mode should follow appends. `refreshObservedElements` already receives `isLoading` (from `_loading` in `Virtualize.cs:513`), so that signal is available.

I have not captured the DOM at failure time, so I cannot say which ordering CI actually hit.

## Testing

`Virtualize.test.ts` was a 13-line export smoke test, so none of this state machine was covered. `VirtualizeEndAnchorLatch.test.ts` adds:

- `switching into End mode at the top does not jump to the bottom after a transient short list` — fails without the fix, passes with it.
- `End mode still follows appends once the viewport has actually reached the bottom` — passes both ways, so the first is not vacuous.

Caveat on fidelity: the first test was constructed from reading the state machine, not from an observed failure DOM, and it deliberately mutates geometry without an intervening render so that `setAnchorMode` is the deciding step. It demonstrates the state-coherence bug; it should not be read as reproducing the CI failure.

The focused Virtualize suites pass. The broader `Web.JS` run is not a clean signal: 5 suites fail to load with pre-existing `Cannot find module '@microsoft/signalr'` resolution errors, identical with and without this change. `eslint` on `Virtualize.ts` goes from 40 to 38 reported problems.

## Next steps before this leaves draft

- Build a deterministic E2E repro using the existing provider gate (`qg-toggle-provider-gate` / `qg-release-provider-gate`) to pin down the actual ordering, capturing item count, spacer heights, `scrollHeight`, loading state and mode at each stage.
- Extend the fix to the general case if that repro confirms it.
- Only then re-enable the test.

## Related

- #68691 also edits `Virtualize.ts` substantially.
- Separate defect, still open: the `InitialItemIndex` near-end failure (#68724). #68709 reduced its failure rate to 2/4 and was closed in favour of #68691.
- `QuickGrid_AnchorMode_End_AppendAfterLeavingBottom_DoesNotReengage` has live failures on `main` and is not quarantined; it shares the async-provider/Server/Mono signature and may share a cause with this.
