### PR TITLE
Clarify form limits for multipart requests

### DIFF
--- a/src/Http/Http.Abstractions/src/Metadata/IFormOptionsMetadata.cs
+++ b/src/Http/Http.Abstractions/src/Metadata/IFormOptionsMetadata.cs
@@ -34,6 +34,9 @@ public interface IFormOptionsMetadata
     /// <summary>
     /// A limit on the length of individual keys. Forms containing keys that
     /// exceed this limit will throw an InvalidDataException when parsed.
+    /// This limit applies only to forms with an <c>application/x-www-form-urlencoded</c>
+    /// content type. For forms with a <c>multipart/form-data</c> content type,
+    /// the length of a key is limited by <see cref="MultipartHeadersLengthLimit"/>.
     /// Defaults to 2,048 bytes, which is approximately 2KB.
     /// </summary>
     int? KeyLengthLimit { get; }
@@ -41,7 +44,10 @@ public interface IFormOptionsMetadata
     /// <summary>
     /// A limit on the length of individual form values. Forms containing
     /// values that exceed this limit will throw an InvalidDataException
-    /// when parsed. Defaults to 4,194,304 bytes, which is approximately 4MB.
+    /// when parsed. This limit applies only to forms with an
+    /// <c>application/x-www-form-urlencoded</c> content type. For forms with a
+    /// <c>multipart/form-data</c> content type, use <see cref="MultipartBodyLengthLimit"/>.
+    /// Defaults to 4,194,304 bytes, which is approximately 4MB.
     /// </summary>
     int? ValueLengthLimit { get; }
 

--- a/src/Http/Http/src/Features/FormOptions.cs
+++ b/src/Http/Http/src/Features/FormOptions.cs
@@ -67,6 +67,9 @@ public class FormOptions
     /// <summary>
     /// A limit on the length of individual keys. Forms containing keys that exceed this limit will
     /// throw an <see cref="InvalidDataException"/> when parsed.
+    /// This limit applies only to forms with an <c>application/x-www-form-urlencoded</c> content type.
+    /// For forms with a <c>multipart/form-data</c> content type, the length of a key is limited by
+    /// <see cref="MultipartHeadersLengthLimit"/>.
     /// Defaults to 2,048 bytes, which is approximately 2KB.
     /// </summary>
     public int KeyLengthLimit { get; set; } = FormReader.DefaultKeyLengthLimit;
@@ -74,6 +77,8 @@ public class FormOptions
     /// <summary>
     /// A limit on the length of individual form values. Forms containing values that exceed this
     /// limit will throw an <see cref="InvalidDataException"/> when parsed.
+    /// This limit applies only to forms with an <c>application/x-www-form-urlencoded</c> content type.
+    /// For forms with a <c>multipart/form-data</c> content type, use <see cref="MultipartBodyLengthLimit"/>.
     /// Defaults to 4,194,304 bytes, which is approximately 4MB.
     /// </summary>
     public int ValueLengthLimit { get; set; } = FormReader.DefaultValueLengthLimit;

--- a/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
+++ b/src/Http/Routing/src/Builder/RoutingEndpointConventionBuilderExtensions.cs
@@ -207,8 +207,8 @@ public static class RoutingEndpointConventionBuilderExtensions
     /// <param name="memoryBufferThreshold">Configures how many bytes of the body will be buffered in memory. Defaults to 65,536 bytes, which is approximately 64KB.</param>
     /// <param name="bufferBodyLengthLimit">Limit for the total number of bytes that will be buffered. Defaults to 128MB.</param>
     /// <param name="valueCountLimit">Limit for the number of form entries to allow. Defaults to <see cref="FormReader.DefaultValueCountLimit"/>.</param>
-    /// <param name="keyLengthLimit">Limit on the length of individual keys. Defaults to <see cref="FormReader.DefaultKeyLengthLimit"/>.</param>
-    /// <param name="valueLengthLimit">Limit on the length of individual form values. Defaults to <see cref="FormReader.DefaultValueLengthLimit"/>.</param>
+    /// <param name="keyLengthLimit">Limit on the length of individual keys for <c>application/x-www-form-urlencoded</c> forms. For <c>multipart/form-data</c> forms, the length of a key is limited by <paramref name="multipartHeadersLengthLimit"/>. Defaults to <see cref="FormReader.DefaultKeyLengthLimit"/>.</param>
+    /// <param name="valueLengthLimit">Limit on the length of individual form values for <c>application/x-www-form-urlencoded</c> forms. For <c>multipart/form-data</c> forms, use <paramref name="multipartBodyLengthLimit"/>. Defaults to <see cref="FormReader.DefaultValueLengthLimit"/>.</param>
     /// <param name="multipartBoundaryLengthLimit">Limit for the length of the boundary identifier. Defaults to 128 bytes.</param>
     /// <param name="multipartHeadersCountLimit">Limit for the number of headers to allow in each multipart section. Defaults to <see cref="MultipartReader.DefaultHeadersCountLimit"/>.</param>
     /// <param name="multipartHeadersLengthLimit">Limit for the total length of the header keys and values in each multipart section. Defaults to <see cref="MultipartReader.DefaultHeadersLengthLimit"/>.</param>

--- a/src/Mvc/Mvc.Core/src/RequestFormLimitsAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/RequestFormLimitsAttribute.cs
@@ -91,6 +91,9 @@ public class RequestFormLimitsAttribute : Attribute, IFilterFactory, IOrderedFil
     /// <summary>
     /// A limit on the length of individual keys. Forms containing keys that exceed this limit will
     /// throw an <see cref="InvalidDataException"/> when parsed.
+    /// This limit applies only to forms with an <c>application/x-www-form-urlencoded</c> content type.
+    /// For forms with a <c>multipart/form-data</c> content type, the length of a key is limited by
+    /// <see cref="MultipartHeadersLengthLimit"/>.
     /// </summary>
     public int KeyLengthLimit
     {
@@ -103,6 +106,8 @@ public class RequestFormLimitsAttribute : Attribute, IFilterFactory, IOrderedFil
     /// <summary>
     /// A limit on the length of individual form values. Forms containing values that exceed this
     /// limit will throw an <see cref="InvalidDataException"/> when parsed.
+    /// This limit applies only to forms with an <c>application/x-www-form-urlencoded</c> content type.
+    /// For forms with a <c>multipart/form-data</c> content type, use <see cref="MultipartBodyLengthLimit"/>.
     /// </summary>
     public int ValueLengthLimit
     {


### PR DESCRIPTION
## Summary

- clarify that `KeyLengthLimit` and `ValueLengthLimit` apply to `application/x-www-form-urlencoded` forms
- direct multipart callers to `MultipartHeadersLengthLimit` and `MultipartBodyLengthLimit`
- update `FormOptions`, `IFormOptionsMetadata`, `RequestFormLimitsAttribute`, and `WithFormOptions` consistently

## Testing

- built the four affected assemblies successfully