### PR TITLE
Stabilize Virtualize initial item positioning

### DIFF
--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -660,7 +660,12 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
 
     // Target row should be measured against the committed window, not a stale spacer height.
     flushPendingStyleMutations();
-    const delta = measureLocalChildOffset(localIndex);
+    const alignmentOffset = isTable
+      && scrollContainer
+      && (localIndex !== 0 || spacerBefore.offsetHeight !== 0)
+      ? Math.min(scrollContainer.clientTop * getScaleFactor(spacerBefore, spacerAfter), 1)
+      : 0;
+    const delta = measureLocalChildOffset(localIndex) + alignmentOffset;
     if (Number.isNaN(delta)) {
       // Target item isn't in the committed window.
       pendingAlignLocalIndex = localIndex;

--- a/src/Components/Web.JS/src/Virtualize.ts
+++ b/src/Components/Web.JS/src/Virtualize.ts
@@ -660,12 +660,7 @@ function init(dotNetHelper: DotNet.DotNetObject, spacerBefore: HTMLElement, spac
 
     // Target row should be measured against the committed window, not a stale spacer height.
     flushPendingStyleMutations();
-    const alignmentOffset = isTable
-      && scrollContainer
-      && (localIndex !== 0 || spacerBefore.offsetHeight !== 0)
-      ? Math.min(scrollContainer.clientTop * getScaleFactor(spacerBefore, spacerAfter), 1)
-      : 0;
-    const delta = measureLocalChildOffset(localIndex) + alignmentOffset;
+    const delta = measureLocalChildOffset(localIndex);
     if (Number.isNaN(delta)) {
       // Target item isn't in the committed window.
       pendingAlignLocalIndex = localIndex;

--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -512,7 +512,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
         {
             if (InitialItemIndex > 0)
             {
-                _initialIndex.BeginPending(_itemSize);
+                _initialIndex.BeginFillingViewport(_itemSize);
                 await ScrollToItemAsyncCore(InitialItemIndex, CancellationToken.None);
             }
             else if (_itemCount > 0)
@@ -529,7 +529,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
             && _initialIndex.IsPositioning)
         {
             var fillDirection = await AlignToTargetAsync(InitialItemIndex, CancellationToken.None);
-            if (fillDirection is null && _initialIndex.Phase == InitialIndexPhase.Committing)
+            if (fillDirection is null && _initialIndex.Phase == InitialIndexPhase.ApplyingMeasuredGeometry)
             {
                 _initialIndex.Complete();
             }
@@ -644,7 +644,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
 
     private void UpdateItemSizeFromRenderedContent(float spacerSize, float spacerSeparation, float containerSize)
     {
-        if (_initialIndex.Phase != InitialIndexPhase.Pending)
+        if (_initialIndex.Phase != InitialIndexPhase.FillingViewport)
         {
             return;
         }
@@ -688,7 +688,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
             case SpacerVisibilityReason.ViewportFill:
                 // A fill callback while our own scroll is in flight is a side effect of that scroll —
                 // acting on it would move the target.
-                if (_currentScrollCts is not null || _initialIndex.Phase == InitialIndexPhase.Committing)
+                if (_currentScrollCts is not null || _initialIndex.Phase == InitialIndexPhase.ApplyingMeasuredGeometry)
                 {
                     return;
                 }
@@ -731,7 +731,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
             CancelInFlightScrollForUserInteraction();
         }
         else if (reason == SpacerVisibilityReason.ViewportFill
-            && (_currentScrollCts is not null || _initialIndex.Phase == InitialIndexPhase.Committing))
+            && (_currentScrollCts is not null || _initialIndex.Phase == InitialIndexPhase.ApplyingMeasuredGeometry))
         {
             // Bottom-spacer fill while our own scroll is in flight: the window moved but scrollTop hasn't
             // landed, so acting on it would undo the target. The real fill runs once the scroll completes.
@@ -817,7 +817,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
 
     private void AdvanceInitialIndexPhase()
     {
-        if (_initialIndex.Phase == InitialIndexPhase.Pending)
+        if (_initialIndex.Phase == InitialIndexPhase.FillingViewport)
         {
             if (_lastRenderedItemCount == 0 || _lastRenderedPlaceholderCount > 0)
             {
@@ -828,7 +828,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
             var committedItemSize = _itemSize > 0 ? _itemSize : ItemSize;
             _totalMeasuredHeight = committedItemSize * _lastRenderedItemCount;
             _measuredItemCount = _lastRenderedItemCount;
-            _initialIndex.BeginCommit(committedItemSize);
+            _initialIndex.BeginApplyingMeasuredGeometry(committedItemSize);
             StateHasChanged();
         }
         else
@@ -1211,33 +1211,33 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
     private enum InitialIndexPhase
     {
         None,
-        Pending,
-        Committing,
+        FillingViewport,
+        ApplyingMeasuredGeometry,
         Completed,
     }
 
     private sealed class InitialIndexState
     {
-        private float _alignItemSize;
+        private float _spacerItemSize;
 
         public InitialIndexPhase Phase { get; private set; }
 
-        public bool IsPositioning => Phase is InitialIndexPhase.Pending or InitialIndexPhase.Committing;
+        public bool IsPositioning => Phase is InitialIndexPhase.FillingViewport or InitialIndexPhase.ApplyingMeasuredGeometry;
 
-        public float SpacerItemSize => _alignItemSize;
+        public float SpacerItemSize => _spacerItemSize;
 
         public void Complete() => Phase = InitialIndexPhase.Completed;
 
-        public void BeginPending(float itemSize)
+        public void BeginFillingViewport(float itemSize)
         {
-            Phase = InitialIndexPhase.Pending;
-            _alignItemSize = itemSize;
+            Phase = InitialIndexPhase.FillingViewport;
+            _spacerItemSize = itemSize;
         }
 
-        public void BeginCommit(float itemSize)
+        public void BeginApplyingMeasuredGeometry(float itemSize)
         {
-            Phase = InitialIndexPhase.Committing;
-            _alignItemSize = itemSize;
+            Phase = InitialIndexPhase.ApplyingMeasuredGeometry;
+            _spacerItemSize = itemSize;
         }
 
         public void Abort()

--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -364,14 +364,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
             return null;
         }
 
-        var initialItemSize = _itemSize;
         var fillDirection = await _jsInterop.AlignToItemAsync(localIndex, token);
-        if (_initialIndex.Phase == InitialIndexPhase.Pending && _itemSize != initialItemSize)
-        {
-            StateHasChanged();
-            return null;
-        }
-
         return fillDirection;
     }
 
@@ -533,10 +526,17 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
             && _loadedItemsStartIndex == _itemsBefore
             && _lastRenderedItemCount > 0
             && _lastRenderedPlaceholderCount == 0
-            && _initialIndex.Phase == InitialIndexPhase.Pending)
+            && _initialIndex.IsPositioning)
         {
             var fillDirection = await AlignToTargetAsync(InitialItemIndex, CancellationToken.None);
-            UpdateWindowFromViewport(fillDirection, _visibleItemCapacity, _unusedItemCapacity);
+            if (fillDirection is null && _initialIndex.Phase == InitialIndexPhase.Committing)
+            {
+                _initialIndex.Complete();
+            }
+            else
+            {
+                UpdateWindowFromViewport(fillDirection, _visibleItemCapacity, _unusedItemCapacity);
+            }
         }
     }
 
@@ -635,6 +635,11 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
         => (itemCount * GetItemHeight()).ToString(CultureInfo.InvariantCulture);
 
     private float GetItemHeight()
+        => _initialIndex.IsPositioning
+            ? _initialIndex.SpacerItemSize
+            : GetMeasuredItemHeight();
+
+    private float GetMeasuredItemHeight()
         => _measuredItemCount > 0 ? _totalMeasuredHeight / _measuredItemCount : _itemSize;
 
     private void UpdateItemSizeFromRenderedContent(float spacerSize, float spacerSeparation, float containerSize)
@@ -683,7 +688,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
             case SpacerVisibilityReason.ViewportFill:
                 // A fill callback while our own scroll is in flight is a side effect of that scroll —
                 // acting on it would move the target.
-                if (_currentScrollCts is not null)
+                if (_currentScrollCts is not null || _initialIndex.Phase == InitialIndexPhase.Committing)
                 {
                     return;
                 }
@@ -692,7 +697,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
 
         CalculateItemDistribution(spacerSize, spacerSeparation, containerSize, out var itemsBefore, out var visibleItemCapacity, out var unusedItemCapacity);
 
-        if (_initialIndex.Phase == InitialIndexPhase.Pending)
+        if (_initialIndex.IsPositioning)
         {
             UpdateWindowFromViewport(
                 ViewportFillDirection.Before,
@@ -725,7 +730,8 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
         {
             CancelInFlightScrollForUserInteraction();
         }
-        else if (reason == SpacerVisibilityReason.ViewportFill && _currentScrollCts is not null)
+        else if (reason == SpacerVisibilityReason.ViewportFill
+            && (_currentScrollCts is not null || _initialIndex.Phase == InitialIndexPhase.Committing))
         {
             // Bottom-spacer fill while our own scroll is in flight: the window moved but scrollTop hasn't
             // landed, so acting on it would undo the target. The real fill runs once the scroll completes.
@@ -733,7 +739,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
         }
         var hadNewMeasurements = CalculateItemDistribution(spacerSize, spacerSeparation, containerSize, out var itemsAfter, out var visibleItemCapacity, out var unusedItemCapacity);
 
-        if (_initialIndex.Phase == InitialIndexPhase.Pending)
+        if (_initialIndex.IsPositioning)
         {
             UpdateWindowFromViewport(
                 ViewportFillDirection.After,
@@ -771,9 +777,9 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
     {
         if (fillDirection == ViewportFillDirection.Covered)
         {
-            if (_initialIndex.Phase == InitialIndexPhase.Pending && _lastRenderedPlaceholderCount == 0)
+            if (_initialIndex.IsPositioning && _lastRenderedPlaceholderCount == 0)
             {
-                _initialIndex.Complete();
+                AdvanceInitialIndexPhase();
             }
             return;
         }
@@ -803,7 +809,29 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
                 _visibleItemCapacity + addedItems,
                 unusedItemCapacity);
         }
-        else if (_initialIndex.Phase == InitialIndexPhase.Pending && !_loading)
+        else if (_initialIndex.IsPositioning && !_loading)
+        {
+            AdvanceInitialIndexPhase();
+        }
+    }
+
+    private void AdvanceInitialIndexPhase()
+    {
+        if (_initialIndex.Phase == InitialIndexPhase.Pending)
+        {
+            if (_lastRenderedItemCount == 0 || _lastRenderedPlaceholderCount > 0)
+            {
+                _initialIndex.Complete();
+                return;
+            }
+
+            var committedItemSize = _itemSize > 0 ? _itemSize : ItemSize;
+            _totalMeasuredHeight = committedItemSize * _lastRenderedItemCount;
+            _measuredItemCount = _lastRenderedItemCount;
+            _initialIndex.BeginCommit(committedItemSize);
+            StateHasChanged();
+        }
+        else
         {
             _initialIndex.Complete();
         }
@@ -1184,6 +1212,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
     {
         None,
         Pending,
+        Committing,
         Completed,
     }
 
@@ -1193,6 +1222,10 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
 
         public InitialIndexPhase Phase { get; private set; }
 
+        public bool IsPositioning => Phase is InitialIndexPhase.Pending or InitialIndexPhase.Committing;
+
+        public float SpacerItemSize => _alignItemSize;
+
         public void Complete() => Phase = InitialIndexPhase.Completed;
 
         public void BeginPending(float itemSize)
@@ -1201,9 +1234,15 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
             _alignItemSize = itemSize;
         }
 
+        public void BeginCommit(float itemSize)
+        {
+            Phase = InitialIndexPhase.Committing;
+            _alignItemSize = itemSize;
+        }
+
         public void Abort()
         {
-            if (Phase == InitialIndexPhase.Pending)
+            if (IsPositioning)
             {
                 Phase = InitialIndexPhase.Completed;
             }

--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -826,9 +826,7 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
                 return;
             }
 
-            var committedItemSize = _itemSize > 0 ? _itemSize : ItemSize;
-            _totalMeasuredHeight = committedItemSize * _lastRenderedItemCount;
-            _measuredItemCount = _lastRenderedItemCount;
+            var committedItemSize = GetMeasuredItemHeight();
             _initialIndex.BeginApplyingMeasuredGeometry(committedItemSize);
             StateHasChanged();
         }

--- a/src/Components/Web/src/Virtualization/Virtualize.cs
+++ b/src/Components/Web/src/Virtualization/Virtualize.cs
@@ -529,14 +529,15 @@ public sealed class Virtualize<TItem> : ComponentBase, IVirtualizeJsCallbacks, I
             && _initialIndex.IsPositioning)
         {
             var fillDirection = await AlignToTargetAsync(InitialItemIndex, CancellationToken.None);
-            if (fillDirection is null && _initialIndex.Phase == InitialIndexPhase.ApplyingMeasuredGeometry)
+            var finalAlignmentUnavailable = fillDirection is null
+                && _initialIndex.Phase == InitialIndexPhase.ApplyingMeasuredGeometry;
+            if (finalAlignmentUnavailable)
             {
-                _initialIndex.Complete();
+                _initialIndex.Abort();
+                return;
             }
-            else
-            {
-                UpdateWindowFromViewport(fillDirection, _visibleItemCapacity, _unusedItemCapacity);
-            }
+
+            UpdateWindowFromViewport(fillDirection, _visibleItemCapacity, _unusedItemCapacity);
         }
     }
 

--- a/src/Components/Web/test/Virtualization/VirtualizeTest.cs
+++ b/src/Components/Web/test/Virtualization/VirtualizeTest.cs
@@ -136,6 +136,54 @@ public class VirtualizeTest
     }
 
     [Fact]
