### PR TITLE
Support HTTP HEAD requests in CacheView

### DIFF
--- a/src/Components/Endpoints/src/CacheView/CacheViewService.cs
+++ b/src/Components/Endpoints/src/CacheView/CacheViewService.cs
@@ -78,9 +78,12 @@ internal sealed partial class CacheViewService : IDisposable
 
     public async Task<CacheViewRenderState?> PrepareAsync(CacheView cacheView, HttpContext httpContext)
     {
-        // Skip cache if method is not GET, caching is disabled, or the cacheView is rendered inside a
-        // streaming render context (not yet supported).
-        if (!cacheView.Enabled || !HttpMethods.IsGet(httpContext.Request.Method) || cacheView.IsInStreamingContext)
+        // Skip cache if the method is not GET or HEAD, caching is disabled, or the cacheView is rendered
+        // inside a streaming render context (not yet supported). HEAD shares GET's cache entries because it
+        // renders the identical representation; the response body is dropped by the server below the
+        // capturing writer, so a HEAD-populated entry is identical to a GET-populated one.
+        var method = httpContext.Request.Method;
+        if (!cacheView.Enabled || !(HttpMethods.IsGet(method) || HttpMethods.IsHead(method)) || cacheView.IsInStreamingContext)
         {
             return null;
         }

--- a/src/Components/Endpoints/src/CacheView/CacheViewService.cs
+++ b/src/Components/Endpoints/src/CacheView/CacheViewService.cs
@@ -73,17 +73,18 @@ internal sealed partial class CacheViewService : IDisposable
         return varyByMatches;
     }
 
-   private static string FormatVaryByFlags(CacheVaryBy varyBy)
+    private static string FormatVaryByFlags(CacheVaryBy varyBy)
         => "CacheVaryBy." + varyBy.ToString().Replace(", ", " | CacheVaryBy.");
+
+    // HEAD shares GET's cache entries: it renders the identical representation, and the server drops the
+    // response body below the capturing writer, so a HEAD-populated entry matches a GET-populated one.
+    private static bool IsCacheableRequestMethod(string method)
+        => HttpMethods.IsGet(method) || HttpMethods.IsHead(method);
 
     public async Task<CacheViewRenderState?> PrepareAsync(CacheView cacheView, HttpContext httpContext)
     {
-        // Skip cache if the method is not GET or HEAD, caching is disabled, or the cacheView is rendered
-        // inside a streaming render context (not yet supported). HEAD shares GET's cache entries because it
-        // renders the identical representation; the response body is dropped by the server below the
-        // capturing writer, so a HEAD-populated entry is identical to a GET-populated one.
-        var method = httpContext.Request.Method;
-        if (!cacheView.Enabled || !(HttpMethods.IsGet(method) || HttpMethods.IsHead(method)) || cacheView.IsInStreamingContext)
+        // Rendering inside a streaming render context is not supported yet.
+        if (!cacheView.Enabled || !IsCacheableRequestMethod(httpContext.Request.Method) || cacheView.IsInStreamingContext)
         {
             return null;
         }

--- a/src/Components/test/E2ETest/Tests/CacheViewTestBase.cs
+++ b/src/Components/test/E2ETest/Tests/CacheViewTestBase.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net.Http;
 using Components.TestServer.RazorComponents;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
@@ -185,5 +186,50 @@ public abstract class CacheViewTestBase : ServerTestBase<BasicTestAppServerSiteF
         Navigate(TestUrl("cache-component"));
         Browser.Equal(staticGuid, () => Browser.FindElement(By.Id("test-8")).FindElement(By.CssSelector(".cached-static")).Text);
         Browser.NotEqual(streamingGuid, () => Browser.FindElement(By.Id("test-8")).FindElement(By.CssSelector(".streaming-live-cached")).Text);
+    }
+
+    [Fact]
+    public async Task CacheViewServesCachedContentToHeadRequests()
+    {
+        var url = TestUrl("cache-component-head");
+
+        Navigate(url);
+        Navigate(url);
+        var cachedGuid = Browser.FindElement(By.Id("test-head")).FindElement(By.CssSelector(".head-cached-guid")).Text;
+        Browser.Equal("1", () => Browser.FindElement(By.Id("head-render-count")).Text);
+
+        await IssueHeadRequestsAsync(url, count: 3);
+
+        // Each HEAD must be served from the cache, so neither the cached content nor the render count changes.
+        Navigate(url);
+        Browser.Equal(cachedGuid, () => Browser.FindElement(By.Id("test-head")).FindElement(By.CssSelector(".head-cached-guid")).Text);
+        Browser.Equal("1", () => Browser.FindElement(By.Id("head-render-count")).Text);
+    }
+
+    [Fact]
+    public async Task CacheViewPopulatedByHeadRequest_IsServedToLaterGetRequest()
+    {
+        var url = TestUrl("cache-component-head");
+
+        await IssueHeadRequestsAsync(url, count: 1);
+
+        Navigate(url);
+        var cachedGuid = Browser.FindElement(By.Id("test-head")).FindElement(By.CssSelector(".head-cached-guid")).Text;
+
+        Navigate(url);
+        Browser.Equal("1", () => Browser.FindElement(By.Id("head-render-count")).Text);
+        Browser.Equal(cachedGuid, () => Browser.FindElement(By.Id("test-head")).FindElement(By.CssSelector(".head-cached-guid")).Text);
+    }
+
+    private async Task IssueHeadRequestsAsync(string relativeUrl, int count)
+    {
+        using var httpClient = new HttpClient();
+        var requestUri = new Uri(_serverFixture.RootUri, relativeUrl);
+
+        for (var i = 0; i < count; i++)
+        {
+            using var response = await httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Head, requestUri));
+            response.EnsureSuccessStatusCode();
+        }
     }
 }

