### PR TITLE
Delete the nonce cookie when the OIDC callback returns an error

### DIFF
--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -455,6 +455,12 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
         {
             message.Nonce = Options.ProtocolValidator.GenerateNonce();
             WriteNonceCookie(message.Nonce);
+
+            // Remember the nonce in the protected state so the matching nonce cookie can still be
+            // deleted when the authorization response comes back as an error. Error responses carry
+            // no id_token, which is what ReadNonceCookie normally uses to locate the cookie.
+            // See https://github.com/dotnet/aspnetcore/issues/53048.
+            properties.Items[NonceProperty] = message.Nonce;
         }
 
         GenerateCorrelationId(properties);
@@ -734,9 +740,28 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
                 return HandleRequestResult.Fail("Correlation failed.", properties);
             }
 
+            // Recover the nonce stored in the protected state during the challenge and drop it from
+            // the properties so it never flows into the authentication ticket. It is only needed to
+            // clean up the nonce cookie on error responses below.
+            string? challengeNonce = null;
+            if (properties.Items.TryGetValue(NonceProperty, out var storedNonce))
+            {
+                properties.Items.Remove(NonceProperty);
+                challengeNonce = storedNonce;
+            }
+
             // if any of the error fields are set, throw error null
             if (!string.IsNullOrEmpty(authorizationResponse.Error))
             {
+                // An error response carries no id_token or code, so ReadNonceCookie cannot match the
+                // cookie against a returned nonce. Delete the specific nonce cookie recorded in the
+                // state instead, otherwise repeated failed sign-ins leave nonce cookies behind until
+                // they expire. See https://github.com/dotnet/aspnetcore/issues/53048.
+                if (!string.IsNullOrEmpty(challengeNonce))
+                {
+                    ReadNonceCookie(challengeNonce);
+                }
+
                 // Note: access_denied errors are special protocol errors indicating the user didn't
                 // approve the authorization demand requested by the remote authorization server.
                 // Since it's a frequent scenario (that is not caused by incorrect configuration),

--- a/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
+++ b/src/Security/Authentication/OpenIdConnect/src/OpenIdConnectHandler.cs
@@ -742,13 +742,8 @@ public class OpenIdConnectHandler : RemoteAuthenticationHandler<OpenIdConnectOpt
 
             // Recover the nonce stored in the protected state during the challenge and drop it from
             // the properties so it never flows into the authentication ticket. It is only needed to
-            // clean up the nonce cookie on error responses below.
-            string? challengeNonce = null;
-            if (properties.Items.TryGetValue(NonceProperty, out var storedNonce))
-            {
-                properties.Items.Remove(NonceProperty);
-                challengeNonce = storedNonce;
-            }
+            // clean up the nonce cookie on error responses below, and stays null when absent.
+            properties.Items.Remove(NonceProperty, out var challengeNonce);
 
             // if any of the error fields are set, throw error null
             if (!string.IsNullOrEmpty(authorizationResponse.Error))

--- a/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectAuthenticateTests.cs
+++ b/src/Security/Authentication/test/OpenIdConnect/OpenIdConnectAuthenticateTests.cs
@@ -100,6 +100,49 @@ public class OpenIdConnectAuthenticateTests
         Assert.StartsWith("/error?FailureMessage=", transaction.Response.Headers.GetValues("Location").First());
     }
 
