### PR TITLE
[Blazor] Add E2E testing skill

### DIFF
--- a/.github/skills/blazor-e2e-testing/SKILL.md
+++ b/.github/skills/blazor-e2e-testing/SKILL.md
@@ -1,55 +1,20 @@
 ---
 name: blazor-e2e-testing
 description: >-
-  Build, run, and debug Blazor end-to-end tests in dotnet/aspnetcore. USE FOR validating Components changes with targeted Selenium E2E tests, preparing test assets after C# or JavaScript changes, reproducing a failing Blazor E2E test interactively with Components.TestServer and Playwright, and distinguishing quarantined tests from new failures. DO NOT USE FOR running the full Components E2E suite locally, validating a feature in a temporary sample before permanent test coverage (use validate-blazor-feature), unit tests, or non-Components areas.
+  Run a bounded selection of Blazor end-to-end tests in dotnet/aspnetcore. USE FOR validating a focused Components change with one test or class, and validating a major Blazor change by splitting affected Selenium E2E tests into small logical groups and running them sequentially. DO NOT USE FOR running the full Components E2E suite locally, repository setup or build troubleshooting, temporary sample validation (use validate-blazor-feature), unit tests, or non-Components areas.
 ---
 
-# Test Blazor end to end
+# Run bounded Blazor E2E test groups
 
-Run the smallest targeted Selenium E2E set that exercises the changed behavior. Never run the full Components E2E suite locally; full coverage belongs in CI.
+`src/Components/AGENTS.md` is the source of truth for repository setup, asset freshness, build commands, interactive debugging, and test policy. Follow its current instructions before using this workflow; if this skill differs from that file, `AGENTS.md` wins.
 
-## 1. Define the test scope
+Determine only **which tests to run and in what order**. Keep local validation bounded; full coverage belongs in CI.
 
-Identify the existing test class and method nearest to the behavior. Tests live in `src/Components/test/E2ETest`; reusable scenarios and hosts live in `src/Components/test/testassets`.
+## Focused changes
 
-For a behavior spanning renderers or runtimes, state the required cells before running tests: Server/WebAssembly/Auto, global/per-page interactivity, initial activation/enhanced navigation, prerendered/non-prerendered, and interactive `Router` present/absent. Run only the cells required by the change and report broader compatibility separately.
+For a localized change, select the nearest existing test method. Include additional methods only when they exercise another affected render mode, runtime, or lifecycle boundary.
 
-For a new feature or behavioral fix, use the `validate-blazor-feature` skill first to exercise the scenario in a canonical sample. Add permanent E2E coverage only after the sample behavior works in a browser.
-
-## 2. Prepare the repository and assets
-
-Activate the repository SDK before any `dotnet` command:
-
-```powershell
-. ./activate.ps1
-```
-
-In a fresh worktree, initialize submodules before building:
-
-```powershell
-git submodule update --init --recursive
-```
-
-If JavaScript or TypeScript under `src/Components/Web.JS` changed, rebuild the Debug bundle from that directory. Do not use `build:production` on its own because the E2E build consumes the Debug bundle.
-
-```powershell
-Push-Location src/Components/Web.JS
-npm run build
-Pop-Location
-```
-
-Build the E2E project and all referenced test apps. Do not use `--no-dependencies` for this preparation step because stale test-app outputs can make a test pass or fail for the wrong reason.
-
-```powershell
-dotnet build src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj `
-    --no-restore -v:q -p:UseIisNativeAssets=false
-```
-
-If restore inputs changed, run `.\restore.cmd` first. If the build reports unresolved MessagePack types, confirm the submodules were initialized rather than retrying with different build flags.
-
-## 3. Run only the targeted tests
-
-After the dependency-aware build succeeds, use `--no-build` for the focused loop:
+After completing the dependency-aware E2E build from `AGENTS.md`, run a method:
 
 ```powershell
 dotnet test src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj `
@@ -58,38 +23,38 @@ dotnet test src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests
     -l "console;verbosity=minimal"
 ```
 
-Use a class filter when several methods jointly cover the behavior.
+Use the containing class instead when its methods jointly cover the affected behavior:
 
