### PR TITLE
Update Helix Job Monitor to 11.0.0-beta.26427.10

### DIFF
--- a/.azure/pipelines/ci-public.yml
+++ b/.azure/pipelines/ci-public.yml
@@ -62,8 +62,6 @@ variables:
     value: true
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
-- name: enableHelixJobMonitor
-  value: false
 - name: _BuildArgs
   value: '/p:SkipTestBuild=true /p:PostBuildSign=$(PostBuildSign)'
 - name: _PublishArgs
@@ -610,7 +608,7 @@ stages:
           displayName: Build shared fx
         # -noBuildNative -noBuild to avoid repeating work done in the previous step.
         - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
-                  -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:EnableHelixJobMonitor=$(enableHelixJobMonitor)
+                  -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:EnableHelixJobMonitor=true
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
                   /p:VsTestUseMSBuildOutput=false /p:RunTemplateTests=false /p:HelixSubset=1
           displayName: Run build.cmd helix target
@@ -639,7 +637,7 @@ stages:
           displayName: Build shared fx
         # -noBuildNative -noBuild to avoid repeating work done in the previous step.
         - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
-                  -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:EnableHelixJobMonitor=$(enableHelixJobMonitor)
+                  -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:EnableHelixJobMonitor=true
                   /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
                   /p:VsTestUseMSBuildOutput=false /p:RunTemplateTests=false /p:HelixSubset=2
           displayName: Run build.cmd helix target
@@ -655,7 +653,6 @@ stages:
 
     - template: /eng/common/core-templates/job/helix-job-monitor.yml
       parameters:
-        condition: eq(variables['enableHelixJobMonitor'], 'true')
         helixAccessToken: $(HelixApiAccessToken)
 
     # Local development validation

--- a/.azure/pipelines/ci-unofficial.yml
+++ b/.azure/pipelines/ci-unofficial.yml
@@ -29,8 +29,6 @@ variables:
   value: ''
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
-- name: enableHelixJobMonitor
-  value: false
 - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
   - name: _BuildArgs
     value: /p:TeamName=$(_TeamName)
@@ -645,7 +643,7 @@ extends:
             # -noBuildNative -noBuild to avoid repeating work done in the previous step.
             - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
                       -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=1
-                      /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /p:EnableHelixJobMonitor=$(enableHelixJobMonitor) $(_InternalRuntimeDownloadArgs)
+                      /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /p:EnableHelixJobMonitor=true $(_InternalRuntimeDownloadArgs)
               displayName: Run build.cmd helix target
               env:
                 HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
@@ -677,7 +675,7 @@ extends:
             # -noBuildNative -noBuild to avoid repeating work done in the previous step.
             - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
                       -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=2
-                      /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /p:EnableHelixJobMonitor=$(enableHelixJobMonitor) $(_InternalRuntimeDownloadArgs)
+                      /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log /p:EnableHelixJobMonitor=true $(_InternalRuntimeDownloadArgs)
               displayName: Run build.cmd helix target
               env:
                 HelixApiAccessToken: $(HelixApiAccessToken) # Needed for internal queues
@@ -691,7 +689,6 @@ extends:
 
         - template: /eng/common/core-templates/job/helix-job-monitor.yml@self
           parameters:
-            condition: eq(variables['enableHelixJobMonitor'], 'true')
             helixAccessToken: $(HelixApiAccessToken)
 
         # Local development validation

--- a/.azure/pipelines/ci.yml
+++ b/.azure/pipelines/ci.yml
@@ -49,8 +49,6 @@ variables:
     value: --publish
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
-- name: enableHelixJobMonitor
-  value: false
 - ${{ if notin(variables['Build.Reason'], 'PullRequest') }}:
   - name: _BuildArgs
     value: /p:TeamName=$(_TeamName)
@@ -640,7 +638,7 @@ extends:
               displayName: Build shared fx
             # -noBuildNative -noBuild to avoid repeating work done in the previous step.
             - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
