### PR TITLE
Kestrel: Reject backslash in Uri parsing

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -43,6 +43,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
     private const byte ByteLF = (byte)'\n';
     private const byte ByteAsterisk = (byte)'*';
     private const byte ByteForwardSlash = (byte)'/';
+    private const byte ByteBackSlash = (byte)'\\';
     private const string Asterisk = "*";
     private const string ForwardSlash = "/";
 
@@ -704,6 +705,16 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
             // Validation of absolute URIs is slow, but clients
             // should not be sending this form anyways, so perf optimization
             // not high priority
+
+            // System.Uri treats '\' as a path separator (a Windows/WinINet compatibility
+            // behavior) and collapses dot-segments around it, so uri.AbsolutePath (and thus
+            // Path) would be silently normalized in a way RawTarget doesn't reflect. Per
+            // RFC 3986, '\' is not a valid URI path character, so reject the request instead.
+            // Only the target before the query string is checked (query is target[targetPath.Length..]).
+            if (target[..targetPath.Length].IndexOf(ByteBackSlash) >= 0)
+            {
+                ThrowRequestTargetRejected(target);
+            }
 
             if (!Uri.TryCreate(RawTarget, UriKind.Absolute, out var uri))
             {

--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1Connection.cs
@@ -711,7 +711,7 @@ internal partial class Http1Connection : HttpProtocol, IRequestProcessor, IHttpO
             // Path) would be silently normalized in a way RawTarget doesn't reflect. Per
             // RFC 3986, '\' is not a valid URI path character, so reject the request instead.
             // Only the target before the query string is checked (query is target[targetPath.Length..]).
-            if (target[..targetPath.Length].IndexOf(ByteBackSlash) >= 0)
+            if (target[..targetPath.Length].Contains(ByteBackSlash))
             {
                 ThrowRequestTargetRejected(target);
             }

--- a/src/Servers/Kestrel/shared/test/HttpParsingData.cs
+++ b/src/Servers/Kestrel/shared/test/HttpParsingData.cs
@@ -324,6 +324,11 @@ public class HttpParsingData
             data.Add("GET", "http://user@/abc");
             data.Add("GET", "http://abc%20xyz/abc");
             data.Add("GET", "http://%20/abc?query=%0A");
+            // Backslash is not a valid URI path character (RFC 3986); it must not be
+            // silently normalized by System.Uri (https://github.com/dotnet/aspnetcore/issues/68636)
+            data.Add("GET", "http://host/foo\\..\\bar");
+            data.Add("GET", "http://host/foo\\bar");
+            data.Add("GET", "http://host/\\");
             // Valid absolute-form but with unsupported schemes
             data.Add("GET", "otherscheme://host/");
             data.Add("GET", "ws://host/");


### PR DESCRIPTION
Fixes #68636