### PR TITLE
Surface WebAssembly root component activation faults

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Rendering/WebAssemblyRenderer.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Rendering/WebAssemblyRenderer.cs
@@ -71,18 +71,18 @@ internal sealed partial class WebAssemblyRenderer : WebRenderer
             switch (operation.Type)
             {
                 case RootComponentOperationType.Add:
-                    _ = webRootComponentManager.AddRootComponentAsync(
+                    ObserveActivationFault(webRootComponentManager.AddRootComponentAsync(
                         operation.SsrComponentId,
                         operation.Descriptor!.ComponentType,
                         operation.Marker!.Value.Key!,
-                        operation.Descriptor!.Parameters);
+                        operation.Descriptor!.Parameters));
                     break;
                 case RootComponentOperationType.Update:
-                    _ = webRootComponentManager.UpdateRootComponentAsync(
+                    ObserveActivationFault(webRootComponentManager.UpdateRootComponentAsync(
                         operation.SsrComponentId,
                         operation.Descriptor!.ComponentType,
                         operation.Marker?.Key,
-                        operation.Descriptor!.Parameters);
+                        operation.Descriptor!.Parameters));
                     break;
                 case RootComponentOperationType.Remove:
                     webRootComponentManager.RemoveRootComponent(operation.SsrComponentId);
@@ -103,6 +103,17 @@ internal sealed partial class WebAssemblyRenderer : WebRenderer
         await task;
         await componentStatePersistenceManager.RestoreStateAsync(store, RestoreContext.ValueUpdate);
     }
+
+    // Root component activation is otherwise fire-and-forget, so a fault would be silently discarded
+    // instead of being logged and surfacing the error UI like other unhandled rendering exceptions.
+    // Use a fault-only continuation to avoid allocating an async state machine on the success path.
+    private void ObserveActivationFault(Task activationTask)
+        => activationTask.ContinueWith(
+            static (task, state) => ((WebAssemblyRenderer)state!).HandleException(task.Exception!),
+            this,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Current);
 
     protected override IComponentRenderMode? GetComponentRenderMode(IComponent component) => RenderMode.InteractiveWebAssembly;
 

--- a/src/Components/test/E2ETest/ServerRenderingTests/InteractivityTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/InteractivityTest.cs
@@ -152,6 +152,23 @@ public class InteractivityTest : ServerTestBase<BasicTestAppServerSiteFixture<Ra
         Browser.Equal("4", () => countWasmElem.Text);
     }
 
