### PR TITLE
Update branding to 2.3.13

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -39,13 +39,9 @@
     <!-- ANCM always builds every patch as we don't push temporary nuget packages anymore and that ANCM itself is a global singleton -->
     <IsPackageInThisPatch Condition="'$(IsANCMPackage)' == 'true'">true</IsPackageInThisPatch>
 
-    <!-- We shipped every package other than Razor in 2.3.12 -->
-    <IsPackageInThisPatch Condition=" '$(AspNetCorePatchVersion)' == '12'">true</IsPackageInThisPatch>
+    <!-- We shipped every package in 2.3.13 -->
+    <IsPackageInThisPatch Condition=" '$(AspNetCorePatchVersion)' == '13'">true</IsPackageInThisPatch>
     
-    <IsPackageInThisPatch Condition="$(PackageId.StartsWith('Microsoft.AspNetCore.Razor'))">false</IsPackageInThisPatch>
-    <IsPackageInThisPatch Condition="$(PackageId.StartsWith('Microsoft.AspNetCore.Mvc.Razor'))">false</IsPackageInThisPatch>
-    <IsPackageInThisPatch Condition="$(PackageId.StartsWith('Microsoft.AspNetCore.Mvc.Razor.ViewCompilation'))">false</IsPackageInThisPatch>
-    <IsPackageInThisPatch Condition="$(PackageId.StartsWith('Microsoft.AspNetCore.Mvc.Analyzers'))">false</IsPackageInThisPatch>
     <IsPackageInThisPatch Condition="$(PackageId.StartsWith('Microsoft.AspNetCore.DataProtection.AzureKeyVault'))">false</IsPackageInThisPatch>
     <IsPackageInThisPatch Condition="$(PackageId.StartsWith('Microsoft.AspNetCore.DataProtection.AzureStorage'))">false</IsPackageInThisPatch>
     <IsPackageInThisPatch Condition="$(PackageId.StartsWith('Microsoft.AspNetCore.DataProtection.Redis'))">false</IsPackageInThisPatch>

--- a/eng/Baseline.Designer.props
+++ b/eng/Baseline.Designer.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-    <AspNetCoreBaselineVersion>2.3.11</AspNetCoreBaselineVersion>
+    <AspNetCoreBaselineVersion>2.3.12</AspNetCoreBaselineVersion>
   </PropertyGroup>
   <!-- Package: dotnet-dev-certs-->
   <PropertyGroup Condition=" '$(PackageId)' == 'dotnet-dev-certs' ">
