### PR TITLE
Fix standalone Blazor WASM hot reload in Gateway

### DIFF
--- a/src/Components/Gateway/src/BlazorGateway.cs
+++ b/src/Components/Gateway/src/BlazorGateway.cs
@@ -1,8 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.StaticAssets;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Net.Http.Headers;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
@@ -19,7 +22,9 @@ public static class BlazorGateway
     /// Reads ClientApps config section for endpoint manifests and YARP reverse proxy configuration.
     /// </summary>
     public static WebApplication BuildWebHost(string[] args) =>
-        BuildWebHost(WebApplication.CreateSlimBuilder(args));
+        BuildWebHost(RuntimeFeature.IsDynamicCodeSupported
+            ? WebApplication.CreateBuilder(args)
+            : WebApplication.CreateSlimBuilder(args));
 
     internal static WebApplication BuildWebHost(WebApplicationBuilder builder)
     {
@@ -113,11 +118,55 @@ public static class BlazorGateway
 
             if (!string.IsNullOrEmpty(appConfig.EndpointsManifest))
             {
-                app.MapGroup(appConfig.PathPrefix ?? "").MapStaticAssets(appConfig.EndpointsManifest);
+                var staticAssets = app.MapGroup(appConfig.PathPrefix ?? "").MapStaticAssets(appConfig.EndpointsManifest);
+                if (app.Environment.IsDevelopment())
+                {
+                    staticAssets.Add(DisableSpaFallbackCaching);
+                }
             }
         }
 
         return app;
+    }
+
+    private static void DisableSpaFallbackCaching(EndpointBuilder endpointBuilder)
+    {
+        if (endpointBuilder is not RouteEndpointBuilder { Order: int.MaxValue, RequestDelegate: { } next } ||
+            GetStaticAssetDescriptor(endpointBuilder) is not { Route: var route } ||
+            !route.StartsWith("{**", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        endpointBuilder.RequestDelegate = context =>
+        {
+            // The dotnet-watch middleware injects its browser refresh script into the response body.
+            // A conditional response has no body, so preserve the old DevServer's no-store behavior.
+            context.Request.Headers.Remove(HeaderNames.IfNoneMatch);
+            context.Request.Headers.Remove(HeaderNames.IfModifiedSince);
+            context.Response.OnStarting(static state =>
+            {
+                var response = (HttpResponse)state;
+                response.Headers[HeaderNames.CacheControl] = "no-store";
+
+                return Task.CompletedTask;
+            }, context.Response);
+
+            return next(context);
+        };
+    }
+
+    private static StaticAssetDescriptor? GetStaticAssetDescriptor(EndpointBuilder endpointBuilder)
+    {
+        foreach (var metadata in endpointBuilder.Metadata)
+        {
+            if (metadata is StaticAssetDescriptor descriptor)
+            {
+                return descriptor;
+            }
+        }
+
+        return null;
     }
 
     private static IHostApplicationBuilder ConfigureOpenTelemetry(this IHostApplicationBuilder builder, BlazorGatewayOptions.TelemetryOptions telemetry)

--- a/src/Components/Gateway/test/BlazorGatewayTests.cs
+++ b/src/Components/Gateway/test/BlazorGatewayTests.cs
@@ -10,10 +10,14 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
+[assembly: HostingStartup(typeof(Microsoft.AspNetCore.Components.Gateway.BlazorGatewayTests.TestHostingStartup))]
+
 namespace Microsoft.AspNetCore.Components.Gateway;
 
 public class BlazorGatewayTests
 {
+    private const string HostingStartupHeaderName = "X-Test-Hosting-Startup";
+
     [Fact]
     public async Task HealthChecks_ReturnsOk_InDevelopment_WithDefaultOptions()
     {
@@ -216,6 +220,51 @@ public class BlazorGatewayTests
         Assert.Contains(app.Urls, address => address.StartsWith("https://127.0.0.1:", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public async Task BuildWebHost_RunsConfiguredHostingStartup()
+    {
+        var hostingStartupAssembly = typeof(TestHostingStartup).Assembly.GetName().Name!;
+        await using var app = BlazorGateway.BuildWebHost(
+        [
+            "--environment", Environments.Development,
+            "--hostingStartupAssemblies", hostingStartupAssembly,
+            "--urls", "http://127.0.0.1:0",
+        ]);
+
+        await app.StartAsync();
+
+        using var client = new HttpClient
+        {
+            BaseAddress = new Uri(app.Urls.Single()),
+        };
+        var response = await client.GetAsync("/health");
+
+        Assert.Equal("true", response.Headers.GetValues(HostingStartupHeaderName).Single());
+    }
+
+    [Fact]
+    public async Task SpaFallback_DisablesDocumentCachingInDevelopment()
+    {
+        await using var gateway = await StartSpaFallbackGatewayAsync(Environments.Development);
+
+        var response = await gateway.Client.SendAsync(CreateConditionalDocumentRequest());
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.True(response.Headers.CacheControl?.NoStore);
+        Assert.Contains("Gateway", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task SpaFallback_PreservesDocumentCachingInProduction()
+    {
+        await using var gateway = await StartSpaFallbackGatewayAsync(Environments.Production);
+
+        var response = await gateway.Client.SendAsync(CreateConditionalDocumentRequest());
+
+        Assert.Equal(HttpStatusCode.NotModified, response.StatusCode);
+        Assert.False(response.Headers.CacheControl?.NoStore);
+    }
+
     private static bool IsRedirect(HttpStatusCode status) =>
         status is HttpStatusCode.MovedPermanently
             or HttpStatusCode.Found
@@ -229,4 +278,55 @@ public class BlazorGatewayTests
         string environment,
         Dictionary<string, string?> configuration) =>
         GatewayTestHelpers.StartGatewayAsync(environment, configuration);
+
+    private static async Task<GatewayUnderTest> StartSpaFallbackGatewayAsync(string environment)
+    {
+        var webRoot = Path.Combine(AppContext.BaseDirectory, "TestAssets");
+        var manifest = Path.Combine(webRoot, "test.staticwebassets.endpoints.json");
+        var builder = WebApplication.CreateSlimBuilder(new WebApplicationOptions
+        {
+            EnvironmentName = environment,
+            WebRootPath = webRoot,
+        });
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["ClientApps:app:EndpointsManifest"] = manifest,
+        });
+        builder.WebHost.UseTestServer();
+
+        var app = BlazorGateway.BuildWebHost(builder);
+        await app.StartAsync();
+
+        return new GatewayUnderTest(app);
+    }
+
+    private static HttpRequestMessage CreateConditionalDocumentRequest()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, "/");
+        request.Headers.Accept.ParseAdd("text/html");
+        request.Headers.Add("Sec-Fetch-Dest", "document");
+        request.Headers.TryAddWithoutValidation("If-None-Match", "\"test-etag\"");
+
+        return request;
+    }
+
+    public sealed class TestHostingStartup : IHostingStartup
+    {
+        public void Configure(IWebHostBuilder builder) =>
+            builder.ConfigureServices(services => services.AddSingleton<IStartupFilter, TestStartupFilter>());
+    }
+
+    public sealed class TestStartupFilter : IStartupFilter
+    {
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) =>
+            app =>
+            {
+                app.Use(async (context, next) =>
+                {
+                    context.Response.Headers[HostingStartupHeaderName] = "true";
+                    await next(context);
+                });
+                next(app);
+            };
+    }
 }

--- a/src/Components/Gateway/test/Microsoft.AspNetCore.Components.Gateway.Tests.csproj
+++ b/src/Components/Gateway/test/Microsoft.AspNetCore.Components.Gateway.Tests.csproj
@@ -22,6 +22,7 @@
     <Reference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" />
     <Reference Include="Yarp.ReverseProxy" />
     <Content Include="$(SharedSourceRoot)TestCertificates\*.pfx" LinkBase="shared\TestCertificates" CopyToOutputDirectory="PreserveNewest" />
+    <Content Include="TestAssets\**" CopyToOutputDirectory="PreserveNewest" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryExporterOpenTelemetryProtocolVersion)" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryExtensionsHostingVersion)" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryInstrumentationAspNetCoreVersion)" />

