### PR TITLE
[Hosting] Add recommended HTTP server span attributes

### DIFF
--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -464,12 +464,22 @@ internal sealed class HostingApplicationDiagnostics
         // https://github.com/open-telemetry/semantic-conventions/blob/27735ccca3746d7bb7fa061dfb73d93bcbae2b6e/docs/http/http-spans.md#L581-L592
         // Missing values recommended by the spec are:
         // - url.query (need configuration around redaction to do properly)
-        // - http.request.header.<key>
+        // - http.request.header.<key> (opt-in)
+        // - client.port (opt-in)
+        // - network.protocol.name (only required if not "http", which is never the case here)
         //
         // Note that these tags are added even if Activity.IsAllDataRequested is false, as they may be used in sampling decisions.
 
         var request = httpContext.Request;
         var creationTags = new TagList();
+
+        if (httpContext.Connection.RemoteIpAddress is { } remoteIpAddress)
+        {
+            var remoteIpAddressString = remoteIpAddress.ToString();
+            creationTags.Add(HostingTelemetryHelpers.AttributeClientAddress, remoteIpAddressString);
+            creationTags.Add(HostingTelemetryHelpers.AttributeNetworkPeerAddress, remoteIpAddressString);
+            creationTags.Add(HostingTelemetryHelpers.AttributeNetworkPeerPort, httpContext.Connection.RemotePort);
+        }
 
         if (request.Host.HasValue)
         {

--- a/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingApplicationDiagnostics.cs
@@ -478,7 +478,11 @@ internal sealed class HostingApplicationDiagnostics
             var remoteIpAddressString = remoteIpAddress.ToString();
             creationTags.Add(HostingTelemetryHelpers.AttributeClientAddress, remoteIpAddressString);
             creationTags.Add(HostingTelemetryHelpers.AttributeNetworkPeerAddress, remoteIpAddressString);
-            creationTags.Add(HostingTelemetryHelpers.AttributeNetworkPeerPort, httpContext.Connection.RemotePort);
+
+            if (httpContext.Connection.RemotePort is { } remotePort && remotePort > 0)
+            {
+                creationTags.Add(HostingTelemetryHelpers.AttributeNetworkPeerPort, remotePort);
+            }
         }
 
         if (request.Host.HasValue)

--- a/src/Hosting/Hosting/src/Internal/HostingTelemetryHelpers.cs
+++ b/src/Hosting/Hosting/src/Internal/HostingTelemetryHelpers.cs
@@ -17,8 +17,11 @@ internal static class HostingTelemetryHelpers
     public const string AttributeHttpRoute = "http.route";
     public const string AttributeUrlScheme = "url.scheme";
     public const string AttributeUrlPath = "url.path";
+    public const string AttributeClientAddress = "client.address";
     public const string AttributeServerAddress = "server.address";
     public const string AttributeServerPort = "server.port";
+    public const string AttributeNetworkPeerAddress = "network.peer.address";
+    public const string AttributeNetworkPeerPort = "network.peer.port";
     public const string AttributeUserAgentOriginal = "user_agent.original";
     public const string AttributeNetworkProtocolVersion = "network.protocol.version";
     public const string AttributeErrorType = "error.type";

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -1223,6 +1223,45 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
     }
 
     [Fact]
