### PR TITLE
 [DirectTls] Add metrics, logging, and epoll telemetry

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelEventSource.cs
@@ -5,6 +5,7 @@ using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 using System.Net.Security;
+using System.Security.Authentication;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
@@ -167,13 +168,17 @@ internal sealed class KestrelEventSource : EventSource
 
     [NonEvent]
     public void TlsHandshakeStart(BaseConnectionContext connectionContext, SslServerAuthenticationOptions sslOptions)
+        => TlsHandshakeStart(connectionContext, sslOptions.EnabledSslProtocols);
+
+    [NonEvent]
+    public void TlsHandshakeStart(BaseConnectionContext connectionContext, SslProtocols sslProtocols)
     {
         Interlocked.Increment(ref _currentTlsHandshakes);
         Interlocked.Increment(ref _totalTlsHandshakes);
 
         if (IsEnabled(EventLevel.Informational, EventKeywords.None))
         {
-            TlsHandshakeStart(connectionContext.ConnectionId, sslOptions.EnabledSslProtocols.ToString());
+            TlsHandshakeStart(connectionContext.ConnectionId, sslProtocols.ToString());
         }
     }
 
@@ -186,16 +191,18 @@ internal sealed class KestrelEventSource : EventSource
 
     [NonEvent]
     public void TlsHandshakeStop(BaseConnectionContext connectionContext, TlsConnectionFeature? feature)
+        => TlsHandshakeStop(connectionContext, feature?.Protocol, feature?.ApplicationProtocol ?? default, feature?.HostName);
+
+    [NonEvent]
+    public void TlsHandshakeStop(BaseConnectionContext connectionContext, SslProtocols? protocol, ReadOnlyMemory<byte> applicationProtocol, string? hostName)
     {
         Interlocked.Decrement(ref _currentTlsHandshakes);
 
         if (IsEnabled(EventLevel.Informational, EventKeywords.None))
         {
             // TODO: Write this without a string allocation using WriteEventData
-            var applicationProtocol = feature == null ? string.Empty : Encoding.UTF8.GetString(feature.ApplicationProtocol.Span);
-            var sslProtocols = feature?.Protocol.ToString() ?? string.Empty;
-            var hostName = feature?.HostName ?? string.Empty;
-            TlsHandshakeStop(connectionContext.ConnectionId, sslProtocols, applicationProtocol, hostName);
+            var applicationProtocolString = applicationProtocol.IsEmpty ? string.Empty : Encoding.UTF8.GetString(applicationProtocol.Span);
+            TlsHandshakeStop(connectionContext.ConnectionId, protocol?.ToString() ?? string.Empty, applicationProtocolString, hostName ?? string.Empty);
         }
     }
 

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelMetrics.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/KestrelMetrics.cs
@@ -289,20 +289,31 @@ internal sealed class KestrelMetrics
         _currentUpgradedRequestsCounter.Add(-1, tags);
     }
 
+    public bool TlsHandshakeMetricsEnabled
+        => _activeTlsHandshakesCounter.Enabled || _tlsHandshakeDuration.Enabled;
+
     public void TlsHandshakeStart(ConnectionMetricsContext metricsContext)
     {
         if (metricsContext.CurrentTlsHandshakesCounterEnabled)
         {
-            TlsHandshakeStartCore(metricsContext);
+            TlsHandshakeStartCore(metricsContext.ConnectionContext);
+        }
+    }
+
+    public void TlsHandshakeStart(TlsHandshakeMetricsContext metricsContext)
+    {
+        if (metricsContext.CurrentTlsHandshakesCounterEnabled)
+        {
+            TlsHandshakeStartCore(metricsContext.ConnectionContext);
         }
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void TlsHandshakeStartCore(ConnectionMetricsContext metricsContext)
+    private void TlsHandshakeStartCore(BaseConnectionContext connectionContext)
     {
         // Tags must match TLS handshake end.
         var tags = new TagList();
-        InitializeConnectionTags(ref tags, metricsContext);
+        ConnectionEndpointTags.AddConnectionEndpointTags(ref tags, connectionContext);
         _activeTlsHandshakesCounter.Add(1, tags);
     }
 
@@ -310,17 +321,43 @@ internal sealed class KestrelMetrics
     {
         if (metricsContext.CurrentTlsHandshakesCounterEnabled || _tlsHandshakeDuration.Enabled)
         {
-            TlsHandshakeStopCore(metricsContext, startTimestamp, currentTimestamp, protocol, exception);
+            TlsHandshakeStopCore(
+                metricsContext.ConnectionContext,
+                metricsContext.CurrentTlsHandshakesCounterEnabled,
+                startTimestamp,
+                currentTimestamp,
+                protocol,
+                exception);
+        }
+    }
+
+    public void TlsHandshakeStop(TlsHandshakeMetricsContext metricsContext, long startTimestamp, long currentTimestamp, SslProtocols? protocol = null, Exception? exception = null)
+    {
+        if (metricsContext.CurrentTlsHandshakesCounterEnabled || _tlsHandshakeDuration.Enabled)
+        {
+            TlsHandshakeStopCore(
+                metricsContext.ConnectionContext,
+                metricsContext.CurrentTlsHandshakesCounterEnabled,
+                startTimestamp,
+                currentTimestamp,
+                protocol,
+                exception);
         }
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void TlsHandshakeStopCore(ConnectionMetricsContext metricsContext, long startTimestamp, long currentTimestamp, SslProtocols? protocol = null, Exception? exception = null)
+    private void TlsHandshakeStopCore(
+        BaseConnectionContext connectionContext,
+        bool currentTlsHandshakesCounterEnabled,
+        long startTimestamp,
+        long currentTimestamp,
+        SslProtocols? protocol,
+        Exception? exception)
     {
         var tags = new TagList();
-        InitializeConnectionTags(ref tags, metricsContext);
+        ConnectionEndpointTags.AddConnectionEndpointTags(ref tags, connectionContext);
 
-        if (metricsContext.CurrentTlsHandshakesCounterEnabled)
+        if (currentTlsHandshakesCounterEnabled)
         {
             // Tags must match TLS handshake start.
             _activeTlsHandshakesCounter.Add(-1, tags);
@@ -328,7 +365,6 @@ internal sealed class KestrelMetrics
 
         if (protocol != null && TryGetHandshakeProtocol(protocol.Value, out var protocolName, out var protocolVersion))
         {
-            // Protocol name should always be TLS. Have logic to a tls.protocol.name tag if not TLS just in case.
             if (protocolName != "tls")
             {
                 tags.Add("tls.protocol.name", protocolName);
@@ -337,7 +373,6 @@ internal sealed class KestrelMetrics
         }
         if (exception != null)
         {
-            // Set exception name as error.type if there isn't already a value.
             tags.TryAddTag(ErrorTypeAttributeName, exception.GetType().FullName);
         }
 
@@ -364,6 +399,9 @@ internal sealed class KestrelMetrics
             CurrentTlsHandshakesCounterEnabled = _activeTlsHandshakesCounter.Enabled
         };
     }
+
+    public TlsHandshakeMetricsContext CreateTlsHandshakeContext(BaseConnectionContext connection)
+        => new(connection, _activeTlsHandshakesCounter.Enabled);
 
     public static bool TryGetHandshakeProtocol(SslProtocols protocols, [NotNullWhen(true)] out string? name, [NotNullWhen(true)] out string? version)
     {

--- a/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TlsHandshakeMetricsContext.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Infrastructure/TlsHandshakeMetricsContext.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Connections;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+
+internal readonly struct TlsHandshakeMetricsContext
+{
+    public TlsHandshakeMetricsContext(BaseConnectionContext connectionContext, bool currentTlsHandshakesCounterEnabled)
+    {
+        ConnectionContext = connectionContext;
+        CurrentTlsHandshakesCounterEnabled = currentTlsHandshakesCounterEnabled;
+    }
+
+    public BaseConnectionContext ConnectionContext { get; }
+
+    public bool CurrentTlsHandshakesCounterEnabled { get; }
+}

--- a/src/Servers/Kestrel/Transport.DirectTls/src/Connection/DirectTlsConnection.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/Connection/DirectTlsConnection.cs
@@ -28,6 +28,7 @@ internal sealed partial class DirectTlsConnection : TransportConnection
     // Mirrors the sockets transport's SocketConnection.MinAllocBufferSize (PinnedBlockMemoryPool.BlockSize / 2).
     // Avoids defragmentation of the transport's shared memory pool
     private const int MinAllocBufferSize = 4096 / 2;
+    private const string GracefulSendLoopCompletion = "The DirectTls transport's send loop completed gracefully.";
 
     private readonly ConnectionIoState _connectionState;
     private readonly TlsEventPump _pump;
@@ -64,6 +65,7 @@ internal sealed partial class DirectTlsConnection : TransportConnection
         _pump = pump;
         _memoryPool = memoryPool;
         _logger = logger;
+        _connectionState.SetConnectionId(ConnectionId);
 
         LocalEndPoint = localEndPoint;
         RemoteEndPoint = remoteEndPoint;
@@ -270,6 +272,7 @@ internal sealed partial class DirectTlsConnection : TransportConnection
                 else if (bytesRead == 0)
                 {
                     // Connection closed (EOF)
+                    DirectTlsLog.ConnectionReadFin(_logger, ConnectionId);
                     break;
                 }
                 else
@@ -287,6 +290,7 @@ internal sealed partial class DirectTlsConnection : TransportConnection
         catch (Exception ex)
         {
             error = ex;
+            LogConnectionError(ex);
         }
         finally
         {
@@ -330,6 +334,7 @@ internal sealed partial class DirectTlsConnection : TransportConnection
                             if (written == 0)
                             {
                                 // Peer closed the connection mid-send.
+                                DirectTlsLog.ConnectionReset(_logger, ConnectionId);
                                 Application.Input.AdvanceTo(buffer.End);
                                 return;
                             }
@@ -342,6 +347,7 @@ internal sealed partial class DirectTlsConnection : TransportConnection
                 // Check completion AFTER processing and advancing (matches Kestrel's DoSend pattern)
                 if (result.IsCompleted)
                 {
+                    DirectTlsLog.ConnectionWriteFin(_logger, ConnectionId, GracefulSendLoopCompletion);
                     break;
                 }
             }
@@ -353,6 +359,7 @@ internal sealed partial class DirectTlsConnection : TransportConnection
         catch (Exception ex)
         {
             error = ex;
+            LogConnectionError(ex);
         }
         finally
         {
@@ -367,6 +374,7 @@ internal sealed partial class DirectTlsConnection : TransportConnection
             return;
         }
         _aborted = true;
+        DirectTlsLog.ConnectionWriteRst(_logger, ConnectionId, abortReason.Message);
 
         // Unblock BOTH loops so the connection tears down immediately instead of leaving the socket
         // half-open until the peer times out. SocketConnection.Abort closes the socket synchronously
@@ -396,7 +404,7 @@ internal sealed partial class DirectTlsConnection : TransportConnection
             return;
         }
 
-        _logger.LogDebug(ex, "TLS fatal error for fd={Fd}, aborting connection", _connectionState.Fd);
+        LogConnectionError(ex);
 
         // Just abort to cancel pending operations - don't trigger disposal here. Kestrel calls DisposeAsync
         // when it's done with the connection, which prevents premature disposal while SendLoop is still writing.
@@ -414,6 +422,18 @@ internal sealed partial class DirectTlsConnection : TransportConnection
         {
             // a throwing callback must not escape and abandon the rest of the teardown
             _logger.LogError(0, ex, $"Unexpected exception in {nameof(DirectTlsConnection)}.{nameof(CancelConnectionClosedToken)}.");
+        }
+    }
+
+    private void LogConnectionError(Exception exception)
+    {
+        if (exception is ConnectionResetException)
+        {
+            DirectTlsLog.ConnectionReset(_logger, ConnectionId);
+        }
+        else
+        {
+            DirectTlsLog.ConnectionError(_logger, ConnectionId, exception);
         }
     }
 
@@ -461,7 +481,7 @@ internal sealed partial class DirectTlsConnection : TransportConnection
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "TLS shutdown failed for fd={Fd}", _connectionState.Fd);
+            DirectTlsLog.ConnectionError(_logger, ConnectionId, ex);
         }
 
         // 7. Signal connection closed

--- a/src/Servers/Kestrel/Transport.DirectTls/src/Connection/DirectTlsConnection.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/Connection/DirectTlsConnection.cs
@@ -65,10 +65,9 @@ internal sealed partial class DirectTlsConnection : TransportConnection
         _pump = pump;
         _memoryPool = memoryPool;
         _logger = logger;
-        _connectionState.SetConnectionId(ConnectionId);
-
         LocalEndPoint = localEndPoint;
         RemoteEndPoint = remoteEndPoint;
+        _connectionState.SetConnection(this);
         ConnectionClosed = _connectionClosedTokenSource.Token;
 
         // A managed Socket over the raw fd (non-owning) is offered, matching the standard sockets

--- a/src/Servers/Kestrel/Transport.DirectTls/src/ConnectionIoState.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/ConnectionIoState.cs
@@ -33,6 +33,7 @@ internal class ConnectionIoState : IDisposable
     private readonly TlsSocketSession _session;
     private readonly DirectTlsMetrics _metrics;
     private string? _connectionId;
+    private uint _currentEpollInterest;
 
     // Serializes every native SSL operation (SSL_read / SSL_write / SSL_shutdown) on this connection's
     // session. TlsSocketSession is not safe for concurrent Read/Write from different threads - one SSL*
@@ -104,6 +105,15 @@ internal class ConnectionIoState : IDisposable
     internal void SetConnectionId(string connectionId)
     {
         _connectionId = connectionId;
+    }
+
+    internal string ConnectionId => _connectionId ?? string.Empty;
+
+    internal uint CurrentEpollInterest => Volatile.Read(ref _currentEpollInterest);
+
+    internal void SetCurrentEpollInterest(uint events)
+    {
+        Volatile.Write(ref _currentEpollInterest, events);
     }
 
     /// <summary>

--- a/src/Servers/Kestrel/Transport.DirectTls/src/ConnectionIoState.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/ConnectionIoState.cs
@@ -226,6 +226,8 @@ internal class ConnectionIoState : IDisposable
     // that still needs to read (_writeWantsRead) keeps EPOLLIN armed. Re-armed by ResumeReadInterest.
     internal void SuspendReadInterest()
     {
+        string? connectionId;
+
         lock (_sslLock)
         {
             if (_readInterestSuspended)
@@ -235,17 +237,20 @@ internal class ConnectionIoState : IDisposable
 
             _readInterestSuspended = true;
             UpdateEvents();
-
             _pausedConnectionsCounterEnabled = _metrics.ConnectionPaused();
-            if (_connectionId is { } connectionId)
-            {
-                DirectTlsLog.ConnectionPause(_logger, connectionId);
-            }
+            connectionId = _connectionId;
+        }
+
+        if (connectionId is not null)
+        {
+            DirectTlsLog.ConnectionPause(_logger, connectionId);
         }
     }
 
     internal void ResumeReadInterest()
     {
+        string? connectionId;
+
         lock (_sslLock)
         {
             if (!_readInterestSuspended)
@@ -255,12 +260,13 @@ internal class ConnectionIoState : IDisposable
 
             _readInterestSuspended = false;
             UpdateEvents();
-
             ReleasePauseTelemetry();
-            if (_connectionId is { } connectionId)
-            {
-                DirectTlsLog.ConnectionResume(_logger, connectionId);
-            }
+            connectionId = _connectionId;
+        }
+
+        if (connectionId is not null)
+        {
+            DirectTlsLog.ConnectionResume(_logger, connectionId);
         }
     }
 

--- a/src/Servers/Kestrel/Transport.DirectTls/src/ConnectionIoState.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/ConnectionIoState.cs
@@ -31,6 +31,8 @@ internal class ConnectionIoState : IDisposable
 {
     private readonly ILogger _logger;
     private readonly TlsSocketSession _session;
+    private readonly DirectTlsMetrics _metrics;
+    private string? _connectionId;
 
     // Serializes every native SSL operation (SSL_read / SSL_write / SSL_shutdown) on this connection's
     // session. TlsSocketSession is not safe for concurrent Read/Write from different threads - one SSL*
@@ -84,13 +86,24 @@ internal class ConnectionIoState : IDisposable
     private bool _writeWantsRead;                // Write needs the socket to become readable (renegotiation)
     private bool _writeWantsWrite;               // Write hit WouldBlock and needs the socket to become writable
     private bool _readInterestSuspended;         // Receive loop parked on backpressure; drop EPOLLIN to avoid a level-triggered spin
+    private bool? _pausedConnectionsCounterEnabled;
 
-    public ConnectionIoState(int fd, TlsSocketSession session, ILogger logger)
+    public ConnectionIoState(
+        int fd,
+        TlsSocketSession session,
+        ILogger logger,
+        DirectTlsMetrics? metrics = null)
     {
         _logger = logger;
+        _metrics = metrics ?? DirectTlsMetrics.Disabled;
 
         Fd = fd;
         _session = session;
+    }
+
+    internal void SetConnectionId(string connectionId)
+    {
+        _connectionId = connectionId;
     }
 
     /// <summary>
@@ -141,6 +154,11 @@ internal class ConnectionIoState : IDisposable
     private TlsOperationStatus TlsRead(Span<byte> buffer, out int bytesRead)
     {
         var status = RawRead(buffer, out bytesRead);
+        if (bytesRead > 0)
+        {
+            _metrics.BytesRead(bytesRead);
+        }
+
         return status is TlsOperationStatus.Complete or TlsOperationStatus.NeedMoreData
             or TlsOperationStatus.DestinationTooSmall or TlsOperationStatus.Closed
             ? status
@@ -152,6 +170,11 @@ internal class ConnectionIoState : IDisposable
     private TlsOperationStatus TlsWrite(ReadOnlySpan<byte> buffer, out int bytesWritten)
     {
         var status = RawWrite(buffer, out bytesWritten);
+        if (bytesWritten > 0)
+        {
+            _metrics.BytesWritten(bytesWritten);
+        }
+
         return status is TlsOperationStatus.Complete or TlsOperationStatus.NeedMoreData
             or TlsOperationStatus.DestinationTooSmall or TlsOperationStatus.Closed
             ? status
@@ -202,6 +225,12 @@ internal class ConnectionIoState : IDisposable
 
             _readInterestSuspended = true;
             UpdateEvents();
+
+            _pausedConnectionsCounterEnabled = _metrics.ConnectionPaused();
+            if (_connectionId is { } connectionId)
+            {
+                DirectTlsLog.ConnectionPause(_logger, connectionId);
+            }
         }
     }
 
@@ -216,7 +245,24 @@ internal class ConnectionIoState : IDisposable
 
             _readInterestSuspended = false;
             UpdateEvents();
+
+            ReleasePauseTelemetry();
+            if (_connectionId is { } connectionId)
+            {
+                DirectTlsLog.ConnectionResume(_logger, connectionId);
+            }
         }
+    }
+
+    private void ReleasePauseTelemetry()
+    {
+        if (_pausedConnectionsCounterEnabled is not { } pausedConnectionsCounterEnabled)
+        {
+            return;
+        }
+
+        _pausedConnectionsCounterEnabled = null;
+        _metrics.ConnectionResumed(pausedConnectionsCounterEnabled);
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -543,6 +589,16 @@ internal class ConnectionIoState : IDisposable
             // on an fd DisposeAsync is about to unregister from epoll.
             _readAwaitable.Cancel();
             _writeAwaitable.Cancel();
+
+            // DisposeAsync unregisters the fd before it cancels a backpressured pipe flush. Release the gauge
+            // here so the receive loop's eventual ResumeReadInterest does not try to re-arm an unregistered fd
+            // and leave the connection counted as paused after teardown.
+            if (_readInterestSuspended)
+            {
+                _readInterestSuspended = false;
+            }
+
+            ReleasePauseTelemetry();
         }
     }
 