--- a/src/Components/Gateway/test/TestAssets/index.html
+++ b/src/Components/Gateway/test/TestAssets/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><body>Gateway</body>

--- a/src/Components/Gateway/test/TestAssets/test.staticwebassets.endpoints.json
+++ b/src/Components/Gateway/test/TestAssets/test.staticwebassets.endpoints.json
@@ -1,0 +1,35 @@
+{
+  "Version": 1,
+  "ManifestType": "Build",
+  "Endpoints": [
+    {
+      "Route": "{**fallback:nonfile}",
+      "AssetFile": "index.html",
+      "Order": "2147483647",
+      "Selectors": [],
+      "EndpointProperties": [],
+      "ResponseHeaders": [
+        {
+          "Name": "Cache-Control",
+          "Value": "no-cache"
+        },
+        {
+          "Name": "Content-Length",
+          "Value": "36"
+        },
+        {
+          "Name": "Content-Type",
+          "Value": "text/html"
+        },
+        {
+          "Name": "ETag",
+          "Value": "\"test-etag\""
+        },
+        {
+          "Name": "Last-Modified",
+          "Value": "Fri, 28 Aug 2026 00:00:00 GMT"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #67611

## Summary

- use the full `WebApplication` builder when dynamic code is supported so `dotnet watch` and IDE hosting-startup middleware is executed
- retain `CreateSlimBuilder` under NativeAOT via `RuntimeFeature.IsDynamicCodeSupported`
- disable conditional caching for the development SPA fallback so browser-refresh script injection always receives a response body
- add regressions for hosting-startup execution and development/production SPA fallback caching

## Validation

- Gateway test suite: 24 passed, 9 package-dependent tests skipped
- generated standalone Blazor WASM template with the locally packed Gateway: browser connected to the refresh server and a Razor edit updated the live Chromium DOM with no console errors
- conditional browser document request returned `200`, `Cache-Control: no-store`, and the injected browser-refresh script
- NativeAOT publish retained the exact slim-builder executable size on macOS arm64 and `/alive` returned `200`