--- a/src/Components/test/E2ETest/Tests/CacheViewTestBase.cs
+++ b/src/Components/test/E2ETest/Tests/CacheViewTestBase.cs
@@ -226,10 +226,11 @@ public abstract class CacheViewTestBase : ServerTestBase<BasicTestAppServerSiteF
         using var httpClient = new HttpClient();
         var requestUri = new Uri(_serverFixture.RootUri, relativeUrl);
 
-        for (var i = 0; i < count; i++)
-        {
-            using var response = await httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Head, requestUri));
-            response.EnsureSuccessStatusCode();
-        }
+for (var i = 0; i < count; i++)
+{
+    using var request = new HttpRequestMessage(HttpMethod.Head, requestUri);
+    using var response = await httpClient.SendAsync(request);
+    response.EnsureSuccessStatusCode();
+}
     }
 }

--- a/src/Components/test/E2ETest/Tests/CacheViewTestBase.cs
+++ b/src/Components/test/E2ETest/Tests/CacheViewTestBase.cs
@@ -226,11 +226,11 @@ public abstract class CacheViewTestBase : ServerTestBase<BasicTestAppServerSiteF
         using var httpClient = new HttpClient();
         var requestUri = new Uri(_serverFixture.RootUri, relativeUrl);
 
-for (var i = 0; i < count; i++)
-{
-    using var request = new HttpRequestMessage(HttpMethod.Head, requestUri);
-    using var response = await httpClient.SendAsync(request);
-    response.EnsureSuccessStatusCode();
-}
+        for (var i = 0; i < count; i++)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Head, requestUri);
+            using var response = await httpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+        }
     }
 }

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/CacheViewTest/CacheViewHeadPage.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/CacheViewTest/CacheViewHeadPage.razor
@@ -1,0 +1,26 @@
+@page "/cache-component-head"
+@using System.Collections.Concurrent
+
+<h3>CacheView HEAD</h3>
+
+<div id="test-head">
+    <CacheView ExpiresAfter="TimeSpan.FromHours(1)" VaryByQuery="testId">
+        <p class="head-cached-guid">@RecordFragmentRender()</p>
+    </CacheView>
+    <p id="head-render-count">@FragmentRenderCount</p>
+</div>
+
+@code
+{
+    private static readonly ConcurrentDictionary<string, int> FragmentRenderCounts = new();
+
+    [SupplyParameterFromQuery] private string? TestId { get; set; }
+
+    private int FragmentRenderCount => FragmentRenderCounts.TryGetValue(TestId ?? "", out var count) ? count : 0;
+
+    private string RecordFragmentRender()
+    {
+        FragmentRenderCounts.AddOrUpdate(TestId ?? "", 1, static (_, count) => count + 1);
+        return Guid.NewGuid().ToString("N");
+    }
+}