+    public async Task InitialIndex_MeasurementDoesNotChangeSpacerUntilPositioningCompletes()
+    {
+        Virtualize<int> virtualize = null;
+        var rootComponent = new VirtualizeTestHostcomponent
+        {
+            InnerContent = builder =>
+            {
+                builder.OpenComponent<Virtualize<int>>(0);
+                builder.AddComponentParameter(1, "ItemSize", 50f);
+                builder.AddComponentParameter(2, "Items", (ICollection<int>)Enumerable.Range(0, 1000).ToList());
+                builder.AddComponentParameter(3, "InitialItemIndex", 950);
+                builder.AddComponentParameter(4, "OverscanCount", 3);
+                builder.AddComponentParameter(5, "ChildContent", SimpleItemTemplate);
+                builder.AddComponentReferenceCapture(6, component => virtualize = (Virtualize<int>)component);
+                builder.CloseComponent();
+            }
+        };
+
+        var serviceProvider = new ServiceCollection()
+            .AddTransient((sp) => Mock.Of<IJSRuntime>())
+            .BuildServiceProvider();
+
+        var testRenderer = new TestRenderer(serviceProvider);
+        var componentId = testRenderer.AssignRootComponentId(rootComponent);
+        await testRenderer.RenderRootComponentAsync(componentId);
+
+        var callbacks = (IVirtualizeJsCallbacks)virtualize;
+        await testRenderer.Dispatcher.InvokeAsync(() =>
+            callbacks.OnBeforeSpacerVisible(
+                0f,
+                1253f,
+                2000f,
+                SpacerVisibilityReason.RenderedContentMeasurement));
+        await testRenderer.RenderRootComponentAsync(componentId);
+
+        var spacerHeights = testRenderer.Batches
+            .SelectMany(batch => batch.ReferenceFrames)
+            .Where(frame => frame.FrameType == RenderTreeFrameType.Attribute
+                && frame.AttributeName == "data-blazor-virtualize-reserved-height")
+            .Select(frame => (string)frame.AttributeValue)
+            .ToList();
+
+        Assert.Equal(1253f, virtualize._totalMeasuredHeight);
+        Assert.Equal(7, virtualize._measuredItemCount);
+        Assert.Equal("47350", spacerHeights[^2]);
+    }
+
+    [Fact]
     public async Task Virtualize_ZeroSpacerSeparationDoesNotCorruptAverage()
     {
         // BuildVirtualizeWithContent provides Items + ChildContent so the test renderer

--- a/src/Components/Web/test/Virtualization/VirtualizeTest.cs
+++ b/src/Components/Web/test/Virtualization/VirtualizeTest.cs
@@ -171,16 +171,22 @@ public class VirtualizeTest
                 SpacerVisibilityReason.RenderedContentMeasurement));
         await testRenderer.RenderRootComponentAsync(componentId);
 
