### PR TITLE
Fix stale JS bundle and E2E build blockers in Components AGENTS.md

### DIFF
--- a/src/Components/AGENTS.md
+++ b/src/Components/AGENTS.md
@@ -84,12 +84,19 @@ To avoid unnecessary full repository builds, follow this optimized approach:
 Before running any commands, check if a full build has already been completed:
 - Look for `artifacts\agent-sentinel.txt` in the repository root
 - If this file exists, skip to step 2
-- If not present, run the initial build and create the sentinel file:
+- If not present, initialize submodules, run the initial build, and create the sentinel file:
 
 ```bash
+git submodule update --init --recursive
 .\eng\build.cmd
 echo "We ran eng\build.cmd successfully" > artifacts\agent-sentinel.txt
 ```
+
+**Always initialize submodules first in a fresh worktree.** Components code depends transitively on `src\submodules\MessagePack-CSharp`; without it the build fails on unresolved MessagePack types. Worktrees do not inherit the submodules of the checkout they were created from, so do this once per worktree.
+
+#### Standard build flags
+
+Unless you are specifically working on IIS, append `-p:UseIisNativeAssets=false` to every `dotnet build` in this repo. Components work never needs the ANCM native assets, and without this flag builds that pull in IIS projects fail because ANCM has not been built. The commands below already include it.
 
 #### 2. Check that JavaScript Assets are Fresh
 