--- a/src/Servers/Kestrel/Transport.DirectTls/src/ConnectionIoState.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/ConnectionIoState.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Net.Security;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Logging;
 
 #pragma warning disable SYSLIB5007 // TlsSocketSession/TlsOperationStatus are experimental.
@@ -32,7 +33,7 @@ internal class ConnectionIoState : IDisposable
     private readonly ILogger _logger;
     private readonly TlsSocketSession _session;
     private readonly DirectTlsMetrics _metrics;
-    private string? _connectionId;
+    private BaseConnectionContext? _connection;
     private uint _currentEpollInterest;
 
     // Serializes every native SSL operation (SSL_read / SSL_write / SSL_shutdown) on this connection's
@@ -87,7 +88,8 @@ internal class ConnectionIoState : IDisposable
     private bool _writeWantsRead;                // Write needs the socket to become readable (renegotiation)
     private bool _writeWantsWrite;               // Write hit WouldBlock and needs the socket to become writable
     private bool _readInterestSuspended;         // Receive loop parked on backpressure; drop EPOLLIN to avoid a level-triggered spin
-    private bool? _pausedConnectionsCounterEnabled;
+    private bool? _readBackpressureCounterEnabled;
+    private bool? _writeBackpressureCounterEnabled;
 
     public ConnectionIoState(
         int fd,
@@ -102,12 +104,12 @@ internal class ConnectionIoState : IDisposable
         _session = session;
     }
 
-    internal void SetConnectionId(string connectionId)
+    internal void SetConnection(BaseConnectionContext connection)
     {
-        _connectionId = connectionId;
+        _connection = connection;
     }
 
-    internal string ConnectionId => _connectionId ?? string.Empty;
+    internal string ConnectionId => _connection?.ConnectionId ?? string.Empty;
 
     internal uint CurrentEpollInterest => Volatile.Read(ref _currentEpollInterest);
 
@@ -237,8 +239,8 @@ internal class ConnectionIoState : IDisposable
 
             _readInterestSuspended = true;
             UpdateEvents();
-            _pausedConnectionsCounterEnabled = _metrics.ConnectionPaused();
-            connectionId = _connectionId;
+            _readBackpressureCounterEnabled = _metrics.ReadConnectionPaused(_connection);
+            connectionId = _connection?.ConnectionId;
         }
 
         if (connectionId is not null)
@@ -260,8 +262,8 @@ internal class ConnectionIoState : IDisposable
 
             _readInterestSuspended = false;
             UpdateEvents();
-            ReleasePauseTelemetry();
-            connectionId = _connectionId;
+            ReleaseReadBackpressureTelemetry();
+            connectionId = _connection?.ConnectionId;
         }
 
         if (connectionId is not null)
@@ -270,15 +272,31 @@ internal class ConnectionIoState : IDisposable
         }
     }
 
-    private void ReleasePauseTelemetry()
+    private void ReleaseReadBackpressureTelemetry()
     {
-        if (_pausedConnectionsCounterEnabled is not { } pausedConnectionsCounterEnabled)
+        if (_readBackpressureCounterEnabled is not { } counterEnabled)
         {
             return;
         }
 
-        _pausedConnectionsCounterEnabled = null;
-        _metrics.ConnectionResumed(pausedConnectionsCounterEnabled);
+        _readBackpressureCounterEnabled = null;
+        _metrics.ReadConnectionResumed(counterEnabled, _connection);
+    }
+
+    private void StartWriteBackpressureTelemetry()
+    {
+        _writeBackpressureCounterEnabled = _metrics.WriteConnectionPaused(_connection);
+    }
+
+    private void ReleaseWriteBackpressureTelemetry()
+    {
+        if (_writeBackpressureCounterEnabled is not { } counterEnabled)
+        {
+            return;
+        }
+
+        _writeBackpressureCounterEnabled = null;
+        _metrics.WriteConnectionResumed(counterEnabled, _connection);
     }
 
     // ═══════════════════════════════════════════════════════════════
@@ -450,6 +468,7 @@ internal class ConnectionIoState : IDisposable
                     _writeWantsWrite = true;
                     var pending = _writeAwaitable.Reset();
                     UpdateEvents();
+                    StartWriteBackpressureTelemetry();
                     return pending;
 
                 case TlsOperationStatus.NeedMoreData:
@@ -484,6 +503,7 @@ internal class ConnectionIoState : IDisposable
         if (!_writeAwaitable.IsActive)
         {
             // Spurious EPOLLOUT - no write is pending, so drop the write side's writable interest.
+            ReleaseWriteBackpressureTelemetry();
             _writeWantsWrite = false;
             UpdateEvents();
             return;
@@ -494,6 +514,7 @@ internal class ConnectionIoState : IDisposable
         switch (status)
         {
             case TlsOperationStatus.Complete:
+                ReleaseWriteBackpressureTelemetry();
                 _writeBuffer = default;
                 _writeWantsRead = false;
                 _writeWantsWrite = false;
@@ -506,6 +527,7 @@ internal class ConnectionIoState : IDisposable
                 _writeBuffer = _writeBuffer.Slice(written);
                 if (_writeWantsRead || !_writeWantsWrite)
                 {
+                    StartWriteBackpressureTelemetry();
                     _writeWantsRead = false;
                     _writeWantsWrite = true;
                     UpdateEvents();
@@ -517,6 +539,7 @@ internal class ConnectionIoState : IDisposable
                 _writeBuffer = _writeBuffer.Slice(written);
                 if (!_writeWantsRead)
                 {
+                    ReleaseWriteBackpressureTelemetry();
                     _writeWantsRead = true;
                     _writeWantsWrite = false;
                     UpdateEvents();
@@ -525,6 +548,7 @@ internal class ConnectionIoState : IDisposable
 
             case TlsOperationStatus.Closed:
             default:
+                ReleaseWriteBackpressureTelemetry();
                 _writeBuffer = default;
                 _writeWantsRead = false;
                 _writeWantsWrite = false;
@@ -593,6 +617,8 @@ internal class ConnectionIoState : IDisposable
     /// </summary>
     internal void Cancel()
     {
+        string? resumedConnectionId = null;
+
         // Hold _sslLock so cancellation waits out any in-flight SSL_read/SSL_write (both run under it):
         // completing the awaitable while the pump is mid SSL_read would let the receive loop complete the pipe
         // and recycle _readBuffer while the native write is still filling it (mirror race: SSL_write reading a
@@ -609,12 +635,19 @@ internal class ConnectionIoState : IDisposable
             // DisposeAsync unregisters the fd before it cancels a backpressured pipe flush. Release the gauge
             // here so the receive loop's eventual ResumeReadInterest does not try to re-arm an unregistered fd
             // and leave the connection counted as paused after teardown.
-            if (_readInterestSuspended)
+            if (_readBackpressureCounterEnabled is not null)
             {
-                _readInterestSuspended = false;
+                resumedConnectionId = _connection?.ConnectionId;
             }
 
-            ReleasePauseTelemetry();
+            _readInterestSuspended = false;
+            ReleaseReadBackpressureTelemetry();
+            ReleaseWriteBackpressureTelemetry();
+        }
+
+        if (resumedConnectionId is not null)
+        {
+            DirectTlsLog.ConnectionResume(_logger, resumedConnectionId);
         }
     }
 

--- a/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsEventSource.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsEventSource.cs
@@ -1,0 +1,164 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls;
+
+[EventSource(Name = EventSourceName)]
+internal sealed class DirectTlsEventSource : EventSource
+{
+    public const string EventSourceName = "Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls";
+
+    public static readonly DirectTlsEventSource Log = new();
+
+    private PollingCounter? _connectionsOwnedCounter;
+    private IncrementingPollingCounter? _acceptsCounter;
+    private PollingCounter? _connectionsPausedCounter;
+    private IncrementingPollingCounter? _bytesReadCounter;
+    private IncrementingPollingCounter? _bytesWrittenCounter;
+
+    private long _connectionsOwned;
+    private long _accepts;
+    private long _connectionsPaused;
+    private long _bytesRead;
+    private long _bytesWritten;
+
+    public DirectTlsEventSource()
+    {
+    }
+
+    internal DirectTlsEventSource(string eventSourceName)
+        : base(eventSourceName)
+    {
+    }
+
+    [NonEvent]
+    public void Accepted(int pumpId)
+    {
+        if (IsEnabled())
+        {
+            ConnectionAcceptedCore(pumpId);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [NonEvent]
+    private void ConnectionAcceptedCore(int pumpId)
+    {
+        Interlocked.Increment(ref _accepts);
+        ConnectionAccepted(pumpId);
+    }
+
+    [NonEvent]
+    public void ConnectionOwned(int pumpId, int pumpConnectionCount)
+    {
+        Interlocked.Increment(ref _connectionsOwned);
+
+        if (IsEnabled())
+        {
+            PumpConnections(pumpId, pumpConnectionCount);
+        }
+    }
+
+    [NonEvent]
+    public void ConnectionReleased(int pumpId, int pumpConnectionCount)
+    {
+        var count = Interlocked.Decrement(ref _connectionsOwned);
+        Debug.Assert(count >= 0);
+
+        if (IsEnabled())
+        {
+            PumpConnections(pumpId, pumpConnectionCount);
+        }
+    }
+
+    [NonEvent]
+    public void ConnectionPaused()
+    {
+        var count = Interlocked.Increment(ref _connectionsPaused);
+        Debug.Assert(count > 0);
+    }
+
+    [NonEvent]
+    public void ConnectionResumed()
+    {
+        var count = Interlocked.Decrement(ref _connectionsPaused);
+        Debug.Assert(count >= 0);
+    }
+
+    [NonEvent]
+    public void BytesRead(int count)
+    {
+        if (IsEnabled())
+        {
+            BytesReadCore(count);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [NonEvent]
+    private void BytesReadCore(int count)
+    {
+        Debug.Assert(count >= 0);
+        Interlocked.Add(ref _bytesRead, count);
+    }
+
+    [NonEvent]
+    public void BytesWritten(int count)
+    {
+        if (IsEnabled())
+        {
+            BytesWrittenCore(count);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [NonEvent]
+    private void BytesWrittenCore(int count)
+    {
+        Debug.Assert(count >= 0);
+        Interlocked.Add(ref _bytesWritten, count);
+    }
+
+    [Event(1, Level = EventLevel.Informational)]
+    private void ConnectionAccepted(int pumpId)
+        => WriteEvent(1, pumpId);
+
+    [Event(2, Level = EventLevel.Informational)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void PumpConnections(int pumpId, int connectionCount)
+        => WriteEvent(2, pumpId, connectionCount);
+
+    protected override void OnEventCommand(EventCommandEventArgs command)
+    {
+        if (command.Command == EventCommand.Enable)
+        {
+            _connectionsOwnedCounter ??= new PollingCounter("connections-owned", this, () => Interlocked.Read(ref _connectionsOwned))
+            {
+                DisplayName = "Connections Owned"
+            };
+            _acceptsCounter ??= new IncrementingPollingCounter("accepts", this, () => Interlocked.Read(ref _accepts))
+            {
+                DisplayName = "Connections Accepted",
+                DisplayRateTimeScale = TimeSpan.FromSeconds(1)
+            };
+            _connectionsPausedCounter ??= new PollingCounter("connections-paused", this, () => Interlocked.Read(ref _connectionsPaused))
+            {
+                DisplayName = "Connections Paused by Backpressure"
+            };
+            _bytesReadCounter ??= new IncrementingPollingCounter("bytes-read", this, () => Interlocked.Read(ref _bytesRead))
+            {
+                DisplayName = "Bytes Read",
+                DisplayRateTimeScale = TimeSpan.FromSeconds(1)
+            };
+            _bytesWrittenCounter ??= new IncrementingPollingCounter("bytes-written", this, () => Interlocked.Read(ref _bytesWritten))
+            {
+                DisplayName = "Bytes Written",
+                DisplayRateTimeScale = TimeSpan.FromSeconds(1)
+            };
+        }
+    }
+}

--- a/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsEventSource.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsEventSource.cs
@@ -19,12 +19,21 @@ internal sealed class DirectTlsEventSource : EventSource
     private PollingCounter? _connectionsPausedCounter;
     private IncrementingPollingCounter? _bytesReadCounter;
     private IncrementingPollingCounter? _bytesWrittenCounter;
+    private IncrementingPollingCounter? _epollWaitsCounter;
+    private IncrementingPollingCounter? _epollWakeupsCounter;
+    private IncrementingPollingCounter? _epollTimeoutsCounter;
+    private IncrementingPollingCounter? _epollReadyEventsCounter;
+    private EventCounter? _epollReadyBatchSizeCounter;
 
     private long _connectionsOwned;
     private long _accepts;
     private long _connectionsPaused;
     private long _bytesRead;
     private long _bytesWritten;
+    private long _epollWaits;
+    private long _epollWakeups;
+    private long _epollTimeouts;
+    private long _epollReadyEvents;
 
     public DirectTlsEventSource()
     {
@@ -123,6 +132,89 @@ internal sealed class DirectTlsEventSource : EventSource
         Interlocked.Add(ref _bytesWritten, count);
     }
 
+    [NonEvent]
+    public void EpollWaitCompleted(int readyEventCount)
+    {
+        if (IsEnabled())
+        {
+            EpollWaitCompletedCore(readyEventCount);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [NonEvent]
+    private void EpollWaitCompletedCore(int readyEventCount)
+    {
+        Debug.Assert(readyEventCount >= 0);
+        Interlocked.Increment(ref _epollWaits);
+
+        if (readyEventCount == 0)
+        {
+            Interlocked.Increment(ref _epollTimeouts);
+            return;
+        }
+
+        Interlocked.Increment(ref _epollWakeups);
+        Interlocked.Add(ref _epollReadyEvents, readyEventCount);
+        _epollReadyBatchSizeCounter?.WriteMetric(readyEventCount);
+    }
+
+    [NonEvent]
+    public void RecordEpollConnectionRegistered(int pumpId, int fileDescriptor, string connectionId, uint events)
+    {
+        if (IsEnabled(EventLevel.Verbose, EventKeywords.All))
+        {
+            EpollConnectionRegisteredCore(pumpId, fileDescriptor, connectionId, events);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [NonEvent]
+    private void EpollConnectionRegisteredCore(int pumpId, int fileDescriptor, string connectionId, uint events)
+        => EpollConnectionRegistered(pumpId, fileDescriptor, connectionId, events);
+
+    [NonEvent]
+    public void RecordEpollInterestChanged(int pumpId, int fileDescriptor, string connectionId, uint previousEvents, uint events)
+    {
+        if (IsEnabled(EventLevel.Verbose, EventKeywords.All))
+        {
+            EpollInterestChangedCore(pumpId, fileDescriptor, connectionId, previousEvents, events);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [NonEvent]
+    private void EpollInterestChangedCore(int pumpId, int fileDescriptor, string connectionId, uint previousEvents, uint events)
+        => EpollInterestChanged(pumpId, fileDescriptor, connectionId, previousEvents, events);
+
+    [NonEvent]
+    public void RecordEpollReady(int pumpId, int fileDescriptor, string connectionId, uint events)
+    {
+        if (IsEnabled(EventLevel.Verbose, EventKeywords.All))
+        {
+            EpollReadyCore(pumpId, fileDescriptor, connectionId, events);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [NonEvent]
+    private void EpollReadyCore(int pumpId, int fileDescriptor, string connectionId, uint events)
+        => EpollReady(pumpId, fileDescriptor, connectionId, events);
+
+    [NonEvent]
+    public void RecordEpollConnectionUnregistered(int pumpId, int fileDescriptor, string connectionId, uint events)
+    {
+        if (IsEnabled(EventLevel.Verbose, EventKeywords.All))
+        {
+            EpollConnectionUnregisteredCore(pumpId, fileDescriptor, connectionId, events);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [NonEvent]
+    private void EpollConnectionUnregisteredCore(int pumpId, int fileDescriptor, string connectionId, uint events)
+        => EpollConnectionUnregistered(pumpId, fileDescriptor, connectionId, events);
+
     [Event(1, Level = EventLevel.Informational)]
     private void ConnectionAccepted(int pumpId)
         => WriteEvent(1, pumpId);
@@ -131,6 +223,22 @@ internal sealed class DirectTlsEventSource : EventSource
     [MethodImpl(MethodImplOptions.NoInlining)]
     private void PumpConnections(int pumpId, int connectionCount)
         => WriteEvent(2, pumpId, connectionCount);
+
+    [Event(3, Level = EventLevel.Verbose)]
+    private void EpollConnectionRegistered(int pumpId, int fileDescriptor, string connectionId, uint events)
+        => WriteEvent(3, pumpId, fileDescriptor, connectionId, events);
+
+    [Event(4, Level = EventLevel.Verbose)]
+    private void EpollInterestChanged(int pumpId, int fileDescriptor, string connectionId, uint previousEvents, uint events)
+        => WriteEvent(4, pumpId, fileDescriptor, connectionId, previousEvents, events);
+
+    [Event(5, Level = EventLevel.Verbose)]
+    private void EpollReady(int pumpId, int fileDescriptor, string connectionId, uint events)
+        => WriteEvent(5, pumpId, fileDescriptor, connectionId, events);
+
+    [Event(6, Level = EventLevel.Verbose)]
+    private void EpollConnectionUnregistered(int pumpId, int fileDescriptor, string connectionId, uint events)
+        => WriteEvent(6, pumpId, fileDescriptor, connectionId, events);
 
     protected override void OnEventCommand(EventCommandEventArgs command)
     {
@@ -158,6 +266,30 @@ internal sealed class DirectTlsEventSource : EventSource
             {
                 DisplayName = "Bytes Written",
                 DisplayRateTimeScale = TimeSpan.FromSeconds(1)
+            };
+            _epollWaitsCounter ??= new IncrementingPollingCounter("epoll-waits", this, () => Interlocked.Read(ref _epollWaits))
+            {
+                DisplayName = "Epoll Waits",
+                DisplayRateTimeScale = TimeSpan.FromSeconds(1)
+            };
+            _epollWakeupsCounter ??= new IncrementingPollingCounter("epoll-wakeups", this, () => Interlocked.Read(ref _epollWakeups))
+            {
+                DisplayName = "Epoll Wakeups",
+                DisplayRateTimeScale = TimeSpan.FromSeconds(1)
+            };
+            _epollTimeoutsCounter ??= new IncrementingPollingCounter("epoll-timeouts", this, () => Interlocked.Read(ref _epollTimeouts))
+            {
+                DisplayName = "Epoll Timeouts",
+                DisplayRateTimeScale = TimeSpan.FromSeconds(1)
+            };
+            _epollReadyEventsCounter ??= new IncrementingPollingCounter("epoll-ready-events", this, () => Interlocked.Read(ref _epollReadyEvents))
+            {
+                DisplayName = "Epoll Ready Events",
+                DisplayRateTimeScale = TimeSpan.FromSeconds(1)
+            };
+            _epollReadyBatchSizeCounter ??= new EventCounter("epoll-ready-batch-size", this)
+            {
+                DisplayName = "Epoll Ready Batch Size"
             };
         }
     }

--- a/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsEventSource.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsEventSource.cs
@@ -16,7 +16,8 @@ internal sealed class DirectTlsEventSource : EventSource
 
     private PollingCounter? _connectionsOwnedCounter;
     private IncrementingPollingCounter? _acceptsCounter;
-    private PollingCounter? _connectionsPausedCounter;
+    private PollingCounter? _readConnectionsPausedCounter;
+    private PollingCounter? _writeConnectionsPausedCounter;
     private IncrementingPollingCounter? _bytesReadCounter;
     private IncrementingPollingCounter? _bytesWrittenCounter;
     private IncrementingPollingCounter? _epollWaitsCounter;
@@ -27,7 +28,8 @@ internal sealed class DirectTlsEventSource : EventSource
 
     private long _connectionsOwned;
     private long _accepts;
-    private long _connectionsPaused;
+    private long _readConnectionsPaused;
+    private long _writeConnectionsPaused;
     private long _bytesRead;
     private long _bytesWritten;
     private long _epollWaits;
@@ -85,16 +87,30 @@ internal sealed class DirectTlsEventSource : EventSource
     }
 
     [NonEvent]
-    public void ConnectionPaused()
+    public void ReadConnectionPaused()
     {
-        var count = Interlocked.Increment(ref _connectionsPaused);
+        var count = Interlocked.Increment(ref _readConnectionsPaused);
         Debug.Assert(count > 0);
     }
 
     [NonEvent]
-    public void ConnectionResumed()
+    public void ReadConnectionResumed()
     {
-        var count = Interlocked.Decrement(ref _connectionsPaused);
+        var count = Interlocked.Decrement(ref _readConnectionsPaused);
+        Debug.Assert(count >= 0);
+    }
+
+    [NonEvent]
+    public void WriteConnectionPaused()
+    {
+        var count = Interlocked.Increment(ref _writeConnectionsPaused);
+        Debug.Assert(count > 0);
+    }
+
+    [NonEvent]
+    public void WriteConnectionResumed()
+    {
+        var count = Interlocked.Decrement(ref _writeConnectionsPaused);
         Debug.Assert(count >= 0);
     }
 
@@ -253,9 +269,13 @@ internal sealed class DirectTlsEventSource : EventSource
                 DisplayName = "Connections Accepted",
                 DisplayRateTimeScale = TimeSpan.FromSeconds(1)
             };
-            _connectionsPausedCounter ??= new PollingCounter("connections-paused", this, () => Interlocked.Read(ref _connectionsPaused))
+            _readConnectionsPausedCounter ??= new PollingCounter("read-connections-paused", this, () => Interlocked.Read(ref _readConnectionsPaused))
             {
-                DisplayName = "Connections Paused by Backpressure"
+                DisplayName = "Connections Paused by Read Backpressure"
+            };
+            _writeConnectionsPausedCounter ??= new PollingCounter("write-connections-paused", this, () => Interlocked.Read(ref _writeConnectionsPaused))
+            {
+                DisplayName = "Connections Paused by Write Backpressure"
             };
             _bytesReadCounter ??= new IncrementingPollingCounter("bytes-read", this, () => Interlocked.Read(ref _bytesRead))
             {

--- a/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsLog.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsLog.cs
@@ -85,4 +85,37 @@ internal static partial class DirectTlsLog
             ConnectionResetCore(logger, connectionId);
         }
     }
+
+    [LoggerMessage(20, LogLevel.Trace, @"Connection id ""{ConnectionId}"" registered with epoll pump {PumpId} as fd {FileDescriptor} with events {Events}.", EventName = "EpollConnectionRegistered", SkipEnabledCheck = true)]
+    private static partial void EpollConnectionRegisteredCore(ILogger logger, string connectionId, int pumpId, int fileDescriptor, uint events);
+
+    public static void EpollConnectionRegistered(ILogger logger, string connectionId, int pumpId, int fileDescriptor, uint events)
+    {
+        if (logger.IsEnabled(LogLevel.Trace))
+        {
+            EpollConnectionRegisteredCore(logger, connectionId, pumpId, fileDescriptor, events);
+        }
+    }
+
+    [LoggerMessage(21, LogLevel.Trace, @"Connection id ""{ConnectionId}"" changed epoll interest on pump {PumpId}, fd {FileDescriptor}, from {PreviousEvents} to {Events}.", EventName = "EpollInterestChanged", SkipEnabledCheck = true)]
+    private static partial void EpollInterestChangedCore(ILogger logger, string connectionId, int pumpId, int fileDescriptor, uint previousEvents, uint events);
+
+    public static void EpollInterestChanged(ILogger logger, string connectionId, int pumpId, int fileDescriptor, uint previousEvents, uint events)
+    {
+        if (logger.IsEnabled(LogLevel.Trace))
+        {
+            EpollInterestChangedCore(logger, connectionId, pumpId, fileDescriptor, previousEvents, events);
+        }
+    }
+
+    [LoggerMessage(22, LogLevel.Trace, @"Connection id ""{ConnectionId}"" unregistered from epoll pump {PumpId} as fd {FileDescriptor}; last events were {Events}.", EventName = "EpollConnectionUnregistered", SkipEnabledCheck = true)]
+    private static partial void EpollConnectionUnregisteredCore(ILogger logger, string connectionId, int pumpId, int fileDescriptor, uint events);
+
+    public static void EpollConnectionUnregistered(ILogger logger, string connectionId, int pumpId, int fileDescriptor, uint events)
+    {
+        if (logger.IsEnabled(LogLevel.Trace))
+        {
+            EpollConnectionUnregisteredCore(logger, connectionId, pumpId, fileDescriptor, events);
+        }
+    }
 }

--- a/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsLog.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsLog.cs
@@ -1,0 +1,88 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls;
+
+// Mirrors SocketsLog events:
+// https://github.com/dotnet/aspnetcore/blob/main/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketsLog.cs
+internal static partial class DirectTlsLog
+{
+    [LoggerMessage(4, LogLevel.Debug, @"Connection id ""{ConnectionId}"" paused.", EventName = "ConnectionPause", SkipEnabledCheck = true)]
+    private static partial void ConnectionPauseCore(ILogger logger, string connectionId);
+
+    public static void ConnectionPause(ILogger logger, string connectionId)
+    {
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            ConnectionPauseCore(logger, connectionId);
+        }
+    }
+
+    [LoggerMessage(5, LogLevel.Debug, @"Connection id ""{ConnectionId}"" resumed.", EventName = "ConnectionResume", SkipEnabledCheck = true)]
+    private static partial void ConnectionResumeCore(ILogger logger, string connectionId);
+
+    public static void ConnectionResume(ILogger logger, string connectionId)
+    {
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            ConnectionResumeCore(logger, connectionId);
+        }
+    }
+
+    [LoggerMessage(6, LogLevel.Debug, @"Connection id ""{ConnectionId}"" received FIN.", EventName = "ConnectionReadFin", SkipEnabledCheck = true)]
+    private static partial void ConnectionReadFinCore(ILogger logger, string connectionId);
+
+    public static void ConnectionReadFin(ILogger logger, string connectionId)
+    {
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            ConnectionReadFinCore(logger, connectionId);
+        }
+    }
+
+    [LoggerMessage(7, LogLevel.Debug, @"Connection id ""{ConnectionId}"" sending FIN because: ""{Reason}""", EventName = "ConnectionWriteFin", SkipEnabledCheck = true)]
+    private static partial void ConnectionWriteFinCore(ILogger logger, string connectionId, string reason);
+
+    public static void ConnectionWriteFin(ILogger logger, string connectionId, string reason)
+    {
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            ConnectionWriteFinCore(logger, connectionId, reason);
+        }
+    }
+
+    [LoggerMessage(8, LogLevel.Debug, @"Connection id ""{ConnectionId}"" sending RST because: ""{Reason}""", EventName = "ConnectionWriteRst", SkipEnabledCheck = true)]
+    private static partial void ConnectionWriteRstCore(ILogger logger, string connectionId, string reason);
+
+    public static void ConnectionWriteRst(ILogger logger, string connectionId, string reason)
+    {
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            ConnectionWriteRstCore(logger, connectionId, reason);
+        }
+    }
+
+    [LoggerMessage(14, LogLevel.Debug, @"Connection id ""{ConnectionId}"" communication error.", EventName = "ConnectionError", SkipEnabledCheck = true)]
+    private static partial void ConnectionErrorCore(ILogger logger, string connectionId, Exception exception);
+
+    public static void ConnectionError(ILogger logger, string connectionId, Exception exception)
+    {
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            ConnectionErrorCore(logger, connectionId, exception);
+        }
+    }
+
+    [LoggerMessage(19, LogLevel.Debug, @"Connection id ""{ConnectionId}"" reset.", EventName = "ConnectionReset", SkipEnabledCheck = true)]
+    private static partial void ConnectionResetCore(ILogger logger, string connectionId);
+
+    public static void ConnectionReset(ILogger logger, string connectionId)
+    {
+        if (logger.IsEnabled(LogLevel.Debug))
+        {
+            ConnectionResetCore(logger, connectionId);
+        }
+    }
+}

--- a/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsMetrics.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsMetrics.cs
@@ -21,6 +21,10 @@ internal sealed class DirectTlsMetrics
     private readonly UpDownCounter<long>? _writeBackpressureConnections;
     private readonly DirectTlsEventSource _eventSource = DirectTlsEventSource.Log;
 
+    private DirectTlsMetrics()
+    {
+    }
+
     public DirectTlsMetrics(IMeterFactory meterFactory)
         : this(meterFactory.Create(KestrelMetrics.MeterName))
     {

--- a/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsMetrics.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsMetrics.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.Metrics;
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls;
+
+internal sealed class DirectTlsMetrics
+{
+    public const string PausedConnectionsInstrumentName = "kestrel.direct_tls.connections_paused";
+
+    public static readonly DirectTlsMetrics Disabled = new();
+
+    private readonly UpDownCounter<long>? _pausedConnections;
+    private readonly DirectTlsEventSource _eventSource = DirectTlsEventSource.Log;
+
+    private DirectTlsMetrics()
+    {
+    }
+
+    public DirectTlsMetrics(IMeterFactory meterFactory)
+        : this(meterFactory.Create(KestrelMetrics.MeterName))
+    {
+    }
+
+    internal DirectTlsMetrics(Meter meter)
+    {
+        _pausedConnections = meter.CreateUpDownCounter<long>(
+            PausedConnectionsInstrumentName,
+            unit: "{connection}",
+            description: "Number of DirectTls connections that are paused by input-pipe backpressure.");
+    }
+
+    public bool ConnectionPaused()
+    {
+        _eventSource.ConnectionPaused();
+
+        if (_pausedConnections?.Enabled == true)
+        {
+            ConnectionPausedCore();
+            return true;
+        }
+
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ConnectionPausedCore()
+        => _pausedConnections!.Add(1);
+
+    public void ConnectionResumed(bool pausedConnectionsCounterEnabled)
+    {
+        _eventSource.ConnectionResumed();
+
+        if (pausedConnectionsCounterEnabled)
+        {
+            ConnectionResumedCore();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void ConnectionResumedCore()
+        => _pausedConnections!.Add(-1);
+
+    public void BytesRead(int count)
+        => _eventSource.BytesRead(count);
+
+    public void BytesWritten(int count)
+        => _eventSource.BytesWritten(count);
+}

--- a/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsMetrics.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsMetrics.cs
@@ -1,24 +1,25 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+using Microsoft.AspNetCore.Shared;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls;
 
 internal sealed class DirectTlsMetrics
 {
-    public const string PausedConnectionsInstrumentName = "kestrel.direct_tls.connections_paused";
+    public const string ReadBackpressureConnectionsInstrumentName = "kestrel.direct_tls.read_backpressure_connections";
+    public const string WriteBackpressureConnectionsInstrumentName = "kestrel.direct_tls.write_backpressure_connections";
 
     public static readonly DirectTlsMetrics Disabled = new();
 
-    private readonly UpDownCounter<long>? _pausedConnections;
+    private readonly UpDownCounter<long>? _readBackpressureConnections;
+    private readonly UpDownCounter<long>? _writeBackpressureConnections;
     private readonly DirectTlsEventSource _eventSource = DirectTlsEventSource.Log;
-
-    private DirectTlsMetrics()
-    {
-    }
 
     public DirectTlsMetrics(IMeterFactory meterFactory)
         : this(meterFactory.Create(KestrelMetrics.MeterName))
@@ -27,42 +28,85 @@ internal sealed class DirectTlsMetrics
 
     internal DirectTlsMetrics(Meter meter)
     {
-        _pausedConnections = meter.CreateUpDownCounter<long>(
-            PausedConnectionsInstrumentName,
+        _readBackpressureConnections = meter.CreateUpDownCounter<long>(
+            ReadBackpressureConnectionsInstrumentName,
             unit: "{connection}",
-            description: "Number of DirectTls connections that are paused by input-pipe backpressure.");
+            description: "Number of DirectTls connections paused by input-pipe backpressure.");
+        _writeBackpressureConnections = meter.CreateUpDownCounter<long>(
+            WriteBackpressureConnectionsInstrumentName,
+            unit: "{connection}",
+            description: "Number of DirectTls connections whose TLS writes are waiting for socket writability.");
     }
 
-    public bool ConnectionPaused()
+    public bool ReadConnectionPaused(BaseConnectionContext? connection)
     {
-        _eventSource.ConnectionPaused();
+        _eventSource.ReadConnectionPaused();
 
-        if (_pausedConnections?.Enabled == true)
+        if (_readBackpressureConnections?.Enabled == true)
         {
-            ConnectionPausedCore();
+            ConnectionPausedCore(_readBackpressureConnections, connection);
             return true;
         }
 
         return false;
     }
 
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private void ConnectionPausedCore()
-        => _pausedConnections!.Add(1);
-
-    public void ConnectionResumed(bool pausedConnectionsCounterEnabled)
+    public void ReadConnectionResumed(bool counterEnabled, BaseConnectionContext? connection)
     {
-        _eventSource.ConnectionResumed();
+        _eventSource.ReadConnectionResumed();
 
-        if (pausedConnectionsCounterEnabled)
+        if (counterEnabled)
         {
-            ConnectionResumedCore();
+            ConnectionResumedCore(_readBackpressureConnections!, connection);
+        }
+    }
+
+    public bool WriteConnectionPaused(BaseConnectionContext? connection)
+    {
+        _eventSource.WriteConnectionPaused();
+
+        if (_writeBackpressureConnections?.Enabled == true)
+        {
+            ConnectionPausedCore(_writeBackpressureConnections, connection);
+            return true;
+        }
+
+        return false;
+    }
+
+    public void WriteConnectionResumed(bool counterEnabled, BaseConnectionContext? connection)
+    {
+        _eventSource.WriteConnectionResumed();
+
+        if (counterEnabled)
+        {
+            ConnectionResumedCore(_writeBackpressureConnections!, connection);
         }
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void ConnectionResumedCore()
-        => _pausedConnections!.Add(-1);
+    private static void ConnectionPausedCore(UpDownCounter<long> counter, BaseConnectionContext? connection)
+    {
+        var tags = new TagList();
+        if (connection is not null)
+        {
+            ConnectionEndpointTags.AddConnectionEndpointTags(ref tags, connection);
+        }
+
+        counter.Add(1, tags);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ConnectionResumedCore(UpDownCounter<long> counter, BaseConnectionContext? connection)
+    {
+        var tags = new TagList();
+        if (connection is not null)
+        {
+            ConnectionEndpointTags.AddConnectionEndpointTags(ref tags, connection);
+        }
+
+        counter.Add(-1, tags);
+    }
 
     public void BytesRead(int count)
         => _eventSource.BytesRead(count);

--- a/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsTransportFactory.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsTransportFactory.cs
@@ -171,7 +171,8 @@ internal sealed class DirectTlsTransportFactory : IConnectionListenerFactory, IC
             _loggerFactory,
             endpointOptions.HandshakeTimeout,
             _kestrelMetrics,
-            _directTlsMetrics);
+            _directTlsMetrics,
+            endpointOptions.SslProtocols);
 
         var memoryPool = _options.MemoryPoolFactory.Create(DirectTlsTransportOptions.MemoryPoolOptions);
 

--- a/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsTransportFactory.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/DirectTlsTransportFactory.cs
@@ -3,14 +3,17 @@
 
 using System.Buffers;
 using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
 using System.Net;
 using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls.Connection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -28,6 +31,8 @@ internal sealed class DirectTlsTransportFactory : IConnectionListenerFactory, IC
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger _logger;
     private readonly IHostApplicationLifetime _applicationLifetime;
+    private readonly KestrelMetrics? _kestrelMetrics;
+    private readonly DirectTlsMetrics _directTlsMetrics;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DirectTlsTransportFactory"/> class.
@@ -38,10 +43,12 @@ internal sealed class DirectTlsTransportFactory : IConnectionListenerFactory, IC
     /// The host application lifetime, used to stop the host if a pump fails unrecoverably. Supplied by the DI
     /// container.
     /// </param>
+    /// <param name="serviceProvider">The application service provider used to resolve Kestrel telemetry services.</param>
     public DirectTlsTransportFactory(
         IOptions<DirectTlsTransportOptions> options,
         ILoggerFactory loggerFactory,
-        IHostApplicationLifetime applicationLifetime)
+        IHostApplicationLifetime applicationLifetime,
+        IServiceProvider? serviceProvider = null)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(loggerFactory);
@@ -51,6 +58,11 @@ internal sealed class DirectTlsTransportFactory : IConnectionListenerFactory, IC
         _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<DirectTlsTransportFactory>();
         _applicationLifetime = applicationLifetime;
+
+        _kestrelMetrics = serviceProvider?.GetService<KestrelMetrics>();
+        _directTlsMetrics = serviceProvider?.GetService<IMeterFactory>() is { } meterFactory
+            ? new DirectTlsMetrics(meterFactory)
+            : DirectTlsMetrics.Disabled;
     }
 
     /// <inheritdoc />
@@ -154,7 +166,12 @@ internal sealed class DirectTlsTransportFactory : IConnectionListenerFactory, IC
         // correctly, at the cost of WorkerCount threads per endpoint. The endpoint may override the
         // transport-wide worker count so multi-endpoint servers can bound their total thread count.
         var workerCount = endpointOptions.WorkerCount ?? _options.WorkerCount;
-        var pumpPool = new TlsEventPumpPool(workerCount, _loggerFactory, endpointOptions.HandshakeTimeout);
+        var pumpPool = new TlsEventPumpPool(
+            workerCount,
+            _loggerFactory,
+            endpointOptions.HandshakeTimeout,
+            _kestrelMetrics,
+            _directTlsMetrics);
 
         var memoryPool = _options.MemoryPoolFactory.Create(DirectTlsTransportOptions.MemoryPoolOptions);
 

--- a/src/Servers/Kestrel/Transport.DirectTls/src/TlsEventPump.UserCallbacks.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/TlsEventPump.UserCallbacks.cs
@@ -93,6 +93,8 @@ internal partial class TlsEventPump
     {
         foreach (var conn in _handshakesAwaitingCallback)
         {
+            StopTlsHandshakeMetrics(conn, failed: true);
+            ConnectionReleased();
             ReleaseHandshakeResources(conn);
         }
 
@@ -255,7 +257,7 @@ internal partial class TlsEventPump
             // The ClientHello listener, the certificate selector, or the client-certificate validation callback
             // threw. Fail this one connection (matching the socket-transport TlsListener) and log it.
             _logger.LogDebug(failure, "A TLS handshake callback failed for fd={Fd}; dropping connection.", fd);
-            DropHandshake(fd, conn);
+            DropHandshake(fd, conn, failure);
             return;
         }
 
@@ -280,7 +282,7 @@ internal partial class TlsEventPump
                 catch (Exception ex)
                 {
                     _logger.LogDebug(ex, "Installing the resolved TLS context failed for fd={Fd}", fd);
-                    DropHandshake(fd, conn);
+                    DropHandshake(fd, conn, ex);
                     return;
                 }
 
@@ -311,7 +313,7 @@ internal partial class TlsEventPump
                 catch (Exception ex)
                 {
                     _logger.LogDebug(ex, "Recording the client certificate verdict failed for fd={Fd}; dropping connection.", fd);
-                    DropHandshake(fd, conn);
+                    DropHandshake(fd, conn, ex);
                     return;
                 }
 

--- a/src/Servers/Kestrel/Transport.DirectTls/src/TlsEventPump.UserCallbacks.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/TlsEventPump.UserCallbacks.cs
@@ -93,7 +93,7 @@ internal partial class TlsEventPump
     {
         foreach (var conn in _handshakesAwaitingCallback)
         {
-            StopTlsHandshakeMetrics(conn, failed: true);
+            StopTlsHandshakeTelemetry(conn, failed: true);
             ConnectionReleased();
             ReleaseHandshakeResources(conn);
         }

--- a/src/Servers/Kestrel/Transport.DirectTls/src/TlsEventPump.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/TlsEventPump.cs
@@ -285,9 +285,13 @@ internal partial class TlsEventPump : IDisposable
     // tight-spins the pump thread at 100% CPU and starves every other connection this pump owns.
     private void DropEstablishedConnection(int fd)
     {
-        if (_connections.TryRemove(fd, out _))
+        if (_connections.TryRemove(fd, out var connection))
         {
             ConnectionReleased();
+            DeregisterFromEpoll(fd);
+            DirectTlsLog.EpollConnectionUnregistered(_logger, connection.ConnectionId, _id, fd, connection.CurrentEpollInterest);
+            DirectTlsEventSource.Log.RecordEpollConnectionUnregistered(_id, fd, connection.ConnectionId, connection.CurrentEpollInterest);
+            return;
         }
 
         DeregisterFromEpoll(fd);
@@ -350,7 +354,7 @@ internal partial class TlsEventPump : IDisposable
     /// kernel never applied - a blocked write waiting on an EPOLLOUT that was never armed, or a level-triggered
     /// spin on writable interest that could not be cleared.
     /// </returns>
-    public virtual bool ModifyEvents(int fd, uint events)
+    public bool ModifyEvents(int fd, uint events)
     {
         // Level-triggered mode (no EPOLLET) for stability. EPOLLRDHUP (peer half-close) rides with read interest:
         // arm it only when EPOLLIN is requested, so a connection whose read interest is suspended for backpressure
@@ -360,6 +364,27 @@ internal partial class TlsEventPump : IDisposable
             events |= NativeTls.EPOLLRDHUP;
         }
 
+        if (!TryModifyEstablishedInterest(fd, events))
+        {
+            return false;
+        }
+
+        if (_connections.TryGetValue(fd, out var connection))
+        {
+            uint previousEvents = connection.CurrentEpollInterest;
+            connection.SetCurrentEpollInterest(events);
+            if (previousEvents != events)
+            {
+                DirectTlsLog.EpollInterestChanged(_logger, connection.ConnectionId, _id, fd, previousEvents, events);
+                DirectTlsEventSource.Log.RecordEpollInterestChanged(_id, fd, connection.ConnectionId, previousEvents, events);
+            }
+        }
+
+        return true;
+    }
+
+    private protected virtual bool TryModifyEstablishedInterest(int fd, uint events)
+    {
         var ev = new EpollEvent
         {
             Events = events,
@@ -442,6 +467,8 @@ internal partial class TlsEventPump : IDisposable
 
                         break;
                     }
+
+                    DirectTlsEventSource.Log.EpollWaitCompleted(numEvents);
 
                     for (int i = 0; i < numEvents; i++)
                     {
@@ -565,6 +592,8 @@ internal partial class TlsEventPump : IDisposable
             return;
         }
 
+        DirectTlsEventSource.Log.RecordEpollReady(_id, fd, conn.ConnectionId, mask);
+
         // EPOLLERR/EPOLLHUP are terminal: the socket is errored or fully hung up and can make no further
         // progress. They are also level-triggered, so the event re-fires on every epoll_wait until the fd is
         // de-registered. Force a final read/write dispatch below so an active awaitable can observe the real
@@ -628,7 +657,10 @@ internal partial class TlsEventPump : IDisposable
     {
         if (_connections.TryAdd(fd, conn))
         {
+            conn.SetCurrentEpollInterest(DefaultEpollInterest);
             ConnectionOwned();
+            DirectTlsLog.EpollConnectionRegistered(_logger, conn.ConnectionId, _id, fd, DefaultEpollInterest);
+            DirectTlsEventSource.Log.RecordEpollConnectionRegistered(_id, fd, conn.ConnectionId, DefaultEpollInterest);
         }
     }
 
@@ -1172,7 +1204,10 @@ internal partial class TlsEventPump : IDisposable
         }
 
         _connections[fd] = connectionState;
+        connectionState.SetCurrentEpollInterest(DefaultEpollInterest);
         _handshaking.Remove(fd);
+        DirectTlsLog.EpollConnectionRegistered(_logger, connectionState.ConnectionId, _id, fd, DefaultEpollInterest);
+        DirectTlsEventSource.Log.RecordEpollConnectionRegistered(_id, fd, connectionState.ConnectionId, DefaultEpollInterest);
         return true;
     }
 

--- a/src/Servers/Kestrel/Transport.DirectTls/src/TlsEventPump.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/TlsEventPump.cs
@@ -7,10 +7,13 @@ using System.Diagnostics;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls.Connection;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls.Interop;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls.UserCallbacks;
@@ -27,6 +30,9 @@ internal partial class TlsEventPump : IDisposable
 {
     private readonly ILogger _logger;
     private readonly int _id;
+    private readonly KestrelMetrics? _kestrelMetrics;
+    private readonly DirectTlsMetrics _directTlsMetrics;
+    private int _ownedConnectionCount;
 
     // Maximum time a connection is allowed to spend handshaking before the pump drops it. Stored as
     // milliseconds for cheap comparison against Environment.TickCount64. long.MaxValue means "no timeout"
@@ -161,12 +167,28 @@ internal partial class TlsEventPump : IDisposable
         /// (fd recycled, connection already torn down) is discarded instead of resuming a stale handshake.
         /// </summary>
         public HandshakeUserCallback? PendingUserCallback;
+        /// <summary>
+        /// Kestrel metric state captured when the handshake began. Null when neither TLS handshake instrument
+        /// was enabled at accept time.
+        /// </summary>
+        public TlsHandshakeMetricsContext? MetricsContext;
+        /// <summary>
+        /// Stopwatch timestamp captured immediately before the active-handshake metric was started.
+        /// </summary>
+        public long HandshakeStartTimestamp;
     }
 
-    public TlsEventPump(ILogger tlsPumpLogger, int id, TimeSpan handshakeTimeout)
+    public TlsEventPump(
+        ILogger tlsPumpLogger,
+        int id,
+        TimeSpan handshakeTimeout,
+        KestrelMetrics? kestrelMetrics = null,
+        DirectTlsMetrics? directTlsMetrics = null)
     {
         _id = id;
         _logger = tlsPumpLogger;
+        _kestrelMetrics = kestrelMetrics;
+        _directTlsMetrics = directTlsMetrics ?? DirectTlsMetrics.Disabled;
         _handshakeTimeoutMs = handshakeTimeout == Timeout.InfiniteTimeSpan || handshakeTimeout == TimeSpan.MaxValue
             ? long.MaxValue
             : (long)handshakeTimeout.TotalMilliseconds;
@@ -263,9 +285,15 @@ internal partial class TlsEventPump : IDisposable
     // tight-spins the pump thread at 100% CPU and starves every other connection this pump owns.
     private void DropEstablishedConnection(int fd)
     {
-        _connections.TryRemove(fd, out _);
+        if (_connections.TryRemove(fd, out _))
+        {
+            ConnectionReleased();
+        }
+
         DeregisterFromEpoll(fd);
     }
+
+    internal int Id => _id;
 
     // The single epoll de-registration syscall, isolated as a virtual seam (like RawRead/AcceptOne) so
     // tests can observe which fds the pump removes from its interest set without a live epoll instance.
@@ -520,6 +548,8 @@ internal partial class TlsEventPump : IDisposable
                 continue;
             }
 
+            StopTlsHandshakeMetrics(kvp.Value, failed: true);
+            ConnectionReleased();
             ReleaseHandshakeResources(kvp.Value);
         }
 
@@ -577,7 +607,7 @@ internal partial class TlsEventPump : IDisposable
         if (errorOrHangup)
         {
             DropEstablishedConnection(fd);
-            conn.OnError(new IOException("Connection error or hangup (EPOLLERR/EPOLLHUP)"));
+            conn.OnError(new ConnectionResetException("Connection error or hangup (EPOLLERR/EPOLLHUP)"));
             return;
         }
 
@@ -588,13 +618,19 @@ internal partial class TlsEventPump : IDisposable
             {
                 // No data to read, peer closed - signal error.
                 DropEstablishedConnection(fd);
-                conn.OnError(new IOException("Peer closed connection"));
+                conn.OnError(new ConnectionResetException("Peer closed connection"));
             }
         }
     }
 
     // internal for testing: seed an established connection without running the native handshake.
-    internal void TrackConnectionForTest(int fd, ConnectionIoState conn) => _connections[fd] = conn;
+    internal void TrackConnectionForTest(int fd, ConnectionIoState conn)
+    {
+        if (_connections.TryAdd(fd, conn))
+        {
+            ConnectionOwned();
+        }
+    }
 
     /// <summary>
     /// Accept new connections from the listen fd via <c>accept4</c>.
@@ -640,6 +676,8 @@ internal partial class TlsEventPump : IDisposable
                 _logger.LogDebug("Accept failed: errno={Errno}", errno);
                 break;
             }
+
+            DirectTlsEventSource.Log.Accepted(_id);
 
             Socket socket = WrapAcceptedFd(accepted);
             try
@@ -718,6 +756,14 @@ internal partial class TlsEventPump : IDisposable
         // Create a socket-bound TLS session and attach the shared server context.
         // SetContext configures SSL_set_fd + server accept state internally.
         var session = new TlsSocketSession(socketHandle);
+        TlsHandshakeMetricsContext? metricsContext = null;
+        long handshakeStartTimestamp = 0;
+
+        if (_kestrelMetrics?.TlsHandshakeMetricsEnabled == true)
+        {
+            metricsContext = StartTlsHandshakeMetrics(remoteEndPoint, out handshakeStartTimestamp);
+        }
+
         try
         {
             session.SetContext(_tlsContext!);
@@ -725,6 +771,7 @@ internal partial class TlsEventPump : IDisposable
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Failed to initialize TLS session for fd={Fd}", clientFd);
+            StopTlsHandshakeMetrics(metricsContext, handshakeStartTimestamp, protocol: null, ex);
             session.Dispose();
             _connectionTracker.ReleaseHandshake();
             return;
@@ -733,6 +780,7 @@ internal partial class TlsEventPump : IDisposable
         // Register client socket with epoll for handshake events
         if (!TryArmHandshakeInterest(clientFd, DefaultEpollInterest))
         {
+            StopTlsHandshakeMetrics(metricsContext, handshakeStartTimestamp, protocol: null, exception: null);
             session.Dispose();
             _connectionTracker.ReleaseHandshake();
             return;
@@ -747,7 +795,10 @@ internal partial class TlsEventPump : IDisposable
             RemoteEndPoint = remoteEndPoint,
             HandshakeDeadlineTimestamp = ComputeHandshakeDeadline(Environment.TickCount64),
             CurrentEpollInterest = DefaultEpollInterest,
+            MetricsContext = metricsContext,
+            HandshakeStartTimestamp = handshakeStartTimestamp,
         };
+        ConnectionOwned();
 
         // Try handshake immediately (might complete for resumed sessions)
         TryAdvanceHandshake(clientFd, _handshaking[clientFd]);
@@ -792,7 +843,7 @@ internal partial class TlsEventPump : IDisposable
             // throw would tear down the whole process. Isolate it and drop just this
             // connection - one bad client must not affect the others.
             _logger.LogDebug(ex, "Handshake threw for fd={Fd}", fd);
-            DropHandshake(fd, conn);
+            DropHandshake(fd, conn, ex);
             return;
         }
 
@@ -887,7 +938,7 @@ internal partial class TlsEventPump : IDisposable
             bool firstSuspension = conn.Connection is null;
             if (firstSuspension && _memoryPool is not null)
             {
-                var earlyState = new ConnectionIoState(fd, conn.Session, _connectionIoStateLogger) { Pump = this };
+                var earlyState = new ConnectionIoState(fd, conn.Session, _connectionIoStateLogger, _directTlsMetrics) { Pump = this };
                 var earlyConnection = new DirectTlsConnection(
                     earlyState,
                     this,
@@ -954,7 +1005,7 @@ internal partial class TlsEventPump : IDisposable
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Resolving the TLS context failed for fd={Fd}; dropping connection.", fd);
-            DropHandshake(fd, conn);
+            DropHandshake(fd, conn, ex);
             return;
         }
 
@@ -965,7 +1016,7 @@ internal partial class TlsEventPump : IDisposable
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Installing the resolved TLS context failed for fd={Fd}", fd);
-            DropHandshake(fd, conn);
+            DropHandshake(fd, conn, ex);
             return;
         }
 
@@ -1003,7 +1054,7 @@ internal partial class TlsEventPump : IDisposable
             // ConnectionId the listener already observed. Otherwise create both now. Its ConnectionIoState
             // has Pump already set (early path) or set here (default path).
             connectionState = earlyConnection?.ConnectionState
-                ?? new ConnectionIoState(fd, conn.Session, _connectionIoStateLogger) { Pump = this };
+                ?? new ConnectionIoState(fd, conn.Session, _connectionIoStateLogger, _directTlsMetrics) { Pump = this };
             connectionState.SetHandshakeComplete();
 
             // Create DirectTlsConnection using fd directly (no Socket wrapper).
@@ -1034,7 +1085,7 @@ internal partial class TlsEventPump : IDisposable
         {
             // Post-handshake activities failed. De-register fd here
             _logger.LogDebug(ex, "Completing handshake threw for fd={Fd}", fd);
-            DropHandshake(fd, conn);
+            DropHandshake(fd, conn, ex);
             return;
         }
 
@@ -1044,10 +1095,12 @@ internal partial class TlsEventPump : IDisposable
             // connection whose epoll interest is wrong (it would spin the pump on a stuck EPOLLOUT). It was
             // built but never Started and the fd is still registered as handshaking, so tear it down on
             // that path.
+            StopTlsHandshakeMetrics(conn, failed: true);
             DropCompletedHandshake(fd, directConnection);
             return;
         }
 
+        StopTlsHandshakeMetrics(conn, failed: false);
         directConnection.Start();
 
         if (!_readyConnections.TryWrite(directConnection))
@@ -1130,7 +1183,11 @@ internal partial class TlsEventPump : IDisposable
     // and default connection paths - instead of releasing the raw handshake session a second time.
     private void DropCompletedHandshake(int fd, DirectTlsConnection connection)
     {
-        _handshaking.Remove(fd);
+        if (_handshaking.Remove(fd))
+        {
+            ConnectionReleased();
+        }
+
         _connectionTracker.ReleaseHandshake();
         NativeTls.epoll_ctl(_epollFd, NativeTls.EPOLL_CTL_DEL, fd, IntPtr.Zero);
         connection.AbortBeforeStart();
@@ -1175,12 +1232,91 @@ internal partial class TlsEventPump : IDisposable
     // released without the graceful TLS close_notify - a half-open session cannot shut down cleanly, so
     // AbortBeforeStart just completes the (never-started) pipes and closes the socket fd. Otherwise the
     // session is disposed directly, which closes the fd.
-    private void DropHandshake(int fd, in HandshakingConnection conn)
+    private void DropHandshake(int fd, in HandshakingConnection conn, Exception? exception = null)
     {
-        _handshaking.Remove(fd);
+        StopTlsHandshakeMetrics(conn, failed: true, exception);
+        if (_handshaking.Remove(fd))
+        {
+            ConnectionReleased();
+        }
+
         _connectionTracker.ReleaseHandshake();
         NativeTls.epoll_ctl(_epollFd, NativeTls.EPOLL_CTL_DEL, fd, IntPtr.Zero);
         ReleaseHandshakeResources(conn);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private TlsHandshakeMetricsContext StartTlsHandshakeMetrics(IPEndPoint? remoteEndPoint, out long startTimestamp)
+    {
+        var connectionContext = new DefaultConnectionContext
+        {
+            LocalEndPoint = _listenEndPoint,
+            RemoteEndPoint = remoteEndPoint
+        };
+        var metricsContext = _kestrelMetrics!.CreateTlsHandshakeContext(connectionContext);
+        startTimestamp = Stopwatch.GetTimestamp();
+        _kestrelMetrics.TlsHandshakeStart(metricsContext);
+
+        return metricsContext;
+    }
+
+    private void StopTlsHandshakeMetrics(in HandshakingConnection connection, bool failed, Exception? exception = null)
+    {
+        if (connection.MetricsContext is { } metricsContext)
+        {
+            StopTlsHandshakeMetrics(
+                metricsContext,
+                connection.HandshakeStartTimestamp,
+                failed ? null : connection.Session.NegotiatedProtocol,
+                failed ? exception : null);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void StopTlsHandshakeMetrics(
+        TlsHandshakeMetricsContext? metricsContext,
+        long startTimestamp,
+        SslProtocols? protocol,
+        Exception? exception)
+    {
+        if (metricsContext is not { } context)
+        {
+            return;
+        }
+
+        if (protocol is null)
+        {
+            exception ??= new AuthenticationException("The DirectTls handshake failed.");
+        }
+
+        _kestrelMetrics!.TlsHandshakeStop(
+            context,
+            startTimestamp,
+            Stopwatch.GetTimestamp(),
+            protocol,
+            exception);
+    }
+
+    private void ConnectionOwned()
+    {
+        var count = Interlocked.Increment(ref _ownedConnectionCount);
+        DirectTlsEventSource.Log.ConnectionOwned(_id, count);
+    }
+
+    private void ConnectionReleased()
+    {
+        int current;
+        do
+        {
+            current = Volatile.Read(ref _ownedConnectionCount);
+            if (current == 0)
+            {
+                return;
+            }
+        }
+        while (Interlocked.CompareExchange(ref _ownedConnectionCount, current - 1, current) != current);
+
+        DirectTlsEventSource.Log.ConnectionReleased(_id, current - 1);
     }
 
     // Releases the native resources of a dropped handshake. Split out from DropHandshake (which owns the

--- a/src/Servers/Kestrel/Transport.DirectTls/src/TlsEventPump.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/TlsEventPump.cs
@@ -32,6 +32,7 @@ internal partial class TlsEventPump : IDisposable
     private readonly int _id;
     private readonly KestrelMetrics? _kestrelMetrics;
     private readonly DirectTlsMetrics _directTlsMetrics;
+    private readonly SslProtocols _enabledSslProtocols;
     private int _ownedConnectionCount;
 
     // Maximum time a connection is allowed to spend handshaking before the pump drops it. Stored as
@@ -173,6 +174,10 @@ internal partial class TlsEventPump : IDisposable
         /// </summary>
         public TlsHandshakeMetricsContext? MetricsContext;
         /// <summary>
+        /// Connection identity and endpoints shared by Kestrel handshake events and metrics.
+        /// </summary>
+        public BaseConnectionContext ConnectionContext;
+        /// <summary>
         /// Stopwatch timestamp captured immediately before the active-handshake metric was started.
         /// </summary>
         public long HandshakeStartTimestamp;
@@ -183,12 +188,14 @@ internal partial class TlsEventPump : IDisposable
         int id,
         TimeSpan handshakeTimeout,
         KestrelMetrics? kestrelMetrics = null,
-        DirectTlsMetrics? directTlsMetrics = null)
+        DirectTlsMetrics? directTlsMetrics = null,
+        SslProtocols enabledSslProtocols = SslProtocols.None)
     {
         _id = id;
         _logger = tlsPumpLogger;
         _kestrelMetrics = kestrelMetrics;
         _directTlsMetrics = directTlsMetrics ?? DirectTlsMetrics.Disabled;
+        _enabledSslProtocols = enabledSslProtocols;
         _handshakeTimeoutMs = handshakeTimeout == Timeout.InfiniteTimeSpan || handshakeTimeout == TimeSpan.MaxValue
             ? long.MaxValue
             : (long)handshakeTimeout.TotalMilliseconds;
@@ -575,7 +582,7 @@ internal partial class TlsEventPump : IDisposable
                 continue;
             }
 
-            StopTlsHandshakeMetrics(kvp.Value, failed: true);
+            StopTlsHandshakeTelemetry(kvp.Value, failed: true);
             ConnectionReleased();
             ReleaseHandshakeResources(kvp.Value);
         }
@@ -788,13 +795,12 @@ internal partial class TlsEventPump : IDisposable
         // Create a socket-bound TLS session and attach the shared server context.
         // SetContext configures SSL_set_fd + server accept state internally.
         var session = new TlsSocketSession(socketHandle);
-        TlsHandshakeMetricsContext? metricsContext = null;
-        long handshakeStartTimestamp = 0;
-
-        if (_kestrelMetrics?.TlsHandshakeMetricsEnabled == true)
+        var connectionContext = new DefaultConnectionContext
         {
-            metricsContext = StartTlsHandshakeMetrics(remoteEndPoint, out handshakeStartTimestamp);
-        }
+            LocalEndPoint = _listenEndPoint,
+            RemoteEndPoint = remoteEndPoint
+        };
+        var metricsContext = StartTlsHandshakeTelemetry(connectionContext, out var handshakeStartTimestamp);
 
         try
         {
@@ -803,7 +809,7 @@ internal partial class TlsEventPump : IDisposable
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Failed to initialize TLS session for fd={Fd}", clientFd);
-            StopTlsHandshakeMetrics(metricsContext, handshakeStartTimestamp, protocol: null, ex);
+            StopTlsHandshakeTelemetry(connectionContext, metricsContext, handshakeStartTimestamp, protocol: null, applicationProtocol: default, hostName: null, ex);
             session.Dispose();
             _connectionTracker.ReleaseHandshake();
             return;
@@ -812,7 +818,7 @@ internal partial class TlsEventPump : IDisposable
         // Register client socket with epoll for handshake events
         if (!TryArmHandshakeInterest(clientFd, DefaultEpollInterest))
         {
-            StopTlsHandshakeMetrics(metricsContext, handshakeStartTimestamp, protocol: null, exception: null);
+            StopTlsHandshakeTelemetry(connectionContext, metricsContext, handshakeStartTimestamp, protocol: null, applicationProtocol: default, hostName: null, exception: null);
             session.Dispose();
             _connectionTracker.ReleaseHandshake();
             return;
@@ -828,6 +834,7 @@ internal partial class TlsEventPump : IDisposable
             HandshakeDeadlineTimestamp = ComputeHandshakeDeadline(Environment.TickCount64),
             CurrentEpollInterest = DefaultEpollInterest,
             MetricsContext = metricsContext,
+            ConnectionContext = connectionContext,
             HandshakeStartTimestamp = handshakeStartTimestamp,
         };
         ConnectionOwned();
@@ -980,6 +987,7 @@ internal partial class TlsEventPump : IDisposable
                     _maxReadBufferSize,
                     _maxWriteBufferSize,
                     _directTlsConnectionLogger!);
+                earlyConnection.ConnectionId = conn.ConnectionContext.ConnectionId;
                 conn.Connection = earlyConnection;
                 _handshaking[fd] = conn;
             }
@@ -1111,6 +1119,7 @@ internal partial class TlsEventPump : IDisposable
                     _directTlsConnectionLogger!,
                     negotiatedApplicationProtocol: conn.Session.NegotiatedApplicationProtocol,
                     clientCertificate: clientCertificate);  // Non-null only when the peer presented a client cert (mTLS)
+                directConnection.ConnectionId = conn.ConnectionContext.ConnectionId;
             }
         }
         catch (Exception ex)
@@ -1127,12 +1136,12 @@ internal partial class TlsEventPump : IDisposable
             // connection whose epoll interest is wrong (it would spin the pump on a stuck EPOLLOUT). It was
             // built but never Started and the fd is still registered as handshaking, so tear it down on
             // that path.
-            StopTlsHandshakeMetrics(conn, failed: true);
+            StopTlsHandshakeTelemetry(conn, failed: true);
             DropCompletedHandshake(fd, directConnection);
             return;
         }
 
-        StopTlsHandshakeMetrics(conn, failed: false);
+        StopTlsHandshakeTelemetry(conn, failed: false);
         directConnection.Start();
 
         if (!_readyConnections.TryWrite(directConnection))
@@ -1269,7 +1278,7 @@ internal partial class TlsEventPump : IDisposable
     // session is disposed directly, which closes the fd.
     private void DropHandshake(int fd, in HandshakingConnection conn, Exception? exception = null)
     {
-        StopTlsHandshakeMetrics(conn, failed: true, exception);
+        StopTlsHandshakeTelemetry(conn, failed: true, exception);
         if (_handshaking.Remove(fd))
         {
             ConnectionReleased();
@@ -1281,13 +1290,18 @@ internal partial class TlsEventPump : IDisposable
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private TlsHandshakeMetricsContext StartTlsHandshakeMetrics(IPEndPoint? remoteEndPoint, out long startTimestamp)
+    private TlsHandshakeMetricsContext? StartTlsHandshakeTelemetry(
+        BaseConnectionContext connectionContext,
+        out long startTimestamp)
     {
-        var connectionContext = new DefaultConnectionContext
+        KestrelEventSource.Log.TlsHandshakeStart(connectionContext, _enabledSslProtocols);
+
+        if (_kestrelMetrics?.TlsHandshakeMetricsEnabled != true)
         {
-            LocalEndPoint = _listenEndPoint,
-            RemoteEndPoint = remoteEndPoint
-        };
+            startTimestamp = 0;
+            return null;
+        }
+
         var metricsContext = _kestrelMetrics!.CreateTlsHandshakeContext(connectionContext);
         startTimestamp = Stopwatch.GetTimestamp();
         _kestrelMetrics.TlsHandshakeStart(metricsContext);
@@ -1295,41 +1309,54 @@ internal partial class TlsEventPump : IDisposable
         return metricsContext;
     }
 
-    private void StopTlsHandshakeMetrics(in HandshakingConnection connection, bool failed, Exception? exception = null)
+    private void StopTlsHandshakeTelemetry(in HandshakingConnection connection, bool failed, Exception? exception = null)
     {
-        if (connection.MetricsContext is { } metricsContext)
-        {
-            StopTlsHandshakeMetrics(
-                metricsContext,
-                connection.HandshakeStartTimestamp,
-                failed ? null : connection.Session.NegotiatedProtocol,
-                failed ? exception : null);
-        }
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private void StopTlsHandshakeMetrics(
-        TlsHandshakeMetricsContext? metricsContext,
-        long startTimestamp,
-        SslProtocols? protocol,
-        Exception? exception)
-    {
-        if (metricsContext is not { } context)
+        if (connection.ConnectionContext is not { } connectionContext)
         {
             return;
         }
 
+        StopTlsHandshakeTelemetry(
+            connectionContext,
+            connection.MetricsContext,
+            connection.HandshakeStartTimestamp,
+            failed ? null : connection.Session.NegotiatedProtocol,
+            failed ? default : connection.Session.NegotiatedApplicationProtocol.Protocol,
+            connection.Session.TargetHostName,
+            failed ? exception : null);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void StopTlsHandshakeTelemetry(
+        BaseConnectionContext connectionContext,
+        TlsHandshakeMetricsContext? metricsContext,
+        long startTimestamp,
+        SslProtocols? protocol,
+        ReadOnlyMemory<byte> applicationProtocol,
+        string? hostName,
+        Exception? exception)
+    {
         if (protocol is null)
         {
-            exception ??= new AuthenticationException("The DirectTls handshake failed.");
+            KestrelEventSource.Log.TlsHandshakeFailed(connectionContext.ConnectionId);
         }
 
-        _kestrelMetrics!.TlsHandshakeStop(
-            context,
-            startTimestamp,
-            Stopwatch.GetTimestamp(),
-            protocol,
-            exception);
+        KestrelEventSource.Log.TlsHandshakeStop(connectionContext, protocol, applicationProtocol, hostName);
+
+        if (metricsContext is { } context)
+        {
+            if (protocol is null)
+            {
+                exception ??= new AuthenticationException("The DirectTls handshake failed.");
+            }
+
+            _kestrelMetrics!.TlsHandshakeStop(
+                context,
+                startTimestamp,
+                Stopwatch.GetTimestamp(),
+                protocol,
+                exception);
+        }
     }
 
     private void ConnectionOwned()

--- a/src/Servers/Kestrel/Transport.DirectTls/src/TlsEventPumpPool.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/TlsEventPumpPool.cs
@@ -4,6 +4,7 @@
 using System.Buffers;
 using System.Net;
 using System.Net.Security;
+using System.Security.Authentication;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
@@ -31,7 +32,8 @@ internal sealed class TlsEventPumpPool : IDisposable
         ILoggerFactory loggerFactory,
         TimeSpan? handshakeTimeout = null,
         KestrelMetrics? kestrelMetrics = null,
-        DirectTlsMetrics? directTlsMetrics = null)
+        DirectTlsMetrics? directTlsMetrics = null,
+        SslProtocols enabledSslProtocols = SslProtocols.None)
     {
         _loggerFactory = loggerFactory;
         _kestrelMetrics = kestrelMetrics;
@@ -52,7 +54,8 @@ internal sealed class TlsEventPumpPool : IDisposable
                 i,
                 effectiveHandshakeTimeout,
                 _kestrelMetrics,
-                _directTlsMetrics);
+                _directTlsMetrics,
+                enabledSslProtocols);
         }
     }
 

