### PR TITLE
Improve Components validation guidance

### DIFF
--- a/.github/skills/validate-blazor-feature/SKILL.md
+++ b/.github/skills/validate-blazor-feature/SKILL.md
@@ -67,6 +67,8 @@ Read the launch URL from stdout: Web App hosts print `Now listening on: http://l
 
 Use the `playwright-browser_*` tools. For an interactive behavior, prove it behaviorally; rendered markup alone is a false positive (static SSR emits the same HTML).
 
+For transient DOM or browser-state behavior, first run the probe against the unmodified baseline and confirm that it detects the reported transition. A passing probe that cannot observe the known failure is not evidence for the fix. Choose instrumentation whose timing matches the behavior: `MutationObserver` callbacks run after synchronous mutations, so reading live DOM state in the callback may expose only the final state. Inspect the mutation records or instrument the exact operation when an intermediate synchronous state matters.
+
 1. `playwright-browser_navigate` to `<base>/<route>`.
 2. For WebAssembly/Auto/standalone, the runtime boots asynchronously: `playwright-browser_wait_for` the expected text (e.g. `Current count`) before interacting. First paint can take many seconds.
 3. `playwright-browser_snapshot` to read current state.

--- a/src/Components/AGENTS.md
+++ b/src/Components/AGENTS.md
@@ -80,6 +80,8 @@ Together these cover every interactivity platform (Server/WebAssembly/Auto/None)
 
 To avoid unnecessary full repository builds, follow this optimized approach:
 
+After a build fails, identify whether the cause is a source error in the changed project, a missing or stale prerequisite, or unrelated repository infrastructure before changing commands. Use the smallest supported build that still exercises the change. Do not repeatedly retry broad builds with different exclusions unless each retry addresses an identified failure cause, and report any validation boundary that remains untested.
+
 #### 1. Initial Setup - Check for First Build
 Before running any commands, check if a full build has already been completed:
 - Look for `artifacts\agent-sentinel.txt` in the repository root


### PR DESCRIPTION
## Summary

- classify build failures before changing commands, keep validation targeted, and report untested boundaries
- require baseline-sensitive probes for transient browser behavior and document `MutationObserver` timing limitations

The browser guidance reflects an investigation where reading `document.title` from a `MutationObserver` callback exposed only the final state in both baseline and fix, while synchronous title-node instrumentation detected the baseline transition.

Documentation-only change; no builds or tests were run.