@@ -26,22 +26,22 @@
   <ItemGroup Condition=" '$(PackageId)' == 'dotnet-watch' AND '$(TargetFramework)' == 'netcoreapp2.1' " />
   <!-- Package: Microsoft.AspNetCore.Antiforgery-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Antiforgery' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Antiforgery' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.ObjectPool" Version="[8.0.11, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.ApplicationInsights.HostingStartup-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ApplicationInsights.HostingStartup' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ApplicationInsights.HostingStartup' AND '$(TargetFramework)' == 'net462' ">
     <BaselinePackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="[2.1.1, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="[2.3.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration.Json" Version="[8.0.1, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="[2.3.0, )" />
@@ -50,134 +50,134 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Abstractions' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Abstractions' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.AzureAD.UI-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.AzureAD.UI' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.AzureAD.UI' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.AzureADB2C.UI-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.AzureADB2C.UI' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.AzureADB2C.UI' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.Cookies-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Cookies' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Cookies' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.Core-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Core' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Core' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.Facebook-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Facebook' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Facebook' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.Google-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Google' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Google' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.JwtBearer-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.JwtBearer' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.JwtBearer' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="[5.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.MicrosoftAccount-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.MicrosoftAccount' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.MicrosoftAccount' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.OAuth-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.OAuth' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.OAuth' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Newtonsoft.Json" Version="[11.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.OpenIdConnect-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.OpenIdConnect' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.OpenIdConnect' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="[5.7.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.Twitter-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Twitter' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.Twitter' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.OAuth" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication.WsFederation-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.WsFederation' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication.WsFederation' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.IdentityModel.Protocols.WsFederation" Version="[5.7.0, )" />
     <BaselinePackageReference Include="System.IdentityModel.Tokens.Jwt" Version="[8.3.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authentication-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authentication' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Core" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Core" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.WebEncoders" Version="[8.0.11, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authorization.Policy-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authorization.Policy' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authorization.Policy' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Authorization-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authorization' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Authorization' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
@@ -185,43 +185,43 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.AzureAppServices.HostingStartup-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServices.HostingStartup' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServices.HostingStartup' AND '$(TargetFramework)' == 'net462' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[8.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.AzureAppServicesIntegration-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServicesIntegration' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.AzureAppServicesIntegration' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="[8.0.11, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Connections.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Connections.Abstractions' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Connections.Abstractions' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[2.3.12, )" />
     <BaselinePackageReference Include="System.IO.Pipelines" Version="[8.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.CookiePolicy-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.CookiePolicy' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.CookiePolicy' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Cors-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cors' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cors' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[8.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
@@ -229,19 +229,19 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Cryptography.Internal-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cryptography.Internal' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cryptography.Internal' AND '$(TargetFramework)' == 'netstandard2.0' " />
   <!-- Package: Microsoft.AspNetCore.Cryptography.KeyDerivation-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cryptography.KeyDerivation' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Cryptography.KeyDerivation' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Abstractions' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Abstractions' AND '$(TargetFramework)' == 'netstandard2.0' " />
   <!-- Package: Microsoft.AspNetCore.DataProtection.AzureKeyVault-->
@@ -264,10 +264,10 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection.Extensions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Extensions' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.Extensions' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[8.0.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection.Redis-->
@@ -280,20 +280,20 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection.SystemWeb-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.SystemWeb' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection.SystemWeb' AND '$(TargetFramework)' == 'net462' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[8.0.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.DataProtection-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.DataProtection' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.Internal" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
@@ -303,26 +303,26 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Diagnostics.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Diagnostics.Abstractions' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Diagnostics.Abstractions' AND '$(TargetFramework)' == 'netstandard2.0' " />
   <!-- Package: Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[2.1.14, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Diagnostics-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Diagnostics' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Diagnostics' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="[8.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
@@ -331,50 +331,50 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.HostFiltering-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.HostFiltering' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.HostFiltering' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Hosting.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Hosting.Abstractions' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Hosting.Abstractions' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.0.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Hosting.Server.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Hosting.Server.Abstractions' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Hosting.Server.Abstractions' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[8.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Hosting.WindowsServices-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Hosting.WindowsServices' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Hosting.WindowsServices' AND '$(TargetFramework)' == 'net462' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.3.12, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Hosting.WindowsServices' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.3.12, )" />
     <BaselinePackageReference Include="System.ServiceProcess.ServiceController" Version="[8.0.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Hosting-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Hosting' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Hosting' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration" Version="[8.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[8.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="[8.0.1, )" />
@@ -389,22 +389,22 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Html.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Html.Abstractions' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Html.Abstractions' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="System.Text.Encodings.Web" Version="[8.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Http.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Abstractions' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Abstractions' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Features" Version="[2.3.12, )" />
     <BaselinePackageReference Include="System.Text.Encodings.Web" Version="[8.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Http.Connections.Client-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Client' ">
-    <BaselinePackageVersion>1.2.11</BaselinePackageVersion>
+    <BaselinePackageVersion>1.2.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Client' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Connections.Common" Version="[1.2.0, )" />
@@ -412,91 +412,91 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Http.Connections.Common-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Common' ">
-    <BaselinePackageVersion>1.2.11</BaselinePackageVersion>
+    <BaselinePackageVersion>1.2.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections.Common' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Newtonsoft.Json" Version="[11.0.2, )" />
     <BaselinePackageReference Include="System.Buffers" Version="[4.6.0, )" />
     <BaselinePackageReference Include="System.IO.Pipelines" Version="[8.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Http.Connections-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections' ">
-    <BaselinePackageVersion>1.2.11</BaselinePackageVersion>
+    <BaselinePackageVersion>1.2.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Connections' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization.Policy" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization.Policy" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Connections.Common" Version="[1.2.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Routing" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.WebSockets" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Routing" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.WebSockets" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Newtonsoft.Json" Version="[11.0.2, )" />
     <BaselinePackageReference Include="System.Net.WebSockets.WebSocketProtocol" Version="[5.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Http.Extensions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Extensions' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Extensions' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="[8.0.0, )" />
-    <BaselinePackageReference Include="Microsoft.Net.Http.Headers" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.Net.Http.Headers" Version="[2.3.12, )" />
     <BaselinePackageReference Include="System.Buffers" Version="[4.6.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Http.Features-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Features' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http.Features' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[8.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Http-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Http' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.ObjectPool" Version="[8.0.11, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
-    <BaselinePackageReference Include="Microsoft.Net.Http.Headers" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.Net.Http.Headers" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.HttpOverrides-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.HttpOverrides' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.HttpOverrides' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.HttpsPolicy-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.HttpsPolicy' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.HttpsPolicy' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Identity.EntityFrameworkCore-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.EntityFrameworkCore' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.EntityFrameworkCore' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Identity" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Identity" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="[2.1.14, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Stores" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Stores" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Identity.Specification.Tests-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.Specification.Tests' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.Specification.Tests' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Identity" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Identity" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration" Version="[8.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[8.0.1, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[8.0.1, )" />
@@ -504,28 +504,28 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Identity.UI-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.UI' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity.UI' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Identity" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Identity" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="[8.0.11, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Stores" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Stores" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Identity-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Identity' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="[2.3.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Core" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Core" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.JsonPatch-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.JsonPatch' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.JsonPatch' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.CSharp" Version="[4.5.0, )" />
@@ -533,38 +533,38 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Localization.Routing-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Localization.Routing' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Localization.Routing' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Localization" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Localization" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Localization-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Localization' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Localization' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="[8.0.11, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.MiddlewareAnalysis-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.MiddlewareAnalysis' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.MiddlewareAnalysis' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[8.0.2, )" />
     <BaselinePackageReference Include="System.Diagnostics.DiagnosticSource" Version="[8.0.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Abstractions' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Abstractions' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.Net.Http.Headers" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.Net.Http.Headers" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.Analyzers-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Analyzers' ">
@@ -573,24 +573,24 @@
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Analyzers' AND '$(TargetFramework)' == 'netstandard1.3' " />
   <!-- Package: Microsoft.AspNetCore.Mvc.ApiExplorer-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.ApiExplorer' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.ApiExplorer' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.Core-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Core' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Core' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Core" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization.Policy" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.ResponseCaching.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Routing" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Core" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization.Policy" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.ResponseCaching.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Routing" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[8.0.1, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.DependencyModel" Version="[2.1.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="[8.0.0, )" />
@@ -600,42 +600,42 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.Cors-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Cors' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Cors' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Cors" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Cors" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.DataAnnotations-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.DataAnnotations' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.DataAnnotations' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Localization" Version="[8.0.11, )" />
     <BaselinePackageReference Include="System.ComponentModel.Annotations" Version="[5.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.Formatters.Json-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Formatters.Json' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Formatters.Json' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.Formatters.Xml-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Formatters.Xml' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Formatters.Xml' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.Localization-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Localization' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Localization' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Localization" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Localization" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="[2.3.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[8.0.1, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Localization" Version="[8.0.11, )" />
@@ -645,11 +645,11 @@
     <BaselinePackageVersion>2.3.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Razor.Extensions' AND '$(TargetFramework)' == 'net46' ">
-    <BaselinePackageReference Include="Microsoft.CodeAnalysis.Razor" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.CodeAnalysis.Razor" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="[2.3.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Razor.Extensions' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.CodeAnalysis.Razor" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.CodeAnalysis.Razor" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="[2.3.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.Razor-->
@@ -657,20 +657,20 @@
     <BaselinePackageVersion>2.3.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Razor' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="[2.3.0, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="[2.3.0, )" />
     <BaselinePackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="[2.8.2, )" />
-    <BaselinePackageReference Include="Microsoft.CodeAnalysis.Razor" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.CodeAnalysis.Razor" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Caching.Memory" Version="[8.0.1, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="[8.0.0, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Razor' AND '$(TargetFramework)' == 'net462' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="[2.3.0, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="[2.3.0, )" />
     <BaselinePackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="[2.8.2, )" />
-    <BaselinePackageReference Include="Microsoft.CodeAnalysis.Razor" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.CodeAnalysis.Razor" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Caching.Memory" Version="[8.0.1, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="[8.0.0, )" />
     <BaselinePackageReference Include="Microsoft.DiaSymReader.Native" Version="[1.7.0, )" />
@@ -680,7 +680,7 @@
     <BaselinePackageVersion>2.3.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Razor.ViewCompilation' AND '$(TargetFramework)' == 'net462' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.RazorPages" Version="[2.3.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.RazorPages-->
@@ -692,84 +692,84 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.TagHelpers-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.TagHelpers' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.TagHelpers' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="[2.3.0, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Razor.Runtime" Version="[2.3.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Caching.Memory" Version="[8.0.1, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="[8.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[8.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.Testing-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Testing' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.Testing' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.TestHost" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.TestHost" Version="[2.3.12, )" />
     <BaselinePackageReference Include="System.IO.Pipelines" Version="[8.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.ViewFeatures-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.ViewFeatures' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.ViewFeatures' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Antiforgery" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Antiforgery" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.WebEncoders" Version="[8.0.11, )" />
     <BaselinePackageReference Include="Newtonsoft.Json" Version="[13.0.1, )" />
     <BaselinePackageReference Include="Newtonsoft.Json.Bson" Version="[1.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc.WebApiCompatShim-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.WebApiCompatShim' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc.WebApiCompatShim' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.AspNet.WebApi.Client" Version="[5.2.7, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Mvc-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Mvc' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Cors" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Cors" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Localization" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="[2.3.0, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.RazorPages" Version="[2.3.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="[2.3.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Caching.Memory" Version="[8.0.1, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[8.0.1, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.NodeServices-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.NodeServices' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.NodeServices' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Console" Version="[8.0.1, )" />
     <BaselinePackageReference Include="Newtonsoft.Json" Version="[11.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Owin-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Owin' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Owin' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Razor.Design-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Razor.Design' ">
@@ -787,7 +787,7 @@
     <BaselinePackageVersion>2.3.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Razor.Runtime' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.Razor" Version="[2.3.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Razor-->
@@ -795,45 +795,45 @@
     <BaselinePackageVersion>2.3.0</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Razor' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.ResponseCaching.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ResponseCaching.Abstractions' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ResponseCaching.Abstractions' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[8.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.ResponseCaching-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ResponseCaching' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ResponseCaching' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.ResponseCaching.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.ResponseCaching.Abstractions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Caching.Memory" Version="[8.0.1, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.ResponseCompression-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ResponseCompression' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ResponseCompression' AND '$(TargetFramework)' == 'net462' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
   </ItemGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.ResponseCompression' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Rewrite-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Rewrite' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Rewrite' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[8.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="[8.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
@@ -841,43 +841,43 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Routing.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Routing.Abstractions' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Routing.Abstractions' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Routing-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Routing' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Routing' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Routing.Abstractions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.ObjectPool" Version="[8.0.11, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Server.HttpSys-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.HttpSys' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.HttpSys' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Core" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.Net.Http.Headers" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Core" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.Net.Http.Headers" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Win32.Registry" Version="[4.5.0, )" />
     <BaselinePackageReference Include="System.Security.Principal.Windows" Version="[5.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Server.IISIntegration-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.IISIntegration' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.IISIntegration' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Core" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.HttpOverrides" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authentication.Core" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.HttpOverrides" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
     <BaselinePackageReference Include="System.Buffers" Version="[4.6.0, )" />
@@ -889,17 +889,17 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Server.Kestrel.Core-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.Kestrel.Core' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.Kestrel.Core' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration" Version="[8.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
-    <BaselinePackageReference Include="Microsoft.Net.Http.Headers" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.Net.Http.Headers" Version="[2.3.12, )" />
     <BaselinePackageReference Include="System.Memory" Version="[4.6.0, )" />
     <BaselinePackageReference Include="System.Numerics.Vectors" Version="[4.6.0, )" />
     <BaselinePackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="[6.1.0, )" />
@@ -908,66 +908,66 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Server.Kestrel.Https-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.Kestrel.Https' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.Kestrel.Https' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="System.IO.Pipelines" Version="[8.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Libuv" Version="[1.10.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
     <BaselinePackageReference Include="System.IO.Pipelines" Version="[8.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Server.Kestrel-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.Kestrel' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Server.Kestrel' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="[2.3.12, )" />
     <BaselinePackageReference Include="System.IO.Pipelines" Version="[8.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.Session-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Session' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.Session' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="[8.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Client.Core-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Client.Core' ">
-    <BaselinePackageVersion>1.2.11</BaselinePackageVersion>
+    <BaselinePackageVersion>1.2.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Client.Core' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[1.2.0, )" />
@@ -979,7 +979,7 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Client-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Client' ">
-    <BaselinePackageVersion>1.2.11</BaselinePackageVersion>
+    <BaselinePackageVersion>1.2.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Client' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Connections.Client" Version="[1.2.0, )" />
@@ -988,20 +988,20 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Common-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Common' ">
-    <BaselinePackageVersion>1.2.11</BaselinePackageVersion>
+    <BaselinePackageVersion>1.2.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Common' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Connections.Abstractions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Newtonsoft.Json" Version="[11.0.2, )" />
     <BaselinePackageReference Include="System.Buffers" Version="[4.6.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Core-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Core' ">
-    <BaselinePackageVersion>1.2.11</BaselinePackageVersion>
+    <BaselinePackageVersion>1.2.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Core' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Authorization" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[1.2.0, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="[1.2.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[8.0.2, )" />
@@ -1012,7 +1012,7 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR.Protocols.Json-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.Json' ">
-    <BaselinePackageVersion>1.2.11</BaselinePackageVersion>
+    <BaselinePackageVersion>1.2.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR.Protocols.Json' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="[1.2.0, )" />
@@ -1021,83 +1021,83 @@
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SignalR-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR' ">
-    <BaselinePackageVersion>1.2.11</BaselinePackageVersion>
+    <BaselinePackageVersion>1.2.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SignalR' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Connections" Version="[1.2.0, )" />
     <BaselinePackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="[1.2.0, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.WebSockets" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.WebSockets" Version="[2.3.12, )" />
     <BaselinePackageReference Include="System.IO.Pipelines" Version="[8.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SpaServices.Extensions-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SpaServices.Extensions' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SpaServices.Extensions' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.SpaServices" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.WebSockets" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.SpaServices" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.WebSockets" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="[8.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.SpaServices-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SpaServices' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.SpaServices' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.NodeServices" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.NodeServices" Version="[2.3.12, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.StaticFiles-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.StaticFiles' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.StaticFiles' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="[8.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[8.0.2, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.WebEncoders" Version="[8.0.11, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.TestHost-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.TestHost' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.TestHost' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.3.12, )" />
     <BaselinePackageReference Include="System.IO.Pipelines" Version="[8.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.WebSockets-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.WebSockets' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.WebSockets' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Options" Version="[8.0.2, )" />
     <BaselinePackageReference Include="System.Net.WebSockets.WebSocketProtocol" Version="[5.1.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore.WebUtilities-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.WebUtilities' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore.WebUtilities' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.Net.Http.Headers" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.Net.Http.Headers" Version="[2.3.12, )" />
     <BaselinePackageReference Include="System.Text.Encodings.Web" Version="[8.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.AspNetCore-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.AspNetCore' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.HostFiltering" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Routing" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="[2.3.11, )" />
-    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.HostFiltering" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Hosting" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Routing" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="[2.3.12, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Https" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="[8.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="[8.0.0, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="[8.0.1, )" />
@@ -1110,7 +1110,7 @@
   </ItemGroup>
   <!-- Package: Microsoft.CodeAnalysis.Razor-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.CodeAnalysis.Razor' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.CodeAnalysis.Razor' AND '$(TargetFramework)' == 'net46' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="[2.3.0, )" />
@@ -1125,7 +1125,7 @@
   </ItemGroup>
   <!-- Package: Microsoft.Extensions.Identity.Core-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Core' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Core' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="[2.3.0, )" />
@@ -1135,16 +1135,16 @@
   </ItemGroup>
   <!-- Package: Microsoft.Extensions.Identity.Stores-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Stores' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Extensions.Identity.Stores' AND '$(TargetFramework)' == 'netstandard2.0' ">
-    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Core" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.Extensions.Identity.Core" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Extensions.Logging" Version="[8.0.1, )" />
     <BaselinePackageReference Include="System.ComponentModel.Annotations" Version="[5.0.0, )" />
   </ItemGroup>
   <!-- Package: Microsoft.Net.Http.Headers-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Net.Http.Headers' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Net.Http.Headers' AND '$(TargetFramework)' == 'netstandard2.0' ">
     <BaselinePackageReference Include="Microsoft.Extensions.Primitives" Version="[8.0.0, )" />
@@ -1152,15 +1152,15 @@
   </ItemGroup>
   <!-- Package: Microsoft.Net.Sdk.Razor-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Net.Sdk.Razor' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Net.Sdk.Razor' AND '$(TargetFramework)' == 'netstandard2.0' " />
   <!-- Package: Microsoft.Owin.Security.Interop-->
   <PropertyGroup Condition=" '$(PackageId)' == 'Microsoft.Owin.Security.Interop' ">
-    <BaselinePackageVersion>2.3.11</BaselinePackageVersion>
+    <BaselinePackageVersion>2.3.12</BaselinePackageVersion>
   </PropertyGroup>
   <ItemGroup Condition=" '$(PackageId)' == 'Microsoft.Owin.Security.Interop' AND '$(TargetFramework)' == 'net462' ">
-    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="[2.3.11, )" />
+    <BaselinePackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="[2.3.12, )" />
     <BaselinePackageReference Include="Microsoft.Owin.Security" Version="[4.2.2, )" />
   </ItemGroup>
 </Project>

--- a/eng/Baseline.xml
+++ b/eng/Baseline.xml
@@ -4,125 +4,125 @@ This file contains a list of all the packages and their versions which were rele
 build of ASP.NET Core 2.3.x. Update this list when preparing for a new patch.
 
 -->
-<Baseline Version="2.3.11">
+<Baseline Version="2.3.12">
   <Package Id="dotnet-dev-certs" Version="2.1.1" />
   <Package Id="dotnet-sql-cache" Version="2.1.1" />
   <Package Id="dotnet-user-secrets" Version="2.1.1" />
   <Package Id="dotnet-watch" Version="2.1.1" />
-  <Package Id="Microsoft.AspNetCore.Antiforgery" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Authentication.Cookies" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Authentication.Core" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Authentication.Facebook" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Authentication.Google" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Authentication.OAuth" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Authentication.Twitter" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Authentication.WsFederation" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Authentication" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Authorization.Policy" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Authorization" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Connections.Abstractions" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.CookiePolicy" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Cors" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Cryptography.Internal" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.DataProtection.Abstractions" Version="2.3.11" />
+  <Package Id="Microsoft.AspNetCore.Antiforgery" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.ApplicationInsights.HostingStartup" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Authentication.Cookies" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Authentication.Core" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Authentication.Facebook" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Authentication.Google" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Authentication.MicrosoftAccount" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Authentication.OAuth" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Authentication.Twitter" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Authentication.WsFederation" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Authentication" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Authorization.Policy" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Authorization" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.AzureAppServices.HostingStartup" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.AzureAppServicesIntegration" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Connections.Abstractions" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.CookiePolicy" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Cors" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Cryptography.Internal" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.DataProtection.Abstractions" Version="2.3.12" />
   <Package Id="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="2.1.24" />
   <Package Id="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="2.1.24" />
-  <Package Id="Microsoft.AspNetCore.DataProtection.Extensions" Version="2.3.11" />
+  <Package Id="Microsoft.AspNetCore.DataProtection.Extensions" Version="2.3.12" />
   <Package Id="Microsoft.AspNetCore.DataProtection.Redis" Version="0.4.1" />
-  <Package Id="Microsoft.AspNetCore.DataProtection.SystemWeb" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.DataProtection" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Diagnostics" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.HostFiltering" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Hosting.WindowsServices" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Hosting" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Html.Abstractions" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Http.Connections.Client" Version="1.2.11" />
-  <Package Id="Microsoft.AspNetCore.Http.Connections.Common" Version="1.2.11" />
-  <Package Id="Microsoft.AspNetCore.Http.Connections" Version="1.2.11" />
-  <Package Id="Microsoft.AspNetCore.Http.Extensions" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Http.Features" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Http" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.HttpOverrides" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.HttpsPolicy" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Identity.Specification.Tests" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Identity.UI" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Identity" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.JsonPatch" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Localization.Routing" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Localization" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.MiddlewareAnalysis" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.11" />
+  <Package Id="Microsoft.AspNetCore.DataProtection.SystemWeb" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.DataProtection" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Diagnostics.Abstractions" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Diagnostics" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.HostFiltering" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Hosting.Server.Abstractions" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Hosting.WindowsServices" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Hosting" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Html.Abstractions" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Http.Connections.Client" Version="1.2.12" />
+  <Package Id="Microsoft.AspNetCore.Http.Connections.Common" Version="1.2.12" />
+  <Package Id="Microsoft.AspNetCore.Http.Connections" Version="1.2.12" />
+  <Package Id="Microsoft.AspNetCore.Http.Extensions" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Http.Features" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Http" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.HttpOverrides" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.HttpsPolicy" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Identity.Specification.Tests" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Identity.UI" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Identity" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.JsonPatch" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Localization.Routing" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Localization" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.MiddlewareAnalysis" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.3.12" />
   <Package Id="Microsoft.AspNetCore.Mvc.Analyzers" Version="2.3.0" />
-  <Package Id="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Mvc.Core" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Mvc.Cors" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Mvc.Localization" Version="2.3.11" />
+  <Package Id="Microsoft.AspNetCore.Mvc.ApiExplorer" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Mvc.Core" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Mvc.Cors" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Mvc.DataAnnotations" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Mvc.Localization" Version="2.3.12" />
   <Package Id="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="2.3.0" />
   <Package Id="Microsoft.AspNetCore.Mvc.Razor" Version="2.3.0" />
   <Package Id="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation" Version="2.3.0" />
   <Package Id="Microsoft.AspNetCore.Mvc.RazorPages" Version="2.3.0" />
-  <Package Id="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Mvc.Testing" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Mvc" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.NodeServices" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Owin" Version="2.3.11" />
+  <Package Id="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Mvc.Testing" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Mvc.ViewFeatures" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Mvc" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.NodeServices" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Owin" Version="2.3.12" />
   <Package Id="Microsoft.AspNetCore.Razor.Design" Version="2.3.0" />
   <Package Id="Microsoft.AspNetCore.Razor.Language" Version="2.3.0" />
   <Package Id="Microsoft.AspNetCore.Razor.Runtime" Version="2.3.0" />
   <Package Id="Microsoft.AspNetCore.Razor" Version="2.3.0" />
-  <Package Id="Microsoft.AspNetCore.ResponseCaching.Abstractions" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.ResponseCaching" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.ResponseCompression" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Rewrite" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Routing.Abstractions" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Routing" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Server.HttpSys" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Server.IISIntegration" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.Session" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Client.Core" Version="1.2.11" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Client" Version="1.2.11" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Common" Version="1.2.11" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Core" Version="1.2.11" />
-  <Package Id="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="1.2.11" />
-  <Package Id="Microsoft.AspNetCore.SignalR" Version="1.2.11" />
-  <Package Id="Microsoft.AspNetCore.SpaServices.Extensions" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.SpaServices" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.StaticFiles" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.TestHost" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.WebSockets" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore.WebUtilities" Version="2.3.11" />
-  <Package Id="Microsoft.AspNetCore" Version="2.3.11" />
-  <Package Id="Microsoft.CodeAnalysis.Razor" Version="2.3.11" />
-  <Package Id="Microsoft.Extensions.Identity.Core" Version="2.3.11" />
-  <Package Id="Microsoft.Extensions.Identity.Stores" Version="2.3.11" />
-  <Package Id="Microsoft.Net.Http.Headers" Version="2.3.11" />
-  <Package Id="Microsoft.Net.Sdk.Razor" Version="2.3.11" />
-  <Package Id="Microsoft.Owin.Security.Interop" Version="2.3.11" />
+  <Package Id="Microsoft.AspNetCore.ResponseCaching.Abstractions" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.ResponseCaching" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.ResponseCompression" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Rewrite" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Routing.Abstractions" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Routing" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Server.HttpSys" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Server.IISIntegration" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Server.Kestrel.Https" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Server.Kestrel" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.Session" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Client.Core" Version="1.2.12" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Client" Version="1.2.12" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Common" Version="1.2.12" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Core" Version="1.2.12" />
+  <Package Id="Microsoft.AspNetCore.SignalR.Protocols.Json" Version="1.2.12" />
+  <Package Id="Microsoft.AspNetCore.SignalR" Version="1.2.12" />
+  <Package Id="Microsoft.AspNetCore.SpaServices.Extensions" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.SpaServices" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.StaticFiles" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.TestHost" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.WebSockets" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore.WebUtilities" Version="2.3.12" />
+  <Package Id="Microsoft.AspNetCore" Version="2.3.12" />
+  <Package Id="Microsoft.CodeAnalysis.Razor" Version="2.3.12" />
+  <Package Id="Microsoft.Extensions.Identity.Core" Version="2.3.12" />
+  <Package Id="Microsoft.Extensions.Identity.Stores" Version="2.3.12" />
+  <Package Id="Microsoft.Net.Http.Headers" Version="2.3.12" />
+  <Package Id="Microsoft.Net.Sdk.Razor" Version="2.3.12" />
+  <Package Id="Microsoft.Owin.Security.Interop" Version="2.3.12" />
 </Baseline>

--- a/eng/PatchConfig.props
+++ b/eng/PatchConfig.props
@@ -76,4 +76,8 @@ Later on, this will be checked using this condition:
     <PackagesInPatch>
     </PackagesInPatch>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(VersionPrefix)' == '2.3.13' ">
+    <PackagesInPatch>
+    </PackagesInPatch>
+  </PropertyGroup>
 </Project>

--- a/src/Mvc/Mvc.Analyzers/src/Microsoft.AspNetCore.Mvc.Analyzers.csproj
+++ b/src/Mvc/Mvc.Analyzers/src/Microsoft.AspNetCore.Mvc.Analyzers.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <SignedPackageFile Include="Microsoft.AspNetCore.Mvc.Analyzers.dll" Certificate="MicrosoftSHA2" Visible="false" />
+    <SignedPackageFile Include="$(TargetPath)" Certificate="MicrosoftSHA2" PackagePath="analyzers/dotnet/cs/$(TargetFileName)" Visible="false" />
   </ItemGroup>
 
   <Target Name="PopulateNuspec" BeforeTargets="GenerateNuspec" DependsOnTargets="Build">

--- a/src/Mvc/Mvc.Razor/src/Microsoft.AspNetCore.Mvc.Razor.csproj
+++ b/src/Mvc/Mvc.Razor/src/Microsoft.AspNetCore.Mvc.Razor.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <SignedPackageFile Include="Microsoft.AspNetCore.Mvc.Razor.dll" Certificate="MicrosoftSHA2" Visible="false" />
+    <SignedPackageFile Include="$(TargetPath)" Certificate="MicrosoftSHA2" PackagePath="lib/$(TargetFramework)/$(TargetFileName)" Visible="false" />
   </ItemGroup>
 
   <Target Name="PopulateNuspec" BeforeTargets="GenerateNuspec" DependsOnTargets="BuiltProjectOutputGroup;DebugSymbolsProjectOutputGroup;DocumentationProjectOutputGroup">

--- a/src/Mvc/ViewCompilation/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.csproj
+++ b/src/Mvc/ViewCompilation/src/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.csproj
@@ -35,11 +35,10 @@
     <PackageReference Update="Microsoft.NETCore.App" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup>
-    <SignedPackageFile Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.dll" Certificate="MicrosoftSHA2" Visible="false" />
-    <SignedPackageFile Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.Tasks.dll" Certificate="MicrosoftSHA2" Visible="false" />
-    <SignedPackageFile Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation-x86.exe" Certificate="MicrosoftSHA2" Visible="false" />
-    <SignedPackageFile Include="Microsoft.AspNetCore.Mvc.Razor.ViewCompilation-x64.exe" Certificate="MicrosoftSHA2" Visible="false" />
+  <ItemGroup Condition="'$(TargetFramework)'==''">
+    <SignedPackageFile Include="$(TasksProjectDirectory)bin\$(Configuration)\netstandard2.0\Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.Tasks.dll" Certificate="MicrosoftSHA2" PackagePath="build/netstandard2.0/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation.Tasks.dll" Visible="false" />
+    <SignedPackageFile Include="$(MSBuildProjectDirectory)\bin\$(Configuration)\net462\win7-x86\Microsoft.AspNetCore.Mvc.Razor.ViewCompilation-x86.exe" Certificate="MicrosoftSHA2" PackagePath="build/netstandard2.0/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation-x86.exe" Visible="false" />
+    <SignedPackageFile Include="$(MSBuildProjectDirectory)\bin\$(Configuration)\net462\win7-x64\Microsoft.AspNetCore.Mvc.Razor.ViewCompilation-x64.exe" Certificate="MicrosoftSHA2" PackagePath="build/netstandard2.0/Microsoft.AspNetCore.Mvc.Razor.ViewCompilation-x64.exe" Visible="false" />
   </ItemGroup>
 
   <Target Name="BuildX64" AfterTargets="AfterBuild" Condition="'$(TargetFramework)'=='net462' AND '$(PlatformTarget)'!='x64'">

--- a/src/Razor/Razor.Design/src/Microsoft.AspNetCore.Razor.Design.csproj
+++ b/src/Razor/Razor.Design/src/Microsoft.AspNetCore.Razor.Design.csproj
@@ -42,13 +42,15 @@
 
   <ItemGroup>
     <!-- These files should be signed by aspnet/razor -->
-    <ExcludePackageFileFromSigning Include="Microsoft.CodeAnalysis.dll"  />
-    <ExcludePackageFileFromSigning Include="Microsoft.CodeAnalysis.CSharp.dll"  />
+    <ExcludePackageFileFromSigning Include="$(MSBuildProjectDirectory)\$(OutputPath)tools\Microsoft.CodeAnalysis.dll" PackagePath="tools/Microsoft.CodeAnalysis.dll" />
+    <ExcludePackageFileFromSigning Include="$(MSBuildProjectDirectory)\$(OutputPath)tools\Microsoft.CodeAnalysis.CSharp.dll" PackagePath="tools/Microsoft.CodeAnalysis.CSharp.dll" />
     <!-- These files should be signed by dotnet/corefx -->
-    <ExcludePackageFileFromSigning Include="System.Text.Encoding.CodePages.dll" />
-    <SignedPackageFile Include="rzc.dll" Certificate="MicrosoftSHA2" Visible="false" />
-    <SignedPackageFile Include="Microsoft.AspNetCore.Razor.Tasks.dll" Certificate="MicrosoftSHA2" Visible="false" />
-    <SignedPackageFile Include="Newtonsoft.Json.dll" Certificate="3PartySHA2" Visible="false" />
+    <ExcludePackageFileFromSigning Include="$(MSBuildProjectDirectory)\$(OutputPath)tools\runtimes\unix\lib\netstandard1.3\System.Text.Encoding.CodePages.dll" PackagePath="tools/runtimes/unix/lib/netstandard1.3/System.Text.Encoding.CodePages.dll" />
+    <ExcludePackageFileFromSigning Include="$(MSBuildProjectDirectory)\$(OutputPath)tools\runtimes\win\lib\netstandard1.3\System.Text.Encoding.CodePages.dll" PackagePath="tools/runtimes/win/lib/netstandard1.3/System.Text.Encoding.CodePages.dll" />
+    <SignedPackageFile Include="$(MSBuildProjectDirectory)\$(OutputPath)tools\rzc.dll" Certificate="MicrosoftSHA2" PackagePath="tools/rzc.dll" Visible="false" />
+    <SignedPackageFile Include="$(TaskDirNetStandard)Microsoft.AspNetCore.Razor.Tasks.dll" Certificate="MicrosoftSHA2" PackagePath="tasks/net46/Microsoft.AspNetCore.Razor.Tasks.dll" Visible="false" />
+    <SignedPackageFile Include="$(TaskDirNetStandard)Microsoft.AspNetCore.Razor.Tasks.dll" Certificate="MicrosoftSHA2" PackagePath="tasks/netstandard2.0/Microsoft.AspNetCore.Razor.Tasks.dll" Visible="false" />
+    <SignedPackageFile Include="$(MSBuildProjectDirectory)\$(OutputPath)tools\Newtonsoft.Json.dll" Certificate="3PartySHA2" PackagePath="tools/Newtonsoft.Json.dll" Visible="false" />
   </ItemGroup>
 
   <Target Name="_BuildDependencyProjects">

--- a/version.props
+++ b/version.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AspNetCoreMajorVersion>2</AspNetCoreMajorVersion>
     <AspNetCoreMinorVersion>3</AspNetCoreMinorVersion>
-    <AspNetCorePatchVersion>12</AspNetCorePatchVersion>
+    <AspNetCorePatchVersion>13</AspNetCorePatchVersion>
     <ValidateBaseline>true</ValidateBaseline>
 
     <PreReleaseLabel>servicing</PreReleaseLabel>


### PR DESCRIPTION
Updates the ASP.NET Core 2.3 servicing branding following #67686:

- Bumps `AspNetCorePatchVersion` from 12 to 13
- Refreshes `eng/Baseline.xml` and `eng/Baseline.Designer.props` from 2.3.11 to the shipped 2.3.12 packages, including SignalR/HTTP Connections packages from 1.2.11 to 1.2.12
- Adds the empty 2.3.13 `PackagesInPatch` block

NuGet.org was unavailable from this environment, so every changed package/version pair was checked against the public `dotnet-public` feed. All 104 pairs were found.

`dotnet msbuild version.props` reports `2.3.13-servicing-t000`.