+    [Fact]
+    // Regression test for https://github.com/dotnet/aspnetcore/issues/53048. An error response
+    // (for example prompt=none returning error=login_required) must still delete the nonce and
+    // correlation cookies for that flow, otherwise they accumulate on repeated failed sign-ins
+    // until the request headers grow too large.
+    public async Task ErrorResponseDeletesNonceAndCorrelationCookies()
+    {
+        var settings = new TestSettings(
+            opt =>
+            {
+                opt.StateDataFormat = new TestStateDataFormatWithNonce();
+                // Identity string protection keeps the nonce cookie name deterministic for the test.
+                opt.StringDataFormat = new TestStringDataFormat();
+                opt.Authority = TestServerBuilder.DefaultAuthority;
+                opt.ClientId = "Test Id";
+                opt.Events = new OpenIdConnectEvents()
+                {
+                    OnRemoteFailure = ctx =>
+                    {
+                        ctx.HandleResponse();
+                        ctx.Response.StatusCode = StatusCodes.Status200OK;
+                        return Task.CompletedTask;
+                    }
+                };
+            });
+
+        var server = settings.CreateTestServer();
+
+        var nonceCookieName = OpenIdConnectDefaults.CookieNoncePrefix + "nonce-value";
+
+        var transaction = await server.SendAsync(
+            "https://example.com/signin-oidc?error=login_required&state=protected_state",
+            $".AspNetCore.Correlation.correlationId=N; {nonceCookieName}=N");
+
+        Assert.Equal(HttpStatusCode.OK, transaction.Response.StatusCode);
+        Assert.Contains(
+            transaction.SetCookie,
+            cookie => cookie.StartsWith($"{nonceCookieName}=; expires=Thu, 01 Jan 1970", StringComparison.Ordinal));
+        Assert.Contains(
+            transaction.SetCookie,
+            cookie => cookie.StartsWith(".AspNetCore.Correlation.correlationId=; expires=Thu, 01 Jan 1970", StringComparison.Ordinal));
+    }
+
     private class TestStateDataFormat : ISecureDataFormat<AuthenticationProperties>
     {
         private AuthenticationProperties Data { get; set; }
@@ -130,5 +173,37 @@ public class OpenIdConnectAuthenticateTests
         {
             throw new NotImplementedException();
         }
+    }
+
+    private class TestStateDataFormatWithNonce : ISecureDataFormat<AuthenticationProperties>
+    {
+        public string Protect(AuthenticationProperties data) => "protected_state";
+
+        public string Protect(AuthenticationProperties data, string purpose) => throw new NotImplementedException();
+
+        public AuthenticationProperties Unprotect(string protectedText)
+        {
+            Assert.Equal("protected_state", protectedText);
+            var properties = new AuthenticationProperties(new Dictionary<string, string>()
+                {
+                    { ".xsrf", "correlationId" },
+                    { "N", "nonce-value" },
+                });
+            properties.RedirectUri = "http://testhost/redirect";
+            return properties;
+        }
+
+        public AuthenticationProperties Unprotect(string protectedText, string purpose) => throw new NotImplementedException();
+    }
+
+    private class TestStringDataFormat : ISecureDataFormat<string>
+    {
+        public string Protect(string data) => data;
+
+        public string Protect(string data, string purpose) => data;
+
+        public string Unprotect(string protectedText) => protectedText;
+
+        public string Unprotect(string protectedText, string purpose) => protectedText;
     }
 }


### PR DESCRIPTION
### Summary

Fixes #53048. When an OpenID Connect silent sign-in (`prompt=none`) returns `error=login_required`, `OpenIdConnectHandler.HandleRemoteAuthenticateAsync` returns on the error branch before `ReadNonceCookie` runs. `ReadNonceCookie` locates the nonce cookie by matching the nonce value carried in the id_token, and an error response has no id_token, so the nonce cookie is never deleted. On a legitimate, repeatable silent-login flow these cookies accumulate until they expire, and in practice the request headers grow too large after only a handful of failed sign-ins. The correlation cookie is already removed in this path by `ValidateCorrelationId`.

### Change

- At challenge time, record the generated nonce in the protected authentication state, next to where the correlation id is kept.
- On the callback, after correlation validation, read the nonce back and remove it from the properties so it does not flow into the authentication ticket. On the error branch, use it to delete the specific nonce cookie for this flow.

Deleting the exact recorded nonce cookie, rather than clearing every nonce cookie, keeps other sign-ins that are in progress in other browser tabs intact. This also mirrors how the correlation id already round-trips in the protected state.

### Testing

Added `ErrorResponseDeletesNonceAndCorrelationCookies` to `OpenIdConnectAuthenticateTests`, modeled on the existing `ErrorResponseWithDetails`. It fails without the change and passes with it. The full OpenIdConnect test suite (168 tests) passes on both Linux and Windows.