--- a/src/Servers/Kestrel/Transport.DirectTls/src/TlsEventPumpPool.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/src/TlsEventPumpPool.cs
@@ -6,6 +6,7 @@ using System.Net;
 using System.Net.Security;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls.Connection;
 using Microsoft.Extensions.Logging;
 
@@ -22,10 +23,19 @@ internal sealed class TlsEventPumpPool : IDisposable
 {
     private readonly TlsEventPump[] _pumps;
     private readonly ILoggerFactory _loggerFactory;
+    private readonly KestrelMetrics? _kestrelMetrics;
+    private readonly DirectTlsMetrics _directTlsMetrics;
 
-    public TlsEventPumpPool(int pumpCount, ILoggerFactory loggerFactory, TimeSpan? handshakeTimeout = null)
+    public TlsEventPumpPool(
+        int pumpCount,
+        ILoggerFactory loggerFactory,
+        TimeSpan? handshakeTimeout = null,
+        KestrelMetrics? kestrelMetrics = null,
+        DirectTlsMetrics? directTlsMetrics = null)
     {
         _loggerFactory = loggerFactory;
+        _kestrelMetrics = kestrelMetrics;
+        _directTlsMetrics = directTlsMetrics ?? DirectTlsMetrics.Disabled;
 
         // Default: 1 pump per CPU core
         pumpCount = pumpCount > 0 ? pumpCount : Environment.ProcessorCount;
@@ -37,7 +47,12 @@ internal sealed class TlsEventPumpPool : IDisposable
         _pumps = new TlsEventPump[pumpCount];
         for (int i = 0; i < pumpCount; i++)
         {
-            _pumps[i] = new TlsEventPump(loggerFactory.CreateLogger<TlsEventPump>(), i, effectiveHandshakeTimeout);
+            _pumps[i] = new TlsEventPump(
+                loggerFactory.CreateLogger<TlsEventPump>(),
+                i,
+                effectiveHandshakeTimeout,
+                _kestrelMetrics,
+                _directTlsMetrics);
         }
     }
 

--- a/src/Servers/Kestrel/Transport.DirectTls/test/ConnectionIoStateTests.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/test/ConnectionIoStateTests.cs
@@ -591,6 +591,6 @@ public class ConnectionIoStateTests
         {
         }
 
-        public override bool ModifyEvents(int fd, uint events) => false;
+        private protected override bool TryModifyEstablishedInterest(int fd, uint events) => false;
     }
 }