-        var spacerHeights = testRenderer.Batches
+        var virtualizeComponentId = testRenderer.Batches
             .SelectMany(batch => batch.ReferenceFrames)
+            .Single(frame => frame.FrameType == RenderTreeFrameType.Component
+                && ReferenceEquals(frame.Component, virtualize))
+            .ComponentId;
+        var spacerHeights = testRenderer.GetCurrentRenderTreeFrames(virtualizeComponentId)
+            .AsEnumerable()
             .Where(frame => frame.FrameType == RenderTreeFrameType.Attribute
-                && frame.AttributeName == "data-blazor-virtualize-reserved-height")
-            .Select(frame => (string)frame.AttributeValue)
-            .ToList();
+                && frame.AttributeName == "data-blazor-virtualize-reserved-height");
 
         Assert.Equal(1253f, virtualize._totalMeasuredHeight);
         Assert.Equal(7, virtualize._measuredItemCount);
-        Assert.Equal("47350", spacerHeights[^2]);
+        Assert.Collection(
+            spacerHeights,
+            spacerBefore => Assert.Equal("47350", spacerBefore.AttributeValue),
+            spacerAfter => Assert.Equal("2300", spacerAfter.AttributeValue));
     }
 
     [Fact]

--- a/src/Components/Web/test/Virtualization/VirtualizeTest.cs
+++ b/src/Components/Web/test/Virtualization/VirtualizeTest.cs
@@ -190,6 +190,51 @@ public class VirtualizeTest
     }
 
     [Fact]