+    public void ActivityListeners_NetworkPeerPortTagNotAddedWhenZero()
+    {
+        var testSource = new ActivitySource(Path.GetRandomFileName());
+        var hostingApplication = CreateApplication(out var features, activitySource: testSource, suppressActivityOpenTelemetryData: false,
+            configure: c =>
+            {
+                c.Connection.RemoteIpAddress = IPAddress.Parse("192.0.2.1");
+                c.Connection.RemotePort = 0;
+            });
+        var tags = new Dictionary<string, object>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = activitySource => ReferenceEquals(activitySource, testSource),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity =>
+            {
+                tags = Activity.Current.TagObjects.ToDictionary();
+            }
+        };
+
+        ActivitySource.AddActivityListener(listener);
+
+        features.Set<IHttpRequestFeature>(new HttpRequestFeature()
+        {
+            Headers = new HeaderDictionary()
+            {
+                {"host", "localhost" }
+            },
+            Scheme = "http",
+        });
+
+        hostingApplication.CreateContext(features);
+
+        Assert.Equal("192.0.2.1", tags[HostingTelemetryHelpers.AttributeClientAddress]);
+        Assert.Equal("192.0.2.1", tags[HostingTelemetryHelpers.AttributeNetworkPeerAddress]);
+        Assert.False(tags.ContainsKey(HostingTelemetryHelpers.AttributeNetworkPeerPort));
+    }
+
+    [Fact]
     public void ActivityListeners_NoRemoteIpAddress_ClientAndNetworkPeerAddressTagsNotAdded()
     {
         var testSource = new ActivitySource(Path.GetRandomFileName());

--- a/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
+++ b/src/Hosting/Hosting/test/HostingApplicationDiagnosticsTests.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Diagnostics.Tracing;
 using System.Globalization;
+using System.Net;
 using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -1180,6 +1181,79 @@ public class HostingApplicationDiagnosticsTests : LoggedTest
             Assert.Equal(key, pair.Key);
             Assert.Equal(value, pair.Value);
         }
+    }
+
+    [Fact]
+    public void ActivityListeners_ClientAndNetworkPeerAddressTagsAdded()
+    {
+        var testSource = new ActivitySource(Path.GetRandomFileName());
+        var hostingApplication = CreateApplication(out var features, activitySource: testSource, suppressActivityOpenTelemetryData: false,
+            configure: c =>
+            {
+                c.Connection.RemoteIpAddress = IPAddress.Parse("192.0.2.1");
+                c.Connection.RemotePort = 65123;
+            });
+        var tags = new Dictionary<string, object>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = activitySource => ReferenceEquals(activitySource, testSource),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity =>
+            {
+                tags = Activity.Current.TagObjects.ToDictionary();
+            }
+        };
+
+        ActivitySource.AddActivityListener(listener);
+
+        features.Set<IHttpRequestFeature>(new HttpRequestFeature()
+        {
+            Headers = new HeaderDictionary()
+            {
+                {"host", "localhost" }
+            },
+            Scheme = "http",
+        });
+
+        hostingApplication.CreateContext(features);
+
+        Assert.Equal("192.0.2.1", tags[HostingTelemetryHelpers.AttributeClientAddress]);
+        Assert.Equal("192.0.2.1", tags[HostingTelemetryHelpers.AttributeNetworkPeerAddress]);
+        Assert.Equal(65123, tags[HostingTelemetryHelpers.AttributeNetworkPeerPort]);
+    }
+
+    [Fact]
+    public void ActivityListeners_NoRemoteIpAddress_ClientAndNetworkPeerAddressTagsNotAdded()
+    {
+        var testSource = new ActivitySource(Path.GetRandomFileName());
+        var hostingApplication = CreateApplication(out var features, activitySource: testSource, suppressActivityOpenTelemetryData: false);
+        var tags = new Dictionary<string, object>();
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = activitySource => ReferenceEquals(activitySource, testSource),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity =>
+            {
+                tags = Activity.Current.TagObjects.ToDictionary();
+            }
+        };
+
+        ActivitySource.AddActivityListener(listener);
+
+        features.Set<IHttpRequestFeature>(new HttpRequestFeature()
+        {
+            Headers = new HeaderDictionary()
+            {
+                {"host", "localhost" }
+            },
+            Scheme = "http",
+        });
+
+        hostingApplication.CreateContext(features);
+
+        Assert.False(tags.ContainsKey(HostingTelemetryHelpers.AttributeClientAddress));
+        Assert.False(tags.ContainsKey(HostingTelemetryHelpers.AttributeNetworkPeerAddress));
+        Assert.False(tags.ContainsKey(HostingTelemetryHelpers.AttributeNetworkPeerPort));
     }
 
     [Theory]


### PR DESCRIPTION
# Add recommended HTTP server attributes

Add recommended HTTP server span attributes that are not currently added.

## Description

Add the following recommended trace attributes for [HTTP server span](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#http-server-span) semantic conventions, where available:

- `client.address`
- `network.peer.address`
- `network.peer.port`

See https://github.com/dotnet/aspnetcore/issues/65873#issuecomment-5326996035.

Contributes to #65873.
