### PR TITLE
Fix LoginWith2fa remember-machine checkbox label association

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/LoginWith2fa.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/LoginWith2fa.razor
@@ -28,7 +28,7 @@
                 <ValidationMessage For="() => Input.TwoFactorCode" class="text-danger" />
             </div>
             <div class="checkbox mb-3">
-                <label for="remember-machine" class="form-label">
+                <label class="form-label">
                     <InputCheckbox @bind-Value="Input.RememberMachine" />
                     Remember this machine
                 </label>

--- a/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs
@@ -63,7 +63,7 @@ public class BlazorWebTemplateTest(ProjectFactoryFixture projectFactory) : Blazo
         var loginWith2faPath = Path.Combine(project.TemplateOutputDir, "Components", "Account", "Pages", "LoginWith2fa.razor");
         var loginWith2fa = await File.ReadAllTextAsync(loginWith2faPath);
 
-•	    Assert.Contains("Input.RememberMachine", loginWith2fa);
+	    Assert.Contains("Input.RememberMachine", loginWith2fa);
         Assert.DoesNotContain("for=\"remember-machine\"", loginWith2fa);
     }
 

--- a/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs
@@ -53,6 +53,20 @@ public class BlazorWebTemplateTest(ProjectFactoryFixture projectFactory) : Blazo
         }
     }
 
+    [Fact]
+    public async Task BlazorWebTemplate_LoginWith2faRememberMachineHasAssociatedLabel()
+    {
+        var project = await CreateBuildPublishAsync(
+            args: ["-int", "None", "-au", "Individual"],
+            onlyCreate: true);
+
+        var loginWith2faPath = Path.Combine(project.TemplateOutputDir, "Components", "Account", "Pages", "LoginWith2fa.razor");
+        var loginWith2fa = await File.ReadAllTextAsync(loginWith2faPath);
+
+•	    Assert.Contains("Input.RememberMachine", loginWith2fa);
+        Assert.DoesNotContain("for=\"remember-machine\"", loginWith2fa);
+    }
+
     [Theory]
     [InlineData(BrowserKind.Chromium)]
     public async Task BlazorWebTemplate_CanUsePasskeys(BrowserKind browserKind)

--- a/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs
+++ b/src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs
@@ -53,20 +53,6 @@ public class BlazorWebTemplateTest(ProjectFactoryFixture projectFactory) : Blazo
         }
     }
 
-    [Fact]
-    public async Task BlazorWebTemplate_LoginWith2faRememberMachineHasAssociatedLabel()
-    {
-        var project = await CreateBuildPublishAsync(
-            args: ["-int", "None", "-au", "Individual"],
-            onlyCreate: true);
-
-        var loginWith2faPath = Path.Combine(project.TemplateOutputDir, "Components", "Account", "Pages", "LoginWith2fa.razor");
-        var loginWith2fa = await File.ReadAllTextAsync(loginWith2faPath);
-
-	    Assert.Contains("Input.RememberMachine", loginWith2fa);
-        Assert.DoesNotContain("for=\"remember-machine\"", loginWith2fa);
-    }
-
     [Theory]
     [InlineData(BrowserKind.Chromium)]
     public async Task BlazorWebTemplate_CanUsePasskeys(BrowserKind browserKind)


### PR DESCRIPTION
## Description

This PR fixes an accessibility issue in the Blazor Web App (Individual auth) template where the "Remember this machine" checkbox label used `for="remember-machine"` without a matching element id.

### Changes
- Removed the invalid `for` attribute so the checkbox uses implicit association via the wrapping `<label>`
- Added a regression test in `src/ProjectTemplates/test/Templates.Blazor.Tests/BlazorWebTemplateTest.cs` checking whether:
  - `"Input.RememberMachine"` is present
  - `"for=\"remember-machine\""` is not present

Fixes #67669

## Customer Impact

Because the label declares a `for` that matches no element, the browser does not fall back to the implicit wrapping association, so the checkbox ends up with no associated label: screen readers announce an unlabeled checkbox and clicking the visible text does not toggle it.

## Regression?

- [x] Yes
- [ ] No

Introduced in #51134, which removed `id="remember-machine"` from the `InputCheckbox` but left `for="remember-machine"` on the label. The markup was correct when originally added in #50722. 

## Risk

- [ ] High
- [ ] Medium
- [x] Low

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A