+    [Fact]
+    public void SurfacesExceptionThrownDuringWebAssemblyRootComponentActivation()
+    {
+        // Boot the WebAssembly runtime on the launcher page so the subsequent navigation
+        // adds the failing component through the OnUpdateRootComponents runtime update path
+        // (rather than the initial component batch, which surfaces faults separately).
+        Navigate($"{ServerPathBase}/wasm-activation-failure-launcher");
+        Browser.Equal("WebAssembly", () => Browser.FindElement(By.Id("render-mode-launcher")).Text);
+        Browser.Equal("True", () => Browser.FindElement(By.Id("is-interactive-launcher")).Text);
+
+        // Enhanced-navigate to a page whose component throws during activation. Before the fix,
+        // this fault was fire-and-forgotten and never logged or surfaced.
+        Browser.Click(By.Id("go-to-activation-failure"));
+
+        AssertBrowserLogContainsMessage("Simulated: component activation fails on the WebAssembly runtime.");
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/WasmActivationFailure.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/WasmActivationFailure.razor
@@ -1,0 +1,6 @@
+@page "/wasm-activation-failure"
+@using Microsoft.AspNetCore.Components.Web
+
+<h1 id="wasm-activation-failure">WebAssembly activation failure</h1>
+
+<TestContentPackage.WebAssemblyActivationThrowingComponent @rendermode="@(new InteractiveWebAssemblyRenderMode(prerender: false))" />

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/WasmActivationFailureLauncher.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/WasmActivationFailureLauncher.razor
@@ -1,0 +1,15 @@
+@page "/wasm-activation-failure-launcher"
+@using Microsoft.AspNetCore.Components.Web
+
+<h1 id="wasm-activation-launcher">WebAssembly activation failure launcher</h1>
+
+<p>
+    This page boots the WebAssembly runtime by rendering an interactive component.
+    Once it reports WebAssembly interactivity, an enhanced navigation to
+    <code>/wasm-activation-failure</code> activates a component that throws during
+    activation via <code>OnUpdateRootComponents</code> (the runtime update path).
+</p>
+
+<TestContentPackage.Counter @rendermode="@(new InteractiveWebAssemblyRenderMode(prerender: false))" IncrementAmount="1" IdSuffix="launcher" />
+
+<a id="go-to-activation-failure" href="wasm-activation-failure">Go to activation failure</a>

--- a/src/Components/test/testassets/TestContentPackage/WebAssemblyActivationThrowingComponent.razor
+++ b/src/Components/test/testassets/TestContentPackage/WebAssemblyActivationThrowingComponent.razor
@@ -1,0 +1,12 @@
+@namespace TestContentPackage
+
+<p id="wasm-activation-throwing-component">This should never render because activation throws.</p>
+
+@code {
+    // Throwing from the constructor simulates a failure during interactive component activation
+    // on the WebAssembly runtime (e.g. a ctor-injected DI service that fails to construct).
+    public WebAssemblyActivationThrowingComponent()
+    {
+        throw new InvalidOperationException("Simulated: component activation fails on the WebAssembly runtime.");
+    }
+}


### PR DESCRIPTION
Surface exceptions thrown during WebAssembly root component activation.

## Description

`WebAssemblyRenderer.OnUpdateRootComponents` fire-and-forgot the `Add`/`Update` root component activation tasks (`_ = webRootComponentManager.AddRootComponentAsync(...)`). If activation threw — a throwing component constructor, a failing ctor-injected DI service, a type-initializer that only fails under WASM — the fault landed on a discarded `Task` and was **silently swallowed**: no browser console output, no `ILogger` entry, no `blazor-error-ui`, and (for `InteractiveAuto`) no fallback to Server. The user was left on a permanently dead prerender.

### Why only this path

Blazor surfaces the **first render** of a root component through the `Task` returned by the activation call (so the initiator can react), which is distinct from autonomous re-renders that route to `HandleException`. Every sibling activation call site observes that task — Server `CircuitHost` (via `WhenAll` / circuit termination) and the WASM initial-boot path in `WebAssemblyHost` (via `Task.WhenAll` + `SetException`) — **except** the WASM runtime-update path `OnUpdateRootComponents`, which discarded it. That path is only reached when a root component is added/updated while the runtime is already running (e.g. enhanced navigation to a page that introduces a new WASM interactive component after boot), which is why it escaped notice.

### Fix

Route the activation fault to `HandleException` (the same path that logs at `Critical` and raises `blazor-error-ui` for every other unhandled WASM render exception) via a fault-only `ContinueWith` continuation:

- `TaskContinuationOptions.OnlyOnFaulted` — no work on the success path.
- `ExecuteSynchronously` + cached `static` continuation with `this` passed as state — no async state machine and no per-call delegate/closure allocation on the render hot path.

`task.Exception` is an `AggregateException`, which the existing `HandleException` already flattens and logs per inner exception.

This addresses expected behavior 1) from the issue (log + error UI). It does **not** implement the `InteractiveAuto` → Server fallback (expected behavior 2), which is a larger, separate change.

### Testing

Adds E2E test `InteractivityTest.SurfacesExceptionThrownDuringWebAssemblyRootComponentActivation`, plus test assets: a component that throws during activation and a launcher page that boots the WASM runtime then enhanced-navigates to it (ensuring the `OnUpdateRootComponents` path is exercised rather than the initial batch). The test asserts the exception message reaches the browser console.

Verified red/green: without the fix the test fails (message never surfaces); with the fix it passes.

Fixes #67980