+    public async Task InitialIndex_ApplyingMeasuredGeometry_PreservesRunningAverage()
+    {
+        Virtualize<int> virtualize = null;
+        var rootComponent = new VirtualizeTestHostcomponent
+        {
+            InnerContent = builder =>
+            {
+                builder.OpenComponent<Virtualize<int>>(0);
+                builder.AddComponentParameter(1, "ItemSize", 50f);
+                builder.AddComponentParameter(2, "Items", (ICollection<int>)Enumerable.Range(0, 7).ToList());
+                builder.AddComponentParameter(3, "InitialItemIndex", 5);
+                builder.AddComponentParameter(4, "OverscanCount", 3);
+                builder.AddComponentParameter(5, "ChildContent", SimpleItemTemplate);
+                builder.AddComponentReferenceCapture(6, component => virtualize = (Virtualize<int>)component);
+                builder.CloseComponent();
+            }
+        };
+
+        var serviceProvider = new ServiceCollection()
+            .AddTransient((sp) => Mock.Of<IJSRuntime>())
+            .BuildServiceProvider();
+
+        var testRenderer = new TestRenderer(serviceProvider);
+        var componentId = testRenderer.AssignRootComponentId(rootComponent);
+        await testRenderer.RenderRootComponentAsync(componentId);
+
+        var callbacks = (IVirtualizeJsCallbacks)virtualize;
+        await testRenderer.Dispatcher.InvokeAsync(() =>
+            callbacks.OnBeforeSpacerVisible(
+                0f,
+                1253f,
+                2000f,
+                SpacerVisibilityReason.RenderedContentMeasurement));
+        await testRenderer.Dispatcher.InvokeAsync(() =>
+            callbacks.OnAfterSpacerVisible(
+                0f,
+                1253f,
+                2000f,
+                SpacerVisibilityReason.ViewportFill));
+
+        Assert.Equal(2506f, virtualize._totalMeasuredHeight);
+        Assert.Equal(14, virtualize._measuredItemCount);
+    }
+
+    [Fact]
     public async Task Virtualize_ZeroSpacerSeparationDoesNotCorruptAverage()
     {
         // BuildVirtualizeWithContent provides Items + ChildContent so the test renderer

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -5536,19 +5536,22 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
             var edge = arguments[0];
             var c = document.getElementById('scroll-container');
             var rect = c.getBoundingClientRect();
+            var scale = c.offsetHeight > 0 ? rect.height / c.offsetHeight : 1;
+            var viewportTop = rect.top + c.clientTop * scale;
+            var viewportBottom = viewportTop + c.clientHeight * scale;
             var items = c.querySelectorAll('.item');
             var best = edge === 'top' ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
             for (var i = 0; i < items.length; i++) {
                 var r = items[i].getBoundingClientRect();
-                if (r.bottom <= rect.top + 1) continue; // above viewport
-                if (r.top >= rect.bottom - 1) continue;  // below viewport
+                if (r.bottom <= viewportTop + 1) continue; // above viewport
+                if (r.top >= viewportBottom - 1) continue;  // below viewport
                 if (edge === 'top') {
                     if (r.top < best) best = r.top;
                 } else {
                     if (r.bottom > best) best = r.bottom;
                 }
             }
-            return edge === 'top' ? (best <= rect.top + 2) : (best >= rect.bottom - 2);
+            return edge === 'top' ? (best <= viewportTop + 2) : (best >= viewportBottom - 2);
         ", edge);
     }
 

