### PR TITLE
Return 500 for invalid transfer encoding on non-body responses

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/HttpProtocol.cs
@@ -1018,9 +1018,9 @@ internal abstract partial class HttpProtocol : IHttpResponseControl
 
         _isLeasedMemoryInvalid = true;
 
-        _requestProcessingStatus = RequestProcessingStatus.HeadersCommitted;
-
         var responseHeaders = CreateResponseHeaders(appCompleted);
+
+        _requestProcessingStatus = RequestProcessingStatus.HeadersCommitted;
 
         Output.WriteResponseHeaders(StatusCode, ReasonPhrase, responseHeaders, _responseBodyMode, appCompleted);
     }

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/ResponseTests.cs
@@ -571,6 +571,37 @@ public class ResponseTests : TestApplicationErrorLoggerLoggedTest
         }
     }
 
+    [Theory]
+    [InlineData(HttpMethod.Get, StatusCodes.Status204NoContent)]
+    [InlineData(HttpMethod.Get, StatusCodes.Status205ResetContent)]
+    [InlineData(HttpMethod.Get, StatusCodes.Status304NotModified)]
+    [InlineData(HttpMethod.Head, StatusCodes.Status200OK)]
+    public async Task InvalidTransferEncodingOnCompletedNonBodyResponseProduces500(HttpMethod httpMethod, int statusCode)
+    {
+        await using var server = new TestServer(httpContext =>
+        {
+            httpContext.Response.StatusCode = statusCode;
+            httpContext.Response.Headers.TransferEncoding = "chunked";
+
+            return Task.CompletedTask;
+        }, new TestServiceContext(LoggerFactory));
+
+        using var connection = server.CreateConnection();
+
+        await connection.Send(
+            $"{HttpUtilities.MethodToString(httpMethod)} / HTTP/1.1",
+            "Host:",
+            "",
+            "");
+
+        await connection.Receive(
+            "HTTP/1.1 500 Internal Server Error",
+            "Content-Length: 0",
+            $"Date: {server.Context.DateHeaderValue}",
+            "",
+            "");
+    }
+
     [Fact]
     public async Task ContentLengthZeroSetOn205Response()
     {


### PR DESCRIPTION
- [x] You've read the Contributor Guide and Code of Conduct.
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making.

Return a 500 response instead of terminating the connection when an
application completes with an invalid Transfer-Encoding header on a
non-body response.

## Description

`HttpProtocol.ProduceStart` marked the response as `HeadersCommitted`
before calling `CreateResponseHeaders`.

When header validation detected an invalid `Transfer-Encoding` after the
application had completed, Kestrel attempted to replace the response with
a 500 response. This failed because the response was already considered
started, causing the connection to terminate without sending a response.

This change moves the transition to `HeadersCommitted` until after response
header creation and validation succeeds, while keeping it before
`Output.WriteResponseHeaders`.

A functional regression test covers GET responses with status codes 204,
205, and 304, as well as HEAD responses. Existing explicit response-start
behavior remains unchanged.

## Testing

- Passed all tests under `src/Servers/Kestrel/test`.
- Verified all four regression test cases pass.

Fixes #4382