-                      -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=1 /p:EnableHelixJobMonitor=$(enableHelixJobMonitor)
+                      -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=1 /p:EnableHelixJobMonitor=true
                       /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
               displayName: Run build.cmd helix target
               env:
@@ -669,7 +667,7 @@ extends:
               displayName: Build shared fx
             # -noBuildNative -noBuild to avoid repeating work done in the previous step.
             - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
-                      -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=2 /p:EnableHelixJobMonitor=$(enableHelixJobMonitor)
+                      -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true /p:HelixSubset=2 /p:EnableHelixJobMonitor=true
                       /p:CrossgenOutput=false /p:RunTemplateTests=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log $(_InternalRuntimeDownloadArgs)
               displayName: Run build.cmd helix target
               env:
@@ -684,7 +682,6 @@ extends:
 
         - template: /eng/common/core-templates/job/helix-job-monitor.yml@self
           parameters:
-            condition: eq(variables['enableHelixJobMonitor'], 'true')
             helixAccessToken: $(HelixApiAccessToken)
 
         # Local development validation

--- a/.azure/pipelines/helix-matrix.yml
+++ b/.azure/pipelines/helix-matrix.yml
@@ -18,8 +18,6 @@ schedules:
 variables:
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
-- name: enableHelixJobMonitor
-  value: false
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-HelixApi-Access
 - template: /eng/common/templates/variables/pool-providers.yml
@@ -38,7 +36,7 @@ jobs:
       displayName: Build shared fx
     # -noBuildNative -noBuild to avoid repeating work done in the previous step.
     - script: .\eng\build.cmd -ci -prepareMachine -nobl -all -noBuildNative -noBuild -test
-              -projects eng\helix\helix.proj /p:IsHelixJob=true /p:EnableHelixJobMonitor=$(enableHelixJobMonitor)
+              -projects eng\helix\helix.proj /p:IsHelixJob=true /p:EnableHelixJobMonitor=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
       displayName: Run build.cmd helix target
       env:
@@ -51,5 +49,4 @@ jobs:
 
 - template: /eng/common/core-templates/job/helix-job-monitor.yml
   parameters:
-    condition: eq(variables['enableHelixJobMonitor'], 'true')
     helixAccessToken: $(HelixApiAccessToken)

--- a/.azure/pipelines/identitymodel-helix-matrix.yml
+++ b/.azure/pipelines/identitymodel-helix-matrix.yml
@@ -14,8 +14,6 @@ schedules:
 variables:
 - name: _UseHelixOpenQueues
   value: false
-- name: enableHelixJobMonitor
-  value: false
 - group: DotNet-HelixApi-Access
 - template: /eng/common/templates-official/variables/pool-providers.yml@self
 
@@ -95,7 +93,7 @@ extends:
             displayName: Build shared fx
           # -noBuildNative -noBuild to avoid repeating work done in the previous step.
           - script: .\eng\build.cmd -ci -prepareMachine -nobl -all -noBuildNative -noBuild -test
-                    -projects eng\helix\helix.proj /p:IsHelixJob=true /p:RunTemplateTests=false /p:EnableHelixJobMonitor=$(enableHelixJobMonitor)
+                    -projects eng\helix\helix.proj /p:IsHelixJob=true /p:RunTemplateTests=false /p:EnableHelixJobMonitor=true
                     /p:CrossgenOutput=false /p:IsIdentityModelTestJob=true /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
             displayName: Run build.cmd helix target
             env:
@@ -108,5 +106,4 @@ extends:
 
       - template: /eng/common/core-templates/job/helix-job-monitor.yml@self
         parameters:
-          condition: eq(variables['enableHelixJobMonitor'], 'true')
           helixAccessToken: $(HelixApiAccessToken)

--- a/.azure/pipelines/template-tests-pr.yml
+++ b/.azure/pipelines/template-tests-pr.yml
@@ -25,8 +25,6 @@ pr:
 variables:
 - name: _UseHelixOpenQueues
   value: ${{ ne(variables['System.TeamProject'], 'internal') }}