--- a/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsBackpressureTelemetryTests.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsBackpressureTelemetryTests.cs
@@ -1,0 +1,292 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using System.Net.Security;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls.Connection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls.Tests;
+
+public class DirectTlsBackpressureTelemetryTests : LoggedTest
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    [ConditionalFact]
+    [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX)]
+    public async Task ReceiveBackpressure_LogsPauseAndResume()
+    {
+        using var meter = new Meter($"{nameof(DirectTlsBackpressureTelemetryTests)}.{Guid.NewGuid():N}");
+        using var meterListener = new MeterListener();
+        var pausedConnectionMeasurements = new ConcurrentQueue<long>();
+        var pauseMeasurementRecorded = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var resumeMeasurementRecorded = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        meterListener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Meter.Name == meter.Name &&
+                instrument.Name == DirectTlsMetrics.PausedConnectionsInstrumentName)
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<long>((_, measurement, _, _) =>
+        {
+            pausedConnectionMeasurements.Enqueue(measurement);
+            (measurement == 1 ? pauseMeasurementRecorded : resumeMeasurementRecorded).TrySetResult();
+        });
+        meterListener.Start();
+
+        using var pump = new TestTlsEventPump();
+        var connectionState = new BackpressureConnectionIoState(
+            LoggerFactory.CreateLogger<ConnectionIoState>(),
+            new DirectTlsMetrics(meter))
+        {
+            Pump = pump
+        };
+        var connection = new DirectTlsConnection(
+            connectionState,
+            pump,
+            localEndPoint: null,
+            remoteEndPoint: null,
+            MemoryPool<byte>.Shared,
+            maxReadBufferSize: 1,
+            maxWriteBufferSize: 0,
+            LoggerFactory.CreateLogger<DirectTlsConnection>());
+
+        connection.Start();
+
+        await connectionState.ReadInterestSuspended.Task.WaitAsync(Timeout);
+        await pauseMeasurementRecorded.Task.WaitAsync(Timeout);
+        await WaitForLogAsync("ConnectionPause");
+
+        Assert.Contains(TestSink.Writes, write =>
+            write.EventId.Name == "ConnectionPause" &&
+            write.Message.Contains(connection.ConnectionId, StringComparison.Ordinal));
+        Assert.Equal([1L], pausedConnectionMeasurements);
+
+        var readResult = await connection.Transport.Input.ReadAsync().AsTask().WaitAsync(Timeout);
+        connection.Transport.Input.AdvanceTo(readResult.Buffer.End);
+
+        await connectionState.ReadInterestResumed.Task.WaitAsync(Timeout);
+        await resumeMeasurementRecorded.Task.WaitAsync(Timeout);
+        await WaitForLogAsync("ConnectionResume");
+
+        Assert.Contains(TestSink.Writes, write =>
+            write.EventId.Name == "ConnectionResume" &&
+            write.Message.Contains(connection.ConnectionId, StringComparison.Ordinal));
+        Assert.Equal([1L, -1L], pausedConnectionMeasurements);
+
+        connection.Abort(new ConnectionAbortedException("Test complete."));
+        await connection.DisposeAsync();
+    }
+
+    [ConditionalFact]
+    [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX)]
+    public void CancelWhilePaused_ReleasesPausedConnectionMeasurement()
+    {
+        using var meter = new Meter($"{nameof(DirectTlsBackpressureTelemetryTests)}.{Guid.NewGuid():N}");
+        using var meterListener = new MeterListener();
+        var pausedConnectionMeasurements = new ConcurrentQueue<long>();
+        meterListener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Meter.Name == meter.Name &&
+                instrument.Name == DirectTlsMetrics.PausedConnectionsInstrumentName)
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<long>((_, measurement, _, _) =>
+        {
+            pausedConnectionMeasurements.Enqueue(measurement);
+        });
+        meterListener.Start();
+
+        var connectionState = new BackpressureConnectionIoState(
+            LoggerFactory.CreateLogger<ConnectionIoState>(),
+            new DirectTlsMetrics(meter));
+
+        connectionState.SuspendReadInterest();
+        connectionState.Cancel();
+
+        Assert.Equal([1L, -1L], pausedConnectionMeasurements);
+    }
+
+    [ConditionalFact]
+    [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX)]
+    public void FailedSuspend_DoesNotRecordPausedConnectionMeasurement()
+    {
+        using var meter = new Meter($"{nameof(DirectTlsBackpressureTelemetryTests)}.{Guid.NewGuid():N}");
+        using var meterListener = new MeterListener();
+        var pausedConnectionMeasurements = new ConcurrentQueue<long>();
+        meterListener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Meter.Name == meter.Name &&
+                instrument.Name == DirectTlsMetrics.PausedConnectionsInstrumentName)
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<long>((_, measurement, _, _) =>
+        {
+            pausedConnectionMeasurements.Enqueue(measurement);
+        });
+        meterListener.Start();
+
+        var connectionState = new BackpressureConnectionIoState(
+            LoggerFactory.CreateLogger<ConnectionIoState>(),
+            new DirectTlsMetrics(meter))
+        {
+            ThrowOnApplyEvents = true
+        };
+
+        Assert.Throws<InvalidOperationException>(connectionState.SuspendReadInterest);
+        connectionState.Cancel();
+
+        Assert.Empty(pausedConnectionMeasurements);
+    }
+
+    [ConditionalFact]
+    [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX)]
+    public void FailedResume_ReleasesPausedConnectionMeasurementOnCancel()
+    {
+        using var meter = new Meter($"{nameof(DirectTlsBackpressureTelemetryTests)}.{Guid.NewGuid():N}");
+        using var meterListener = new MeterListener();
+        var pausedConnectionMeasurements = new ConcurrentQueue<long>();
+        meterListener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Meter.Name == meter.Name &&
+                instrument.Name == DirectTlsMetrics.PausedConnectionsInstrumentName)
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<long>((_, measurement, _, _) =>
+        {
+            pausedConnectionMeasurements.Enqueue(measurement);
+        });
+        meterListener.Start();
+
+        var connectionState = new BackpressureConnectionIoState(
+            LoggerFactory.CreateLogger<ConnectionIoState>(),
+            new DirectTlsMetrics(meter));
+
+        connectionState.SuspendReadInterest();
+        connectionState.ThrowOnApplyEvents = true;
+        Assert.Throws<InvalidOperationException>(connectionState.ResumeReadInterest);
+        connectionState.Cancel();
+
+        Assert.Equal([1L, -1L], pausedConnectionMeasurements);
+    }
+
+    [ConditionalFact]
+    [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX)]
+    public void ListenerEnabledWhilePaused_DoesNotRecordUnmatchedResumeMeasurement()
+    {
+        using var meter = new Meter($"{nameof(DirectTlsBackpressureTelemetryTests)}.{Guid.NewGuid():N}");
+        var connectionState = new BackpressureConnectionIoState(
+            LoggerFactory.CreateLogger<ConnectionIoState>(),
+            new DirectTlsMetrics(meter));
+
+        connectionState.SuspendReadInterest();
+
+        using var meterListener = new MeterListener();
+        var pausedConnectionMeasurements = new ConcurrentQueue<long>();
+        meterListener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Meter.Name == meter.Name &&
+                instrument.Name == DirectTlsMetrics.PausedConnectionsInstrumentName)
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<long>((_, measurement, _, _) =>
+        {
+            pausedConnectionMeasurements.Enqueue(measurement);
+        });
+        meterListener.Start();
+
+        connectionState.ResumeReadInterest();
+
+        Assert.Empty(pausedConnectionMeasurements);
+    }
+
+    private async Task WaitForLogAsync(string eventName)
+    {
+        var timeoutAt = DateTime.UtcNow + Timeout;
+        while (!TestSink.Writes.Any(write => write.EventId.Name == eventName))
+        {
+            Assert.True(DateTime.UtcNow < timeoutAt, $"Timed out waiting for log event '{eventName}'.");
+            await Task.Delay(10);
+        }
+    }
+
+    private sealed class BackpressureConnectionIoState : ConnectionIoState
+    {
+        private int _readCount;
+
+        public BackpressureConnectionIoState(ILogger logger, DirectTlsMetrics metrics)
+            : base(fd: 7, session: null!, logger, metrics)
+        {
+            SetHandshakeComplete();
+        }
+
+        public TaskCompletionSource ReadInterestSuspended { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource ReadInterestResumed { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool ThrowOnApplyEvents { get; set; }
+
+        internal override TlsOperationStatus RawRead(Span<byte> buffer, out int bytesRead)
+        {
+            if (Interlocked.Increment(ref _readCount) == 1)
+            {
+                buffer[0] = 42;
+                bytesRead = 1;
+                return TlsOperationStatus.Complete;
+            }
+
+            bytesRead = 0;
+            return TlsOperationStatus.NeedMoreData;
+        }
+
+        internal override void ApplyEvents(uint events)
+        {
+            if (ThrowOnApplyEvents)
+            {
+                throw new InvalidOperationException("Test event update failure.");
+            }
+
+            if ((events & NativeTls.EPOLLIN) == 0)
+            {
+                ReadInterestSuspended.TrySetResult();
+            }
+            else
+            {
+                ReadInterestResumed.TrySetResult();
+            }
+        }
+
+        internal override void ShutdownSession()
+        {
+        }
+
+        internal override void DisposeSession()
+        {
+        }
+    }
+
+    private sealed class TestTlsEventPump()
+        : TlsEventPump(NullLogger<TlsEventPump>.Instance, id: 0, System.Threading.Timeout.InfiniteTimeSpan)
+    {
+        internal override void DeregisterFromEpoll(int fd)
+        {
+        }
+    }
+}

--- a/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsBackpressureTelemetryTests.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsBackpressureTelemetryTests.cs
@@ -1,9 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
+
 using System.Buffers;
 using System.Collections.Concurrent;
 using System.Diagnostics.Metrics;
+using System.Net;
 using System.Net.Security;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.InternalTesting;
@@ -23,20 +26,20 @@ public class DirectTlsBackpressureTelemetryTests : LoggedTest
     {
         using var meter = new Meter($"{nameof(DirectTlsBackpressureTelemetryTests)}.{Guid.NewGuid():N}");
         using var meterListener = new MeterListener();
-        var pausedConnectionMeasurements = new ConcurrentQueue<long>();
+        var pausedConnectionMeasurements = new ConcurrentQueue<MetricMeasurement>();
         var pauseMeasurementRecorded = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var resumeMeasurementRecorded = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         meterListener.InstrumentPublished = (instrument, listener) =>
         {
             if (instrument.Meter.Name == meter.Name &&
-                instrument.Name == DirectTlsMetrics.PausedConnectionsInstrumentName)
+                instrument.Name == DirectTlsMetrics.ReadBackpressureConnectionsInstrumentName)
             {
                 listener.EnableMeasurementEvents(instrument);
             }
         };
-        meterListener.SetMeasurementEventCallback<long>((_, measurement, _, _) =>
+        meterListener.SetMeasurementEventCallback<long>((_, measurement, tags, _) =>
         {
-            pausedConnectionMeasurements.Enqueue(measurement);
+            pausedConnectionMeasurements.Enqueue(new(measurement, tags.ToArray()));
             (measurement == 1 ? pauseMeasurementRecorded : resumeMeasurementRecorded).TrySetResult();
         });
         meterListener.Start();
@@ -67,7 +70,7 @@ public class DirectTlsBackpressureTelemetryTests : LoggedTest
         Assert.Contains(TestSink.Writes, write =>
             write.EventId.Name == "ConnectionPause" &&
             write.Message.Contains(connection.ConnectionId, StringComparison.Ordinal));
-        Assert.Equal([1L], pausedConnectionMeasurements);
+        Assert.Equal([1L], pausedConnectionMeasurements.Select(measurement => measurement.Value));
 
         var readResult = await connection.Transport.Input.ReadAsync().AsTask().WaitAsync(Timeout);
         connection.Transport.Input.AdvanceTo(readResult.Buffer.End);
@@ -79,7 +82,7 @@ public class DirectTlsBackpressureTelemetryTests : LoggedTest
         Assert.Contains(TestSink.Writes, write =>
             write.EventId.Name == "ConnectionResume" &&
             write.Message.Contains(connection.ConnectionId, StringComparison.Ordinal));
-        Assert.Equal([1L, -1L], pausedConnectionMeasurements);
+        Assert.Equal([1L, -1L], pausedConnectionMeasurements.Select(measurement => measurement.Value));
 
         connection.Abort(new ConnectionAbortedException("Test complete."));
         await connection.DisposeAsync();
@@ -91,29 +94,120 @@ public class DirectTlsBackpressureTelemetryTests : LoggedTest
     {
         using var meter = new Meter($"{nameof(DirectTlsBackpressureTelemetryTests)}.{Guid.NewGuid():N}");
         using var meterListener = new MeterListener();
-        var pausedConnectionMeasurements = new ConcurrentQueue<long>();
+        var pausedConnectionMeasurements = new ConcurrentQueue<MetricMeasurement>();
         meterListener.InstrumentPublished = (instrument, listener) =>
         {
             if (instrument.Meter.Name == meter.Name &&
-                instrument.Name == DirectTlsMetrics.PausedConnectionsInstrumentName)
+                instrument.Name == DirectTlsMetrics.ReadBackpressureConnectionsInstrumentName)
             {
                 listener.EnableMeasurementEvents(instrument);
             }
         };
-        meterListener.SetMeasurementEventCallback<long>((_, measurement, _, _) =>
+        meterListener.SetMeasurementEventCallback<long>((_, measurement, tags, _) =>
         {
-            pausedConnectionMeasurements.Enqueue(measurement);
+            pausedConnectionMeasurements.Enqueue(new(measurement, tags.ToArray()));
         });
         meterListener.Start();
 
         var connectionState = new BackpressureConnectionIoState(
             LoggerFactory.CreateLogger<ConnectionIoState>(),
             new DirectTlsMetrics(meter));
+        connectionState.SetConnection(new DefaultConnectionContext
+        {
+            ConnectionId = "connection-id",
+            LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 5001)
+        });
 
         connectionState.SuspendReadInterest();
         connectionState.Cancel();
 
-        Assert.Equal([1L, -1L], pausedConnectionMeasurements);
+        Assert.Equal([1L, -1L], pausedConnectionMeasurements.Select(measurement => measurement.Value));
+        Assert.All(pausedConnectionMeasurements, measurement =>
+        {
+            Assert.Equal("127.0.0.1", measurement.GetTag("server.address"));
+            Assert.Equal(5001, measurement.GetTag("server.port"));
+            Assert.Equal("ipv4", measurement.GetTag("network.type"));
+            Assert.Equal("tcp", measurement.GetTag("network.transport"));
+        });
+        Assert.Contains(TestSink.Writes, write =>
+            write.EventId.Name == "ConnectionResume" &&
+            write.Message.Contains("connection-id", StringComparison.Ordinal));
+    }
+
+    [ConditionalFact]
+    [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX)]
+    public async Task WriteWouldBlock_RecordsWriteBackpressureWithEndpointTags()
+    {
+        using var meter = new Meter($"{nameof(DirectTlsBackpressureTelemetryTests)}.{Guid.NewGuid():N}");
+        using var meterListener = new MeterListener();
+        var measurements = new ConcurrentQueue<MetricMeasurement>();
+        meterListener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Meter.Name == meter.Name &&
+                instrument.Name == DirectTlsMetrics.WriteBackpressureConnectionsInstrumentName)
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<long>((_, measurement, tags, _) =>
+            measurements.Enqueue(new(measurement, tags.ToArray())));
+        meterListener.Start();
+
+        var connectionState = new WriteBackpressureConnectionIoState(
+            LoggerFactory.CreateLogger<ConnectionIoState>(),
+            new DirectTlsMetrics(meter),
+            TlsOperationStatus.DestinationTooSmall,
+            TlsOperationStatus.Complete);
+        connectionState.SetConnection(new DefaultConnectionContext
+        {
+            LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 5002)
+        });
+
+        var write = connectionState.WriteAsync(new byte[1]);
+        Assert.False(write.IsCompleted);
+        connectionState.OnWritable();
+        Assert.Equal(1, await write);
+
+        Assert.Equal([1L, -1L], measurements.Select(measurement => measurement.Value));
+        Assert.All(measurements, measurement =>
+        {
+            Assert.Equal("127.0.0.1", measurement.GetTag("server.address"));
+            Assert.Equal(5002, measurement.GetTag("server.port"));
+            Assert.Equal("ipv4", measurement.GetTag("network.type"));
+            Assert.Equal("tcp", measurement.GetTag("network.transport"));
+        });
+    }
+
+    [ConditionalFact]
+    [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX)]
+    public async Task WriteWaitingForRead_DoesNotRecordWriteBackpressure()
+    {
+        using var meter = new Meter($"{nameof(DirectTlsBackpressureTelemetryTests)}.{Guid.NewGuid():N}");
+        using var meterListener = new MeterListener();
+        var measurements = new ConcurrentQueue<long>();
+        meterListener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Meter.Name == meter.Name &&
+                instrument.Name == DirectTlsMetrics.WriteBackpressureConnectionsInstrumentName)
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<long>((_, measurement, _, _) => measurements.Enqueue(measurement));
+        meterListener.Start();
+
+        var connectionState = new WriteBackpressureConnectionIoState(
+            LoggerFactory.CreateLogger<ConnectionIoState>(),
+            new DirectTlsMetrics(meter),
+            TlsOperationStatus.NeedMoreData,
+            TlsOperationStatus.Complete);
+
+        var write = connectionState.WriteAsync(new byte[1]);
+        Assert.False(write.IsCompleted);
+        connectionState.OnReadable();
+        Assert.Equal(1, await write);
+
+        Assert.Empty(measurements);
     }
 
     [ConditionalFact]
