### PR TITLE
Fix Virtualize window anchoring after top prepends.

### DIFF
--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -823,7 +823,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
       const rect = el.getBoundingClientRect();
       if (rect.bottom > containerTop) {
         const existing = observersByDotNetObjectId[id].anchorSnapshot;
-        const nativeAnchoringUnavailable = !useNativeAnchoring || (scrollContainer !== null && isAtScrollTop());
+        const nativeAnchoringUnavailable = !useNativeAnchoring || isAtScrollTop();
         // Keep the pre-shift snapshot for None/End modes, and for Start modes that are not actively
         // converging to the top (during top convergence the viewport is repositioned instead).
         const modePinsTopItem = !anchorModeIs.beginning || !convergence.top;

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -4824,7 +4824,6 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     [InlineData(true, false)]
     [InlineData(false, true)]
     [InlineData(true, true)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/68732")]
     public void AnchorMode_WindowScroll_End_PrependAtTop_ViewportStaysStable(bool variableHeight, bool useItemsProvider)
     {
         MountWindowScrollAnchorModeComponent("2", variableHeight, useItemsProvider, delay: useItemsProvider);


### PR DESCRIPTION
Native scroll anchoring is suppressed at scroll position zero for both nested containers and the document scroller. Preserve the pre-shift snapshot for window-scroll scenarios at the top so anchor restoration can compensate after asynchronous prepends.

Fixes https://github.com/dotnet/aspnetcore/issues/68732.