--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -5750,7 +5750,6 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/68724")]
     public void QuickGrid_InitialIndex_TallContainer_NearEnd_FillsViewportWithoutUserScroll(bool useProvider)
     {
         Browser.MountTestComponent<BasicTestApp.QuickGridTest.QuickGridScrollComponent>();


### PR DESCRIPTION
Freeze spacer geometry while the initial viewport fills, then commit the measured item size and realign once. This prevents QuickGrid from oscillating or losing the requested item near the end of a tall container.

## Description

The issue described in https://github.com/dotnet/aspnetcore/pull/68691 is real and can cause bad UX. The solution proposed in the original PR has a potential to fix the broader internal correctness concern: asynchronous geometry from an older rendered slice can be applied to a newer slice. Resize can expose the resulting inaccurate scroll-height model.

However, user facing problem is narrower. We don't promise keeping the index anchored on resize. The problem manifests in `InitialItemIndex` oscillations, see:

https://github.com/user-attachments/assets/85183de3-c515-4cf4-9931-70f5dffe29cb

The visible initial-positioning oscillation occurs because multiple measurements (including valid current-window measurements) are allowed to rewrite spacer geometry while the target is still being positioned. Rejecting stale callbacks can prevent the cross-window measurement feedback that causes the oscillation but the rejection mechanism introduces render versioning and complicates the flow. This change achieves the same targeted UX goal through a narrower approach: it keeps spacer geometry fixed until initial positioning is complete.

## Fix

We keep spacer geometry fixed while filling the initial viewport, then apply the measured size once and realign the requested item before completing.

```text
None
  |
  | InitialItemIndex > 0 and JavaScript is ready
  v
FillingViewport
  |
  | Repeatedly:
  | - render or grow the window
  | - measure the rows
  | - align the requested item
  |
  | Real items cover the viewport
  v
ApplyingMeasuredGeometry
  |
  | - recalculate the spacer heights
  | - render them once
  | - realign the requested item
  v
Completed
```

The consequences of choosing narrower fix: 
- The estimated total scroll range can temporarily be inaccurate
- During ordinary human-speed scrolling, I do not observe viewport jitter, reordered content, or another material UX problem after the initial position had settled.
- Preserving an exact item across arbitrary container resizing is not an existing `Virtualize` contract.

After the fix:

https://github.com/user-attachments/assets/64d59369-4699-4ed1-b391-745a56b62c14

## Changes

-  Test change: Before, the test compared item positions against the scroll container's outer border box which treated the container boarder as part of the visible content area. Now, it compares against the actual scaled content viewport. Without it, `QuickGrid_InitialIndex_TallContainer_NearEnd_FillsViewportWithoutUserScroll(useProvider: false)` would fail (quarantined on main due to flakyness, this PR stabilized the behavior and failure would be deterministic).

- Framework change: in the old design `_itemBefore` change immediately changed spacer geometry. That created a loop: measure -> render spacers -> realign item -> measure -> render spacers etc. With 2 phase process (see diagram above) spacer geometry is frozen during `FillingViewport` so changes of `_itemBefore` do not invalidate alignment. `InitialIndex_MeasurementDoesNotChangeSpacerUntilPositioningCompletes` unit tests checks that process by giving the component very different measurements while initial positioning is active.
There was a rename that chopped `Pending` into these 2 stages: `FillingViewport` & `ApplyingMeasuredGeometry`.


Closes https://github.com/dotnet/aspnetcore/pull/68691.
