### PR TITLE
CacheView optimizations

### DIFF
--- a/src/Components/Endpoints/src/CacheView/CacheViewKeyResolver.cs
+++ b/src/Components/Endpoints/src/CacheView/CacheViewKeyResolver.cs
@@ -1,13 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Globalization;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
-using Microsoft.AspNetCore.Components.HotReload;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Primitives;
 
@@ -15,16 +13,6 @@ namespace Microsoft.AspNetCore.Components.Endpoints;
 
 internal static class CacheViewKeyResolver
 {
-    private static readonly ConcurrentDictionary<string, string[]> _sortedNamesByRawValue = new(StringComparer.Ordinal);
-
-    static CacheViewKeyResolver()
-    {
-        if (HotReloadManager.IsSupported)
-        {
-            HotReloadManager.Default.OnDeltaApplied += _sortedNamesByRawValue.Clear;
-        }
-    }
-
     internal static string ComputeKey(CacheView cacheView, HttpContext httpContext)
     {
         using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
@@ -162,22 +150,21 @@ internal static class CacheViewKeyResolver
         AppendString(hash, ")");
     }
 
-    private static string[] CollectSortedNames(string separatedValues)
-        => _sortedNamesByRawValue.GetOrAdd(separatedValues, static raw =>
+    private static List<string> CollectSortedNames(string separatedValues)
+    {
+        var names = new List<string>();
+        foreach (var segment in separatedValues.AsSpan().Split(','))
         {
-            var names = new List<string>();
-            foreach (var segment in raw.AsSpan().Split(','))
+            var name = separatedValues.AsSpan()[segment].Trim();
+            if (!name.IsEmpty)
             {
-                var name = raw.AsSpan()[segment].Trim();
-                if (!name.IsEmpty)
-                {
-                    names.Add(name.ToString());
-                }
+                names.Add(name.ToString());
             }
+        }
 
-            names.Sort(StringComparer.Ordinal);
-            return names.ToArray();
-        });
+        names.Sort(StringComparer.Ordinal);
+        return names;
+    }
 
     private static void AppendAllQueryValues(IncrementalHash hash, HttpRequest request)
     {


### PR DESCRIPTION
# CacheView optimizations

## Description

In `CacheView` component we use static dictionary that caches results of the sorting of parameters which we use in `VaryBy` parameter optimization. We do not need it and it bring unnecessary complexity for the calculation of CacheKey, because one `VaryBy` parameter usually have 1 to 3 values and sorting those doesn't require caching. 
