### PR TITLE
Perf/type namehash arraypool

### DIFF
--- a/src/Components/Endpoints/src/Rendering/TypeNameHash.cs
+++ b/src/Components/Endpoints/src/Rendering/TypeNameHash.cs
@@ -18,17 +18,31 @@ internal class TypeNameHash
             throw new InvalidOperationException($"Cannot compute a hash for a type without a {nameof(Type.FullName)}.");
         }
 
+        // Try to encode into a stack buffer first to avoid allocations.
         Span<byte> typeNameBytes = stackalloc byte[MaxStackBufferSize];
-
-        if (!Encoding.UTF8.TryGetBytes(typeName, typeNameBytes, out var written))
+        int written;
+        byte[]? rented = null;
+        try
         {
-            typeNameBytes = Encoding.UTF8.GetBytes(typeName);
-            written = typeNameBytes.Length;
+            if (!Encoding.UTF8.TryGetBytes(typeName, typeNameBytes, out written))
+            {
+                // Larger than the stack buffer - rent an array from the pool.
+                var byteCount = Encoding.UTF8.GetByteCount(typeName);
+                rented = ArrayPool<byte>.Shared.Rent(byteCount);
+                written = Encoding.UTF8.GetBytes(typeName, rented);
+                typeNameBytes = rented;
+            }
+
+            Span<byte> typeNameHashBytes = stackalloc byte[SHA256.HashSizeInBytes];
+            SHA256.HashData(typeNameBytes[..written], typeNameHashBytes);
+            return Convert.ToHexString(typeNameHashBytes);
         }
-
-        Span<byte> typeNameHashBytes = stackalloc byte[SHA256.HashSizeInBytes];
-        SHA256.HashData(typeNameBytes[..written], typeNameHashBytes);
-
-        return Convert.ToHexString(typeNameHashBytes);
+        finally
+        {
+            if (rented is not null)
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
     }
 }


### PR DESCRIPTION
Perf: rent array from ArrayPool in TypeNameHash to avoid large allocations

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

Reduce transient allocations by renting buffers from ArrayPool when type names exceed the stack-allocated buffer in [TypeNameHash]. This avoids [Encoding.UTF8.GetBytes] creating a new array for large type names.


Fixes: standalone perf improvements