@@ -118,12 +125,12 @@ if [ ! -f "$bundle" ] || [ -n "$(find src/Components/Web.JS/src -name '*.ts' -ne
 
 **Most of the time (no dependency changes):**
 ```bash
-dotnet build --no-restore -v:q
+dotnet build --no-restore -v:q -p:UseIisNativeAssets=false
 ```
 
 Or with `eng\build.cmd`:
 ```bash
-.\eng\build.cmd -NoRestore -NoBuildDeps -NoBuildNative -NoBuildNodeJS -NoBuildJava -NoBuildInstallers -verbosity:quiet
+.\eng\build.cmd -NoRestore -NoBuildDeps -NoBuildNative -NoBuildNodeJS -NoBuildJava -NoBuildInstallers -verbosity:quiet /p:UseIisNativeAssets=false
 ```
 
 **When you've added/changed project references or package dependencies:**
@@ -135,7 +142,7 @@ First restore:
 
 Then build:
 ```bash
-dotnet build --no-restore -v:q
+dotnet build --no-restore -v:q -p:UseIisNativeAssets=false
 ```
 
 **Note:** The `-v:q` (or `-verbosity:quiet`) flag minimizes build output to only show success/failure and error details. Remove this flag if you need to see detailed build output for debugging.
@@ -145,7 +152,7 @@ dotnet build --no-restore -v:q
 When fixing build errors in a specific project, you can build just that project without its dependencies for even faster iteration:
 
 ```bash
-dotnet build <path-to-project.csproj> --no-restore --no-dependencies -v:q
+dotnet build <path-to-project.csproj> --no-restore --no-dependencies -v:q -p:UseIisNativeAssets=false
 ```
 
 **When to use `--no-dependencies`:**
@@ -161,16 +168,17 @@ dotnet build <path-to-project.csproj> --no-restore --no-dependencies -v:q
 **Example:**
 ```bash
 # Fix a compilation error in Components.Endpoints
-dotnet build src\Components\Endpoints\src\Microsoft.AspNetCore.Components.Endpoints.csproj --no-restore --no-dependencies -v:q
+dotnet build src\Components\Endpoints\src\Microsoft.AspNetCore.Components.Endpoints.csproj --no-restore --no-dependencies -v:q -p:UseIisNativeAssets=false
 ```
 
 #### Quick Reference
 
-1. **First time only**: `.\eng\build.cmd` → create `artifacts\agent-sentinel.txt`
+1. **First time only**: `git submodule update --init --recursive` → `.\eng\build.cmd` → create `artifacts\agent-sentinel.txt`
 2. **Check JS assets are fresh**: Verify `src\Components\Web.JS\dist\Debug\_framework\blazor.web.js` is newer than the newest `.ts` source (see step 2 above for the command); run `npm run build` - never `build:production` alone - if `STALE`
-3. **Most C# changes**: `dotnet build --no-restore -v:q`
-4. **Fixing build errors in one project**: `dotnet build <project.csproj> --no-restore --no-dependencies -v:q`
+3. **Most C# changes**: `dotnet build --no-restore -v:q -p:UseIisNativeAssets=false`
+4. **Fixing build errors in one project**: `dotnet build <project.csproj> --no-restore --no-dependencies -v:q -p:UseIisNativeAssets=false`
 5. **Added/changed dependencies**: Run `.\restore.cmd` first, then use step 3
+6. **Always pass `-p:UseIisNativeAssets=false`** unless you are working on IIS - Components never needs ANCM native assets
 
 ### E2E Testing Structure
 
@@ -185,7 +193,7 @@ Tests live in `src/Components/test`. The structure includes:
 2. **Start Components.TestServer**:
    ```bash
    cd src\Components\test\testassets\Components.TestServer
-   dotnet run --project Components.TestServer.csproj
+   dotnet run --project Components.TestServer.csproj -p:UseIisNativeAssets=false
    ```
 3. **Navigate to the test server** - The main server runs on `http://127.0.0.1:5019/subdir`
 4. **Select a test scenario** - The main page shows a dropdown with all available test components
@@ -254,16 +262,13 @@ The E2E tests use Selenium. To build and run tests:
 
 ```bash
 # Build the E2E test project and its dependencies
-dotnet build src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj --no-restore -v:q
+dotnet build src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj --no-restore -v:q -p:UseIisNativeAssets=false
 
 # After the build succeeds, run a specific test
 dotnet test src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj --no-build --filter "FullyQualifiedName~TestName"
 ```
 
-**If that build fails, check these two first.** Both are common on the first E2E build in a fresh worktree:
-
-- Errors about **MessagePack** types or a missing `src/submodules/MessagePack-CSharp`: the submodule is not initialized. Run `git submodule update --init --recursive src/submodules/MessagePack-CSharp`, then rebuild.
-- An error saying **ANCM has not been built** (missing `AspNetCoreModuleV2` in-process handler): Components E2E tests do not need the IIS native assets. Re-run the build with `-p:UseIisNativeAssets=false` appended.
+`-p:UseIisNativeAssets=false` is required here: the E2E project transitively references IIS projects that otherwise fail because ANCM has not been built. If this build instead fails on MessagePack types, your submodules are not initialized - see step 1 of the Efficient Build Strategy.
 
 For the first E2E run in a fresh worktree, or after relevant build, configuration, or output changes, run the dependency-aware build above. Do not use `--no-dependencies` to prepare E2E tests when referenced test-app outputs may be stale or missing. It may copy existing dependency outputs, but it does not rebuild referenced projects or apps. After the build succeeds, `--no-build` is the supported fast loop for repeated targeted tests while those inputs remain unchanged.
 

--- a/src/Components/AGENTS.md
+++ b/src/Components/AGENTS.md
@@ -260,6 +260,11 @@ dotnet build src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETest
 dotnet test src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj --no-build --filter "FullyQualifiedName~TestName"
 ```
 
+**If that build fails, check these two first.** Both are common on the first E2E build in a fresh worktree:
+
+- Errors about **MessagePack** types or a missing `src/submodules/MessagePack-CSharp`: the submodule is not initialized. Run `git submodule update --init --recursive src/submodules/MessagePack-CSharp`, then rebuild.
+- An error saying **ANCM has not been built** (missing `AspNetCoreModuleV2` in-process handler): Components E2E tests do not need the IIS native assets. Re-run the build with `-p:UseIisNativeAssets=false` appended.
+
 For the first E2E run in a fresh worktree, or after relevant build, configuration, or output changes, run the dependency-aware build above. Do not use `--no-dependencies` to prepare E2E tests when referenced test-app outputs may be stale or missing. It may copy existing dependency outputs, but it does not rebuild referenced projects or apps. After the build succeeds, `--no-build` is the supported fast loop for repeated targeted tests while those inputs remain unchanged.
 
 **Important**: Never run all E2E tests locally as that is extremely costly. Full test runs should only happen on CI machines.

--- a/src/Components/AGENTS.md
+++ b/src/Components/AGENTS.md
@@ -91,10 +91,28 @@ Before running any commands, check if a full build has already been completed:
 echo "We ran eng\build.cmd successfully" > artifacts\agent-sentinel.txt
 ```
 
-#### 2. Check for JavaScript Assets
-Before running tests or samples, verify that JavaScript assets are built:
-- Check for `src\Components\Web.JS\dist\Debug\blazor.web.js`
-- If not present, run from the repository root: `npm run build`
+#### 2. Check that JavaScript Assets are Fresh
+
+The .NET Debug build consumes `src\Components\Web.JS\dist\Debug\_framework\blazor.web.js`. A stale bundle produces **no error** - tests and samples simply behave as if your `.ts` change was never made.
+
+Before running tests or samples, verify the bundle is newer than the newest `.ts` source. Run from the repository root.
+
+PowerShell:
+```powershell
+$newest = Get-ChildItem src\Components\Web.JS\src -Recurse -Filter *.ts | Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+$bundle = Get-Item src\Components\Web.JS\dist\Debug\_framework\blazor.web.js -ErrorAction SilentlyContinue
+if (-not $bundle -or $bundle.LastWriteTimeUtc -lt $newest.LastWriteTimeUtc) { "STALE" } else { "fresh" }
+```
+
+bash:
+```bash
+bundle=src/Components/Web.JS/dist/Debug/_framework/blazor.web.js
+if [ ! -f "$bundle" ] || [ -n "$(find src/Components/Web.JS/src -name '*.ts' -newer "$bundle" -print | head -n 1)" ]; then echo STALE; else echo fresh; fi
+```
+
+- If it reports `STALE`, run `npm run build` from `src\Components\Web.JS`, then re-run the check.
+- Always use `npm run build`. **Never** use `npm run build:production` on its own: it writes only `dist\Release` and leaves `dist\Debug` stale, so the Debug build keeps using your old code.
+- Re-run this check after any `git stash`, `git checkout -- <path>`, or branch switch that touches a `.ts` file - those change the sources without rebuilding the bundle.
 
 #### 3. Iterating on C# Changes
 
@@ -149,7 +167,7 @@ dotnet build src\Components\Endpoints\src\Microsoft.AspNetCore.Components.Endpoi
 #### Quick Reference
 
 1. **First time only**: `.\eng\build.cmd` → create `artifacts\agent-sentinel.txt`
-2. **Check JS assets**: Verify `src\Components\Web.JS\dist\Debug\blazor.web.js` exists, run `npm run build` if missing
+2. **Check JS assets are fresh**: Verify `src\Components\Web.JS\dist\Debug\_framework\blazor.web.js` is newer than the newest `.ts` source (see step 2 above for the command); run `npm run build` - never `build:production` alone - if `STALE`
 3. **Most C# changes**: `dotnet build --no-restore -v:q`
 4. **Fixing build errors in one project**: `dotnet build <project.csproj> --no-restore --no-dependencies -v:q`
 5. **Added/changed dependencies**: Run `.\restore.cmd` first, then use step 3


### PR DESCRIPTION
Three defects in `src/Components/AGENTS.md`, all found by an agent actually hitting them during the investigation that shipped #68088 — not by reading the file.

## 1. The JS asset path was wrong

`src/Components/Web.JS/rollup.config.mjs` maps outputs under `_framework/`, so the real artifact is `dist\Debug\_framework\blazor.web.js`. The documented path omitted `_framework` and therefore never existed, which made the check useless as written.

## 2. Presence is not freshness

`npm run build:production` writes only `dist/Release` and has no `prebuild`/`clean` of its own, so running it alone leaves a stale `dist/Debug`. The .NET Debug build then silently consumes the old bundle and E2E tests behave exactly as if the `.ts` change were never made — no error message anywhere. In the #68088 investigation this burned a full E2E cycle chasing a fix that was never in the bundle under test.

Section 2 now compares the bundle's timestamp against the newest `.ts` source, in both PowerShell and bash, says to use `npm run build` and never `build:production` alone, and notes to re-check after a `git stash`, `git checkout --`, or branch switch that touches a `.ts`.

## 3. Two build blockers that stopped the documented E2E command

The documented E2E build command fails twice on a fresh worktree, and the file pointed agents straight at it for exactly that case. In #68088 this cost ~21 minutes across two consecutive failures.

Rather than documenting these as symptoms to recognize after the fact, the guidance now steers around them up front:

- **Submodules** — `git submodule update --init --recursive` is part of first-time setup, with a note that worktrees do not inherit submodules from the checkout they were created from. (Verified: in a fresh worktree `git submodule status` reports MessagePack-CSharp uninitialized and the directory is empty.)
- **ANCM native assets** — `-p:UseIisNativeAssets=false` is now baked into every documented `dotnet build` / `dotnet run` command, plus a short "Standard build flags" note and a Quick Reference entry saying to pass it unless you are working on IIS. The E2E section keeps a one-line explanation of why it is required there, and a pointer back to step 1 if the build fails on MessagePack instead.

`Components.TestServer` references `Microsoft.AspNetCore.Server.IIS`, the project that raises the ANCM error, so its `dotnet run` line gets the flag too.

## Verification

Both freshness checks were verified on a synthetic tree, no build required: bundle absent → `STALE`; bundle touched after the `.ts` → `fresh`; `.ts` touched again → `STALE`; bundle removed → `STALE`. The literal text as it appears in the doc was re-run from a file to confirm the pasted form behaves identically.

`-print -quit` was deliberately avoided — `-quit` is a GNU `find` extension and is absent on macOS/BSD. The snippet uses only POSIX predicates plus `head -n 1`, and guards the missing-bundle case before reaching `find -newer`.

The MSBuild claims were checked against the repo: `.gitmodules` declares the MessagePack submodule path, and `UseIisNativeAssets` is what gates the ANCM error in `Microsoft.AspNetCore.Server.IIS.csproj:43` and the `ValidateNativeComponentsBuilt` target in `Microsoft.AspNetCore.Server.IntegrationTesting.IIS.csproj:33`.

Documentation-only. No tests were run and none are needed.