@@ -126,7 +220,7 @@ public class DirectTlsBackpressureTelemetryTests : LoggedTest
         meterListener.InstrumentPublished = (instrument, listener) =>
         {
             if (instrument.Meter.Name == meter.Name &&
-                instrument.Name == DirectTlsMetrics.PausedConnectionsInstrumentName)
+                instrument.Name == DirectTlsMetrics.ReadBackpressureConnectionsInstrumentName)
             {
                 listener.EnableMeasurementEvents(instrument);
             }
@@ -160,7 +254,7 @@ public class DirectTlsBackpressureTelemetryTests : LoggedTest
         meterListener.InstrumentPublished = (instrument, listener) =>
         {
             if (instrument.Meter.Name == meter.Name &&
-                instrument.Name == DirectTlsMetrics.PausedConnectionsInstrumentName)
+                instrument.Name == DirectTlsMetrics.ReadBackpressureConnectionsInstrumentName)
             {
                 listener.EnableMeasurementEvents(instrument);
             }
@@ -174,6 +268,7 @@ public class DirectTlsBackpressureTelemetryTests : LoggedTest
         var connectionState = new BackpressureConnectionIoState(
             LoggerFactory.CreateLogger<ConnectionIoState>(),
             new DirectTlsMetrics(meter));
+        connectionState.SetConnection(new DefaultConnectionContext { ConnectionId = "connection-id" });
 
         connectionState.SuspendReadInterest();
         connectionState.ThrowOnApplyEvents = true;
@@ -181,6 +276,9 @@ public class DirectTlsBackpressureTelemetryTests : LoggedTest
         connectionState.Cancel();
 
         Assert.Equal([1L, -1L], pausedConnectionMeasurements);
+        Assert.Contains(TestSink.Writes, write =>
+            write.EventId.Name == "ConnectionResume" &&
+            write.Message.Contains("connection-id", StringComparison.Ordinal));
     }
 
     [ConditionalFact]
@@ -199,7 +297,7 @@ public class DirectTlsBackpressureTelemetryTests : LoggedTest
         meterListener.InstrumentPublished = (instrument, listener) =>
         {
             if (instrument.Meter.Name == meter.Name &&
-                instrument.Name == DirectTlsMetrics.PausedConnectionsInstrumentName)
+                instrument.Name == DirectTlsMetrics.ReadBackpressureConnectionsInstrumentName)
             {
                 listener.EnableMeasurementEvents(instrument);
             }
@@ -280,6 +378,38 @@ public class DirectTlsBackpressureTelemetryTests : LoggedTest
         internal override void DisposeSession()
         {
         }
+    }
+
+    private sealed class WriteBackpressureConnectionIoState : ConnectionIoState
+    {
+        private readonly Queue<TlsOperationStatus> _statuses;
+
+        public WriteBackpressureConnectionIoState(
+            ILogger logger,
+            DirectTlsMetrics metrics,
+            params TlsOperationStatus[] statuses)
+            : base(fd: 7, session: null!, logger, metrics)
+        {
+            _statuses = new Queue<TlsOperationStatus>(statuses);
+            SetHandshakeComplete();
+        }
+
+        internal override TlsOperationStatus RawWrite(ReadOnlySpan<byte> buffer, out int bytesWritten)
+        {
+            var status = _statuses.Dequeue();
+            bytesWritten = status == TlsOperationStatus.Complete ? buffer.Length : 0;
+            return status;
+        }
+
+        internal override void ApplyEvents(uint events)
+        {
+        }
+    }
+
+    private sealed record MetricMeasurement(long Value, KeyValuePair<string, object?>[] Tags)
+    {
+        public object? GetTag(string name)
+            => Tags.FirstOrDefault(tag => tag.Key == name).Value;
     }
 
     private sealed class TestTlsEventPump()

--- a/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsConnectionTelemetryTests.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsConnectionTelemetryTests.cs
@@ -1,0 +1,158 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Net.Security;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls.Connection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls.Tests;
+
+public class DirectTlsConnectionTelemetryTests : LoggedTest
+{
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
+    [ConditionalFact]
+    [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX)]
+    public async Task ReceiveEof_LogsConnectionReadFin()
+    {
+        using var pump = new TestTlsEventPump();
+        var connectionState = new TelemetryConnectionIoState(
+            LoggerFactory.CreateLogger<ConnectionIoState>(),
+            TlsOperationStatus.Closed);
+        var connection = CreateConnection(connectionState, pump);
+
+        connection.Start();
+
+        var readResult = await connection.Transport.Input.ReadAsync().AsTask().WaitAsync(Timeout);
+        connection.Transport.Input.AdvanceTo(readResult.Buffer.End);
+
+        Assert.True(readResult.IsCompleted);
+        Assert.Contains(TestSink.Writes, write => write.EventId.Name == "ConnectionReadFin");
+
+        await connection.DisposeAsync();
+    }
+
+    [ConditionalFact]
+    [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX)]
+    public async Task CompletedOutput_LogsConnectionWriteFin()
+    {
+        using var pump = new TestTlsEventPump();
+        var connectionState = new TelemetryConnectionIoState(
+            LoggerFactory.CreateLogger<ConnectionIoState>(),
+            TlsOperationStatus.NeedMoreData);
+        var connection = CreateConnection(connectionState, pump);
+
+        connection.Start();
+        await connection.Transport.Output.CompleteAsync();
+        await WaitForLogAsync("ConnectionWriteFin");
+
+        await connection.DisposeAsync();
+    }
+
+    [ConditionalFact]
+    [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX)]
+    public async Task Abort_LogsConnectionWriteRst()
+    {
+        using var pump = new TestTlsEventPump();
+        var connectionState = new TelemetryConnectionIoState(
+            LoggerFactory.CreateLogger<ConnectionIoState>(),
+            TlsOperationStatus.NeedMoreData);
+        var connection = CreateConnection(connectionState, pump);
+
+        connection.Abort(new ConnectionAbortedException("Test abort."));
+
+        Assert.Contains(TestSink.Writes, write => write.EventId.Name == "ConnectionWriteRst");
+
+        await connection.DisposeAsync();
+    }
+
+    [ConditionalTheory]
+    [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX)]
+    [InlineData(false, "ConnectionError")]
+    [InlineData(true, "ConnectionReset")]
+    public async Task FatalError_LogsExpectedConnectionEvent(bool reset, string expectedEvent)
+    {
+        using var pump = new TestTlsEventPump();
+        var connectionState = new TelemetryConnectionIoState(
+            LoggerFactory.CreateLogger<ConnectionIoState>(),
+            TlsOperationStatus.NeedMoreData);
+        var connection = CreateConnection(connectionState, pump);
+        Exception error = reset
+            ? new ConnectionResetException("Test reset.")
+            : new IOException("Test error.");
+
+        connection.Start();
+        connectionState.OnError(error);
+        await connection.DisposeAsync();
+
+        Assert.Contains(TestSink.Writes, write => write.EventId.Name == expectedEvent);
+    }
+
+    private DirectTlsConnection CreateConnection(
+        ConnectionIoState connectionState,
+        TlsEventPump pump)
+    {
+        return new DirectTlsConnection(
+            connectionState,
+            pump,
+            localEndPoint: null,
+            remoteEndPoint: null,
+            MemoryPool<byte>.Shared,
+            maxReadBufferSize: 0,
+            maxWriteBufferSize: 0,
+            LoggerFactory.CreateLogger<DirectTlsConnection>());
+    }
+
+    private async Task WaitForLogAsync(string eventName)
+    {
+        using var cts = new CancellationTokenSource(Timeout);
+        while (!TestSink.Writes.Any(write => write.EventId.Name == eventName))
+        {
+            await Task.Delay(10, cts.Token);
+        }
+    }
+
+    private sealed class TelemetryConnectionIoState : ConnectionIoState
+    {
+        private readonly TlsOperationStatus _readStatus;
+
+        public TelemetryConnectionIoState(
+            ILogger logger,
+            TlsOperationStatus readStatus)
+            : base(fd: 7, session: null!, logger)
+        {
+            _readStatus = readStatus;
+            SetHandshakeComplete();
+        }
+
+        internal override TlsOperationStatus RawRead(Span<byte> buffer, out int bytesRead)
+        {
+            bytesRead = 0;
+            return _readStatus;
+        }
+
+        internal override void ApplyEvents(uint events)
+        {
+        }
+
+        internal override void ShutdownSession()
+        {
+        }
+
+        internal override void DisposeSession()
+        {
+        }
+    }
+
+    private sealed class TestTlsEventPump()
+        : TlsEventPump(NullLogger<TlsEventPump>.Instance, id: 0, System.Threading.Timeout.InfiniteTimeSpan)
+    {
+        internal override void DeregisterFromEpoll(int fd)
+        {
+        }
+    }
+}

--- a/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsEpollTelemetryTests.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsEpollTelemetryTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -19,7 +20,7 @@ public class DirectTlsEpollTelemetryTests : LoggedTest
             fd: 42,
             session: null!,
             NullLogger<ConnectionIoState>.Instance);
-        connection.SetConnectionId("connection-id");
+        connection.SetConnection(new DefaultConnectionContext { ConnectionId = "connection-id" });
 
         pump.TrackConnectionForTest(connection.Fd, connection);
         Assert.True(pump.ModifyEvents(connection.Fd, NativeTls.EPOLLOUT));

