### PR TITLE
Temporarily disable Helix JobMonitor

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -62,6 +62,8 @@ variables:
     value: true
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
+- name: enableHelixcJobMonitor
+  value: false
 - name: _BuildArgs
   value: '/p:SkipTestBuild=true /p:PostBuildSign=$(PostBuildSign)'
 - name: _PublishArgs
@@ -608,7 +610,7 @@ stages:
           displayName: Build shared fx
         # -noBuildNative -noBuild to avoid repeating work done in the previous step.
         - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
-                  -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:EnableHelixJobMonitor=true
+                  -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:EnableHelixJobMonitor=$(enableHelixcJobMonitor)
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
                   /p:VsTestUseMSBuildOutput=false /p:RunTemplateTests=false /p:HelixSubset=1
           displayName: Run build.cmd helix target
@@ -637,7 +639,7 @@ stages:
           displayName: Build shared fx
         # -noBuildNative -noBuild to avoid repeating work done in the previous step.
         - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
-                  -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:EnableHelixJobMonitor=true
+                  -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:EnableHelixJobMonitor=$(enableHelixcJobMonitor)
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
                   /p:VsTestUseMSBuildOutput=false /p:RunTemplateTests=false /p:HelixSubset=2
           displayName: Run build.cmd helix target
@@ -653,6 +655,7 @@ stages:
 
     - template: /eng/common/core-templates/job/helix-job-monitor.yml
       parameters:
+        condition: eq(variables['enableHelixcJobMonitor'], 'true')
         helixAccessToken: $(HelixApiAccessToken)
 
     # Local development validation

--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -62,7 +62,7 @@ variables:
     value: true
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
-- name: enableHelixcJobMonitor
+- name: enableHelixJobMonitor
   value: false
 - name: _BuildArgs
   value: '/p:SkipTestBuild=true /p:PostBuildSign=$(PostBuildSign)'
@@ -610,7 +610,7 @@ stages:
           displayName: Build shared fx
         # -noBuildNative -noBuild to avoid repeating work done in the previous step.
         - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
-                  -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:EnableHelixJobMonitor=$(enableHelixcJobMonitor)
+                  -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:EnableHelixJobMonitor=$(enableHelixJobMonitor)
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
                   /p:VsTestUseMSBuildOutput=false /p:RunTemplateTests=false /p:HelixSubset=1
           displayName: Run build.cmd helix target
@@ -639,7 +639,7 @@ stages:
           displayName: Build shared fx
         # -noBuildNative -noBuild to avoid repeating work done in the previous step.
         - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
-                  -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:EnableHelixJobMonitor=$(enableHelixcJobMonitor)
+                  -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:EnableHelixJobMonitor=$(enableHelixJobMonitor)
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
                   /p:VsTestUseMSBuildOutput=false /p:RunTemplateTests=false /p:HelixSubset=2
           displayName: Run build.cmd helix target
@@ -655,7 +655,7 @@ stages:
 
     - template: /eng/common/core-templates/job/helix-job-monitor.yml
       parameters:
-        condition: eq(variables['enableHelixcJobMonitor'], 'true')
+        condition: eq(variables['enableHelixJobMonitor'], 'true')
         helixAccessToken: $(HelixApiAccessToken)
 
     # Local development validation

--- a/.azure/pipelines/ci-unofficial.yml
+++ b/.azure/pipelines/ci-unofficial.yml
@@ -29,7 +29,7 @@ variables:
   value: ''
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
-- name: enableHelixcJobMonitor
+- name: enableHelixJobMonitor
   value: false
 - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
   - name: _BuildArgs
@@ -645,7 +645,7 @@ extends:
             # -noBuildNative -noBuild to avoid repeating work done in the previous step.
             - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
                       -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=1
-                      /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /p:EnableHelixJobMonitor=$(enableHelixcJobMonitor) $(_InternalRuntimeDownloadArgs)
+                      /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /p:EnableHelixJobMonitor=$(enableHelixJobMonitor) $(_InternalRuntimeDownloadArgs)
               displayName: Run build.cmd helix target
               env:
                 HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
@@ -677,7 +677,7 @@ extends:
             # -noBuildNative -noBuild to avoid repeating work done in the previous step.
             - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
                       -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=2