-- name: enableHelixJobMonitor
-  value: false
 - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
   - group: DotNet-HelixApi-Access
 - template: /eng/common/templates/variables/pool-providers.yml
@@ -49,7 +47,7 @@ jobs:
     - script: ./eng/build.cmd -ci -prepareMachine -nativeToolsOnMachine -all -noBuildNative -noBuild -test
               -projects eng\helix\helix.proj /p:IsHelixPRCheck=true /p:IsHelixJob=true
               /p:CrossgenOutput=false /p:ASPNETCORE_TEST_LOG_DIR=artifacts/log
-              /p:VsTestUseMSBuildOutput=false /p:OnlyTestProjectTemplates=true /p:EnableHelixJobMonitor=$(enableHelixJobMonitor)
+              /p:VsTestUseMSBuildOutput=false /p:OnlyTestProjectTemplates=true /p:EnableHelixJobMonitor=true
       displayName: Run build.cmd helix target
       env:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken) # We need to set this env var to publish helix results to Azure Dev Ops
@@ -60,5 +58,4 @@ jobs:
 
 - template: /eng/common/core-templates/job/helix-job-monitor.yml
   parameters:
-    condition: eq(variables['enableHelixJobMonitor'], 'true')
     helixAccessToken: $(HelixApiAccessToken)

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -27,7 +27,7 @@
       ]
     },
     "microsoft.dotnet.helix.jobmonitor": {
-      "version": "11.0.0-beta.26424.125",
+      "version": "11.0.0-beta.26427.10",
       "commands": [
         "dotnet-helix-job-monitor"
       ]

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -14,7 +14,7 @@ This file should be imported by eng/Versions.props
     <MicrosoftDotNetBuildTasksArchivesPackageVersion>11.0.0-beta.26424.125</MicrosoftDotNetBuildTasksArchivesPackageVersion>
     <MicrosoftDotNetBuildTasksInstallersPackageVersion>11.0.0-beta.26424.125</MicrosoftDotNetBuildTasksInstallersPackageVersion>
     <MicrosoftDotNetBuildTasksTemplatingPackageVersion>11.0.0-beta.26424.125</MicrosoftDotNetBuildTasksTemplatingPackageVersion>
-    <MicrosoftDotNetHelixJobMonitorPackageVersion>11.0.0-beta.26424.125</MicrosoftDotNetHelixJobMonitorPackageVersion>
+    <MicrosoftDotNetHelixJobMonitorPackageVersion>11.0.0-beta.26427.10</MicrosoftDotNetHelixJobMonitorPackageVersion>
     <MicrosoftDotNetHelixSdkPackageVersion>11.0.0-beta.26424.125</MicrosoftDotNetHelixSdkPackageVersion>
     <MicrosoftDotNetRemoteExecutorPackageVersion>11.0.0-beta.26424.125</MicrosoftDotNetRemoteExecutorPackageVersion>
     <MicrosoftDotNetSharedFrameworkSdkPackageVersion>11.0.0-beta.26424.125</MicrosoftDotNetSharedFrameworkSdkPackageVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -386,9 +386,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.JobMonitor" Version="11.0.0-beta.26424.125">
-      <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>18aca855818ca5e09075637626229cd6d73011b9</Sha>
+    <Dependency Name="Microsoft.DotNet.Helix.JobMonitor" Version="11.0.0-beta.26427.10">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>2cdfe99944d984749c8bdfc7d8d6a2589ed15d6d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="11.0.0-beta.26424.125">
       <Uri>https://github.com/dotnet/dotnet</Uri>


### PR DESCRIPTION
Updates the Microsoft.DotNet.Helix.JobMonitor tool plus dependency metadata to the fixed 11.0.0-beta.26427.10 Arcade build.

Build: https://dev.azure.com/dnceng/internal/_build/results?buildId=3059358

This also reverts the temporary Helix Job Monitor disablement now that the fixed build is available.