-For a behavioral fix, establish the red/green result at the faithful boundary: confirm the targeted test fails for the expected reason without the fix and passes with it. A passing test that bypasses the browser or runtime mechanism producing the disputed precondition is not evidence for the behavior.
+```powershell
+dotnet test src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj `
+    --no-build `
+    --filter "FullyQualifiedName~Namespace.TestClass" `
+    -l "console;verbosity=minimal"
+```
 
-## 4. Debug a failure interactively
+## Major changes
 
-Do not repeatedly rerun a failing E2E test. After two failures at the same boundary, isolate it with the real test server and browser:
+Split the affected tests into logical groups that each have one reason to fail, such as:
 
-1. Read the failing test and its fixture to identify the host, route, render mode, and interaction.
-2. Start `Components.TestServer` manually:
+1. A small canary group covering the affected startup paths and render modes.
+2. Feature-area groups covering the changed behavior in depth.
+3. Cross-cutting groups covering affected navigation, prerendering, reconnection, or state-restoration boundaries.
 
-   ```powershell
-   dotnet run --project src/Components/test/testassets/Components.TestServer/Components.TestServer.csproj `
-       --no-build -p:UseIisNativeAssets=false
-   ```
+Construct each group by OR-combining the fully qualified names of relevant existing methods or classes:
 