--- a/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsEpollTelemetryTests.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsEpollTelemetryTests.cs
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls.Tests;
+
+[Microsoft.Extensions.Logging.Testing.LogLevel(LogLevel.Trace)]
+public class DirectTlsEpollTelemetryTests : LoggedTest
+{
+    [ConditionalFact]
+    [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX)]
+    public void EstablishedConnection_LogsEpollStateTransitions()
+    {
+        using var pump = new RecordingPump(LoggerFactory.CreateLogger<TlsEventPump>(), id: 3);
+        var connection = new ConnectionIoState(
+            fd: 42,
+            session: null!,
+            NullLogger<ConnectionIoState>.Instance);
+        connection.SetConnectionId("connection-id");
+
+        pump.TrackConnectionForTest(connection.Fd, connection);
+        Assert.True(pump.ModifyEvents(connection.Fd, NativeTls.EPOLLOUT));
+        pump.Unregister(connection.Fd);
+
+        Assert.Collection(
+            TestSink.Writes,
+            write => Assert.Equal("EpollConnectionRegistered", write.EventId.Name),
+            write => Assert.Equal("EpollInterestChanged", write.EventId.Name),
+            write => Assert.Equal("EpollConnectionUnregistered", write.EventId.Name));
+    }
+
+    private sealed class RecordingPump : TlsEventPump
+    {
+        public RecordingPump(ILogger<TlsEventPump> logger, int id)
+            : base(logger, id, Timeout.InfiniteTimeSpan)
+        {
+        }
+
+        private protected override bool TryModifyEstablishedInterest(int fd, uint events)
+            => true;
+
+        internal override void DeregisterFromEpoll(int fd)
+        {
+        }
+    }
+}

--- a/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsEventSourceTests.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsEventSourceTests.cs
@@ -1,0 +1,135 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System.Collections.Concurrent;
+using System.Diagnostics.Tracing;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls.Tests;
+
+public class DirectTlsEventSourceTests
+{
+    private static readonly string[] ExpectedCounterNames =
+    [
+        "connections-owned",
+        "accepts",
+        "connections-paused",
+        "bytes-read",
+        "bytes-written"
+    ];
+
+    [Fact]
+    public void EmitsPumpEvents()
+    {
+        using var eventSource = new DirectTlsEventSource(
+            $"{DirectTlsEventSource.EventSourceName}.{Guid.NewGuid():N}");
+        using var listener = new TestEventListener(eventSource);
+
+        eventSource.Accepted(pumpId: 3);
+        eventSource.ConnectionOwned(pumpId: 3, pumpConnectionCount: 1);
+        eventSource.ConnectionReleased(pumpId: 3, pumpConnectionCount: 0);
+
+        var eventSourceError = listener.Events
+            .Where(eventData => eventData.EventName == "EventSourceMessage")
+            .Select(eventData => eventData.Payload?[0]?.ToString())
+            .FirstOrDefault();
+        Assert.True(eventSourceError is null, eventSourceError);
+        Assert.Collection(
+            listener.Events,
+            eventData =>
+            {
+                Assert.Equal(1, eventData.EventId);
+                Assert.Equal("ConnectionAccepted", eventData.EventName);
+                Assert.Equal(3, eventData.Payload![0]);
+            },
+            eventData =>
+            {
+                Assert.Equal(2, eventData.EventId);
+                Assert.Equal("PumpConnections", eventData.EventName);
+                Assert.Equal(3, eventData.Payload![0]);
+                Assert.Equal(1, eventData.Payload[1]);
+            },
+            eventData =>
+            {
+                Assert.Equal(2, eventData.EventId);
+                Assert.Equal("PumpConnections", eventData.EventName);
+                Assert.Equal(3, eventData.Payload![0]);
+                Assert.Equal(0, eventData.Payload[1]);
+            });
+    }
+
+    [Fact]
+    public async Task ExposesEngineCounters()
+    {
+        using var eventSource = new DirectTlsEventSource(
+            $"{DirectTlsEventSource.EventSourceName}.{Guid.NewGuid():N}");
+        using var listener = new TestEventListener(eventSource, collectCounters: true);
+
+        eventSource.ConnectionOwned(pumpId: 0, pumpConnectionCount: 1);
+        eventSource.Accepted(pumpId: 0);
+        eventSource.ConnectionPaused();
+        eventSource.BytesRead(10);
+        eventSource.BytesWritten(20);
+
+        await listener.AllCountersObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.Equal(ExpectedCounterNames.Order(), listener.CounterNames.Order());
+
+        eventSource.ConnectionResumed();
+        eventSource.ConnectionReleased(pumpId: 0, pumpConnectionCount: 0);
+    }
+
+    private sealed class TestEventListener : EventListener
+    {
+        private readonly EventSource _eventSource;
+        private readonly bool _collectCounters;
+        private readonly ConcurrentQueue<EventWrittenEventArgs> _events = new();
+        private readonly ConcurrentDictionary<string, byte> _counterNames = new();
+
+        public TestEventListener(EventSource eventSource, bool collectCounters = false)
+        {
+            _eventSource = eventSource;
+            _collectCounters = collectCounters;
+            EnableEvents(
+                eventSource,
+                EventLevel.Informational,
+                EventKeywords.All,
+                collectCounters
+                    ? new Dictionary<string, string?> { ["EventCounterIntervalSec"] = "0.1" }
+                    : null);
+        }
+
+        public EventWrittenEventArgs[] Events => _events.ToArray();
+
+        public string[] CounterNames => _counterNames.Keys.ToArray();
+
+        public TaskCompletionSource AllCountersObserved { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (!ReferenceEquals(eventData.EventSource, _eventSource))
+            {
+                return;
+            }
+
+            if (eventData.EventName == "EventCounters" &&
+                eventData.Payload?[0] is IDictionary<string, object> payload &&
+                payload["Name"] is string counterName)
+            {
+                _counterNames.TryAdd(counterName, 0);
+                if (_counterNames.Count == ExpectedCounterNames.Length)
+                {
+                    AllCountersObserved.TrySetResult();
+                }
+                return;
+            }
+
+            if (!_collectCounters)
+            {
+                _events.Enqueue(eventData);
+            }
+        }
+    }
+}

--- a/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsEventSourceTests.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsEventSourceTests.cs
@@ -16,7 +16,12 @@ public class DirectTlsEventSourceTests
         "accepts",
         "connections-paused",
         "bytes-read",
-        "bytes-written"
+        "bytes-written",
+        "epoll-waits",
+        "epoll-wakeups",
+        "epoll-timeouts",
+        "epoll-ready-events",
+        "epoll-ready-batch-size"
     ];
 
     [Fact]
@@ -60,6 +65,26 @@ public class DirectTlsEventSourceTests
     }
 
     [Fact]
+    public void EmitsEpollEvents()
+    {
+        using var eventSource = new DirectTlsEventSource(
+            $"{DirectTlsEventSource.EventSourceName}.{Guid.NewGuid():N}");
+        using var listener = new TestEventListener(eventSource, level: EventLevel.Verbose);
+
+        eventSource.RecordEpollConnectionRegistered(pumpId: 3, fileDescriptor: 42, "connection-id", events: 1);
+        eventSource.RecordEpollInterestChanged(pumpId: 3, fileDescriptor: 42, "connection-id", previousEvents: 1, events: 4);
+        eventSource.RecordEpollReady(pumpId: 3, fileDescriptor: 42, "connection-id", events: 5);
+        eventSource.RecordEpollConnectionUnregistered(pumpId: 3, fileDescriptor: 42, "connection-id", events: 4);
+
+        Assert.Collection(
+            listener.Events,
+            eventData => AssertEpollEvent(eventData, 3, "EpollConnectionRegistered", [3, 42, "connection-id", 1U]),
+            eventData => AssertEpollEvent(eventData, 4, "EpollInterestChanged", [3, 42, "connection-id", 1U, 4U]),
+            eventData => AssertEpollEvent(eventData, 5, "EpollReady", [3, 42, "connection-id", 5U]),
+            eventData => AssertEpollEvent(eventData, 6, "EpollConnectionUnregistered", [3, 42, "connection-id", 4U]));
+    }
+
+    [Fact]
     public async Task ExposesEngineCounters()
     {
         using var eventSource = new DirectTlsEventSource(
@@ -71,6 +96,8 @@ public class DirectTlsEventSourceTests
         eventSource.ConnectionPaused();
         eventSource.BytesRead(10);
         eventSource.BytesWritten(20);
+        eventSource.EpollWaitCompleted(readyEventCount: 0);
+        eventSource.EpollWaitCompleted(readyEventCount: 3);
 
         await listener.AllCountersObserved.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
@@ -80,6 +107,13 @@ public class DirectTlsEventSourceTests
         eventSource.ConnectionReleased(pumpId: 0, pumpConnectionCount: 0);
     }
 
+    private static void AssertEpollEvent(EventWrittenEventArgs eventData, int eventId, string eventName, object?[] payload)
+    {
+        Assert.Equal(eventId, eventData.EventId);
+        Assert.Equal(eventName, eventData.EventName);
+        Assert.Equal(payload, eventData.Payload);
+    }
+
     private sealed class TestEventListener : EventListener
     {
         private readonly EventSource _eventSource;
@@ -87,13 +121,16 @@ public class DirectTlsEventSourceTests
         private readonly ConcurrentQueue<EventWrittenEventArgs> _events = new();
         private readonly ConcurrentDictionary<string, byte> _counterNames = new();
 
-        public TestEventListener(EventSource eventSource, bool collectCounters = false)
+        public TestEventListener(
+            EventSource eventSource,
+            bool collectCounters = false,
+            EventLevel level = EventLevel.Informational)
         {
             _eventSource = eventSource;
             _collectCounters = collectCounters;
             EnableEvents(
                 eventSource,
-                EventLevel.Informational,
+                level,
                 EventKeywords.All,
                 collectCounters
                     ? new Dictionary<string, string?> { ["EventCounterIntervalSec"] = "0.1" }

--- a/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsEventSourceTests.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsEventSourceTests.cs
@@ -14,7 +14,8 @@ public class DirectTlsEventSourceTests
     [
         "connections-owned",
         "accepts",
-        "connections-paused",
+        "read-connections-paused",
+        "write-connections-paused",
         "bytes-read",
         "bytes-written",
         "epoll-waits",
@@ -93,7 +94,8 @@ public class DirectTlsEventSourceTests
 
         eventSource.ConnectionOwned(pumpId: 0, pumpConnectionCount: 1);
         eventSource.Accepted(pumpId: 0);
-        eventSource.ConnectionPaused();
+        eventSource.ReadConnectionPaused();
+        eventSource.WriteConnectionPaused();
         eventSource.BytesRead(10);
         eventSource.BytesWritten(20);
         eventSource.EpollWaitCompleted(readyEventCount: 0);
@@ -103,7 +105,8 @@ public class DirectTlsEventSourceTests
 
         Assert.Equal(ExpectedCounterNames.Order(), listener.CounterNames.Order());
 
-        eventSource.ConnectionResumed();
+        eventSource.ReadConnectionResumed();
+        eventSource.WriteConnectionResumed();
         eventSource.ConnectionReleased(pumpId: 0, pumpConnectionCount: 0);
     }
 

--- a/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsFunctionalTests.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsFunctionalTests.cs
@@ -4,6 +4,10 @@
 #nullable enable
 
 using System.Buffers;
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using System.Diagnostics.Tracing;
+using System.Globalization;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
@@ -17,15 +21,144 @@ using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls.Tests;
 
 // DirectTls terminates TLS through the runtime's native, file-descriptor-bound OpenSSL session, which is
 // Linux-only. These end-to-end tests start a real Kestrel host on the DirectTls transport and drive it with
 // a standard SslStream client.
-public class DirectTlsFunctionalTests
+public class DirectTlsFunctionalTests : LoggedTest
 {
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(30);
+
+    [ConditionalFact]
+    [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX)]
+    public async Task Handshake_RecordsExistingKestrelTlsMetrics()
+    {
+        using var metrics = new HandshakeMetricCollector();
+        var endpoint = new DirectTlsEndpoint(IPAddress.Loopback, 0);
+        endpoint.Options.ServerCertificate = TestResources.GetTestCertificate();
+
+        using var host = await StartHostAsync(endpoint, context => context.Response.WriteAsync("ok"));
+        var port = host.GetPort();
+
+        using var sslStream = await ConnectAsync(host.GetPort(), "localhost", applicationProtocols: [SslApplicationProtocol.Http11]);
+        await metrics.WaitForDurationAsync(port);
+
+        Assert.Equal([1L, -1L], metrics.ActiveHandshakesForPort(port).Select(measurement => measurement.Value));
+        var duration = Assert.Single(metrics.HandshakeDurationsForPort(port));
+        Assert.True(duration.Value > 0);
+        Assert.Equal(
+            sslStream.SslProtocol == System.Security.Authentication.SslProtocols.Tls13 ? "1.3" : "1.2",
+            duration.GetTag("tls.protocol.version"));
+
+        await host.StopAsync().WaitAsync(Timeout);
+    }
+
+    [ConditionalFact]
+    [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX)]
+    public async Task FailedHandshake_RecordsExistingKestrelTlsMetrics()
+    {
+        using var metrics = new HandshakeMetricCollector();
+        var endpoint = new DirectTlsEndpoint(IPAddress.Loopback, 0);
+        endpoint.Options.ServerCertificate = TestResources.GetTestCertificate();
+
+        using var host = await StartHostAsync(endpoint, context => context.Response.WriteAsync("ok"));
+        var port = host.GetPort();
+
+        using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+        {
+            await socket.ConnectAsync(IPAddress.Loopback, port);
+            await socket.SendAsync("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"u8.ToArray());
+        }
+
+        await metrics.WaitForDurationAsync(port);
+
+        Assert.Equal([1L, -1L], metrics.ActiveHandshakesForPort(port).Select(measurement => measurement.Value));
+        var duration = Assert.Single(metrics.HandshakeDurationsForPort(port));
+        Assert.True(duration.Value > 0);
+        Assert.NotNull(duration.GetTag("error.type"));
+
+        await host.StopAsync().WaitAsync(Timeout);
+    }
+
+    [ConditionalFact]
+    [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX)]
+    public async Task Request_RecordsPumpTelemetry()
+    {
+        using var telemetry = new DirectTlsTelemetryListener();
+        var endpoint = new DirectTlsEndpoint(IPAddress.Loopback, 0);
+        endpoint.Options.ServerCertificate = TestResources.GetTestCertificate();
+
+        using var host = await StartHostAsync(endpoint, context => context.Response.WriteAsync("ok"));
+
+        using (var sslStream = await ConnectAsync(host.GetPort(), "localhost", applicationProtocols: [SslApplicationProtocol.Http11]))
+        {
+            await telemetry.WaitForCounterAsync("connections-owned", value => value > 0);
+            var response = await SendRequestAsync(sslStream, "localhost");
+            Assert.Contains("200 OK", response);
+        }
+
+        await telemetry.WaitForCounterAsync("accepts", value => value > 0);
+        await telemetry.WaitForCounterAsync("bytes-read", value => value > 0);
+        await telemetry.WaitForCounterAsync("bytes-written", value => value > 0);
+
+        Assert.Contains(telemetry.Events, eventData => eventData.EventName == "ConnectionAccepted");
+        Assert.Contains(telemetry.Events, eventData =>
+            eventData.EventName == "PumpConnections" &&
+            eventData.Payload is [_, int connectionCount] &&
+            connectionCount > 0);
+
+        await host.StopAsync().WaitAsync(Timeout);
+    }
+
+    [ConditionalFact]
+    [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX)]
+    public async Task InputBackpressure_RecordsPauseAndResumeTelemetry()
+    {
+        using var telemetry = new DirectTlsTelemetryListener();
+        using var metrics = new PausedConnectionMetricCollector();
+        var startReading = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var applicationStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var endpoint = new DirectTlsEndpoint(IPAddress.Loopback, 0);
+        endpoint.Options.ServerCertificate = TestResources.GetTestCertificate();
+
+        using var host = await StartHostAsync(
+            endpoint,
+            async context =>
+            {
+                applicationStarted.TrySetResult();
+                await startReading.Task;
+                await context.Request.Body.CopyToAsync(Stream.Null);
+                await context.Response.WriteAsync("ok");
+            },
+            configureTransport: options => options.MaxReadBufferSize = 1024);
+
+        using var sslStream = await ConnectAsync(host.GetPort(), "localhost", applicationProtocols: [SslApplicationProtocol.Http11]);
+        const int contentLength = 64 * 1024;
+        await sslStream.WriteAsync(
+            Encoding.ASCII.GetBytes(
+                $"POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: {contentLength}\r\nConnection: close\r\n\r\n"));
+        var bodyWrite = sslStream.WriteAsync(new byte[contentLength]).AsTask();
+
+        await applicationStarted.Task.WaitAsync(Timeout);
+        await WaitForLogAsync("ConnectionPause");
+        await metrics.WaitForMeasurementAsync(1);
+        await telemetry.WaitForCounterAsync("connections-paused", value => value >= 1);
+
+        startReading.TrySetResult();
+        await bodyWrite.WaitAsync(Timeout);
+        await sslStream.FlushAsync();
+        var response = await new StreamReader(sslStream, Encoding.ASCII).ReadToEndAsync().WaitAsync(Timeout);
+
+        Assert.Contains("200 OK", response);
+        await WaitForLogAsync("ConnectionResume");
+        await metrics.WaitForMeasurementAsync(-1);
+
+        await host.StopAsync().WaitAsync(Timeout);
+    }
 
     [ConditionalFact]
     [OSSkipCondition(OperatingSystems.Windows | OperatingSystems.MacOSX)]
@@ -538,13 +671,20 @@ public class DirectTlsFunctionalTests
         await host.StopAsync().WaitAsync(Timeout);
     }
 
