### PR TITLE
Disallow synchronous IIS response flushes

### DIFF
--- a/src/Servers/IIS/IIS/src/Core/HttpResponseStream.cs
+++ b/src/Servers/IIS/IIS/src/Core/HttpResponseStream.cs
@@ -20,6 +20,11 @@ internal sealed class HttpResponseStream : WriteOnlyStreamInternal
 
     public override void Flush()
     {
+        if (!_bodyControl.AllowSynchronousIO)
+        {
+            throw new InvalidOperationException(CoreStrings.SynchronousWritesDisallowed);
+        }
+
         FlushAsync(default).GetAwaiter().GetResult();
     }
 

--- a/src/Servers/IIS/IIS/test/IIS.Tests/HttpBodyControlFeatureTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/HttpBodyControlFeatureTests.cs
@@ -14,10 +14,11 @@ namespace Microsoft.AspNetCore.Server.IIS.FunctionalTests;
 public class HttpBodyControlFeatureTests : StrictTestServerTests
 {
     [ConditionalFact]
-    public async Task ThrowsOnSyncReadOrWrite()
+    public async Task ThrowsOnSyncReadWriteOrFlush()
     {
         Exception writeException = null;
         Exception readException = null;
+        Exception flushException = null;
         using (var testServer = await TestServer.Create(
             ctx =>
             {
@@ -42,6 +43,15 @@ public class HttpBodyControlFeatureTests : StrictTestServerTests
                     readException = ex;
                 }
 
+                try
+                {
+                    ctx.Response.Body.Flush();
+                }
+                catch (Exception ex)
+                {
+                    flushException = ex;
+                }
+
                 return Task.CompletedTask;
             }, LoggerFactory))
         {
@@ -50,5 +60,25 @@ public class HttpBodyControlFeatureTests : StrictTestServerTests
 
         Assert.IsType<InvalidOperationException>(readException);
         Assert.IsType<InvalidOperationException>(writeException);
+        Assert.IsType<InvalidOperationException>(flushException);
+    }
+
+    [ConditionalFact]
+    public async Task AllowsSyncFlushWhenEnabled()
+    {
+        using (var testServer = await TestServer.Create(
+            ctx =>
+            {
+                var bodyControl = ctx.Features.Get<IHttpBodyControlFeature>();
+                Assert.False(bodyControl.AllowSynchronousIO);
+                bodyControl.AllowSynchronousIO = true;
+
+                ctx.Response.Body.Flush();
+
+                return Task.CompletedTask;
+            }, LoggerFactory))
+        {
+            await testServer.HttpClient.GetStringAsync("/");
+        }
     }
 }

--- a/src/Servers/IIS/IIS/test/IIS.Tests/HttpResponseStreamTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/HttpResponseStreamTests.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.IIS;
+using Microsoft.AspNetCore.Server.IIS.Core;
+using Moq;
+using Xunit;
+
+namespace IIS.Tests;
+
+public class HttpResponseStreamTests
+{
+    [Fact]
+    public void FlushThrowsIfSynchronousIOIsDisallowed()
+    {
+        var bodyControl = new Mock<IHttpBodyControlFeature>(MockBehavior.Strict);
+        bodyControl.SetupGet(feature => feature.AllowSynchronousIO).Returns(false);
+        var stream = new HttpResponseStream(bodyControl.Object, context: null!);
+
+        var exception = Assert.Throws<InvalidOperationException>(stream.Flush);
+
+        Assert.Equal(CoreStrings.SynchronousWritesDisallowed, exception.Message);
+    }
+}

--- a/src/Servers/IIS/IIS/test/IIS.Tests/HttpUpgradeStreamTests.cs
+++ b/src/Servers/IIS/IIS/test/IIS.Tests/HttpUpgradeStreamTests.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.IIS;
+using Microsoft.AspNetCore.Server.IIS.Core;
+using Moq;
+using Xunit;
+
+namespace IIS.Tests;
+
+public class HttpUpgradeStreamTests
+{
+    [Fact]
+    public void FlushThrowsIfSynchronousIOIsDisallowed()
+    {
+        var bodyControl = new Mock<IHttpBodyControlFeature>(MockBehavior.Strict);
+        bodyControl.SetupGet(feature => feature.AllowSynchronousIO).Returns(false);
+        var responseStream = new HttpResponseStream(bodyControl.Object, context: null!);
+        var stream = new HttpUpgradeStream(Stream.Null, responseStream);
+
+        var exception = Assert.Throws<InvalidOperationException>(stream.Flush);
+
+        Assert.Equal(CoreStrings.SynchronousWritesDisallowed, exception.Message);
+    }
+}


### PR DESCRIPTION
# Disallow synchronous IIS response flushes

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Honor AllowSynchronousIO when flushing IIS responses

## Description

IIS `HttpResponseStream.Flush()` did not check `IHttpBodyControlFeature.AllowSynchronousIO`, even though synchronous writes do and the behavior described in #7644 includes `Stream.Flush`.

This adds the same guard used by `Write()`, preserving `FlushAsync()` and explicit per-request opt-in behavior. `HttpUpgradeStream.Flush()` delegates to `HttpResponseStream.Flush()`, so upgraded connections inherit the check without a duplicate guard. Stream-level regression tests cover both direct and upgraded response streams, and IIS in-process tests cover the default disallowed setting and opt-in behavior.

Related to #7644