-3. Open `http://127.0.0.1:5019/subdir` and select the scenario used by the test. If the fixture launches a different host, use the URL and route from that fixture instead.
-4. Drive the same interaction with the `playwright-browser_*` tools:
-   - Navigate to the scenario and wait for its expected content.
-   - Take a snapshot before and after the interaction; rendered markup alone does not prove interactivity.
-   - Inspect current-page console errors and network requests for failed `_framework` assets.
-   - Confirm the material effect at the user-visible boundary instead of checking only an internal callback or flag.
-5. Stop only the server process you started, using its exact PID. Do not terminate all `dotnet`, browser, `testhost`, or WebDriver processes by name.
+```powershell
+dotnet test src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj `
+    --no-build `
+    --filter "FullyQualifiedName~FirstTestClass|FullyQualifiedName~SecondTestClass" `
+    -l "console;verbosity=minimal"
+```
 
-After changing C# or test assets, rebuild the E2E project dependency-aware. After changing JavaScript, rebuild `src/Components/Web.JS` first. Restart the server, reproduce the scenario in Playwright, then rerun the exact test with `--no-build`.
+Complete the same dependency-aware E2E build from `AGENTS.md` before running the first group.
 
-## 5. Handle quarantined tests correctly
+Run groups sequentially, from the smallest canary group to the broader feature groups. Stop at the first failing group, narrow it to the failing method, and follow the manual test-server debugging workflow in `AGENTS.md`. Resume with that group only after the focused failure passes.
 
-A failure is a known quarantine only when the test has `[QuarantinedTest("issue-url")]`. Read the linked issue and record that the quarantined test failed. Do not classify `WebDriverTimeoutException`, `StaleElementReferenceException`, or another Selenium exception as a flake based only on exception type; those exceptions can expose real regressions.
-
-An unquarantined failure blocks the targeted validation until it is explained or fixed. If faithful reproduction is impractical, state the exercised boundary and limitation instead of calling the behavior verified.
+Choose groups from the actual impact of the change; do not maintain a fixed list that drifts as tests move. A group must remain small enough that its failure identifies one feature or lifecycle boundary.
 
 ## Completion criteria
 
-The required render-mode and lifecycle cells are explicit, the dependency-aware E2E build succeeds, and every targeted test passes. For a new test or an interactively investigated failure, the browser reproduction must also show the expected user-visible behavior with no relevant console or network errors. Stop every process started manually.
+The selected tests cover every affected behavior boundary, each filter matches the intended nonzero set of tests, and every planned group passes independently.

--- a/.github/skills/blazor-e2e-testing/SKILL.md
+++ b/.github/skills/blazor-e2e-testing/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: blazor-e2e-testing
+description: >-
+  Build, run, and debug Blazor end-to-end tests in dotnet/aspnetcore. USE FOR validating Components changes with targeted Selenium E2E tests, preparing test assets after C# or JavaScript changes, reproducing a failing Blazor E2E test interactively with Components.TestServer and Playwright, and distinguishing quarantined tests from new failures. DO NOT USE FOR running the full Components E2E suite locally, validating a feature in a temporary sample before permanent test coverage (use validate-blazor-feature), unit tests, or non-Components areas.
+---
+
+# Test Blazor end to end
+
+Run the smallest targeted Selenium E2E set that exercises the changed behavior. Never run the full Components E2E suite locally; full coverage belongs in CI.
+
+## 1. Define the test scope
+
+Identify the existing test class and method nearest to the behavior. Tests live in `src/Components/test/E2ETest`; reusable scenarios and hosts live in `src/Components/test/testassets`.
+
+For a behavior spanning renderers or runtimes, state the required cells before running tests: Server/WebAssembly/Auto, global/per-page interactivity, initial activation/enhanced navigation, prerendered/non-prerendered, and interactive `Router` present/absent. Run only the cells required by the change and report broader compatibility separately.
+
+For a new feature or behavioral fix, use the `validate-blazor-feature` skill first to exercise the scenario in a canonical sample. Add permanent E2E coverage only after the sample behavior works in a browser.
+
+## 2. Prepare the repository and assets
+
+Activate the repository SDK before any `dotnet` command:
+
+```powershell
+. ./activate.ps1
+```
+
+In a fresh worktree, initialize submodules before building:
+
+```powershell
+git submodule update --init --recursive
+```
+
+If JavaScript or TypeScript under `src/Components/Web.JS` changed, rebuild the Debug bundle from that directory. Do not use `build:production` on its own because the E2E build consumes the Debug bundle.
+
+```powershell
+Push-Location src/Components/Web.JS
+npm run build
+Pop-Location
+```
+
+Build the E2E project and all referenced test apps. Do not use `--no-dependencies` for this preparation step because stale test-app outputs can make a test pass or fail for the wrong reason.
+
+```powershell
+dotnet build src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj `
+    --no-restore -v:q -p:UseIisNativeAssets=false
+```
+
+If restore inputs changed, run `.\restore.cmd` first. If the build reports unresolved MessagePack types, confirm the submodules were initialized rather than retrying with different build flags.
+
+## 3. Run only the targeted tests
+
+After the dependency-aware build succeeds, use `--no-build` for the focused loop:
+
+```powershell
+dotnet test src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj `
+    --no-build `
+    --filter "FullyQualifiedName~Namespace.TestClass.TestMethod" `
+    -l "console;verbosity=minimal"
+```
+
+Use a class filter when several methods jointly cover the behavior.
+
+For a behavioral fix, establish the red/green result at the faithful boundary: confirm the targeted test fails for the expected reason without the fix and passes with it. A passing test that bypasses the browser or runtime mechanism producing the disputed precondition is not evidence for the behavior.
+
+## 4. Debug a failure interactively
+
+Do not repeatedly rerun a failing E2E test. After two failures at the same boundary, isolate it with the real test server and browser:
+
+1. Read the failing test and its fixture to identify the host, route, render mode, and interaction.
+2. Start `Components.TestServer` manually:
+
+   ```powershell
+   dotnet run --project src/Components/test/testassets/Components.TestServer/Components.TestServer.csproj `
+       --no-build -p:UseIisNativeAssets=false
+   ```
+
+3. Open `http://127.0.0.1:5019/subdir` and select the scenario used by the test. If the fixture launches a different host, use the URL and route from that fixture instead.
+4. Drive the same interaction with the `playwright-browser_*` tools:
+   - Navigate to the scenario and wait for its expected content.
+   - Take a snapshot before and after the interaction; rendered markup alone does not prove interactivity.
+   - Inspect current-page console errors and network requests for failed `_framework` assets.
+   - Confirm the material effect at the user-visible boundary instead of checking only an internal callback or flag.
+5. Stop only the server process you started, using its exact PID. Do not terminate all `dotnet`, browser, `testhost`, or WebDriver processes by name.
+
+After changing C# or test assets, rebuild the E2E project dependency-aware. After changing JavaScript, rebuild `src/Components/Web.JS` first. Restart the server, reproduce the scenario in Playwright, then rerun the exact test with `--no-build`.
+
+## 5. Handle quarantined tests correctly
+
+A failure is a known quarantine only when the test has `[QuarantinedTest("issue-url")]`. Read the linked issue and record that the quarantined test failed. Do not classify `WebDriverTimeoutException`, `StaleElementReferenceException`, or another Selenium exception as a flake based only on exception type; those exceptions can expose real regressions.
+
+An unquarantined failure blocks the targeted validation until it is explained or fixed. If faithful reproduction is impractical, state the exercised boundary and limitation instead of calling the behavior verified.
+
+## Completion criteria
+
+The required render-mode and lifecycle cells are explicit, the dependency-aware E2E build succeeds, and every targeted test passes. For a new test or an interactively investigated failure, the browser reproduction must also show the expected user-visible behavior with no relevant console or network errors. Stop every process started manually.