-    private static async Task<IHost> StartHostAsync(
+    private async Task<IHost> StartHostAsync(
         DirectTlsEndpoint endpoint,
         RequestDelegate app,
         Action<DirectTlsTransportOptions>? configureTransport = null,
         Action<KestrelServerOptions>? configureKestrel = null)
     {
         var host = new HostBuilder()
+            .ConfigureLogging(logging =>
+            {
+                logging.AddProvider(new TestLoggerProvider(TestSink));
+                logging.AddFilter(
+                    "Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls",
+                    LogLevel.Debug);
+            })
             .ConfigureWebHost(webHostBuilder =>
             {
                 webHostBuilder.UseKestrel();
@@ -570,6 +710,15 @@ public class DirectTlsFunctionalTests
 
         await host.StartAsync().WaitAsync(Timeout);
         return host;
+    }
+
+    private async Task WaitForLogAsync(string eventName)
+    {
+        using var cts = new CancellationTokenSource(Timeout);
+        while (!TestSink.Writes.Any(write => write.EventId.Name == eventName))
+        {
+            await Task.Delay(10, cts.Token);
+        }
     }
 
     private static async Task<SslStream> ConnectAsync(
@@ -630,5 +779,153 @@ public class DirectTlsFunctionalTests
             total += read;
         }
         return total;
+    }
+
+    private sealed class HandshakeMetricCollector : IDisposable
+    {
+        private const string MeterName = "Microsoft.AspNetCore.Server.Kestrel";
+        private const string ActiveHandshakesName = "kestrel.active_tls_handshakes";
+        private const string HandshakeDurationName = "kestrel.tls_handshake.duration";
+
+        private readonly MeterListener _listener = new();
+        private readonly ConcurrentQueue<MetricMeasurement<long>> _activeHandshakes = new();
+        private readonly ConcurrentQueue<MetricMeasurement<double>> _handshakeDurations = new();
+
+        public HandshakeMetricCollector()
+        {
+            _listener.InstrumentPublished = static (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == MeterName &&
+                    instrument.Name is ActiveHandshakesName or HandshakeDurationName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            _listener.SetMeasurementEventCallback<long>((_, value, tags, _) =>
+                _activeHandshakes.Enqueue(new MetricMeasurement<long>(value, tags.ToArray())));
+            _listener.SetMeasurementEventCallback<double>((_, value, tags, _) =>
+                _handshakeDurations.Enqueue(new MetricMeasurement<double>(value, tags.ToArray())));
+            _listener.Start();
+        }
+
+        public IEnumerable<MetricMeasurement<long>> ActiveHandshakesForPort(int port)
+            => _activeHandshakes.Where(measurement => measurement.GetTag("server.port") is int measuredPort && measuredPort == port);
+
+        public IEnumerable<MetricMeasurement<double>> HandshakeDurationsForPort(int port)
+            => _handshakeDurations.Where(measurement => measurement.GetTag("server.port") is int measuredPort && measuredPort == port);
+
+        public async Task WaitForDurationAsync(int port)
+        {
+            using var cts = new CancellationTokenSource(Timeout);
+            while (!HandshakeDurationsForPort(port).Any())
+            {
+                await Task.Delay(10, cts.Token);
+            }
+        }
+
+        public void Dispose()
+        {
+            _listener.Dispose();
+        }
+    }
+
+    private sealed class PausedConnectionMetricCollector : IDisposable
+    {
+        private readonly MeterListener _listener = new();
+        private readonly ConcurrentQueue<long> _measurements = new();
+
+        public PausedConnectionMetricCollector()
+        {
+            _listener.InstrumentPublished = static (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == "Microsoft.AspNetCore.Server.Kestrel" &&
+                    instrument.Name == DirectTlsMetrics.PausedConnectionsInstrumentName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            _listener.SetMeasurementEventCallback<long>((_, value, _, _) => _measurements.Enqueue(value));
+            _listener.Start();
+        }
+
+        public async Task WaitForMeasurementAsync(long expected)
+        {
+            using var cts = new CancellationTokenSource(Timeout);
+            while (!_measurements.Contains(expected))
+            {
+                await Task.Delay(10, cts.Token);
+            }
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    private sealed class DirectTlsTelemetryListener : EventListener
+    {
+        private readonly ConcurrentQueue<EventWrittenEventArgs> _events = new();
+        private readonly ConcurrentDictionary<string, double> _counterValues = new();
+
+        public DirectTlsTelemetryListener()
+        {
+            foreach (var eventSource in EventSource.GetSources())
+            {
+                EnableIfDirectTls(eventSource);
+            }
+        }
+
+        public EventWrittenEventArgs[] Events => _events.ToArray();
+
+        public async Task WaitForCounterAsync(string name, Func<double, bool> predicate)
+        {
+            using var cts = new CancellationTokenSource(Timeout);
+            while (!_counterValues.TryGetValue(name, out var value) || !predicate(value))
+            {
+                await Task.Delay(10, cts.Token);
+            }
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+            => EnableIfDirectTls(eventSource);
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (eventData.EventName == "EventCounters" &&
+                eventData.Payload?[0] is IDictionary<string, object> payload &&
+                payload["Name"] is string counterName)
+            {
+                if (payload.TryGetValue("Mean", out var mean))
+                {
+                    _counterValues[counterName] = Convert.ToDouble(mean, CultureInfo.InvariantCulture);
+                }
+                else if (payload.TryGetValue("Increment", out var increment))
+                {
+                    _counterValues[counterName] = Convert.ToDouble(increment, CultureInfo.InvariantCulture);
+                }
+
+                return;
+            }
+
+            _events.Enqueue(eventData);
+        }
+
+        private void EnableIfDirectTls(EventSource eventSource)
+        {
+            if (eventSource.Name == DirectTlsEventSource.EventSourceName)
+            {
+                EnableEvents(
+                    eventSource,
+                    EventLevel.Informational,
+                    EventKeywords.All,
+                    new Dictionary<string, string?> { ["EventCounterIntervalSec"] = "0.1" });
+            }
+        }
+    }
+
+    private sealed record MetricMeasurement<T>(
+        T Value,
+        KeyValuePair<string, object?>[] Tags)
+    {
+        public object? GetTag(string name)
+            => Tags.FirstOrDefault(tag => tag.Key == name).Value;
     }
 }

--- a/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsFunctionalTests.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsFunctionalTests.cs
@@ -38,14 +38,17 @@ public class DirectTlsFunctionalTests : LoggedTest
     public async Task Handshake_RecordsExistingKestrelTlsMetrics()
     {
         using var metrics = new HandshakeMetricCollector();
+        using var events = new KestrelHandshakeEventListener();
         var endpoint = new DirectTlsEndpoint(IPAddress.Loopback, 0);
         endpoint.Options.ServerCertificate = TestResources.GetTestCertificate();
 
         using var host = await StartHostAsync(endpoint, context => context.Response.WriteAsync("ok"));
         var port = host.GetPort();
+        const string targetHost = "directtls-event-source-success.test";
 
-        using var sslStream = await ConnectAsync(host.GetPort(), "localhost", applicationProtocols: [SslApplicationProtocol.Http11]);
+        using var sslStream = await ConnectAsync(host.GetPort(), targetHost, applicationProtocols: [SslApplicationProtocol.Http11]);
         await metrics.WaitForDurationAsync(port);
+        await events.WaitForStopAsync(targetHost);
 
         Assert.Equal([1L, -1L], metrics.ActiveHandshakesForPort(port).Select(measurement => measurement.Value));
         var duration = Assert.Single(metrics.HandshakeDurationsForPort(port));
@@ -53,6 +56,16 @@ public class DirectTlsFunctionalTests : LoggedTest
         Assert.Equal(
             sslStream.SslProtocol == System.Security.Authentication.SslProtocols.Tls13 ? "1.3" : "1.2",
             duration.GetTag("tls.protocol.version"));
+        var handshakeStop = Assert.Single(events.Events, eventData =>
+            eventData.EventName == "TlsHandshakeStop" &&
+            Equals(eventData.Payload![3], targetHost));
+        var handshakeStart = Assert.Single(events.Events, eventData =>
+            eventData.EventName == "TlsHandshakeStart" &&
+            Equals(eventData.Payload![0], handshakeStop.Payload![0]));
+        Assert.Equal(handshakeStart.Payload![0], handshakeStop.Payload![0]);
+        Assert.Equal(sslStream.SslProtocol.ToString(), handshakeStop.Payload[1]);
+        Assert.Equal("http/1.1", handshakeStop.Payload[2]);
+        Assert.Equal(targetHost, handshakeStop.Payload[3]);
 
         await host.StopAsync().WaitAsync(Timeout);
     }
@@ -62,24 +75,35 @@ public class DirectTlsFunctionalTests : LoggedTest
     public async Task FailedHandshake_RecordsExistingKestrelTlsMetrics()
     {
         using var metrics = new HandshakeMetricCollector();
+        using var events = new KestrelHandshakeEventListener();
         var endpoint = new DirectTlsEndpoint(IPAddress.Loopback, 0);
         endpoint.Options.ServerCertificate = TestResources.GetTestCertificate();
+        endpoint.Options.ClientCertificateMode = ClientCertificateMode.RequireCertificate;
 
         using var host = await StartHostAsync(endpoint, context => context.Response.WriteAsync("ok"));
         var port = host.GetPort();
 
-        using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-        {
-            await socket.ConnectAsync(IPAddress.Loopback, port);
-            await socket.SendAsync("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"u8.ToArray());
-        }
+        const string targetHost = "directtls-event-source-failure.test";
+        using var sslStream = await ConnectAsync(port, targetHost, applicationProtocols: [SslApplicationProtocol.Http11]);
 
         await metrics.WaitForDurationAsync(port);
+        await events.WaitForStopAsync(targetHost);
 
         Assert.Equal([1L, -1L], metrics.ActiveHandshakesForPort(port).Select(measurement => measurement.Value));
         var duration = Assert.Single(metrics.HandshakeDurationsForPort(port));
         Assert.True(duration.Value > 0);
         Assert.NotNull(duration.GetTag("error.type"));
+        var handshakeStop = Assert.Single(events.Events, eventData =>
+            eventData.EventName == "TlsHandshakeStop" &&
+            Equals(eventData.Payload![3], targetHost));
+        var handshakeStart = Assert.Single(events.Events, eventData =>
+            eventData.EventName == "TlsHandshakeStart" &&
+            Equals(eventData.Payload![0], handshakeStop.Payload![0]));
+        var handshakeFailed = Assert.Single(events.Events, eventData =>
+            eventData.EventName == "TlsHandshakeFailed" &&
+            Equals(eventData.Payload![0], handshakeStop.Payload![0]));
+        Assert.Equal(handshakeStart.Payload![0], handshakeFailed.Payload![0]);
+        Assert.Equal(handshakeStart.Payload[0], handshakeStop.Payload![0]);
 
         await host.StopAsync().WaitAsync(Timeout);
     }
@@ -150,7 +174,7 @@ public class DirectTlsFunctionalTests : LoggedTest
         await applicationStarted.Task.WaitAsync(Timeout);
         await WaitForLogAsync("ConnectionPause");
         await metrics.WaitForMeasurementAsync(1);
-        await telemetry.WaitForCounterAsync("connections-paused", value => value >= 1);
+        await telemetry.WaitForCounterAsync("read-connections-paused", value => value >= 1);
 
         startReading.TrySetResult();
         await bodyWrite.WaitAsync(Timeout);
@@ -843,7 +867,7 @@ public class DirectTlsFunctionalTests : LoggedTest
             _listener.InstrumentPublished = static (instrument, listener) =>
             {
                 if (instrument.Meter.Name == "Microsoft.AspNetCore.Server.Kestrel" &&
-                    instrument.Name == DirectTlsMetrics.PausedConnectionsInstrumentName)
+                    instrument.Name == DirectTlsMetrics.ReadBackpressureConnectionsInstrumentName)
                 {
                     listener.EnableMeasurementEvents(instrument);
                 }
@@ -875,6 +899,7 @@ public class DirectTlsFunctionalTests : LoggedTest
             {
                 EnableIfDirectTls(eventSource);
             }
+
         }
 
         public EventWrittenEventArgs[] Events => _events.ToArray();
@@ -921,6 +946,40 @@ public class DirectTlsFunctionalTests : LoggedTest
                     EventLevel.Informational,
                     EventKeywords.All,
                     new Dictionary<string, string?> { ["EventCounterIntervalSec"] = "0.1" });
+            }
+        }
+    }
+
+    private sealed class KestrelHandshakeEventListener : EventListener
+    {
+        private readonly ConcurrentQueue<EventWrittenEventArgs> _events = new();
+
+        public EventWrittenEventArgs[] Events => _events.ToArray();
+
+        public async Task WaitForStopAsync(string hostName)
+        {
+            using var cts = new CancellationTokenSource(Timeout);
+            while (!_events.Any(eventData =>
+                eventData.EventName == "TlsHandshakeStop" &&
+                Equals(eventData.Payload![3], hostName)))
+            {
+                await Task.Delay(10, cts.Token);
+            }
+        }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (eventSource.Name == "Microsoft-AspNetCore-Server-Kestrel")
+            {
+                EnableEvents(eventSource, EventLevel.Informational);
+            }
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (eventData.EventName is "TlsHandshakeStart" or "TlsHandshakeStop" or "TlsHandshakeFailed")
+            {
+                _events.Enqueue(eventData);
             }
         }
     }

--- a/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsFunctionalTests.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsFunctionalTests.cs
@@ -104,6 +104,10 @@ public class DirectTlsFunctionalTests : LoggedTest
         await telemetry.WaitForCounterAsync("accepts", value => value > 0);
         await telemetry.WaitForCounterAsync("bytes-read", value => value > 0);
         await telemetry.WaitForCounterAsync("bytes-written", value => value > 0);
+        await telemetry.WaitForCounterAsync("epoll-waits", value => value > 0);
+        await telemetry.WaitForCounterAsync("epoll-wakeups", value => value > 0);
+        await telemetry.WaitForCounterAsync("epoll-ready-events", value => value > 0);
+        await telemetry.WaitForCounterAsync("epoll-ready-batch-size", value => value > 0);
 
         Assert.Contains(telemetry.Events, eventData => eventData.EventName == "ConnectionAccepted");
         Assert.Contains(telemetry.Events, eventData =>

--- a/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsLogTests.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsLogTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls.Tests;
 
+[Microsoft.Extensions.Logging.Testing.LogLevel(LogLevel.Trace)]
 public class DirectTlsLogTests : LoggedTest
 {
     [Fact]
@@ -31,6 +32,23 @@ public class DirectTlsLogTests : LoggedTest
             write => AssertEvent(write.EventId, 8, "ConnectionWriteRst"),
             write => AssertEvent(write.EventId, 14, "ConnectionError"),
             write => AssertEvent(write.EventId, 19, "ConnectionReset"));
+    }
+
+    [Fact]
+    public void EpollEventsHaveExpectedIds()
+    {
+        var logger = LoggerFactory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls");
+        const string connectionId = "connection-id";
+
+        DirectTlsLog.EpollConnectionRegistered(logger, connectionId, pumpId: 3, fileDescriptor: 42, events: 1);
+        DirectTlsLog.EpollInterestChanged(logger, connectionId, pumpId: 3, fileDescriptor: 42, previousEvents: 1, events: 4);
+        DirectTlsLog.EpollConnectionUnregistered(logger, connectionId, pumpId: 3, fileDescriptor: 42, events: 4);
+
+        Assert.Collection(
+            TestSink.Writes,
+            write => AssertEvent(write.EventId, 20, "EpollConnectionRegistered"),
+            write => AssertEvent(write.EventId, 21, "EpollInterestChanged"),
+            write => AssertEvent(write.EventId, 22, "EpollConnectionUnregistered"));
     }
 
     private static void AssertEvent(EventId eventId, int expectedId, string expectedName)

--- a/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsLogTests.cs
+++ b/src/Servers/Kestrel/Transport.DirectTls/test/DirectTlsLogTests.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls.Tests;
+
+public class DirectTlsLogTests : LoggedTest
+{
+    [Fact]
+    public void ConnectionLifecycleEventsMatchSocketsTransport()
+    {
+        var logger = LoggerFactory.CreateLogger("Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls");
+        const string connectionId = "connection-id";
+
+        DirectTlsLog.ConnectionPause(logger, connectionId);
+        DirectTlsLog.ConnectionResume(logger, connectionId);
+        DirectTlsLog.ConnectionReadFin(logger, connectionId);
+        DirectTlsLog.ConnectionWriteFin(logger, connectionId, "fin");
+        DirectTlsLog.ConnectionWriteRst(logger, connectionId, "rst");
+        DirectTlsLog.ConnectionError(logger, connectionId, new IOException("error"));
+        DirectTlsLog.ConnectionReset(logger, connectionId);
+
+        Assert.Collection(
+            TestSink.Writes,
+            write => AssertEvent(write.EventId, 4, "ConnectionPause"),
+            write => AssertEvent(write.EventId, 5, "ConnectionResume"),
+            write => AssertEvent(write.EventId, 6, "ConnectionReadFin"),
+            write => AssertEvent(write.EventId, 7, "ConnectionWriteFin"),
+            write => AssertEvent(write.EventId, 8, "ConnectionWriteRst"),
+            write => AssertEvent(write.EventId, 14, "ConnectionError"),
+            write => AssertEvent(write.EventId, 19, "ConnectionReset"));
+    }
+
+    private static void AssertEvent(EventId eventId, int expectedId, string expectedName)
+    {
+        Assert.Equal(expectedId, eventId.Id);
+        Assert.Equal(expectedName, eventId.Name);
+    }
+}


### PR DESCRIPTION
Adds DirectTls observability comparable to the Sockets transport and runtime socket engine. This reuses Kestrel's existing TLS handshake metrics, mirrors Sockets transport lifecycle logs, and adds DirectTls pump, backpressure and epoll telemetry.

## Metrics — meter `Microsoft.AspNetCore.Server.Kestrel`

| Instrument | Type | Description |
|---|---|---|
| `kestrel.active_tls_handshakes` | `UpDownCounter<long>` | Active DirectTls handshakes using the existing Kestrel instrument and endpoint tags. |
| `kestrel.tls_handshake.duration` | `Histogram<double>` (seconds) | DirectTls handshake duration, protocol, endpoint, and `error.type` on failure. |
| `kestrel.direct_tls.connections_paused` | `UpDownCounter<long>` | DirectTls connections paused by input-pipe backpressure. |

## Logs — DirectTls transport logger

| Event | ID | Level | Description / payload |
|---|---:|---|---|
| `ConnectionPause` | 4 | Debug | Connection paused; connection ID. |
| `ConnectionResume` | 5 | Debug | Connection resumed; connection ID. |
| `ConnectionReadFin` | 6 | Debug | Peer sent FIN; connection ID. |
| `ConnectionWriteFin` | 7 | Debug | Transport sending FIN; connection ID and reason. |
| `ConnectionWriteRst` | 8 | Debug | Transport sending RST; connection ID and reason. |
| `ConnectionError` | 14 | Debug | Communication error; connection ID and exception. |
| `ConnectionReset` | 19 | Debug | Connection reset; connection ID. |
| `EpollConnectionRegistered` | 20 | Trace | Connection ID, pump ID, fd, and event mask. |
| `EpollInterestChanged` | 21 | Trace | Connection ID, pump ID, fd, previous mask, and new mask. |
| `EpollConnectionUnregistered` | 22 | Trace | Connection ID, pump ID, fd, and last event mask. |

## Counters — EventSource `Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls`

| Counter | Type | Description |
|---|---|---|
| `connections-owned` | `PollingCounter` | Current established connections owned across pumps. |
| `accepts` | `IncrementingPollingCounter` | Accepted connections per interval. |
| `connections-paused` | `PollingCounter` | Current connections paused by backpressure. |
| `bytes-read` | `IncrementingPollingCounter` | Plaintext bytes read per interval. |
| `bytes-written` | `IncrementingPollingCounter` | Plaintext bytes written per interval. |
| `epoll-waits` | `IncrementingPollingCounter` | Completed `epoll_wait` calls per interval. |
| `epoll-wakeups` | `IncrementingPollingCounter` | Nonempty `epoll_wait` results per interval. |
| `epoll-timeouts` | `IncrementingPollingCounter` | Empty `epoll_wait` results per interval. |
| `epoll-ready-events` | `IncrementingPollingCounter` | Ready event entries returned per interval. |
| `epoll-ready-batch-size` | `EventCounter` | Distribution of nonempty ready-event batch sizes. |

## Events — EventSource `Microsoft.AspNetCore.Server.Kestrel.Transport.DirectTls`

| Event | ID | Level | Payload |
|---|---:|---|---|
| `ConnectionAccepted` | 1 | Informational | Pump ID. |
| `PumpConnections` | 2 | Informational | Pump ID and current pump connection count. |
| `EpollConnectionRegistered` | 3 | Verbose | Pump ID, fd, connection ID, and event mask. |
| `EpollInterestChanged` | 4 | Verbose | Pump ID, fd, connection ID, previous mask, and new mask. |
| `EpollReady` | 5 | Verbose | Pump ID, fd, connection ID, and ready-event mask. |
| `EpollConnectionUnregistered` | 6 | Verbose | Pump ID, fd, connection ID, and last event mask. |

The lifecycle log IDs and event names match `SocketsLog`. Tests cover TLS handshake success and failure, backpressure transitions, connection lifecycle logs, EventSource payloads and counters, and real-host epoll activity.