### PR TITLE
Harden email change in Identity API

### DIFF
--- a/src/Identity/Core/src/Data/InfoRequest.cs
+++ b/src/Identity/Core/src/Data/InfoRequest.cs
@@ -23,7 +23,8 @@ public sealed class InfoRequest
     public string? NewPassword { get; init; }
 
     /// <summary>
-    /// The old password for the authenticated user. This is only required if a <see cref="NewPassword"/> is provided.
+    /// The old password for the authenticated user. This is required if a <see cref="NewPassword"/> is provided,
+    /// or if a <see cref="NewEmail"/> that differs from the current email is provided and the user has a password set.
     /// </summary>
     public string? OldPassword { get; init; }
 }

--- a/src/Identity/Core/src/IdentityApiEndpointRouteBuilderExtensions.cs
+++ b/src/Identity/Core/src/IdentityApiEndpointRouteBuilderExtensions.cs
@@ -359,6 +359,23 @@ public static class IdentityApiEndpointRouteBuilderExtensions
                 return CreateValidationProblem(IdentityResult.Failed(userManager.ErrorDescriber.InvalidEmail(infoRequest.NewEmail)));
             }
 
+            var email = await userManager.GetEmailAsync(user);
+            var isChangingEmail = !string.IsNullOrEmpty(infoRequest.NewEmail) && email != infoRequest.NewEmail;
+
+            // Require proof of current control of the account before re-pointing the email, which is
+            // frequently used as an account recovery channel. Users without a password (for example,
+            // external logins) cannot be challenged this way, so the check only applies when a password
+            // is set. This runs before the password change below so the old password is still valid to check.
+            if (isChangingEmail && await userManager.HasPasswordAsync(user))
+            {
+                if (string.IsNullOrEmpty(infoRequest.OldPassword) ||
+                    !await userManager.CheckPasswordAsync(user, infoRequest.OldPassword))
+                {
+                    return CreateValidationProblem("OldPasswordRequired",
+                        "The old password is required to change the email address.");
+                }
+            }
+
             if (!string.IsNullOrEmpty(infoRequest.NewPassword))
             {
                 if (string.IsNullOrEmpty(infoRequest.OldPassword))
@@ -374,14 +391,9 @@ public static class IdentityApiEndpointRouteBuilderExtensions
                 }
             }
 
-            if (!string.IsNullOrEmpty(infoRequest.NewEmail))
+            if (isChangingEmail)
             {
-                var email = await userManager.GetEmailAsync(user);
-
-                if (email != infoRequest.NewEmail)
-                {
-                    await SendConfirmationEmailAsync(user, userManager, context, infoRequest.NewEmail, isChange: true);
-                }
+                await SendConfirmationEmailAsync(user, userManager, context, infoRequest.NewEmail!, isChange: true);
             }
 
             return TypedResults.Ok(await CreateInfoResponseAsync(user, userManager));

--- a/src/Identity/test/Identity.FunctionalTests/MapIdentityApiTests.cs
+++ b/src/Identity/test/Identity.FunctionalTests/MapIdentityApiTests.cs
@@ -1054,7 +1054,7 @@ public class MapIdentityApiTests : LoggedTest
         await AssertValidationProblemAsync(await client.PostAsJsonAsync("/identity/manage/info", new { NewEmail = "invalid" }),
             "InvalidEmail");
 
-        var infoPostResponse = await client.PostAsJsonAsync("/identity/manage/info", new { newEmail });
+        var infoPostResponse = await client.PostAsJsonAsync("/identity/manage/info", new { OldPassword = Password, newEmail });
         var infoPostContent = await infoPostResponse.Content.ReadFromJsonAsync<JsonElement>();
         // The email isn't updated until the new email is confirmed.
         Assert.Equal(Email, infoPostContent.GetProperty("email").GetString());
@@ -1145,7 +1145,7 @@ public class MapIdentityApiTests : LoggedTest
         var originalNameIdentifier = GetSingleClaim(infoClaims, ClaimTypes.NameIdentifier);
         var newEmail = $"NewEmailPrefix-{Email}";
 
-        var infoPostResponse = await client.PostAsJsonAsync("/identity/manage/info", new { newEmail });
+        var infoPostResponse = await client.PostAsJsonAsync("/identity/manage/info", new { OldPassword = Password, newEmail });
         // There are no cookie updates because nothing has changed yet.
         Assert.False(infoPostResponse.Headers.Contains(HeaderNames.SetCookie));
 
@@ -1274,6 +1274,47 @@ public class MapIdentityApiTests : LoggedTest
 
         // We can now login with the new email too.
         AssertOk(await client.PostAsJsonAsync("/identity/login", new { Email = newEmail, Password = newPassword }));
+    }
+
+    [Fact]
+    public async Task CannotChangeEmailWithoutTheCurrentPassword()
+    {
+        var emailSender = new TestEmailSender();
+
+        await using var app = await CreateAppAsync(services =>
+        {
+            AddIdentityApiEndpoints(services);
+            services.AddSingleton<IEmailSender>(emailSender);
+        });
+        using var client = app.GetTestClient();
+
+        await RegisterAsync(client);
+
+        // The registration confirmation email should have been sent. We don't need to confirm it.
+        Assert.Single(emailSender.Emails);
+        emailSender.Emails.Clear();
+
+        await LoginAsync(client);
+
+        var newEmail = $"New-{Email}";
+
+        // The email cannot be changed without providing the current password.
+        await AssertValidationProblemAsync(await client.PostAsJsonAsync("/identity/manage/info", new { newEmail }),
+            "OldPasswordRequired");
+
+        // An incorrect current password is also rejected.
+        await AssertValidationProblemAsync(await client.PostAsJsonAsync("/identity/manage/info", new { OldPassword = $"{Password}!", newEmail }),
+            "OldPasswordRequired");
+
+        // Since the requests were rejected, no change email confirmation was sent.
+        Assert.Empty(emailSender.Emails);
+
+        // With the correct current password, the change email confirmation is sent.
+        AssertOk(await client.PostAsJsonAsync("/identity/manage/info", new { OldPassword = Password, newEmail }));
+
+        var changeEmail = Assert.Single(emailSender.Emails);
+        Assert.Equal(newEmail, changeEmail.Address);
+        Assert.Equal("Confirm your email", changeEmail.Subject);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #68469

TODO:

- [ ] Decide if we want to document this as a breaking change.
- [ ] Decide if we want to make `OldPassword` non-nullable.