--- a/.github/skills/blazor-e2e-testing/SKILL.md
+++ b/.github/skills/blazor-e2e-testing/SKILL.md
@@ -6,55 +6,6 @@ description: >-
 
 # Run bounded Blazor E2E test groups
 
-`src/Components/AGENTS.md` is the source of truth for repository setup, asset freshness, build commands, interactive debugging, and test policy. Follow its current instructions before using this workflow; if this skill differs from that file, `AGENTS.md` wins.
+For permanent Selenium E2E coverage, follow [Bounded local E2E validation](../../../src/Components/AGENTS.md#bounded-local-e2e-validation). That section is the source of truth for focused method and class runs, logical groups for major changes, execution order, failure handling, and completion criteria.
 
-Determine only **which tests to run and in what order**. Keep local validation bounded; full coverage belongs in CI.
-
-## Focused changes
-
-For a localized change, select the nearest existing test method. Include additional methods only when they exercise another affected render mode, runtime, or lifecycle boundary.
-
-After completing the dependency-aware E2E build from `AGENTS.md`, run a method:
-
-```powershell
-dotnet test src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj `
-    --no-build `
-    --filter "FullyQualifiedName~Namespace.TestClass.TestMethod" `
-    -l "console;verbosity=minimal"
-```
-
-Use the containing class instead when its methods jointly cover the affected behavior:
-
-```powershell
-dotnet test src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj `
-    --no-build `
-    --filter "FullyQualifiedName~Namespace.TestClass" `
-    -l "console;verbosity=minimal"
-```
-
-## Major changes
-
-Split the affected tests into logical groups that each have one reason to fail, such as:
-
-1. A small canary group covering the affected startup paths and render modes.
-2. Feature-area groups covering the changed behavior in depth.
-3. Cross-cutting groups covering affected navigation, prerendering, reconnection, or state-restoration boundaries.
-
-Construct each group by OR-combining the fully qualified names of relevant existing methods or classes:
-
-```powershell
-dotnet test src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj `
-    --no-build `
-    --filter "FullyQualifiedName~FirstTestClass|FullyQualifiedName~SecondTestClass" `
-    -l "console;verbosity=minimal"
-```
-
-Complete the same dependency-aware E2E build from `AGENTS.md` before running the first group.
-
-Run groups sequentially, from the smallest canary group to the broader feature groups. Stop at the first failing group, narrow it to the failing method, and follow the manual test-server debugging workflow in `AGENTS.md`. Resume with that group only after the focused failure passes.
-
-Choose groups from the actual impact of the change; do not maintain a fixed list that drifts as tests move. A group must remain small enough that its failure identifies one feature or lifecycle boundary.
-
-## Completion criteria
-
-The selected tests cover every affected behavior boundary, each filter matches the intended nonzero set of tests, and every planned group passes independently.
+For temporary sample and browser validation before permanent coverage, use the [`validate-blazor-feature`](../validate-blazor-feature/SKILL.md) skill instead.

--- a/src/Components/AGENTS.md
+++ b/src/Components/AGENTS.md
@@ -283,14 +283,22 @@ For telemetry or distributed-state behavior, assert the real consumer-visible ou
 
 ### Running E2E Tests
 
-The E2E tests use Selenium. To build and run tests:
+The E2E tests use Selenium. Before the first `dotnet` command, complete the initial setup in the Efficient Build Strategy above and activate the repository SDK from the repository root:
 
 ```bash
-# Build the E2E test project and its dependencies
-dotnet build src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj --no-restore -v:q -p:UseIisNativeAssets=false
+# Linux or macOS
+source activate.sh
+```
 
-# After the build succeeds, run a specific test
-dotnet test src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj --no-build --filter "FullyQualifiedName~TestName"
+```powershell
+# Windows
+. ./activate.ps1
+```
+
+Build the E2E test project and its dependencies:
+
+```shell
+dotnet build src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj --no-restore -v:q -p:UseIisNativeAssets=false
 ```
 
 `-p:UseIisNativeAssets=false` is required here: the E2E project transitively references IIS projects that otherwise fail because ANCM has not been built. If this build instead fails on MessagePack types, your submodules are not initialized - see step 1 of the Efficient Build Strategy.
@@ -300,3 +308,33 @@ For the first E2E run in a fresh worktree, or after relevant build, configuratio
 **Important**: Never run all E2E tests locally as that is extremely costly. Full test runs should only happen on CI machines.
 
 If a test is failing, it's best to run the server manually and navigate to the test to investigate. The test output won't be very useful for debugging.
+
+#### Bounded local E2E validation
+
+For a localized change, select the nearest existing test method. Include more methods only when they exercise another affected render mode, runtime, or lifecycle boundary.
+
+Use an exact fully qualified name for one method:
+
+```shell
+dotnet test src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj --no-build --filter "FullyQualifiedName=Namespace.TestClass.TestMethod" -l "console;verbosity=normal"
+```
+
+To run a class, include the separator after its fully qualified name so similarly named classes do not match:
+
+```shell
+dotnet test src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj --no-build --filter "FullyQualifiedName~Namespace.TestClass." -l "console;verbosity=normal"
+```
+
+On the first execution of each filter, inspect the named test results and summary. Confirm that a nonzero number ran and that every executed test was intended. A successful command that ran no tests is not validation.
+
+For a major change, split the affected tests into small logical groups. Start with a canary group for the affected startup paths and render modes, follow with feature-area groups, then add groups for affected cross-cutting boundaries such as navigation, prerendering, reconnection, or state restoration. Each group should have one reason to fail and remain small enough that a failure identifies one feature or lifecycle boundary.
+
+Combine exact methods and class prefixes with `|`:
+
+```shell
+dotnet test src/Components/test/E2ETest/Microsoft.AspNetCore.Components.E2ETests.csproj --no-build --filter "FullyQualifiedName=Namespace.FirstTestClass.TestMethod|FullyQualifiedName~Namespace.SecondTestClass." -l "console;verbosity=normal"
+```
+
+Run groups sequentially from the smallest canary to the broader feature groups. Stop at the first failure, narrow it to the failing method, and use the manual test-server workflow above before resuming. After the final source or test-asset edit, rerun every planned bounded group in order so all passing results come from the final revision.
+
+Validation is complete when the selected tests cover every affected behavior boundary, each filter selects only the intended nonzero set, and every planned group passes on the final revision.


### PR DESCRIPTION
## Summary

- extract the `blazor-e2e-testing` developer skill from the larger Blazor ES-module prototype (historical commit `7528e5d735`)
- retain the skill's semantic routing between permanent Selenium coverage and temporary sample/browser validation
- make `src/Components/AGENTS.md` the single source of truth for bounded local E2E selection and ordering
- document shell-safe exact method filters, class-boundary filters, grouped runs for major changes, executed-test verification, and final-revision replay

This PR contains developer tooling documentation only. It does not change framework/runtime behavior, product code, tests, samples, pipelines, or package manifests.

## Validation

- verified skill frontmatter and both relative documentation links
- verified the diff contains only `.github/skills/blazor-e2e-testing/SKILL.md` and `src/Components/AGENTS.md`
- checked that all test commands are single-line and shell-safe
- checked that method filters are exact, class filters include a boundary separator, and grouped filters combine only bounded selections

The repo-local .NET SDK is not installed in this fresh worktree, so no product build or test was run for this documentation-only change.