-                      /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /p:EnableHelixJobMonitor=$(enableHelixcJobMonitor) $(_InternalRuntimeDownloadArgs)
+                      /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /p:EnableHelixJobMonitor=$(enableHelixJobMonitor) $(_InternalRuntimeDownloadArgs)
               displayName: Run build.cmd helix target
               env:
                 HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
@@ -691,7 +691,7 @@ extends:
 
         - template: /eng/common/core-templates/job/helix-job-monitor.yml@self
           parameters:
-            condition: eq(variables['enableHelixcJobMonitor'], 'true')
+            condition: eq(variables['enableHelixJobMonitor'], 'true')
             helixAccessToken: $(HelixApiAccessToken)
 
         # Local development validation

--- a/.azure/pipelines/ci-unofficial.yml
+++ b/.azure/pipelines/ci-unofficial.yml
@@ -29,6 +29,8 @@ variables:
   value: ''
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
+- name: enableHelixcJobMonitor
+  value: false
 - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
   - name: _BuildArgs
     value: /p:TeamName=$(_TeamName)
@@ -643,7 +645,7 @@ extends:
             # -noBuildNative -noBuild to avoid repeating work done in the previous step.
             - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
                       -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=1
-                      /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /p:EnableHelixJobMonitor=true $(_InternalRuntimeDownloadArgs)
+                      /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /p:EnableHelixJobMonitor=$(enableHelixcJobMonitor) $(_InternalRuntimeDownloadArgs)
               displayName: Run build.cmd helix target
               env:
                 HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
@@ -675,7 +677,7 @@ extends:
             # -noBuildNative -noBuild to avoid repeating work done in the previous step.
             - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
                       -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=2
-                      /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /p:EnableHelixJobMonitor=true $(_InternalRuntimeDownloadArgs)
+                      /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /p:EnableHelixJobMonitor=$(enableHelixcJobMonitor) $(_InternalRuntimeDownloadArgs)
               displayName: Run build.cmd helix target
               env:
                 HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
@@ -689,6 +691,7 @@ extends:
 
         - template: /eng/common/core-templates/job/helix-job-monitor.yml@self
           parameters:
+            condition: eq(variables['enableHelixcJobMonitor'], 'true')
             helixAccessToken: $(HelixApiAccessToken)
 
         # Local development validation
@@ -728,4 +731,3 @@ extends:
                 path: artifacts/log/
                 publishOnError: true
                 includeForks: true
-

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -49,6 +49,8 @@ variables:
     value: --publish
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
+- name: enableHelixcJobMonitor
+  value: false
 - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
   - name: _BuildArgs
     value: /p:TeamName=$(_TeamName)
@@ -638,7 +640,7 @@ extends:
               displayName: Build shared fx
             # -noBuildNative -noBuild to avoid repeating work done in the previous step.
             - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
-                      -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=1 /p:EnableHelixJobMonitor=true
+                      -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=1 /p:EnableHelixJobMonitor=$(enableHelixcJobMonitor)
                       /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
               displayName: Run build.cmd helix target
               env:
@@ -667,7 +669,7 @@ extends:
               displayName: Build shared fx
             # -noBuildNative -noBuild to avoid repeating work done in the previous step.
             - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
-                      -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=2 /p:EnableHelixJobMonitor=true
+                      -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=2 /p:EnableHelixJobMonitor=$(enableHelixcJobMonitor)
                       /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
               displayName: Run build.cmd helix target
               env:
@@ -682,6 +684,7 @@ extends:
 
         - template: /eng/common/core-templates/job/helix-job-monitor.yml@self
           parameters:
+            condition: eq(variables['enableHelixcJobMonitor'], 'true')
             helixAccessToken: $(HelixApiAccessToken)
 
         # Local development validation

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -49,7 +49,7 @@ variables:
     value: --publish
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
-- name: enableHelixcJobMonitor
+- name: enableHelixJobMonitor
   value: false
 - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
   - name: _BuildArgs
@@ -640,7 +640,7 @@ extends:
               displayName: Build shared fx
             # -noBuildNative -noBuild to avoid repeating work done in the previous step.
             - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
-                      -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=1 /p:EnableHelixJobMonitor=$(enableHelixcJobMonitor)
+                      -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=1 /p:EnableHelixJobMonitor=$(enableHelixJobMonitor)
                       /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
               displayName: Run build.cmd helix target
               env:
@@ -669,7 +669,7 @@ extends:
               displayName: Build shared fx
             # -noBuildNative -noBuild to avoid repeating work done in the previous step.
             - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
-                      -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=2 /p:EnableHelixJobMonitor=$(enableHelixcJobMonitor)
+                      -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=2 /p:EnableHelixJobMonitor=$(enableHelixJobMonitor)
                       /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
               displayName: Run build.cmd helix target
               env:
@@ -684,7 +684,7 @@ extends:
 
         - template: /eng/common/core-templates/job/helix-job-monitor.yml@self
           parameters:
-            condition: eq(variables['enableHelixcJobMonitor'], 'true')
+            condition: eq(variables['enableHelixJobMonitor'], 'true')
             helixAccessToken: $(HelixApiAccessToken)
 
         # Local development validation

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -18,7 +18,7 @@ schedules:
 variables:
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
-- name: enableHelixcJobMonitor
+- name: enableHelixJobMonitor
   value: false
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-HelixApi-Access
@@ -38,7 +38,7 @@ jobs:
       displayName: Build shared fx
     # -noBuildNative -noBuild to avoid repeating work done in the previous step.
     - script: .\eng\build.cmd -ci -prepareMachine -nobl -all -noBuildNative -noBuild -test
-              -projects eng\helix\helix.proj /p:IsHelixJob=true /p:EnableHelixJobMonitor=$(enableHelixcJobMonitor)
+              -projects eng\helix\helix.proj /p:IsHelixJob=true /p:EnableHelixJobMonitor=$(enableHelixJobMonitor)
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target
       env:
@@ -51,5 +51,5 @@ jobs:
 
 - template: /eng/common/core-templates/job/helix-job-monitor.yml
   parameters:
-    condition: eq(variables['enableHelixcJobMonitor'], 'true')
+    condition: eq(variables['enableHelixJobMonitor'], 'true')
     helixAccessToken: $(HelixApiAccessToken)

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -18,6 +18,8 @@ schedules:
 variables:
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
+- name: enableHelixcJobMonitor
+  value: false
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-HelixApi-Access
 - template: /eng/common/templates/variables/pool-providers.yml
@@ -36,7 +38,7 @@ jobs:
       displayName: Build shared fx
     # -noBuildNative -noBuild to avoid repeating work done in the previous step.
     - script: .\eng\build.cmd -ci -prepareMachine -nobl -all -noBuildNative -noBuild -test
-              -projects eng\helix\helix.proj /p:IsHelixJob=true /p:EnableHelixJobMonitor=true
+              -projects eng\helix\helix.proj /p:IsHelixJob=true /p:EnableHelixJobMonitor=$(enableHelixcJobMonitor)
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target
       env:
@@ -49,4 +51,5 @@ jobs:
 
 - template: /eng/common/core-templates/job/helix-job-monitor.yml
   parameters:
+    condition: eq(variables['enableHelixcJobMonitor'], 'true')
     helixAccessToken: $(HelixApiAccessToken)

--- a/.azure/pipelines/identitymodel-helix-matrix.yml
+++ b/.azure/pipelines/identitymodel-helix-matrix.yml
@@ -14,6 +14,8 @@ schedules:
 variables:
 - name: _UseHelixOpenQueues
   value: false
+- name: enableHelixcJobMonitor
+  value: false
 - group: DotNet-HelixApi-Access
 - template: /eng/common/templates-official/variables/pool-providers.yml@self
 
@@ -93,7 +95,7 @@ extends:
             displayName: Build shared fx
           # -noBuildNative -noBuild to avoid repeating work done in the previous step.
           - script: .\eng\build.cmd -ci -prepareMachine -nobl -all -noBuildNative -noBuild -test
-                    -projects eng\helix\helix.proj /p:IsHelixJob=true /p:RunTemplateTests=false /p:EnableHelixJobMonitor=true
+                    -projects eng\helix\helix.proj /p:IsHelixJob=true /p:RunTemplateTests=false /p:EnableHelixJobMonitor=$(enableHelixcJobMonitor)
                     /p:CrossgenOutput=false /p:IsIdentityModelTestJob=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
             displayName: Run build.cmd helix target
             env:
@@ -106,4 +108,5 @@ extends:
 
       - template: /eng/common/core-templates/job/helix-job-monitor.yml@self
         parameters:
+          condition: eq(variables['enableHelixcJobMonitor'], 'true')
           helixAccessToken: $(HelixApiAccessToken)

--- a/.azure/pipelines/identitymodel-helix-matrix.yml
+++ b/.azure/pipelines/identitymodel-helix-matrix.yml
@@ -14,7 +14,7 @@ schedules:
 variables:
 - name: _UseHelixOpenQueues
   value: false
-- name: enableHelixcJobMonitor
+- name: enableHelixJobMonitor
   value: false
 - group: DotNet-HelixApi-Access
 - template: /eng/common/templates-official/variables/pool-providers.yml@self
@@ -95,7 +95,7 @@ extends:
             displayName: Build shared fx
           # -noBuildNative -noBuild to avoid repeating work done in the previous step.
           - script: .\eng\build.cmd -ci -prepareMachine -nobl -all -noBuildNative -noBuild -test
-                    -projects eng\helix\helix.proj /p:IsHelixJob=true /p:RunTemplateTests=false /p:EnableHelixJobMonitor=$(enableHelixcJobMonitor)
+                    -projects eng\helix\helix.proj /p:IsHelixJob=true /p:RunTemplateTests=false /p:EnableHelixJobMonitor=$(enableHelixJobMonitor)
                     /p:CrossgenOutput=false /p:IsIdentityModelTestJob=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
             displayName: Run build.cmd helix target
             env:
@@ -108,5 +108,5 @@ extends:
 
       - template: /eng/common/core-templates/job/helix-job-monitor.yml@self
         parameters:
-          condition: eq(variables['enableHelixcJobMonitor'], 'true')
+          condition: eq(variables['enableHelixJobMonitor'], 'true')
           helixAccessToken: $(HelixApiAccessToken)

--- a/.azure/pipelines/template-tests-pr.yml
+++ b/.azure/pipelines/template-tests-pr.yml
@@ -25,6 +25,8 @@ pr:
 variables:
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
+- name: enableHelixcJobMonitor
+  value: false
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-HelixApi-Access
 - template: /eng/common/templates/variables/pool-providers.yml
@@ -47,7 +49,7 @@ jobs:
     - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
               -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
-              /p:VsTestUseMSBuildOutput=false /p:OnlyTestProjectTemplates=true /p:EnableHelixJobMonitor=true
+              /p:VsTestUseMSBuildOutput=false /p:OnlyTestProjectTemplates=true /p:EnableHelixJobMonitor=$(enableHelixcJobMonitor)
       displayName: Run build.cmd helix target
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
@@ -58,4 +60,5 @@ jobs:
 
 - template: /eng/common/core-templates/job/helix-job-monitor.yml
   parameters:
+    condition: eq(variables['enableHelixcJobMonitor'], 'true')
     helixAccessToken: $(HelixApiAccessToken)

--- a/.azure/pipelines/template-tests-pr.yml
+++ b/.azure/pipelines/template-tests-pr.yml
@@ -25,7 +25,7 @@ pr:
 variables:
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
-- name: enableHelixcJobMonitor
+- name: enableHelixJobMonitor
   value: false
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-HelixApi-Access
@@ -49,7 +49,7 @@ jobs:
     - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
               -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
-              /p:VsTestUseMSBuildOutput=false /p:OnlyTestProjectTemplates=true /p:EnableHelixJobMonitor=$(enableHelixcJobMonitor)
+              /p:VsTestUseMSBuildOutput=false /p:OnlyTestProjectTemplates=true /p:EnableHelixJobMonitor=$(enableHelixJobMonitor)
       displayName: Run build.cmd helix target
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
@@ -60,5 +60,5 @@ jobs:
 
 - template: /eng/common/core-templates/job/helix-job-monitor.yml
   parameters:
-    condition: eq(variables['enableHelixcJobMonitor'], 'true')
+    condition: eq(variables['enableHelixJobMonitor'], 'true')
     helixAccessToken: $(HelixApiAccessToken)


### PR DESCRIPTION
Temporarily disabling JobMonitor to reduce Azure DevOps load.

The existing JobMonitor wiring is retained behind the `enableHelixJobMonitor` pipeline variable so it can be restored by changing the variable to `true`.

Tracking: [dnceng/internal#12380](https://dev.azure.com/dnceng/internal/_workitems/edit/12380)