### PR TITLE
[Blazor] Document DOM listener lifecycle ownership

### DIFF
--- a/src/Components/AGENTS.md
+++ b/src/Components/AGENTS.md
@@ -247,6 +247,8 @@ E2E tests are located in `src/Components/test/E2ETest`.
 1. First, check if there are already E2E tests for the component/feature area you're working on
 2. Try to add an additional test to existing test files when possible
 3. When adding test coverage, prefer extending existing test components and assets over creating a set of new ones if it doesn't complicate the existing ones excessively. This reduces test infrastructure complexity and keeps related scenarios together.
+4. Regression tests for lifecycle-sensitive behavior must exercise the render boundary that owns the relevant DOM. A page-level render mode can leave the surrounding layout static, so verify that the DOM under test is actually hydrated or replaced.
+5. When the behavior under test is owned by generated template content, prefer extending the existing browser tests in `src/ProjectTemplates/test/Templates.Blazor.Tests` over duplicating the scenario in Components E2E.
 
 ### Running E2E Tests
 

--- a/src/Components/AGENTS.md
+++ b/src/Components/AGENTS.md
@@ -42,6 +42,16 @@ For implementation work:
 - Do not use public XML documentation to explain internal implementation details,
   including control flow or lifecycle state. Limit it to consumer-observable behavior.
 
+### JavaScript DOM lifecycle
+
+- When behavior targets DOM that can be replaced during the prerender-to-interactive
+  transition or enhanced navigation, bind it to the narrowest lifecycle owner that can
+  survive the replacement or re-register afterward, and clean up when that owner is
+  removed. This can be a component lifecycle, a custom element's
+  `connectedCallback`/`disconnectedCallback`, or a stable scoped ancestor. Do not move
+  element-specific listeners to `document` or `window` merely to survive replacement;
+  reserve global listeners for behavior genuinely owned by the document or window.
+
 ### Overview
 
 The workflow for implementing new features in the Components area follows these steps:


### PR DESCRIPTION
## Summary

- add Components-specific guidance for JavaScript behavior whose target DOM can be replaced during the prerender-to-interactive transition or enhanced navigation
- keep element-specific listeners with the narrowest viable lifecycle owner and require cleanup when that owner is removed
- require lifecycle regression tests to exercise the render boundary that owns the relevant DOM
- route behavior owned by generated template content to the existing generated-template browser tests instead of a parallel Components E2E surface

## Rationale

[#68677](https://github.com/dotnet/aspnetcore/issues/68677) exposed a listener attached once to prerendered menu DOM that was later replaced by the interactive renderer. Both [#68768](https://github.com/dotnet/aspnetcore/pull/68768) and the first revision of [#68809](https://github.com/dotnet/aspnetcore/pull/68809) reached for document-level delegation. Maintainer feedback on #68768 explicitly rejected a global listener for element-specific behavior and requested the narrowest practical scope.

The current #68809 direction uses custom-element connection and disconnection callbacks, matching the lifecycle-owned pattern already used by Blazor client validation in [#67324](https://github.com/dotnet/aspnetcore/pull/67324).

The regression-test investigation exposed a related boundary issue: the template test matrix defaults to per-page interactivity, which can leave the surrounding layout and navigation menu static even when the selected page is interactive. An explicit all-interactive row was required to prove that the target DOM was replaced. Permanent coverage also belongs in the existing generated-template browser tests because the behavior is owned by generated template content.

The guidance remains intentionally scoped to Components. It does not require every listener to use a custom element, every lifecycle test to use global interactivity, or every template-related behavior to move out of Components E2E; those choices follow the ownership boundary of the specific behavior under test.