### PR TITLE
Improve agent guidance for cross-runtime Components work

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,11 @@
 * Never change package.json or package-lock.json files unless explicitly asked to.
 * Never change NuGet.config files unless explicitly asked to.
 
+## Task Scope and Completion
+
+* Before implementing a reported issue, verify the behavior on the current default branch, inspect relevant history and documentation, and establish the smallest faithful reproduction. If the user asks only to investigate or characterize, do not change shipping code or create or update a pull request until implementation is explicitly requested.
+* Define the acceptance criteria before implementation. Do not claim completion or create or update a pull request until the requested acceptance criteria are green; identify any intentionally excluded cases or unverified boundaries.
+
 ## Public API Changes
 
 * Treat any new or changed `public` or `protected` type, member, signature, default, or convention as a potential public API change. Before implementing it, verify that the linked issue is `api-approved`.

--- a/src/Components/AGENTS.md
+++ b/src/Components/AGENTS.md
@@ -26,6 +26,15 @@ For implementation work:
 - Only after the E2E tests are passing, remove the sample code you added in the Samples projects.
   - Use `git checkout` and `git clean -fd` to remove the sample code.
 
+### Cross-runtime design checkpoint
+
+Before editing behavior that crosses Components renderers, runtimes, or DI scopes:
+
+- Define the relevant behavior matrix: Server/WebAssembly/Auto, global/per-page interactivity, initial activation/enhanced navigation, prerendered/non-prerendered, and interactive `Router` present/absent. Mark intentionally excluded cells before implementation.
+- Map the producing owner, consuming owner, DI lifetime and scope, assembly boundary, initial restore ordering, value-update ordering, render-mode destinations, and stale-state clearing.
+- Do not use component descriptors to transport unrelated framework state. Prefer a framework-owned persistent service when state must react to `PersistentComponentState` initial and value updates.
+- Request architecture review before product edits and final correctness review after targeted tests are green. Add another architecture review only when the implementation introduces a new boundary.
+
 ### Code clarity and durable knowledge
 
 - Before adding a comment, make local behavior discoverable through precise names,
@@ -75,6 +84,10 @@ Together these cover every interactivity platform (Server/WebAssembly/Auto/None)
 6. **Clean up sample code** - After your E2E tests are passing, remove the sample code you added to the Samples projects. The sample was only for development and interactive testing; the E2E tests now provide the permanent test coverage. Use `git checkout -- src/Components/Samples` and `git clean -df -- src/Components/Samples` to remove the sample code.
 
 ## Build Tips
+
+### Build and retry discipline
+
+On Windows, serialize builds that share the `artifacts` directory and stop sample or test-server processes before rebuilding. After two consecutive failures at the same E2E boundary, stop rerunning the full command. Isolate the boundary with a focused unit or project check or a manually driven test server, then resume the E2E loop.
 
 ### Efficient Build Strategy
 
@@ -229,6 +242,8 @@ E2E tests are located in `src/Components/test/E2ETest`.
 1. First, check if there are already E2E tests for the component/feature area you're working on
 2. Try to add an additional test to existing test files when possible
 3. When adding test coverage, prefer extending existing test components and assets over creating a set of new ones if it doesn't complicate the existing ones excessively. This reduces test infrastructure complexity and keeps related scenarios together.
+
+For telemetry or distributed-state behavior, assert the real consumer-visible output rather than only an internal component probe. Capture exported activities, metrics, or state; correlate the scenario with a unique test ID and expose a test endpoint when needed; and assert operation names, tags, links, and platform-specific metadata relevant to the contract.
 
 ### Running E2E Tests
 

--- a/src/Components/AGENTS.md
+++ b/src/Components/AGENTS.md
@@ -32,7 +32,6 @@ Before editing behavior that crosses Components renderers, runtimes, or DI scope
 
 - Define the relevant behavior matrix: Server/WebAssembly/Auto, global/per-page interactivity, initial activation/enhanced navigation, prerendered/non-prerendered, and interactive `Router` present/absent. Mark intentionally excluded cells before implementation.
 - Map the producing owner, consuming owner, DI lifetime and scope, assembly boundary, initial restore ordering, value-update ordering, render-mode destinations, and stale-state clearing.
-- Do not use component descriptors to transport unrelated framework state. Prefer a framework-owned persistent service when state must react to `PersistentComponentState` initial and value updates.
 - Request architecture review before product edits and final correctness review after targeted tests are green. Add another architecture review only when the implementation introduces a new boundary.
 
 ### Code clarity and durable knowledge


### PR DESCRIPTION
## Summary

- add a repository-wide investigation/implementation gate so agents respect research-only scope and wait for agreed acceptance criteria before opening or updating a PR
- add a Components cross-runtime design checkpoint covering ownership, DI scope, lifecycle ordering, render-mode destinations, the Blazor behavior matrix, and reviewer placement
- require consumer-visible telemetry/distributed-state assertions and disciplined Windows E2E retry isolation

## Placement

The scope and completion gate belongs in `.github/copilot-instructions.md` because it applies repository-wide. Renderer/runtime ownership, Blazor matrix coverage, telemetry contracts, and Components build-loop rules remain in `src/Components/AGENTS.md`. `.github/instructions/components.instructions.md` remains a thin pointer to that canonical area guide.

## Related guidance reviewed

- #68799 already proposes general task-scoped Components validation and render-mode/lifecycle planning; this PR adds the cross-runtime ownership and ordering details.
- #68800 owns JS freshness, submodule, and ANCM build-prerequisite guidance; those changes are not duplicated here.
- #68804 owns general build-failure classification and baseline-sensitive browser probes; this PR adds only the Windows process/concurrency rule and the two-failure E2E isolation threshold.
- #68803 and #67490 were reviewed but concern issue triage and worktree creation rather than this lifecycle/test contract.

This is based on the completed introspection of the Blazor activity-links investigation. It is independent of and does not modify or stack on draft #68539.

## Validation

Documentation-only change. `git diff --check` passes, and the branch is based on current `origin/main`.