### PR TITLE
Reject authentication schemes on SignalR hub methods

### DIFF
--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -791,6 +791,20 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
         return authorizationResult.Succeeded;
     }
 
+    private static void EnsureNoAuthenticationSchemeSpecified(IReadOnlyList<object> authorizationMetadata)
+    {
+        // It's not meaningful to specify a nonempty scheme, since by the time hub method
+        // authorization runs, the connection already has a specific ClaimsPrincipal (we're stateful).
+        // To avoid any confusion, ensure the developer isn't trying to specify a scheme.
+        for (var i = 0; i < authorizationMetadata.Count; i++)
+        {
+            if (authorizationMetadata[i] is IAuthorizeData entry && !string.IsNullOrEmpty(entry.AuthenticationSchemes))
+            {
+                throw new NotSupportedException($"The authorization data specifies an authentication scheme with value '{entry.AuthenticationSchemes}'. Authentication schemes cannot be specified for hub methods.");
+            }
+        }
+    }
+
     private async Task<bool> ValidateInvocationMode(HubMethodDescriptor hubMethodDescriptor, bool isStreamResponse,
         HubMethodInvocationMessage hubMethodInvocationMessage, HubConnectionContext connection)
     {
@@ -914,6 +928,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
                 : ObjectMethodExecutor.CreateTrimAotCompatible(methodInfo, hubTypeInfo);
 
             var authorizationMetadata = methodInfo.GetCustomAttributes(inherit: true);
+            EnsureNoAuthenticationSchemeSpecified(authorizationMetadata);
             _methods[methodName] = new HubMethodDescriptor(executor, serviceProviderIsService, authorizationMetadata);
             _cachedMethodNames.Add(methodName);
 

--- a/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTestUtils/Hubs.cs
+++ b/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTestUtils/Hubs.cs
@@ -681,6 +681,22 @@ public class GenericMethodHub : Hub
     }
 }
 
+[Authorize(AuthenticationSchemes = "test scheme")]
+public class HubWithAuthenticationScheme : Hub
+{
+    public void Method()
+    {
+    }
+}
+
+public class HubWithMethodAuthenticationScheme : Hub
+{
+    [Authorize(AuthenticationSchemes = "test scheme")]
+    public void Method()
+    {
+    }
+}
+
 public class DisposeTrackingHub : TestHub
 {
     private readonly TrackDispose _trackDispose;

--- a/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
+++ b/src/SignalR/server/SignalR/test/Microsoft.AspNetCore.SignalR.Tests/HubConnectionHandlerTests.cs
@@ -2259,6 +2259,34 @@ public partial class HubConnectionHandlerTests : VerifiableLoggedTest
     }
 
     [Fact]
+    public void HubAuthorizationAllowsNonemptyAuthenticationScheme()
+    {
+        using (StartVerifiableLog())
+        {
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(null, LoggerFactory);
+
+            Assert.NotNull(serviceProvider.GetService<HubConnectionHandler<HubWithAuthenticationScheme>>());
+        }
+    }
+
+    [Fact]
+    public void HubMethodAuthorizationRejectsNonemptyAuthenticationScheme()
+    {
+        using (StartVerifiableLog())
+        {
+            var serviceProvider = HubConnectionHandlerTestUtils.CreateServiceProvider(null, LoggerFactory);
+
+            var exception = Assert.Throws<NotSupportedException>(
+                () => serviceProvider.GetService<HubConnectionHandler<HubWithMethodAuthenticationScheme>>());
+
+            Assert.Equal(
+                "The authorization data specifies an authentication scheme with value 'test scheme'. " +
+                "Authentication schemes cannot be specified for hub methods.",
+                exception.Message);
+        }
+    }
+
+    [Fact]
     public async Task UnauthorizedConnectionCannotInvokeHubMethodWithRequirementDataAuthorization()
     {
         using (StartVerifiableLog())


### PR DESCRIPTION
# Reject authentication schemes on SignalR hub methods

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue. N/A for this follow-up.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Reject unsupported schemes on SignalR hub methods

## Description

SignalR hub method authorization runs against the principal already established for the stateful connection, so a method-level authentication scheme cannot select or re-authenticate a principal and was silently ignored.

This change rejects nonempty `AuthenticationSchemes` on hub methods during hub discovery with a clear `NotSupportedException`. Authentication schemes remain supported on hub classes, where endpoint authorization can apply them. Tests cover both the supported class-level case and rejected method-level case.

Stole this change from Components: https://github.com/dotnet/aspnetcore/blob/d013315aeca63d9ade8a0e70f7d28b64582b6346/src/Components/Authorization/src/AuthorizeViewCore.cs#L126