### PR DESCRIPTION
# Support HTTP HEAD requests in CacheView

## Description

`CacheViewService.PrepareAsync` skipped the cache for any request method other than GET, so `<CacheView>` never served or populated cache entries for HTTP HEAD requests. Razor component endpoints have advertised HEAD since #64613, and HEAD otherwise runs the identical rendering path as GET, so this was the only place in the endpoint pipeline where the two deliberately diverged. The practical effect was that every HEAD request paid the full render cost, which is backwards from the search-engine-crawler scenario that motivated adding HEAD support in the first place.

HEAD now shares GET's cache entries, under the same cache key, in both directions: a HEAD request can be served from an entry created by a GET, and an entry created by a HEAD is served to later GET requests.

### Why sharing the cache key is safe

- HEAD renders the identical representation as GET. Nothing in the framework rendering path branches on the request method, so the captured fragment is the same either way.
- Body suppression happens in Kestrel's `HttpProtocol.CanWriteResponseBody()`, which sits well below the `CacheViewTextWriter` → `BufferedTextWriter` → `HttpResponseStreamWriter` chain. Every character still reaches the capture writer, so a HEAD-populated entry is identical to a GET-populated one.
- POST continues to bypass `CacheView`. Unlike HEAD, a POST reads the request body, validates antiforgery, and dispatches form handlers, so its render is request-specific and must not be cached or replayed.

A separate cache key for HEAD was considered and rejected: it would halve the hit rate for no benefit, since RFC 9110 §9.3.1 explicitly permits a cached GET response to satisfy a subsequent HEAD request.

## Changes

- `CacheViewService.PrepareAsync` now admits HEAD alongside GET when deciding whether caching is active. The cache key is unchanged, so GET and HEAD resolve to the same entry.
- Added two E2E tests to `CacheViewTestBase`, which run against both the memory-cache and HybridCache stores: repeated HEAD requests must neither re-render the cached fragment nor change its content, and an entry populated by a HEAD request must be reused by a later GET.
- Added the `CacheViewHeadPage` test asset (`/cache-component-head`), which exposes a per-`testId` fragment render counter so the effect of a HEAD request is observable on a subsequent GET.

## Testing

Coverage is end-to-end, against the real server stack, because the behavior being fixed is an HTTP-level concern: whether a HEAD request reaches the cache, and whether the entry it produces is shared with GET. The render counter on the test page is what makes a cache hit observable, since a HEAD response itself has no body to assert on.

## Breaking changes

None observable by clients. A HEAD response carries no content at all (RFC 9110 §9.3.2: HEAD is "identical to GET except that the server MUST NOT send content in the response"), so no caller can see a difference in returned markup. Serving a cached GET representation to a HEAD request is explicitly sanctioned by RFC 9110 §9.3.1: "The response to a GET request is cacheable; a cache MAY use it to satisfy subsequent GET and HEAD requests."

The direction worth reviewer attention is the reverse one, which a conventional HTTP cache cannot do at all, because a HEAD response has no body to store: `CacheView` captures the rendered fragment before the server drops it, so a HEAD request can now populate an entry that later GET requests are served from. Nothing in the framework rendering path branches on the request method, so that fragment is identical to what a GET would have produced. The only way to get a divergence is application code inside a `CacheView` that explicitly inspects `HttpContext.Request.Method`. Such a component should be annotated `[CacheBehavior(CacheBehavior.Rerender)]` so it stays live and re-renders on every request, which is already the requirement for any component with per-request output.

Fixes #68916