### PR TITLE
[Blazor] Generalize host startup and initialization

### DIFF
--- a/src/Components/Components/src/Hosting/IHostInitializer.cs
+++ b/src/Components/Components/src/Hosting/IHostInitializer.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+/// <summary>
+/// Initializes services for a component host.
+/// </summary>
+public interface IHostInitializer
+{
+    /// <summary>
+    /// Gets the order in which the initializer executes.
+    /// </summary>
+    /// <remarks>
+    /// Initializers with lower values execute first. Initializers with the same value execute in registration order.
+    /// </remarks>
+    int Order => 0;
+
+    /// <summary>
+    /// Gets a value that indicates whether the initializer requires JavaScript interop.
+    /// </summary>
+    bool RequiresJSInterop => false;
+
+    /// <summary>
+    /// Initializes services for the component host.
+    /// </summary>
+    /// <param name="cancellationToken">A token that can cancel initialization.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous initialization operation.</returns>
+    Task InitializeAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Components/Components/src/Hosting/IHostInitializer.cs
+++ b/src/Components/Components/src/Hosting/IHostInitializer.cs
@@ -6,6 +6,10 @@ namespace Microsoft.AspNetCore.Components.Hosting;
 /// <summary>
 /// Initializes services for a component host.
 /// </summary>
+/// <remarks>
+/// <para>Implementations must be registered as singleton services.</para>
+/// <para>Initializers execute once for each host activation.</para>
+/// </remarks>
 public interface IHostInitializer
 {
     /// <summary>
@@ -19,12 +23,23 @@ public interface IHostInitializer
     /// <summary>
     /// Gets a value that indicates whether the initializer requires JavaScript interop.
     /// </summary>
+    /// <remarks>
+    /// Static server-side rendering skips initializers that require JavaScript interop. Interactive server-side
+    /// rendering defers the first such initializer and the remaining ordered initializers until JavaScript interop
+    /// is available.
+    /// </remarks>
     bool RequiresJSInterop => false;
 
     /// <summary>
     /// Initializes services for the component host.
     /// </summary>
+    /// <param name="services">
+    /// The service provider for the active request scope, circuit scope, or WebAssembly application scope.
+    /// </param>
     /// <param name="cancellationToken">A token that can cancel initialization.</param>
     /// <returns>A <see cref="Task"/> that represents the asynchronous initialization operation.</returns>
-    Task InitializeAsync(CancellationToken cancellationToken = default);
+    /// <remarks>
+    /// The <paramref name="services"/> provider and scoped services resolved from it must not be retained after this method completes.
+    /// </remarks>
+    Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default);
 }

--- a/src/Components/Components/src/Hosting/IHostInitializer.cs
+++ b/src/Components/Components/src/Hosting/IHostInitializer.cs
@@ -7,8 +7,11 @@ namespace Microsoft.AspNetCore.Components.Hosting;
 /// Initializes services for a component host.
 /// </summary>
 /// <remarks>
-/// <para>Implementations must be registered as singleton services.</para>
-/// <para>Initializers execute once for each host activation.</para>
+/// <para>Implementations must be registered as singleton services. Initializers execute once for each host activation.</para>
+/// <para>
+/// The service provider passed to each method represents the active request, circuit, or WebAssembly application scope.
+/// The provider and services resolved from it must not be retained after the method completes.
+/// </para>
 /// </remarks>
 public interface IHostInitializer
 {
@@ -16,22 +19,12 @@ public interface IHostInitializer
     /// Gets the order in which the initializer executes.
     /// </summary>
     /// <remarks>
-    /// Initializers with lower values execute first. Initializers with the same value execute in registration order.
+    /// Initializers with lower values execute first. Order values must be unique within a host.
     /// </remarks>
     int Order => 0;
 
     /// <summary>
-    /// Gets a value that indicates whether the initializer requires JavaScript interop.
-    /// </summary>
-    /// <remarks>
-    /// Static server-side rendering skips initializers that require JavaScript interop. Interactive server-side
-    /// rendering defers the first such initializer and the remaining ordered initializers until JavaScript interop
-    /// is available.
-    /// </remarks>
-    bool RequiresJSInterop => false;
-
-    /// <summary>
-    /// Initializes services for the component host.
+    /// Initializes services during the host phase.
     /// </summary>
     /// <param name="services">
     /// The service provider for the active request scope, circuit scope, or WebAssembly application scope.
@@ -39,7 +32,22 @@ public interface IHostInitializer
     /// <param name="cancellationToken">A token that can cancel initialization.</param>
     /// <returns>A <see cref="Task"/> that represents the asynchronous initialization operation.</returns>
     /// <remarks>
-    /// The <paramref name="services"/> provider and scoped services resolved from it must not be retained after this method completes.
+    /// The host phase runs before browser initialization and does not require an interactive browser.
     /// </remarks>
-    Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default);
+    Task InitializeHostAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    /// <summary>
+    /// Initializes services during the browser phase.
+    /// </summary>
+    /// <param name="services">
+    /// The service provider for the active request scope, circuit scope, or WebAssembly application scope.
+    /// </param>
+    /// <param name="cancellationToken">A token that can cancel initialization.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous initialization operation.</returns>
+    /// <remarks>
+    /// The browser phase runs after host initialization when an interactive browser is available.
+    /// </remarks>
+    Task InitializeBrowserAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
 }

--- a/src/Components/Components/src/Hosting/IHostStartupValues.cs
+++ b/src/Components/Components/src/Hosting/IHostStartupValues.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+/// <summary>
+/// Provides startup values collected from the host environment.
+/// </summary>
+/// <remarks>Keys are compared using ordinal comparison.</remarks>
+public interface IHostStartupValues
+{
+    /// <summary>
+    /// Gets the startup value associated with the specified key.
+    /// </summary>
+    /// <param name="key">The key of the startup value.</param>
+    /// <returns>The startup value, or <see langword="null"/> if the key was not provided.</returns>
+    string? GetValue(string key);
+
+    /// <summary>
+    /// Gets the startup value associated with the specified key.
+    /// </summary>
+    /// <param name="key">The key of the startup value.</param>
+    /// <returns>The startup value.</returns>
+    /// <exception cref="InvalidOperationException">The key was not provided.</exception>
+    string GetRequired(string key);
+}

--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -32,6 +32,9 @@ Microsoft.AspNetCore.Components.NavigationOptions.RelativeToCurrentUri.get -> bo
 Microsoft.AspNetCore.Components.NavigationOptions.RelativeToCurrentUri.init -> void
 Microsoft.AspNetCore.Components.IComponentPropertyActivator
 Microsoft.AspNetCore.Components.IComponentPropertyActivator.GetActivator(System.Type! componentType) -> System.Action<System.IServiceProvider!, Microsoft.AspNetCore.Components.IComponent!>!
+Microsoft.AspNetCore.Components.Hosting.IHostStartupValues
+Microsoft.AspNetCore.Components.Hosting.IHostStartupValues.GetRequired(string! key) -> string!
+Microsoft.AspNetCore.Components.Hosting.IHostStartupValues.GetValue(string! key) -> string?
 *REMOVED*Microsoft.AspNetCore.Components.ResourceAsset.ResourceAsset(string! url, System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Components.ResourceAssetProperty!>? properties) -> void
 *REMOVED*Microsoft.AspNetCore.Components.Routing.Router.PreferExactMatches.get -> bool
 *REMOVED*Microsoft.AspNetCore.Components.Routing.Router.PreferExactMatches.set -> void

--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -32,6 +32,10 @@ Microsoft.AspNetCore.Components.NavigationOptions.RelativeToCurrentUri.get -> bo
 Microsoft.AspNetCore.Components.NavigationOptions.RelativeToCurrentUri.init -> void
 Microsoft.AspNetCore.Components.IComponentPropertyActivator
 Microsoft.AspNetCore.Components.IComponentPropertyActivator.GetActivator(System.Type! componentType) -> System.Action<System.IServiceProvider!, Microsoft.AspNetCore.Components.IComponent!>!
+Microsoft.AspNetCore.Components.Hosting.IHostInitializer
+Microsoft.AspNetCore.Components.Hosting.IHostInitializer.InitializeAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.Hosting.IHostInitializer.Order.get -> int
+Microsoft.AspNetCore.Components.Hosting.IHostInitializer.RequiresJSInterop.get -> bool
 Microsoft.AspNetCore.Components.Hosting.IHostStartupValues
 Microsoft.AspNetCore.Components.Hosting.IHostStartupValues.GetRequired(string! key) -> string!
 Microsoft.AspNetCore.Components.Hosting.IHostStartupValues.GetValue(string! key) -> string?

--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -33,9 +33,9 @@ Microsoft.AspNetCore.Components.NavigationOptions.RelativeToCurrentUri.init -> v
 Microsoft.AspNetCore.Components.IComponentPropertyActivator
 Microsoft.AspNetCore.Components.IComponentPropertyActivator.GetActivator(System.Type! componentType) -> System.Action<System.IServiceProvider!, Microsoft.AspNetCore.Components.IComponent!>!
 Microsoft.AspNetCore.Components.Hosting.IHostInitializer
-Microsoft.AspNetCore.Components.Hosting.IHostInitializer.InitializeAsync(System.IServiceProvider! services, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.Hosting.IHostInitializer.InitializeBrowserAsync(System.IServiceProvider! services, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.Hosting.IHostInitializer.InitializeHostAsync(System.IServiceProvider! services, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.Hosting.IHostInitializer.Order.get -> int
-Microsoft.AspNetCore.Components.Hosting.IHostInitializer.RequiresJSInterop.get -> bool
 Microsoft.AspNetCore.Components.Hosting.IHostStartupValues
 Microsoft.AspNetCore.Components.Hosting.IHostStartupValues.GetRequired(string! key) -> string!
 Microsoft.AspNetCore.Components.Hosting.IHostStartupValues.GetValue(string! key) -> string?

--- a/src/Components/Components/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Components/src/PublicAPI.Unshipped.txt
@@ -33,7 +33,7 @@ Microsoft.AspNetCore.Components.NavigationOptions.RelativeToCurrentUri.init -> v
 Microsoft.AspNetCore.Components.IComponentPropertyActivator
 Microsoft.AspNetCore.Components.IComponentPropertyActivator.GetActivator(System.Type! componentType) -> System.Action<System.IServiceProvider!, Microsoft.AspNetCore.Components.IComponent!>!
 Microsoft.AspNetCore.Components.Hosting.IHostInitializer
-Microsoft.AspNetCore.Components.Hosting.IHostInitializer.InitializeAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Microsoft.AspNetCore.Components.Hosting.IHostInitializer.InitializeAsync(System.IServiceProvider! services, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 Microsoft.AspNetCore.Components.Hosting.IHostInitializer.Order.get -> int
 Microsoft.AspNetCore.Components.Hosting.IHostInitializer.RequiresJSInterop.get -> bool
 Microsoft.AspNetCore.Components.Hosting.IHostStartupValues

--- a/src/Components/Components/test/Hosting/IHostInitializerTest.cs
+++ b/src/Components/Components/test/Hosting/IHostInitializerTest.cs
@@ -9,23 +9,35 @@ public class IHostInitializerTest
     public async Task DefaultsAndCancellationTokenArePassedThrough()
     {
         var initializer = new TestHostInitializer();
+        var services = new TestServiceProvider();
         using var cancellationTokenSource = new CancellationTokenSource();
 
-        await initializer.InitializeAsync(cancellationTokenSource.Token);
+        await initializer.InitializeAsync(services, cancellationTokenSource.Token);
 
         Assert.Equal(0, ((IHostInitializer)initializer).Order);
         Assert.False(((IHostInitializer)initializer).RequiresJSInterop);
+        Assert.Same(services, initializer.Services);
         Assert.Equal(cancellationTokenSource.Token, initializer.CancellationToken);
     }
 
     private sealed class TestHostInitializer : IHostInitializer
     {
+        public IServiceProvider Services { get; private set; }
+
         public CancellationToken CancellationToken { get; private set; }
 
-        public Task InitializeAsync(CancellationToken cancellationToken = default)
+        public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
         {
+            Services = services;
             CancellationToken = cancellationToken;
             return Task.CompletedTask;
         }
+
+    }
+
+    private sealed class TestServiceProvider : IServiceProvider
+    {
+        public object GetService(Type serviceType)
+            => null;
     }
 }

--- a/src/Components/Components/test/Hosting/IHostInitializerTest.cs
+++ b/src/Components/Components/test/Hosting/IHostInitializerTest.cs
@@ -12,10 +12,10 @@ public class IHostInitializerTest
         var services = new TestServiceProvider();
         using var cancellationTokenSource = new CancellationTokenSource();
 
-        await initializer.InitializeAsync(services, cancellationTokenSource.Token);
+        await ((IHostInitializer)initializer).InitializeHostAsync(services, cancellationTokenSource.Token);
+        await initializer.InitializeBrowserAsync(services, cancellationTokenSource.Token);
 
         Assert.Equal(0, ((IHostInitializer)initializer).Order);
-        Assert.False(((IHostInitializer)initializer).RequiresJSInterop);
         Assert.Same(services, initializer.Services);
         Assert.Equal(cancellationTokenSource.Token, initializer.CancellationToken);
     }
@@ -26,7 +26,7 @@ public class IHostInitializerTest
 
         public CancellationToken CancellationToken { get; private set; }
 
-        public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+        public Task InitializeBrowserAsync(IServiceProvider services, CancellationToken cancellationToken = default)
         {
             Services = services;
             CancellationToken = cancellationToken;

--- a/src/Components/Components/test/Hosting/IHostInitializerTest.cs
+++ b/src/Components/Components/test/Hosting/IHostInitializerTest.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+public class IHostInitializerTest
+{
+    [Fact]
+    public async Task DefaultsAndCancellationTokenArePassedThrough()
+    {
+        var initializer = new TestHostInitializer();
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        await initializer.InitializeAsync(cancellationTokenSource.Token);
+
+        Assert.Equal(0, ((IHostInitializer)initializer).Order);
+        Assert.False(((IHostInitializer)initializer).RequiresJSInterop);
+        Assert.Equal(cancellationTokenSource.Token, initializer.CancellationToken);
+    }
+
+    private sealed class TestHostInitializer : IHostInitializer
+    {
+        public CancellationToken CancellationToken { get; private set; }
+
+        public Task InitializeAsync(CancellationToken cancellationToken = default)
+        {
+            CancellationToken = cancellationToken;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
+++ b/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Components.Endpoints.DependencyInjection;
 using Microsoft.AspNetCore.Components.Endpoints.Forms;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Forms.Mapping;
+using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Components.Server;
@@ -65,6 +66,14 @@ public static class RazorComponentsServiceCollectionExtensions
         services.TryAddScoped<ComponentStatePersistenceManager>();
         services.TryAddScoped(sp => sp.GetRequiredService<ComponentStatePersistenceManager>().State);
         services.TryAddScoped<IErrorBoundaryLogger, PrerenderingErrorBoundaryLogger>();
+        services.TryAddKeyedScoped<HttpContextHostStartupValues>(typeof(IHostStartupValues));
+        services.TryAddKeyedScoped<IHostStartupValues>(
+            typeof(IHostStartupValues),
+            static (services, key) => services.GetRequiredKeyedService<HttpContextHostStartupValues>(key));
+        services.TryAddScoped<IHostStartupValues>(
+            static services => services.GetRequiredKeyedService<IHostStartupValues>(typeof(IHostStartupValues)));
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IHttpContextStartupValueProvider, NavigationHttpContextStartupValueProvider>());
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IPostConfigureOptions<RazorComponentsServiceOptions>, DefaultRazorComponentsServiceOptionsConfiguration>());
         services.TryAddScoped<EndpointRoutingStateProvider>();

--- a/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
+++ b/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
@@ -66,14 +66,14 @@ public static class RazorComponentsServiceCollectionExtensions
         services.TryAddScoped<ComponentStatePersistenceManager>();
         services.TryAddScoped(sp => sp.GetRequiredService<ComponentStatePersistenceManager>().State);
         services.TryAddScoped<IErrorBoundaryLogger, PrerenderingErrorBoundaryLogger>();
-        services.TryAddKeyedScoped<HttpContextHostStartupValues>(typeof(IHostStartupValues));
+        services.TryAddKeyedScoped<HttpContextHostStartupValues>(HostInitializerKey.Static);
         services.TryAddKeyedScoped<IHostStartupValues>(
-            typeof(IHostStartupValues),
+            HostInitializerKey.Static,
             static (services, key) => services.GetRequiredKeyedService<HttpContextHostStartupValues>(key));
         services.TryAddScoped<IHostStartupValues>(
-            static services => services.GetRequiredKeyedService<IHostStartupValues>(typeof(IHostStartupValues)));
+            static services => services.GetRequiredKeyedService<IHostStartupValues>(HostInitializerKey.Static));
         services.TryAddEnumerable(
-            ServiceDescriptor.Singleton<IHostInitializer, NavigationManagerInitializer>());
+            ServiceDescriptor.KeyedSingleton<IHostInitializer, NavigationManagerInitializer>(HostInitializerKey.Static));
         services.TryAddSingleton<HostInitializerCollection>();
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IHttpContextStartupValueProvider, NavigationHttpContextStartupValueProvider>());

--- a/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
+++ b/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
@@ -73,7 +73,8 @@ public static class RazorComponentsServiceCollectionExtensions
         services.TryAddScoped<IHostStartupValues>(
             static services => services.GetRequiredKeyedService<IHostStartupValues>(typeof(IHostStartupValues)));
         services.TryAddEnumerable(
-            ServiceDescriptor.Scoped<IHostInitializer, NavigationManagerInitializer>());
+            ServiceDescriptor.Singleton<IHostInitializer, NavigationManagerInitializer>());
+        services.TryAddSingleton<HostInitializerCollection>();
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IHttpContextStartupValueProvider, NavigationHttpContextStartupValueProvider>());
         services.TryAddEnumerable(

--- a/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
+++ b/src/Components/Endpoints/src/DependencyInjection/RazorComponentsServiceCollectionExtensions.cs
@@ -73,6 +73,8 @@ public static class RazorComponentsServiceCollectionExtensions
         services.TryAddScoped<IHostStartupValues>(
             static services => services.GetRequiredKeyedService<IHostStartupValues>(typeof(IHostStartupValues)));
         services.TryAddEnumerable(
+            ServiceDescriptor.Scoped<IHostInitializer, NavigationManagerInitializer>());
+        services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IHttpContextStartupValueProvider, NavigationHttpContextStartupValueProvider>());
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IPostConfigureOptions<RazorComponentsServiceOptions>, DefaultRazorComponentsServiceOptionsConfiguration>());

--- a/src/Components/Endpoints/src/Hosting/HttpContextHostStartupValues.cs
+++ b/src/Components/Endpoints/src/Hosting/HttpContextHostStartupValues.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+internal sealed class HttpContextHostStartupValues(
+    IEnumerable<IHttpContextStartupValueProvider> providers) : IHostStartupValues
+{
+    private IReadOnlyDictionary<string, string>? _values;
+
+    public string? GetValue(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        return _values is not null && _values.TryGetValue(key, out var value) ? value : null;
+    }
+
+    public string GetRequired(string key)
+        => GetValue(key) ?? throw new InvalidOperationException($"Startup value '{key}' was not provided.");
+
+    internal void Initialize(HttpContext httpContext)
+    {
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var provider in providers)
+        {
+            foreach (var (key, value) in provider.GetValues(httpContext))
+            {
+                if (!values.TryAdd(key, value))
+                {
+                    throw new InvalidOperationException($"The startup value key '{key}' was provided more than once.");
+                }
+            }
+        }
+
+        _values = values;
+    }
+}

--- a/src/Components/Endpoints/src/Hosting/IHttpContextStartupValueProvider.cs
+++ b/src/Components/Endpoints/src/Hosting/IHttpContextStartupValueProvider.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+/// <summary>
+/// Provides startup values from an <see cref="HttpContext"/>.
+/// </summary>
+/// <remarks>
+/// Values are available during server rendering and are not emitted to the browser.
+/// Duplicate keys across providers are rejected.
+/// </remarks>
+public interface IHttpContextStartupValueProvider
+{
+    /// <summary>
+    /// Gets startup values from the specified <see cref="HttpContext"/>.
+    /// </summary>
+    /// <param name="httpContext">The current HTTP context.</param>
+    /// <returns>The startup values.</returns>
+    IReadOnlyDictionary<string, string> GetValues(HttpContext httpContext);
+}

--- a/src/Components/Endpoints/src/Hosting/NavigationHttpContextStartupValueProvider.cs
+++ b/src/Components/Endpoints/src/Hosting/NavigationHttpContextStartupValueProvider.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+internal sealed class NavigationHttpContextStartupValueProvider : IHttpContextStartupValueProvider
+{
+    internal const string BaseUriKey = "document.baseURI";
+    internal const string LocationHrefKey = "location.href";
+
+    public IReadOnlyDictionary<string, string> GetValues(HttpContext httpContext)
+        => new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            [BaseUriKey] = GetContextBaseUri(httpContext.Request),
+            [LocationHrefKey] = GetFullUri(httpContext.Request),
+        };
+
+    internal static string GetFullUri(HttpRequest request)
+        => UriHelper.BuildAbsolute(
+            request.Scheme,
+            request.Host,
+            request.PathBase,
+            request.Path,
+            request.QueryString);
+
+    internal static string GetContextBaseUri(HttpRequest request)
+    {
+        var result = UriHelper.BuildAbsolute(request.Scheme, request.Host, request.PathBase);
+
+        return result.EndsWith('/') ? result : result += "/";
+    }
+}

--- a/src/Components/Endpoints/src/Hosting/NavigationManagerInitializer.cs
+++ b/src/Components/Endpoints/src/Hosting/NavigationManagerInitializer.cs
@@ -7,16 +7,15 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Components.Hosting;
 
-internal sealed class NavigationManagerInitializer(
-    IServiceProvider services,
-    IHostStartupValues startupValues) : IHostInitializer
+internal sealed class NavigationManagerInitializer : IHostInitializer
 {
     public int Order => -200;
 
-    public Task InitializeAsync(CancellationToken cancellationToken = default)
+    public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
+        var startupValues = services.GetRequiredService<IHostStartupValues>();
         var httpContextStartupValues =
             services.GetRequiredKeyedService<HttpContextHostStartupValues>(typeof(IHostStartupValues));
         if (!ReferenceEquals(startupValues, httpContextStartupValues))

--- a/src/Components/Endpoints/src/Hosting/NavigationManagerInitializer.cs
+++ b/src/Components/Endpoints/src/Hosting/NavigationManagerInitializer.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Endpoints;
+using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+internal sealed class NavigationManagerInitializer(
+    IServiceProvider services,
+    IHostStartupValues startupValues) : IHostInitializer
+{
+    public int Order => -200;
+
+    public Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var httpContextStartupValues =
+            services.GetRequiredKeyedService<HttpContextHostStartupValues>(typeof(IHostStartupValues));
+        if (!ReferenceEquals(startupValues, httpContextStartupValues))
+        {
+            return Task.CompletedTask;
+        }
+
+        var navigationManager = services.GetRequiredService<NavigationManager>();
+        var renderer = services.GetRequiredService<EndpointHtmlRenderer>();
+        ((IHostEnvironmentNavigationManager)navigationManager).Initialize(
+            startupValues.GetRequired(NavigationHttpContextStartupValueProvider.BaseUriKey),
+            startupValues.GetRequired(NavigationHttpContextStartupValueProvider.LocationHrefKey),
+            renderer.HandleNavigationAsync);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Components/Endpoints/src/Hosting/NavigationManagerInitializer.cs
+++ b/src/Components/Endpoints/src/Hosting/NavigationManagerInitializer.cs
@@ -11,13 +11,13 @@ internal sealed class NavigationManagerInitializer : IHostInitializer
 {
     public int Order => -200;
 
-    public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+    public Task InitializeHostAsync(IServiceProvider services, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         var startupValues = services.GetRequiredService<IHostStartupValues>();
         var httpContextStartupValues =
-            services.GetRequiredKeyedService<HttpContextHostStartupValues>(typeof(IHostStartupValues));
+            services.GetRequiredKeyedService<HttpContextHostStartupValues>(HostInitializerKey.Static);
         if (!ReferenceEquals(startupValues, httpContextStartupValues))
         {
             return Task.CompletedTask;

--- a/src/Components/Endpoints/src/Microsoft.AspNetCore.Components.Endpoints.csproj
+++ b/src/Components/Endpoints/src/Microsoft.AspNetCore.Components.Endpoints.csproj
@@ -45,6 +45,7 @@
     <Compile Include="$(ComponentsSharedSourceRoot)src\RenderFragmentSerializer.cs" />
     <Compile Include="$(ComponentsSharedSourceRoot)src\RenderFragmentCapture.cs" />
     <Compile Include="$(ComponentsSharedSourceRoot)src\ComponentParametersTypeCache.cs" />
+    <Compile Include="$(ComponentsSharedSourceRoot)src\Hosting\HostInitializerCollection.cs" />
 
     <Compile Include="$(SharedSourceRoot)PropertyHelper\**\*.cs" />
 

--- a/src/Components/Endpoints/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Endpoints/src/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.AspNetCore.Components.Hosting.IHttpContextStartupValueProvider
+Microsoft.AspNetCore.Components.Hosting.IHttpContextStartupValueProvider.GetValues(Microsoft.AspNetCore.Http.HttpContext! httpContext) -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
 Microsoft.AspNetCore.Components.Endpoints.BasePath
 Microsoft.AspNetCore.Components.Endpoints.BasePath.BasePath() -> void
 Microsoft.AspNetCore.Components.Endpoints.RazorComponentsServiceOptions.CacheViewSizeLimit.get -> long

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.EventDispatch.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.EventDispatch.cs
@@ -124,6 +124,9 @@ internal partial class EndpointHtmlRenderer
         return $"{baseUri}{path.TrimStart('/')}";
     }
 
+    internal Task HandleNavigationAsync(string uri)
+        => GetErrorHandledTask(OnNavigateTo(uri));
+
     private async Task OnNavigateTo(string uri)
     {
         if (_httpContext.Response.HasStarted)

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Endpoints.DependencyInjection;
 using Microsoft.AspNetCore.Components.Endpoints.Forms;
@@ -90,12 +91,17 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
             .GetRequiredKeyedService<HttpContextHostStartupValues>(typeof(IHostStartupValues))
             .Initialize(httpContext);
 
-        var navigationManager = httpContext.RequestServices.GetRequiredService<NavigationManager>();
-        ((IHostEnvironmentNavigationManager)navigationManager)?.Initialize(
-            NavigationHttpContextStartupValueProvider.GetContextBaseUri(httpContext.Request),
-            NavigationHttpContextStartupValueProvider.GetFullUri(httpContext.Request),
-            uri => GetErrorHandledTask(OnNavigateTo(uri)));
+        var hostInitializers = httpContext.RequestServices.GetServices<IHostInitializer>()
+            .OrderBy(initializer => initializer.Order);
+        foreach (var initializer in hostInitializers)
+        {
+            if (!initializer.RequiresJSInterop)
+            {
+                await initializer.InitializeAsync(httpContext.RequestAborted);
+            }
+        }
 
+        var navigationManager = httpContext.RequestServices.GetRequiredService<NavigationManager>();
         navigationManager?.OnNotFound += (sender, args) => NotFoundEventArgs = args;
 
         var authenticationStateProvider = httpContext.RequestServices.GetService<AuthenticationStateProvider>();

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
@@ -3,7 +3,6 @@
 
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Endpoints.DependencyInjection;
 using Microsoft.AspNetCore.Components.Endpoints.Forms;
@@ -91,13 +90,12 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
             .GetRequiredKeyedService<HttpContextHostStartupValues>(typeof(IHostStartupValues))
             .Initialize(httpContext);
 
-        var hostInitializers = httpContext.RequestServices.GetServices<IHostInitializer>()
-            .OrderBy(initializer => initializer.Order);
-        foreach (var initializer in hostInitializers)
+        var hostInitializers = httpContext.RequestServices.GetRequiredService<HostInitializerCollection>();
+        foreach (var initializer in hostInitializers.Initializers)
         {
             if (!initializer.RequiresJSInterop)
             {
-                await initializer.InitializeAsync(httpContext.RequestAborted);
+                await initializer.InitializeAsync(httpContext.RequestServices, httpContext.RequestAborted);
             }
         }
 

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
@@ -8,13 +8,13 @@ using Microsoft.AspNetCore.Components.Endpoints.DependencyInjection;
 using Microsoft.AspNetCore.Components.Endpoints.Forms;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.HtmlRendering.Infrastructure;
+using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -86,10 +86,14 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
         string? handler = null,
         IFormCollection? form = null)
     {
+        httpContext.RequestServices
+            .GetRequiredKeyedService<HttpContextHostStartupValues>(typeof(IHostStartupValues))
+            .Initialize(httpContext);
+
         var navigationManager = httpContext.RequestServices.GetRequiredService<NavigationManager>();
         ((IHostEnvironmentNavigationManager)navigationManager)?.Initialize(
-            GetContextBaseUri(httpContext.Request),
-            GetFullUri(httpContext.Request),
+            NavigationHttpContextStartupValueProvider.GetContextBaseUri(httpContext.Request),
+            NavigationHttpContextStartupValueProvider.GetFullUri(httpContext.Request),
             uri => GetErrorHandledTask(OnNavigateTo(uri)));
 
         navigationManager?.OnNotFound += (sender, args) => NotFoundEventArgs = args;
@@ -240,25 +244,6 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
             await writerToFlush.FlushAsync();
             await completion;
         }
-    }
-
-    private static string GetFullUri(HttpRequest request)
-    {
-        return UriHelper.BuildAbsolute(
-            request.Scheme,
-            request.Host,
-            request.PathBase,
-            request.Path,
-            request.QueryString);
-    }
-
-    private static string GetContextBaseUri(HttpRequest request)
-    {
-        var result = UriHelper.BuildAbsolute(request.Scheme, request.Host, request.PathBase);
-
-        // PathBase may be "/" or "/some/thing", but to be a well-formed base URI
-        // it has to end with a trailing slash
-        return result.EndsWith('/') ? result : result += "/";
     }
 
     private sealed class FormCollectionReadOnlyDictionary : IReadOnlyDictionary<string, StringValues>

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
@@ -87,17 +87,13 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
         IFormCollection? form = null)
     {
         httpContext.RequestServices
-            .GetRequiredKeyedService<HttpContextHostStartupValues>(typeof(IHostStartupValues))
+            .GetRequiredKeyedService<HttpContextHostStartupValues>(HostInitializerKey.Static)
             .Initialize(httpContext);
 
-        var hostInitializers = httpContext.RequestServices.GetRequiredService<HostInitializerCollection>();
-        foreach (var initializer in hostInitializers.Initializers)
-        {
-            if (!initializer.RequiresJSInterop)
-            {
-                await initializer.InitializeAsync(httpContext.RequestServices, httpContext.RequestAborted);
-            }
-        }
+        var hostInitializerInvoker = httpContext.RequestServices
+            .GetRequiredService<HostInitializerCollection>()
+            .GetInitializerInvoker(httpContext.RequestServices, HostInitializerKey.Static);
+        await hostInitializerInvoker.InitializeHostAsync(httpContext.RequestAborted);
 
         var navigationManager = httpContext.RequestServices.GetRequiredService<NavigationManager>();
         navigationManager?.OnNotFound += (sender, args) => NotFoundEventArgs = args;

--- a/src/Components/Endpoints/test/EndpointHtmlRendererTest.cs
+++ b/src/Components/Endpoints/test/EndpointHtmlRendererTest.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Components.Endpoints.Forms;
 using Microsoft.AspNetCore.Components.Endpoints.Tests.TestComponents;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Forms.Mapping;
+using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Reflection;
 using Microsoft.AspNetCore.Components.Rendering;
@@ -44,11 +45,14 @@ public class EndpointHtmlRendererTest
 
     private static readonly IDataProtectionProvider _dataprotectorProvider = new EphemeralDataProtectionProvider();
 
-    private readonly IServiceProvider _services = CreateDefaultServiceCollection().BuildServiceProvider();
+    private readonly IServiceProvider _services;
     private readonly TestEndpointHtmlRenderer renderer;
 
     public EndpointHtmlRendererTest()
     {
+        var services = CreateDefaultServiceCollection();
+        services.AddSingleton<EndpointHtmlRenderer>(_ => renderer);
+        _services = services.BuildServiceProvider();
         renderer = GetEndpointHtmlRenderer();
     }
 
@@ -998,8 +1002,11 @@ public class EndpointHtmlRendererTest
         using var remoteHandle = RemoteExecutor.Invoke(static async (allowExceptionStr) =>
         {
             var allowException = bool.Parse(allowExceptionStr);
-            var services = CreateDefaultServiceCollection().BuildServiceProvider();
-            var renderer = new TestEndpointHtmlRenderer(services, NullLoggerFactory.Instance);
+            TestEndpointHtmlRenderer renderer = null;
+            var serviceCollection = CreateDefaultServiceCollection();
+            serviceCollection.AddSingleton<EndpointHtmlRenderer>(_ => renderer);
+            var services = serviceCollection.BuildServiceProvider();
+            renderer = new TestEndpointHtmlRenderer(services, NullLoggerFactory.Instance);
 
             var ctx = new DefaultHttpContext();
             ctx.Request.Scheme = "http";
@@ -2029,6 +2036,15 @@ public class EndpointHtmlRendererTest
         services.AddScoped<ResourceCollectionProvider>();
         services.AddScoped<ResourcePreloadService>();
         services.AddSingleton<IHostEnvironment>(new TestEnvironment(Environments.Development));
+        services.AddKeyedSingleton<HttpContextHostStartupValues>(HostInitializerKey.Static);
+        services.AddKeyedSingleton<IHostStartupValues>(
+            HostInitializerKey.Static,
+            static (services, key) => services.GetRequiredKeyedService<HttpContextHostStartupValues>(key));
+        services.AddSingleton<IHostStartupValues>(
+            static services => services.GetRequiredKeyedService<IHostStartupValues>(HostInitializerKey.Static));
+        services.AddKeyedSingleton<IHostInitializer, NavigationManagerInitializer>(HostInitializerKey.Static);
+        services.AddSingleton<IHttpContextStartupValueProvider, NavigationHttpContextStartupValueProvider>();
+        services.AddSingleton<HostInitializerCollection>();
         return services;
     }
 

--- a/src/Components/Endpoints/test/Hosting/HostInitializerTest.cs
+++ b/src/Components/Endpoints/test/Hosting/HostInitializerTest.cs
@@ -36,13 +36,14 @@ public class HostInitializerTest
 
         using var provider = services.BuildServiceProvider();
         using var scope = provider.CreateScope();
-        var initializers = scope.ServiceProvider.GetServices<IHostInitializer>()
-            .OrderBy(initializer => initializer.Order)
-            .ToArray();
+        var collection = provider.GetRequiredService<HostInitializerCollection>();
+        var initializers = collection.Initializers;
 
         Assert.Equal(2, initializers.Length);
         Assert.Same(userInitializer, initializers[registerUserFirst ? 0 : 1]);
         Assert.IsType<NavigationManagerInitializer>(initializers[registerUserFirst ? 1 : 0]);
+        Assert.Same(collection, scope.ServiceProvider.GetRequiredService<HostInitializerCollection>());
+        Assert.Equal(1, userInitializer.OrderAccessCount);
     }
 
     [Fact]
@@ -53,9 +54,19 @@ public class HostInitializerTest
         services.AddRazorComponents();
         services.AddRazorComponents();
 
+        Assert.All(
+            services.Where(descriptor => descriptor.ServiceType == typeof(IHostInitializer)),
+            descriptor => Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime));
+        Assert.Equal(
+            ServiceLifetime.Singleton,
+            Assert.Single(services.Where(descriptor => descriptor.ServiceType == typeof(HostInitializerCollection))).Lifetime);
+
         using var provider = services.BuildServiceProvider();
         using var scope = provider.CreateScope();
         Assert.Single(scope.ServiceProvider.GetServices<IHostInitializer>());
+        Assert.Same(
+            provider.GetRequiredService<HostInitializerCollection>(),
+            scope.ServiceProvider.GetRequiredService<HostInitializerCollection>());
     }
 
     [Fact]
@@ -71,7 +82,42 @@ public class HostInitializerTest
         using var scope = provider.CreateScope();
         var initializer = Assert.Single(scope.ServiceProvider.GetServices<IHostInitializer>());
 
-        await initializer.InitializeAsync();
+        await initializer.InitializeAsync(scope.ServiceProvider);
+    }
+
+    [Fact]
+    public async Task SingletonInitializerUsesTheActiveRequestScope()
+    {
+        var initializer = new ScopeRecordingInitializer();
+        var services = CreateBaseServices();
+        services.AddRazorComponents();
+        services.AddScoped<ScopedDependency>();
+        services.AddSingleton<IHostInitializer>(initializer);
+
+        using var provider = services.BuildServiceProvider();
+        using (var firstScope = provider.CreateScope())
+        {
+            var context = CreateHttpContext(firstScope.ServiceProvider);
+            await firstScope.ServiceProvider.GetRequiredService<EndpointHtmlRenderer>()
+                .InitializeStandardComponentServicesAsync(context);
+        }
+
+        using (var secondScope = provider.CreateScope())
+        {
+            var context = CreateHttpContext(secondScope.ServiceProvider);
+            await secondScope.ServiceProvider.GetRequiredService<EndpointHtmlRenderer>()
+                .InitializeStandardComponentServicesAsync(context);
+        }
+
+        Assert.Collection(
+            initializer.ScopedDependencyIds,
+            first => Assert.NotEqual(Guid.Empty, first),
+            second => Assert.NotEqual(Guid.Empty, second));
+        Assert.NotEqual(initializer.ScopedDependencyIds[0], initializer.ScopedDependencyIds[1]);
+        Assert.Same(
+            initializer,
+            provider.GetRequiredService<HostInitializerCollection>().Initializers.Single(
+                candidate => candidate is ScopeRecordingInitializer));
     }
 
     [Fact]
@@ -180,11 +226,20 @@ public class HostInitializerTest
         Exception? exception = null,
         Action<CancellationToken>? callback = null) : IHostInitializer
     {
-        public int Order => order;
+        public int Order
+        {
+            get
+            {
+                OrderAccessCount++;
+                return order;
+            }
+        }
+
+        public int OrderAccessCount { get; private set; }
 
         public bool RequiresJSInterop => requiresJSInterop;
 
-        public Task InitializeAsync(CancellationToken cancellationToken = default)
+        public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
         {
             calls.Add(name);
             callback?.Invoke(cancellationToken);
@@ -200,6 +255,22 @@ public class HostInitializerTest
 
             return Task.CompletedTask;
         }
+    }
+
+    private sealed class ScopeRecordingInitializer : IHostInitializer
+    {
+        public List<Guid> ScopedDependencyIds { get; } = [];
+
+        public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+        {
+            ScopedDependencyIds.Add(services.GetRequiredService<ScopedDependency>().Id);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ScopedDependency
+    {
+        public Guid Id { get; } = Guid.NewGuid();
     }
 
     private sealed class TestHostStartupValues : IHostStartupValues

--- a/src/Components/Endpoints/test/Hosting/HostInitializerTest.cs
+++ b/src/Components/Endpoints/test/Hosting/HostInitializerTest.cs
@@ -15,35 +15,205 @@ namespace Microsoft.AspNetCore.Components.Endpoints.Tests.Hosting;
 
 public class HostInitializerTest
 {
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void EqualOrderInitializersPreserveServiceRegistrationOrder(bool registerUserFirst)
+    [Fact]
+    public async Task CollectionSortsInitializersByUniqueOrder()
     {
+        var calls = new List<string>();
+        var services = new ServiceCollection();
+        services.AddSingleton<IHostInitializer>(new TestInitializer("later", 20, calls));
+        services.AddSingleton<IHostInitializer>(new TestInitializer("first", -20, calls));
+        services.AddSingleton<HostInitializerCollection>();
+
+        using var provider = services.BuildServiceProvider();
+        var invoker = provider.GetRequiredService<HostInitializerCollection>()
+            .GetInitializerInvoker(provider);
+
+        await invoker.InitializeHostAsync();
+
+        Assert.Equal(["first", "later"], calls);
+    }
+
+    [Fact]
+    public void CollectionRejectsDuplicateSharedOrders()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IHostInitializer, FirstDuplicateInitializer>();
+        services.AddSingleton<IHostInitializer, SecondDuplicateInitializer>();
+        services.AddSingleton<HostInitializerCollection>();
+
+        using var provider = services.BuildServiceProvider();
+        var exception = Assert.Throws<InvalidOperationException>(
+            provider.GetRequiredService<HostInitializerCollection>);
+
+        Assert.Contains(typeof(FirstDuplicateInitializer).FullName!, exception.Message);
+        Assert.Contains(typeof(SecondDuplicateInitializer).FullName!, exception.Message);
+        Assert.Contains("Order '0'", exception.Message);
+    }
+
+    [Fact]
+    public void CollectionRejectsDuplicateSharedAndKeyedOrders()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IHostInitializer, FirstDuplicateInitializer>();
+        services.AddKeyedSingleton<IHostInitializer, SecondDuplicateInitializer>(HostInitializerKey.Static);
+        services.AddSingleton<HostInitializerCollection>();
+
+        using var provider = services.BuildServiceProvider();
+        var exception = Assert.Throws<InvalidOperationException>(
+            provider.GetRequiredService<HostInitializerCollection>);
+
+        Assert.Contains(typeof(FirstDuplicateInitializer).FullName!, exception.Message);
+        Assert.Contains(typeof(SecondDuplicateInitializer).FullName!, exception.Message);
+        Assert.Contains("Order '0'", exception.Message);
+    }
+
+    [Fact]
+    public async Task EqualOrdersInDifferentKeyedSetsAreIsolated()
+    {
+        var calls = new List<string>();
+        var staticInitializer = new TestInitializer("static", 0, calls);
+        var serverInitializer = new TestInitializer("server", 0, calls);
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<IHostInitializer>(HostInitializerKey.Static, staticInitializer);
+        services.AddKeyedSingleton<IHostInitializer>(HostInitializerKey.Server, serverInitializer);
+        services.AddSingleton<HostInitializerCollection>();
+
+        using var provider = services.BuildServiceProvider();
+        var collection = provider.GetRequiredService<HostInitializerCollection>();
+
+        await collection.GetInitializerInvoker(provider, HostInitializerKey.Static).InitializeHostAsync();
+        await collection.GetInitializerInvoker(provider, HostInitializerKey.Server).InitializeHostAsync();
+
+        Assert.Equal(["static", "server"], calls);
+    }
+
+    [Fact]
+    public async Task InvokerCachesHostAndBrowserTasksAndBrowserAwaitsHost()
+    {
+        var calls = new List<string>();
+        var continueHost = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var initializer = new TestInitializer(
+            "initializer",
+            0,
+            calls,
+            hostCallback: _ => continueHost.Task,
+            browserCallback: _ =>
+            {
+                calls.Add("browser");
+                return Task.CompletedTask;
+            });
+        var invoker = CreateInvoker(initializer);
+
+        var hostTask = invoker.InitializeHostAsync();
+        var browserTask = invoker.InitializeBrowserAsync();
+
+        Assert.Same(hostTask, invoker.InitializeHostAsync());
+        Assert.Same(browserTask, invoker.InitializeBrowserAsync());
+        Assert.Equal(["initializer"], calls);
+        Assert.False(browserTask.IsCompleted);
+
+        continueHost.SetResult();
+        await browserTask;
+
+        Assert.Equal(["initializer", "browser"], calls);
+        Assert.Same(hostTask, invoker.InitializeHostAsync());
+    }
+
+    [Fact]
+    public async Task InvokerCachesFailureAndCancellation()
+    {
+        var failure = new InvalidOperationException("Initializer failed.");
+        var failedInvoker = CreateInvoker(new TestInitializer(
+            "failure",
+            0,
+            [],
+            hostCallback: _ => Task.FromException(failure)));
+        var canceledInvoker = CreateInvoker(new TestInitializer(
+            "canceled",
+            0,
+            [],
+            hostCallback: token => Task.FromCanceled(token)));
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        var failedTask = failedInvoker.InitializeHostAsync();
+        var canceledTask = canceledInvoker.InitializeHostAsync(cancellationTokenSource.Token);
+
+        Assert.Same(failedTask, failedInvoker.InitializeHostAsync());
+        Assert.Same(canceledTask, canceledInvoker.InitializeHostAsync());
+        Assert.Same(failure, await Assert.ThrowsAsync<InvalidOperationException>(() => failedTask));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledTask);
+    }
+
+    [Fact]
+    public async Task InvokerCachesBrowserFailureAndCancellation()
+    {
+        var failure = new InvalidOperationException("Browser initialization failed.");
+        var failedInvoker = CreateInvoker(new TestInitializer(
+            "failure",
+            0,
+            [],
+            browserCallback: _ => Task.FromException(failure)));
+        var canceledInvoker = CreateInvoker(new TestInitializer(
+            "canceled",
+            0,
+            [],
+            browserCallback: token => Task.FromCanceled(token)));
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        var failedTask = failedInvoker.InitializeBrowserAsync();
+        var canceledTask = canceledInvoker.InitializeBrowserAsync(cancellationTokenSource.Token);
+
+        Assert.Same(failedTask, failedInvoker.InitializeBrowserAsync());
+        Assert.Same(canceledTask, canceledInvoker.InitializeBrowserAsync());
+        Assert.Same(failure, await Assert.ThrowsAsync<InvalidOperationException>(() => failedTask));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => canceledTask);
+    }
+
+    [Fact]
+    public async Task SeparateInvokersUseActiveScopesWithSharedSingletonInitializer()
+    {
+        var initializer = new ScopeRecordingInitializer();
+        var services = new ServiceCollection();
+        services.AddScoped<ScopedDependency>();
+        services.AddSingleton<IHostInitializer>(initializer);
+        services.AddSingleton<HostInitializerCollection>();
+
+        using var provider = services.BuildServiceProvider();
+        using var firstScope = provider.CreateScope();
+        using var secondScope = provider.CreateScope();
+        var collection = provider.GetRequiredService<HostInitializerCollection>();
+
+        await collection.GetInitializerInvoker(firstScope.ServiceProvider).InitializeHostAsync();
+        await collection.GetInitializerInvoker(secondScope.ServiceProvider).InitializeHostAsync();
+
+        Assert.Equal(2, initializer.ScopedDependencyIds.Count);
+        Assert.NotEqual(initializer.ScopedDependencyIds[0], initializer.ScopedDependencyIds[1]);
+    }
+
+    [Fact]
+    public async Task EndpointUsesSharedAndStaticInitializersOnly()
+    {
+        var calls = new List<string>();
         var services = CreateBaseServices();
-        var userInitializer = new TestInitializer("user", -200, []);
-        if (registerUserFirst)
-        {
-            services.AddSingleton<IHostInitializer>(userInitializer);
-        }
-
+        services.AddSingleton<IHostInitializer>(new TestInitializer("shared", -100, calls));
+        services.AddKeyedSingleton<IHostInitializer>(
+            HostInitializerKey.Static,
+            new TestInitializer("static", 100, calls));
+        services.AddKeyedSingleton<IHostInitializer>(
+            HostInitializerKey.Server,
+            new TestInitializer("server", 200, calls));
         services.AddRazorComponents();
-
-        if (!registerUserFirst)
-        {
-            services.AddSingleton<IHostInitializer>(userInitializer);
-        }
 
         using var provider = services.BuildServiceProvider();
         using var scope = provider.CreateScope();
-        var collection = provider.GetRequiredService<HostInitializerCollection>();
-        var initializers = collection.Initializers;
+        var context = CreateHttpContext(scope.ServiceProvider);
 
-        Assert.Equal(2, initializers.Length);
-        Assert.Same(userInitializer, initializers[registerUserFirst ? 0 : 1]);
-        Assert.IsType<NavigationManagerInitializer>(initializers[registerUserFirst ? 1 : 0]);
-        Assert.Same(collection, scope.ServiceProvider.GetRequiredService<HostInitializerCollection>());
-        Assert.Equal(1, userInitializer.OrderAccessCount);
+        await scope.ServiceProvider.GetRequiredService<EndpointHtmlRenderer>()
+            .InitializeStandardComponentServicesAsync(context);
+
+        Assert.Equal(["shared", "static"], calls);
     }
 
     [Fact]
@@ -54,95 +224,16 @@ public class HostInitializerTest
         services.AddRazorComponents();
         services.AddRazorComponents();
 
-        Assert.All(
-            services.Where(descriptor => descriptor.ServiceType == typeof(IHostInitializer)),
-            descriptor => Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime));
+        Assert.DoesNotContain(
+            services,
+            descriptor => descriptor.ServiceType == typeof(IHostInitializer) && !descriptor.IsKeyedService);
+        Assert.Single(services.Where(
+            descriptor => descriptor.ServiceType == typeof(IHostInitializer) &&
+                Equals(descriptor.ServiceKey, HostInitializerKey.Static)));
         Assert.Equal(
             ServiceLifetime.Singleton,
-            Assert.Single(services.Where(descriptor => descriptor.ServiceType == typeof(HostInitializerCollection))).Lifetime);
-
-        using var provider = services.BuildServiceProvider();
-        using var scope = provider.CreateScope();
-        Assert.Single(scope.ServiceProvider.GetServices<IHostInitializer>());
-        Assert.Same(
-            provider.GetRequiredService<HostInitializerCollection>(),
-            scope.ServiceProvider.GetRequiredService<HostInitializerCollection>());
-    }
-
-    [Fact]
-    public async Task FrameworkInitializerDoesNotResolveEndpointServicesForDifferentStartupValueHolder()
-    {
-        var services = CreateBaseServices();
-        services.AddScoped<IHostStartupValues, TestHostStartupValues>();
-        services.AddRazorComponents();
-        services.AddScoped<NavigationManager>(_ => throw new InvalidOperationException("Unexpected resolution."));
-        services.AddScoped<EndpointHtmlRenderer>(_ => throw new InvalidOperationException("Unexpected resolution."));
-
-        using var provider = services.BuildServiceProvider();
-        using var scope = provider.CreateScope();
-        var initializer = Assert.Single(scope.ServiceProvider.GetServices<IHostInitializer>());
-
-        await initializer.InitializeAsync(scope.ServiceProvider);
-    }
-
-    [Fact]
-    public async Task SingletonInitializerUsesTheActiveRequestScope()
-    {
-        var initializer = new ScopeRecordingInitializer();
-        var services = CreateBaseServices();
-        services.AddRazorComponents();
-        services.AddScoped<ScopedDependency>();
-        services.AddSingleton<IHostInitializer>(initializer);
-
-        using var provider = services.BuildServiceProvider();
-        using (var firstScope = provider.CreateScope())
-        {
-            var context = CreateHttpContext(firstScope.ServiceProvider);
-            await firstScope.ServiceProvider.GetRequiredService<EndpointHtmlRenderer>()
-                .InitializeStandardComponentServicesAsync(context);
-        }
-
-        using (var secondScope = provider.CreateScope())
-        {
-            var context = CreateHttpContext(secondScope.ServiceProvider);
-            await secondScope.ServiceProvider.GetRequiredService<EndpointHtmlRenderer>()
-                .InitializeStandardComponentServicesAsync(context);
-        }
-
-        Assert.Collection(
-            initializer.ScopedDependencyIds,
-            first => Assert.NotEqual(Guid.Empty, first),
-            second => Assert.NotEqual(Guid.Empty, second));
-        Assert.NotEqual(initializer.ScopedDependencyIds[0], initializer.ScopedDependencyIds[1]);
-        Assert.Same(
-            initializer,
-            provider.GetRequiredService<HostInitializerCollection>().Initializers.Single(
-                candidate => candidate is ScopeRecordingInitializer));
-    }
-
-    [Fact]
-    public async Task InitializersRunInStableOrderAndSkipJSInterop()
-    {
-        var calls = new List<string>();
-        NavigationManager? navigationManager = null;
-        using var provider = CreateServices(
-            new TestInitializer("skipped", -300, calls, requiresJSInterop: true),
-            new TestInitializer("lower", -100, calls),
-            new TestInitializer("first-tie", 0, calls),
-            new TestInitializer("second-tie", 0, calls),
-            new TestInitializer("navigation", 100, calls, callback: _ =>
-            {
-                Assert.Equal("https://localhost/subdir/", navigationManager!.BaseUri);
-                Assert.Equal("https://localhost/subdir/page?query=value", navigationManager.Uri);
-            }));
-        using var scope = provider.CreateScope();
-        var context = CreateHttpContext(scope.ServiceProvider);
-        navigationManager = scope.ServiceProvider.GetRequiredService<NavigationManager>();
-
-        await scope.ServiceProvider.GetRequiredService<EndpointHtmlRenderer>()
-            .InitializeStandardComponentServicesAsync(context);
-
-        Assert.Equal(["lower", "first-tie", "second-tie", "navigation"], calls);
+            Assert.Single(services.Where(
+                descriptor => descriptor.ServiceType == typeof(HostInitializerCollection))).Lifetime);
     }
 
     [Fact]
@@ -151,8 +242,12 @@ public class HostInitializerTest
         var calls = new List<string>();
         using var provider = CreateServices(
             new TestInitializer("first", -400, calls),
-            new TestInitializer("failure", -300, calls, exception: new InvalidOperationException("Initializer failed.")),
-            new TestInitializer("not-run", -200, calls));
+            new TestInitializer(
+                "failure",
+                -300,
+                calls,
+                hostCallback: _ => Task.FromException(new InvalidOperationException("Initializer failed."))),
+            new TestInitializer("not-run", -100, calls));
         using var scope = provider.CreateScope();
         var context = CreateHttpContext(scope.ServiceProvider);
 
@@ -169,8 +264,12 @@ public class HostInitializerTest
     {
         var calls = new List<string>();
         using var provider = CreateServices(
-            new TestInitializer("canceled", -300, calls, observeCancellation: true),
-            new TestInitializer("not-run", -200, calls));
+            new TestInitializer(
+                "canceled",
+                -300,
+                calls,
+                hostCallback: token => Task.FromCanceled(token)),
+            new TestInitializer("not-run", -100, calls));
         using var scope = provider.CreateScope();
         var context = CreateHttpContext(scope.ServiceProvider);
         context.RequestAborted = new CancellationToken(canceled: true);
@@ -180,6 +279,15 @@ public class HostInitializerTest
                 .InitializeStandardComponentServicesAsync(context));
 
         Assert.Equal(["canceled"], calls);
+    }
+
+    private static HostInitializerInvoker CreateInvoker(IHostInitializer initializer)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IHostInitializer>(initializer);
+        services.AddSingleton<HostInitializerCollection>();
+        var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<HostInitializerCollection>().GetInitializerInvoker(provider);
     }
 
     private static ServiceProvider CreateServices(params IHostInitializer[] initializers)
@@ -221,47 +329,30 @@ public class HostInitializerTest
         string name,
         int order,
         List<string> calls,
-        bool requiresJSInterop = false,
-        bool observeCancellation = false,
-        Exception? exception = null,
-        Action<CancellationToken>? callback = null) : IHostInitializer
+        Func<CancellationToken, Task>? hostCallback = null,
+        Func<CancellationToken, Task>? browserCallback = null) : IHostInitializer
     {
-        public int Order
-        {
-            get
-            {
-                OrderAccessCount++;
-                return order;
-            }
-        }
+        public int Order => order;
 
-        public int OrderAccessCount { get; private set; }
-
-        public bool RequiresJSInterop => requiresJSInterop;
-
-        public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+        public Task InitializeHostAsync(IServiceProvider services, CancellationToken cancellationToken = default)
         {
             calls.Add(name);
-            callback?.Invoke(cancellationToken);
-            if (observeCancellation)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-            }
-
-            if (exception is not null)
-            {
-                return Task.FromException(exception);
-            }
-
-            return Task.CompletedTask;
+            return hostCallback?.Invoke(cancellationToken) ?? Task.CompletedTask;
         }
+
+        public Task InitializeBrowserAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+            => browserCallback?.Invoke(cancellationToken) ?? Task.CompletedTask;
     }
+
+    private sealed class FirstDuplicateInitializer : IHostInitializer;
+
+    private sealed class SecondDuplicateInitializer : IHostInitializer;
 
     private sealed class ScopeRecordingInitializer : IHostInitializer
     {
         public List<Guid> ScopedDependencyIds { get; } = [];
 
-        public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+        public Task InitializeHostAsync(IServiceProvider services, CancellationToken cancellationToken = default)
         {
             ScopedDependencyIds.Add(services.GetRequiredService<ScopedDependency>().Id);
             return Task.CompletedTask;
@@ -271,15 +362,6 @@ public class HostInitializerTest
     private sealed class ScopedDependency
     {
         public Guid Id { get; } = Guid.NewGuid();
-    }
-
-    private sealed class TestHostStartupValues : IHostStartupValues
-    {
-        public string? GetValue(string key)
-            => null;
-
-        public string GetRequired(string key)
-            => throw new InvalidOperationException("Unexpected access.");
     }
 
     private sealed class TestWebHostEnvironment : IWebHostEnvironment

--- a/src/Components/Endpoints/test/Hosting/HostInitializerTest.cs
+++ b/src/Components/Endpoints/test/Hosting/HostInitializerTest.cs
@@ -1,0 +1,223 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using Microsoft.AspNetCore.Components.Endpoints;
+using Microsoft.AspNetCore.Components.Hosting;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+
+namespace Microsoft.AspNetCore.Components.Endpoints.Tests.Hosting;
+
+public class HostInitializerTest
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void EqualOrderInitializersPreserveServiceRegistrationOrder(bool registerUserFirst)
+    {
+        var services = CreateBaseServices();
+        var userInitializer = new TestInitializer("user", -200, []);
+        if (registerUserFirst)
+        {
+            services.AddSingleton<IHostInitializer>(userInitializer);
+        }
+
+        services.AddRazorComponents();
+
+        if (!registerUserFirst)
+        {
+            services.AddSingleton<IHostInitializer>(userInitializer);
+        }
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var initializers = scope.ServiceProvider.GetServices<IHostInitializer>()
+            .OrderBy(initializer => initializer.Order)
+            .ToArray();
+
+        Assert.Equal(2, initializers.Length);
+        Assert.Same(userInitializer, initializers[registerUserFirst ? 0 : 1]);
+        Assert.IsType<NavigationManagerInitializer>(initializers[registerUserFirst ? 1 : 0]);
+    }
+
+    [Fact]
+    public void RepeatedRegistrationDoesNotDuplicateFrameworkInitializer()
+    {
+        var services = CreateBaseServices();
+
+        services.AddRazorComponents();
+        services.AddRazorComponents();
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        Assert.Single(scope.ServiceProvider.GetServices<IHostInitializer>());
+    }
+
+    [Fact]
+    public async Task FrameworkInitializerDoesNotResolveEndpointServicesForDifferentStartupValueHolder()
+    {
+        var services = CreateBaseServices();
+        services.AddScoped<IHostStartupValues, TestHostStartupValues>();
+        services.AddRazorComponents();
+        services.AddScoped<NavigationManager>(_ => throw new InvalidOperationException("Unexpected resolution."));
+        services.AddScoped<EndpointHtmlRenderer>(_ => throw new InvalidOperationException("Unexpected resolution."));
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var initializer = Assert.Single(scope.ServiceProvider.GetServices<IHostInitializer>());
+
+        await initializer.InitializeAsync();
+    }
+
+    [Fact]
+    public async Task InitializersRunInStableOrderAndSkipJSInterop()
+    {
+        var calls = new List<string>();
+        NavigationManager? navigationManager = null;
+        using var provider = CreateServices(
+            new TestInitializer("skipped", -300, calls, requiresJSInterop: true),
+            new TestInitializer("lower", -100, calls),
+            new TestInitializer("first-tie", 0, calls),
+            new TestInitializer("second-tie", 0, calls),
+            new TestInitializer("navigation", 100, calls, callback: _ =>
+            {
+                Assert.Equal("https://localhost/subdir/", navigationManager!.BaseUri);
+                Assert.Equal("https://localhost/subdir/page?query=value", navigationManager.Uri);
+            }));
+        using var scope = provider.CreateScope();
+        var context = CreateHttpContext(scope.ServiceProvider);
+        navigationManager = scope.ServiceProvider.GetRequiredService<NavigationManager>();
+
+        await scope.ServiceProvider.GetRequiredService<EndpointHtmlRenderer>()
+            .InitializeStandardComponentServicesAsync(context);
+
+        Assert.Equal(["lower", "first-tie", "second-tie", "navigation"], calls);
+    }
+
+    [Fact]
+    public async Task InitializerFailureStopsExecutionAndSurfaces()
+    {
+        var calls = new List<string>();
+        using var provider = CreateServices(
+            new TestInitializer("first", -400, calls),
+            new TestInitializer("failure", -300, calls, exception: new InvalidOperationException("Initializer failed.")),
+            new TestInitializer("not-run", -200, calls));
+        using var scope = provider.CreateScope();
+        var context = CreateHttpContext(scope.ServiceProvider);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            scope.ServiceProvider.GetRequiredService<EndpointHtmlRenderer>()
+                .InitializeStandardComponentServicesAsync(context));
+
+        Assert.Equal("Initializer failed.", exception.Message);
+        Assert.Equal(["first", "failure"], calls);
+    }
+
+    [Fact]
+    public async Task InitializerCancellationStopsExecutionAndSurfaces()
+    {
+        var calls = new List<string>();
+        using var provider = CreateServices(
+            new TestInitializer("canceled", -300, calls, observeCancellation: true),
+            new TestInitializer("not-run", -200, calls));
+        using var scope = provider.CreateScope();
+        var context = CreateHttpContext(scope.ServiceProvider);
+        context.RequestAborted = new CancellationToken(canceled: true);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            scope.ServiceProvider.GetRequiredService<EndpointHtmlRenderer>()
+                .InitializeStandardComponentServicesAsync(context));
+
+        Assert.Equal(["canceled"], calls);
+    }
+
+    private static ServiceProvider CreateServices(params IHostInitializer[] initializers)
+    {
+        var services = CreateBaseServices();
+        services.AddRazorComponents();
+        foreach (var initializer in initializers)
+        {
+            services.AddSingleton(typeof(IHostInitializer), initializer);
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    private static ServiceCollection CreateBaseServices()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddSingleton<IWebHostEnvironment>(new TestWebHostEnvironment());
+        return services;
+    }
+
+    private static DefaultHttpContext CreateHttpContext(IServiceProvider services)
+    {
+        var context = new DefaultHttpContext
+        {
+            RequestServices = services,
+        };
+        context.Request.Scheme = "https";
+        context.Request.Host = new HostString("localhost");
+        context.Request.PathBase = "/subdir";
+        context.Request.Path = "/page";
+        context.Request.QueryString = new QueryString("?query=value");
+
+        return context;
+    }
+
+    private sealed class TestInitializer(
+        string name,
+        int order,
+        List<string> calls,
+        bool requiresJSInterop = false,
+        bool observeCancellation = false,
+        Exception? exception = null,
+        Action<CancellationToken>? callback = null) : IHostInitializer
+    {
+        public int Order => order;
+
+        public bool RequiresJSInterop => requiresJSInterop;
+
+        public Task InitializeAsync(CancellationToken cancellationToken = default)
+        {
+            calls.Add(name);
+            callback?.Invoke(cancellationToken);
+            if (observeCancellation)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            if (exception is not null)
+            {
+                return Task.FromException(exception);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class TestHostStartupValues : IHostStartupValues
+    {
+        public string? GetValue(string key)
+            => null;
+
+        public string GetRequired(string key)
+            => throw new InvalidOperationException("Unexpected access.");
+    }
+
+    private sealed class TestWebHostEnvironment : IWebHostEnvironment
+    {
+        public string ApplicationName { get; set; } = "Test";
+        public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+        public string WebRootPath { get; set; } = "/";
+        public string EnvironmentName { get; set; } = "Test";
+        public string ContentRootPath { get; set; } = "/";
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/src/Components/Endpoints/test/Hosting/HttpContextHostStartupValuesTest.cs
+++ b/src/Components/Endpoints/test/Hosting/HttpContextHostStartupValuesTest.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+public class HttpContextHostStartupValuesTest
+{
+    [Fact]
+    public void GetValueRejectsNullKeyBeforeInitialization()
+    {
+        var startupValues = new HttpContextHostStartupValues([]);
+
+        Assert.Throws<ArgumentNullException>(() => startupValues.GetValue(null!));
+    }
+
+    [Fact]
+    public void CollectsProviderValues()
+    {
+        var startupValues = new HttpContextHostStartupValues(
+        [
+            new TestHttpContextStartupValueProvider("first", "one"),
+            new TestHttpContextStartupValueProvider("second", "two"),
+        ]);
+
+        startupValues.Initialize(new DefaultHttpContext());
+
+        Assert.Equal("one", startupValues.GetValue("first"));
+        Assert.Equal("two", startupValues.GetRequired("second"));
+        Assert.Null(startupValues.GetValue("missing"));
+        var exception = Assert.Throws<InvalidOperationException>(() => startupValues.GetRequired("missing"));
+        Assert.Equal("Startup value 'missing' was not provided.", exception.Message);
+    }
+
+    [Fact]
+    public void RejectsDuplicateProviderValuesEvenWhenValuesMatch()
+    {
+        var startupValues = new HttpContextHostStartupValues(
+        [
+            new TestHttpContextStartupValueProvider("duplicate", "value"),
+            new TestHttpContextStartupValueProvider("duplicate", "value"),
+        ]);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => startupValues.Initialize(new DefaultHttpContext()));
+
+        Assert.Equal("The startup value key 'duplicate' was provided more than once.", exception.Message);
+    }
+
+    [Fact]
+    public void DefaultProviderUsesRequestUris()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Scheme = "https";
+        httpContext.Request.Host = new HostString("example.com");
+        httpContext.Request.PathBase = "/base";
+        httpContext.Request.Path = "/page";
+        httpContext.Request.QueryString = new QueryString("?key=value");
+
+        var values = new NavigationHttpContextStartupValueProvider().GetValues(httpContext);
+
+        Assert.Equal("https://example.com/base/", values["document.baseURI"]);
+        Assert.Equal("https://example.com/base/page?key=value", values["location.href"]);
+    }
+
+    [Fact]
+    public void AddRazorComponentsRegistersAndCollectsAllProviders()
+    {
+        var services = new ServiceCollection();
+        services.AddRazorComponents();
+        services.AddSingleton<IHttpContextStartupValueProvider>(
+            new TestHttpContextStartupValueProvider("custom", "expected"));
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = scope.ServiceProvider,
+        };
+        httpContext.Request.Scheme = "https";
+        httpContext.Request.Host = new HostString("example.com");
+        var holder = scope.ServiceProvider
+            .GetRequiredKeyedService<HttpContextHostStartupValues>(typeof(IHostStartupValues));
+
+        holder.Initialize(httpContext);
+
+        Assert.Equal("expected", scope.ServiceProvider.GetRequiredService<IHostStartupValues>().GetRequired("custom"));
+        Assert.Equal("https://example.com/", holder.GetRequired("document.baseURI"));
+    }
+
+    private sealed class TestHttpContextStartupValueProvider(string key, string value) : IHttpContextStartupValueProvider
+    {
+        public IReadOnlyDictionary<string, string> GetValues(HttpContext httpContext)
+            => new Dictionary<string, string>
+            {
+                [key] = value,
+            };
+    }
+}

--- a/src/Components/Endpoints/test/Hosting/HttpContextHostStartupValuesTest.cs
+++ b/src/Components/Endpoints/test/Hosting/HttpContextHostStartupValuesTest.cs
@@ -81,7 +81,7 @@ public class HttpContextHostStartupValuesTest
         httpContext.Request.Scheme = "https";
         httpContext.Request.Host = new HostString("example.com");
         var holder = scope.ServiceProvider
-            .GetRequiredKeyedService<HttpContextHostStartupValues>(typeof(IHostStartupValues));
+            .GetRequiredKeyedService<HttpContextHostStartupValues>(HostInitializerKey.Static);
 
         holder.Initialize(httpContext);
 

--- a/src/Components/Endpoints/test/RazorComponentEndpointInvokerTest.cs
+++ b/src/Components/Endpoints/test/RazorComponentEndpointInvokerTest.cs
@@ -7,6 +7,7 @@ using System.Text;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Endpoints.Tests.TestComponents;
+using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -97,6 +98,9 @@ public class RazorComponentEndpointInvokerTest
         // The HTTP server (Kestrel) handles suppressing the response body for HEAD requests.
         Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
         Assert.Equal("text/html; charset=utf-8", context.Response.ContentType);
+        var startupValues = services.GetRequiredService<IHostStartupValues>();
+        Assert.Equal("https://localhost/", startupValues.GetRequired("document.baseURI"));
+        Assert.Equal("https://localhost/", startupValues.GetRequired("location.href"));
     }
 
     [Fact]

--- a/src/Components/Endpoints/test/RazorComponentResultTest.cs
+++ b/src/Components/Endpoints/test/RazorComponentResultTest.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Components.Endpoints.Forms;
 using Microsoft.AspNetCore.Components.Endpoints.Tests.TestComponents;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.DataProtection;
@@ -466,6 +467,15 @@ public class RazorComponentResultTest
             .AddSingleton<ComponentStatePersistenceManager>()
             .AddSingleton<PersistentComponentState>(sp => sp.GetRequiredService<ComponentStatePersistenceManager>().State)
             .AddSingleton<AntiforgeryStateProvider, EndpointAntiforgeryStateProvider>()
+            .AddKeyedSingleton<HttpContextHostStartupValues>(HostInitializerKey.Static)
+            .AddKeyedSingleton<IHostStartupValues>(
+                HostInitializerKey.Static,
+                static (services, key) => services.GetRequiredKeyedService<HttpContextHostStartupValues>(key))
+            .AddSingleton<IHostStartupValues>(
+                static services => services.GetRequiredKeyedService<IHostStartupValues>(HostInitializerKey.Static))
+            .AddKeyedSingleton<IHostInitializer, NavigationManagerInitializer>(HostInitializerKey.Static)
+            .AddSingleton<IHttpContextStartupValueProvider, NavigationHttpContextStartupValueProvider>()
+            .AddSingleton<HostInitializerCollection>()
             .AddLogging();
 
         var result = new DefaultHttpContext { RequestServices = serviceCollection.BuildServiceProvider() };

--- a/src/Components/Endpoints/test/RazorComponentsServiceCollectionExtensionsTest.cs
+++ b/src/Components/Endpoints/test/RazorComponentsServiceCollectionExtensionsTest.cs
@@ -40,7 +40,7 @@ public class RazorComponentsServiceCollectionExtensionsTest
             if (singleRegistrationServiceTypes.Contains(service.ServiceType))
             {
                 // 'single-registration' services should only have one implementation registered.
-                AssertServiceCountEquals(services, service.ServiceType, 1);
+                AssertServiceCountEquals(services, service.ServiceType, service.ServiceKey, 1);
             }
             else
             {
@@ -69,7 +69,7 @@ public class RazorComponentsServiceCollectionExtensionsTest
             if (singleRegistrationServiceTypes.Contains(service.ServiceType))
             {
                 // 'single-registration' services should only have one implementation registered.
-                AssertServiceCountEquals(services, service.ServiceType, 1);
+                AssertServiceCountEquals(services, service.ServiceType, service.ServiceKey, 1);
             }
             else
             {
@@ -117,9 +117,12 @@ public class RazorComponentsServiceCollectionExtensionsTest
     private void AssertServiceCountEquals(
         IServiceCollection services,
         Type serviceType,
+        object serviceKey,
         int expectedServiceRegistrationCount)
     {
-        var serviceDescriptors = services.Where(serviceDescriptor => serviceDescriptor.ServiceType == serviceType);
+        var serviceDescriptors = services.Where(
+            serviceDescriptor => serviceDescriptor.ServiceType == serviceType &&
+                Equals(serviceDescriptor.ServiceKey, serviceKey));
         var actual = serviceDescriptors.Count();
 
         Assert.True(

--- a/src/Components/Server/src/Circuits/CircuitFactory.cs
+++ b/src/Components/Server/src/Circuits/CircuitFactory.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using System.Security.Claims;
+using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Components.Web;
@@ -43,11 +44,17 @@ internal sealed partial class CircuitFactory : ICircuitFactory
         CircuitClientProxy client,
         string baseUri,
         string uri,
+        IReadOnlyDictionary<string, string> startupValues,
         ClaimsPrincipal user,
         IPersistentComponentStateStore store,
         ResourceAssetCollection resourceCollection)
     {
         var scope = _scopeFactory.CreateAsyncScope();
+        scope.ServiceProvider.GetRequiredService<InteractiveServerContext>().IsInteractive = true;
+        scope.ServiceProvider
+            .GetRequiredKeyedService<InteractiveHostStartupValues>(typeof(ComponentHub))
+            .Initialize(startupValues);
+
         var jsRuntime = (RemoteJSRuntime)scope.ServiceProvider.GetRequiredService<IJSRuntime>();
         jsRuntime.Initialize(client);
 

--- a/src/Components/Server/src/Circuits/CircuitFactory.cs
+++ b/src/Components/Server/src/Circuits/CircuitFactory.cs
@@ -47,7 +47,6 @@ internal sealed partial class CircuitFactory : ICircuitFactory
         ClaimsPrincipal user,
         IPersistentComponentStateStore store,
         ResourceAssetCollection resourceCollection,
-        bool supportsDeferredHostInitialization,
         CancellationToken cancellationToken)
     {
         var scope = _scopeFactory.CreateAsyncScope();
@@ -69,34 +68,20 @@ internal sealed partial class CircuitFactory : ICircuitFactory
                 .OrderBy(initializer => initializer.Order)
                 .ToArray();
 
-            if (supportsDeferredHostInitialization)
+            var firstDeferredInitializerIndex = Array.FindIndex(
+                hostInitializers,
+                initializer => initializer.RequiresJSInterop);
+            var initializersToRun = firstDeferredInitializerIndex < 0
+                ? hostInitializers
+                : hostInitializers[..firstDeferredInitializerIndex];
+            foreach (var initializer in initializersToRun)
             {
-                var firstDeferredInitializerIndex = Array.FindIndex(
-                    hostInitializers,
-                    initializer => initializer.RequiresJSInterop);
-                var initializersToRun = firstDeferredInitializerIndex < 0
-                    ? hostInitializers
-                    : hostInitializers[..firstDeferredInitializerIndex];
-                foreach (var initializer in initializersToRun)
-                {
-                    await initializer.InitializeAsync(cancellationToken);
-                }
+                await initializer.InitializeAsync(cancellationToken);
+            }
 
-                deferredHostInitializers = firstDeferredInitializerIndex < 0
-                    ? []
-                    : hostInitializers[firstDeferredInitializerIndex..];
-            }
-            else
-            {
-                deferredHostInitializers = [];
-                foreach (var initializer in hostInitializers)
-                {
-                    if (!initializer.RequiresJSInterop || initializer is IServerHostInitializer)
-                    {
-                        await initializer.InitializeAsync(cancellationToken);
-                    }
-                }
-            }
+            deferredHostInitializers = firstDeferredInitializerIndex < 0
+                ? []
+                : hostInitializers[firstDeferredInitializerIndex..];
         }
         catch
         {

--- a/src/Components/Server/src/Circuits/CircuitFactory.cs
+++ b/src/Components/Server/src/Circuits/CircuitFactory.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Infrastructure;
-using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -47,7 +46,9 @@ internal sealed partial class CircuitFactory : ICircuitFactory
         IReadOnlyDictionary<string, string> startupValues,
         ClaimsPrincipal user,
         IPersistentComponentStateStore store,
-        ResourceAssetCollection resourceCollection)
+        ResourceAssetCollection resourceCollection,
+        bool supportsDeferredHostInitialization,
+        CancellationToken cancellationToken)
     {
         var scope = _scopeFactory.CreateAsyncScope();
         scope.ServiceProvider.GetRequiredService<InteractiveServerContext>().IsInteractive = true;
@@ -59,21 +60,48 @@ internal sealed partial class CircuitFactory : ICircuitFactory
         jsRuntime.Initialize(client);
 
         var navigationManager = (RemoteNavigationManager)scope.ServiceProvider.GetRequiredService<NavigationManager>();
-        var navigationInterception = (RemoteNavigationInterception)scope.ServiceProvider.GetRequiredService<INavigationInterception>();
-        var scrollToLocationHash = (RemoteScrollToLocationHash)scope.ServiceProvider.GetRequiredService<IScrollToLocationHash>();
         var circuitActivitySource = scope.ServiceProvider.GetRequiredService<CircuitActivitySource>();
 
-        if (client.Connected)
+        IHostInitializer[] deferredHostInitializers;
+        try
         {
-            navigationManager.AttachJsRuntime(jsRuntime);
-            navigationManager.Initialize(baseUri, uri);
+            var hostInitializers = scope.ServiceProvider.GetServices<IHostInitializer>()
+                .OrderBy(initializer => initializer.Order)
+                .ToArray();
 
-            navigationInterception.AttachJSRuntime(jsRuntime);
-            scrollToLocationHash.AttachJSRuntime(jsRuntime);
+            if (supportsDeferredHostInitialization)
+            {
+                var firstDeferredInitializerIndex = Array.FindIndex(
+                    hostInitializers,
+                    initializer => initializer.RequiresJSInterop);
+                var initializersToRun = firstDeferredInitializerIndex < 0
+                    ? hostInitializers
+                    : hostInitializers[..firstDeferredInitializerIndex];
+                foreach (var initializer in initializersToRun)
+                {
+                    await initializer.InitializeAsync(cancellationToken);
+                }
+
+                deferredHostInitializers = firstDeferredInitializerIndex < 0
+                    ? []
+                    : hostInitializers[firstDeferredInitializerIndex..];
+            }
+            else
+            {
+                deferredHostInitializers = [];
+                foreach (var initializer in hostInitializers)
+                {
+                    if (!initializer.RequiresJSInterop || initializer is IServerHostInitializer)
+                    {
+                        await initializer.InitializeAsync(cancellationToken);
+                    }
+                }
+            }
         }
-        else
+        catch
         {
-            navigationManager.Initialize(baseUri, uri);
+            await scope.DisposeAsync();
+            throw;
         }
 
         if (components.Count > 0)
@@ -119,6 +147,7 @@ internal sealed partial class CircuitFactory : ICircuitFactory
             components,
             jsRuntime,
             navigationManager,
+            deferredHostInitializers,
             circuitHandlers,
             _circuitMetrics,
             circuitActivitySource,

--- a/src/Components/Server/src/Circuits/CircuitFactory.cs
+++ b/src/Components/Server/src/Circuits/CircuitFactory.cs
@@ -19,6 +19,7 @@ internal sealed partial class CircuitFactory : ICircuitFactory
     private readonly ILoggerFactory _loggerFactory;
     private readonly CircuitIdFactory _circuitIdFactory;
     private readonly CircuitOptions _options;
+    private readonly HostInitializerCollection _hostInitializers;
     private readonly ILogger _logger;
     private readonly CircuitMetrics _circuitMetrics;
 
@@ -27,11 +28,13 @@ internal sealed partial class CircuitFactory : ICircuitFactory
         ILoggerFactory loggerFactory,
         CircuitIdFactory circuitIdFactory,
         CircuitMetrics circuitMetrics,
+        HostInitializerCollection hostInitializers,
         IOptions<CircuitOptions> options)
     {
         _scopeFactory = scopeFactory;
         _loggerFactory = loggerFactory;
         _circuitIdFactory = circuitIdFactory;
+        _hostInitializers = hostInitializers;
         _options = options.Value;
         _logger = _loggerFactory.CreateLogger<CircuitFactory>();
 
@@ -64,24 +67,29 @@ internal sealed partial class CircuitFactory : ICircuitFactory
         IHostInitializer[] deferredHostInitializers;
         try
         {
-            var hostInitializers = scope.ServiceProvider.GetServices<IHostInitializer>()
-                .OrderBy(initializer => initializer.Order)
-                .ToArray();
+            var hostInitializers = _hostInitializers.Initializers;
 
-            var firstDeferredInitializerIndex = Array.FindIndex(
-                hostInitializers,
-                initializer => initializer.RequiresJSInterop);
-            var initializersToRun = firstDeferredInitializerIndex < 0
-                ? hostInitializers
-                : hostInitializers[..firstDeferredInitializerIndex];
-            foreach (var initializer in initializersToRun)
+            var firstDeferredInitializerIndex = -1;
+            for (var i = 0; i < hostInitializers.Length; i++)
             {
-                await initializer.InitializeAsync(cancellationToken);
+                if (hostInitializers[i].RequiresJSInterop)
+                {
+                    firstDeferredInitializerIndex = i;
+                    break;
+                }
+            }
+
+            var initializersToRun = firstDeferredInitializerIndex < 0
+                ? hostInitializers.Length
+                : firstDeferredInitializerIndex;
+            for (var i = 0; i < initializersToRun; i++)
+            {
+                await hostInitializers[i].InitializeAsync(scope.ServiceProvider, cancellationToken);
             }
 
             deferredHostInitializers = firstDeferredInitializerIndex < 0
                 ? []
-                : hostInitializers[firstDeferredInitializerIndex..];
+                : hostInitializers.AsSpan(firstDeferredInitializerIndex..).ToArray();
         }
         catch
         {

--- a/src/Components/Server/src/Circuits/CircuitFactory.cs
+++ b/src/Components/Server/src/Circuits/CircuitFactory.cs
@@ -55,7 +55,7 @@ internal sealed partial class CircuitFactory : ICircuitFactory
         var scope = _scopeFactory.CreateAsyncScope();
         scope.ServiceProvider.GetRequiredService<InteractiveServerContext>().IsInteractive = true;
         scope.ServiceProvider
-            .GetRequiredKeyedService<InteractiveHostStartupValues>(typeof(ComponentHub))
+            .GetRequiredKeyedService<InteractiveHostStartupValues>(HostInitializerKey.Server)
             .Initialize(startupValues);
 
         var jsRuntime = (RemoteJSRuntime)scope.ServiceProvider.GetRequiredService<IJSRuntime>();
@@ -64,32 +64,12 @@ internal sealed partial class CircuitFactory : ICircuitFactory
         var navigationManager = (RemoteNavigationManager)scope.ServiceProvider.GetRequiredService<NavigationManager>();
         var circuitActivitySource = scope.ServiceProvider.GetRequiredService<CircuitActivitySource>();
 
-        IHostInitializer[] deferredHostInitializers;
+        var hostInitializerInvoker = _hostInitializers.GetInitializerInvoker(
+            scope.ServiceProvider,
+            HostInitializerKey.Server);
         try
         {
-            var hostInitializers = _hostInitializers.Initializers;
-
-            var firstDeferredInitializerIndex = -1;
-            for (var i = 0; i < hostInitializers.Length; i++)
-            {
-                if (hostInitializers[i].RequiresJSInterop)
-                {
-                    firstDeferredInitializerIndex = i;
-                    break;
-                }
-            }
-
-            var initializersToRun = firstDeferredInitializerIndex < 0
-                ? hostInitializers.Length
-                : firstDeferredInitializerIndex;
-            for (var i = 0; i < initializersToRun; i++)
-            {
-                await hostInitializers[i].InitializeAsync(scope.ServiceProvider, cancellationToken);
-            }
-
-            deferredHostInitializers = firstDeferredInitializerIndex < 0
-                ? []
-                : hostInitializers.AsSpan(firstDeferredInitializerIndex..).ToArray();
+            await hostInitializerInvoker.InitializeHostAsync(cancellationToken);
         }
         catch
         {
@@ -140,7 +120,7 @@ internal sealed partial class CircuitFactory : ICircuitFactory
             components,
             jsRuntime,
             navigationManager,
-            deferredHostInitializers,
+            hostInitializerInvoker,
             circuitHandlers,
             _circuitMetrics,
             circuitActivitySource,

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.SignalR;
@@ -27,7 +28,13 @@ internal partial class CircuitHost : IAsyncDisposable
     private readonly ILogger _logger;
     private readonly CircuitMetrics _circuitMetrics;
     private readonly CircuitActivitySource _circuitActivitySource;
+    private readonly IHostInitializer[] _deferredHostInitializers;
+    private readonly TaskCompletionSource _deferredHostInitializationCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly object _hostInitializationLock = new();
+    private readonly object _rootComponentUpdateLock = new();
+    private Task _rootComponentUpdateQueue = Task.CompletedTask;
     private Func<Func<Task>, Task> _dispatchInboundActivity;
+    private Task _completeHostInitializationTask;
     private CircuitHandler[] _circuitHandlers;
     private bool _initialized;
     private bool _isFirstUpdate = true;
@@ -54,6 +61,7 @@ internal partial class CircuitHost : IAsyncDisposable
         IReadOnlyList<ComponentDescriptor> descriptors,
         RemoteJSRuntime jsRuntime,
         RemoteNavigationManager navigationManager,
+        IHostInitializer[] deferredHostInitializers,
         CircuitHandler[] circuitHandlers,
         CircuitMetrics circuitMetrics,
         CircuitActivitySource circuitActivitySource,
@@ -73,6 +81,7 @@ internal partial class CircuitHost : IAsyncDisposable
         Descriptors = descriptors ?? throw new ArgumentNullException(nameof(descriptors));
         JSRuntime = jsRuntime ?? throw new ArgumentNullException(nameof(jsRuntime));
         _navigationManager = navigationManager ?? throw new ArgumentNullException(nameof(navigationManager));
+        _deferredHostInitializers = deferredHostInitializers ?? throw new ArgumentNullException(nameof(deferredHostInitializers));
         _circuitHandlers = circuitHandlers ?? throw new ArgumentNullException(nameof(circuitHandlers));
         _circuitMetrics = circuitMetrics;
         _circuitActivitySource = circuitActivitySource;
@@ -92,6 +101,11 @@ internal partial class CircuitHost : IAsyncDisposable
         JSRuntime.UnhandledException += ReportAndInvoke_UnhandledException;
 
         _navigationManager.UnhandledException += ReportAndInvoke_UnhandledException;
+
+        if (_deferredHostInitializers.Length == 0)
+        {
+            _deferredHostInitializationCompletion.SetResult();
+        }
     }
 
     public CircuitHandle Handle { get; }
@@ -133,6 +147,8 @@ internal partial class CircuitHost : IAsyncDisposable
 
                 activityHandle = _circuitActivitySource.StartCircuitActivity(CircuitId.Id, httpActivityContext);
                 _startTime = (_circuitMetrics != null && _circuitMetrics.IsDurationEnabled()) ? Stopwatch.GetTimestamp() : 0;
+
+                await _deferredHostInitializationCompletion.Task.WaitAsync(cancellationToken);
 
                 // We only run the handlers in case we are in a Blazor Server scenario, which renders
                 // the components immediately during start.
@@ -189,6 +205,78 @@ internal partial class CircuitHost : IAsyncDisposable
                 await TryNotifyClientErrorAsync(Client, GetClientErrorMessage(ex), ex);
             }
         }));
+    }
+
+    internal void BeginHostInitialization(CancellationToken cancellationToken)
+    {
+        lock (_hostInitializationLock)
+        {
+            _completeHostInitializationTask ??= RunDeferredHostInitializersAsync(cancellationToken);
+        }
+    }
+
+    private async Task RunDeferredHostInitializersAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Renderer.Dispatcher.InvokeAsync(
+                () => ExecuteDeferredHostInitializersAsync(cancellationToken));
+        }
+        catch (Exception exception)
+        {
+            await FailHostInitializationAsync(exception);
+        }
+    }
+
+    private async Task ExecuteDeferredHostInitializersAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            foreach (var initializer in _deferredHostInitializers)
+            {
+                await initializer.InitializeAsync(cancellationToken);
+            }
+
+            _deferredHostInitializationCompletion.TrySetResult();
+            await NotifyHostInitializationCompletionAsync(succeeded: true, error: null);
+        }
+        catch (Exception exception)
+        {
+            await FailHostInitializationAsync(exception);
+        }
+    }
+
+    private async Task FailHostInitializationAsync(Exception exception)
+    {
+        if (exception is OperationCanceledException cancellationException)
+        {
+            _deferredHostInitializationCompletion.TrySetCanceled(cancellationException.CancellationToken);
+        }
+        else
+        {
+            _deferredHostInitializationCompletion.TrySetException(exception);
+        }
+
+        await NotifyHostInitializationCompletionAsync(
+            succeeded: false,
+            error: GetClientErrorMessage(exception));
+    }
+
+    private async Task NotifyHostInitializationCompletionAsync(bool succeeded, string error)
+    {
+        if (!Client.Connected)
+        {
+            return;
+        }
+
+        try
+        {
+            await Client.SendAsync("JS.EndHostInitialization", succeeded, error);
+        }
+        catch (Exception exception)
+        {
+            Log.CircuitTransmitErrorFailed(_logger, CircuitId, exception);
+        }
     }
 
     // We handle errors in DisposeAsync because there's no real value in letting it propagate.
@@ -769,7 +857,59 @@ internal partial class CircuitHost : IAsyncDisposable
     {
         Log.UpdateRootComponentsStarted(_logger);
 
-        return Renderer.Dispatcher.InvokeAsync(async () =>
+        Task predecessor;
+        var queueCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        lock (_rootComponentUpdateLock)
+        {
+            predecessor = _rootComponentUpdateQueue;
+            _rootComponentUpdateQueue = queueCompletion.Task;
+        }
+
+        return ProcessQueuedRootComponentUpdate(
+            operationBatch,
+            store,
+            isRestore,
+            cancellation,
+            predecessor,
+            queueCompletion);
+    }
+
+    private async Task ProcessQueuedRootComponentUpdate(
+        RootComponentOperationBatch operationBatch,
+        IClearableStore store,
+        bool isRestore,
+        CancellationToken cancellation,
+        Task predecessor,
+        TaskCompletionSource queueCompletion)
+    {
+        try
+        {
+            await predecessor;
+            await UpdateRootComponentsCore(operationBatch, store, isRestore, cancellation);
+        }
+        finally
+        {
+            queueCompletion.TrySetResult();
+        }
+    }
+
+    private async Task UpdateRootComponentsCore(
+        RootComponentOperationBatch operationBatch,
+        IClearableStore store,
+        bool isRestore,
+        CancellationToken cancellation)
+    {
+        try
+        {
+            await _deferredHostInitializationCompletion.Task.WaitAsync(cancellation);
+        }
+        catch
+        {
+            // InitializeAsync owns reporting host initialization failures.
+            return;
+        }
+
+        await Renderer.Dispatcher.InvokeAsync(async () =>
         {
             var shouldClearStore = false;
             var shouldWaitForQuiescence = false;

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -29,12 +29,8 @@ internal partial class CircuitHost : IAsyncDisposable
     private readonly CircuitMetrics _circuitMetrics;
     private readonly CircuitActivitySource _circuitActivitySource;
     private readonly IHostInitializer[] _deferredHostInitializers;
-    private readonly TaskCompletionSource _deferredHostInitializationCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
-    private readonly object _hostInitializationLock = new();
-    private readonly object _rootComponentUpdateLock = new();
-    private Task _rootComponentUpdateQueue = Task.CompletedTask;
+    private Task _deferredHostInitializersTask = Task.CompletedTask;
     private Func<Func<Task>, Task> _dispatchInboundActivity;
-    private Task _completeHostInitializationTask;
     private CircuitHandler[] _circuitHandlers;
     private bool _initialized;
     private bool _isFirstUpdate = true;
@@ -102,10 +98,6 @@ internal partial class CircuitHost : IAsyncDisposable
 
         _navigationManager.UnhandledException += ReportAndInvoke_UnhandledException;
 
-        if (_deferredHostInitializers.Length == 0)
-        {
-            _deferredHostInitializationCompletion.SetResult();
-        }
     }
 
     public CircuitHandle Handle { get; }
@@ -148,7 +140,8 @@ internal partial class CircuitHost : IAsyncDisposable
                 activityHandle = _circuitActivitySource.StartCircuitActivity(CircuitId.Id, httpActivityContext);
                 _startTime = (_circuitMetrics != null && _circuitMetrics.IsDurationEnabled()) ? Stopwatch.GetTimestamp() : 0;
 
-                await _deferredHostInitializationCompletion.Task.WaitAsync(cancellationToken);
+                _deferredHostInitializersTask = RunDeferredHostInitializersAsync(cancellationToken);
+                await _deferredHostInitializersTask;
 
                 // We only run the handlers in case we are in a Blazor Server scenario, which renders
                 // the components immediately during start.
@@ -207,75 +200,11 @@ internal partial class CircuitHost : IAsyncDisposable
         }));
     }
 
-    internal void BeginHostInitialization(CancellationToken cancellationToken)
-    {
-        lock (_hostInitializationLock)
-        {
-            _completeHostInitializationTask ??= RunDeferredHostInitializersAsync(cancellationToken);
-        }
-    }
-
     private async Task RunDeferredHostInitializersAsync(CancellationToken cancellationToken)
     {
-        try
+        foreach (var initializer in _deferredHostInitializers)
         {
-            await Renderer.Dispatcher.InvokeAsync(
-                () => ExecuteDeferredHostInitializersAsync(cancellationToken));
-        }
-        catch (Exception exception)
-        {
-            await FailHostInitializationAsync(exception);
-        }
-    }
-
-    private async Task ExecuteDeferredHostInitializersAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            foreach (var initializer in _deferredHostInitializers)
-            {
-                await initializer.InitializeAsync(cancellationToken);
-            }
-
-            _deferredHostInitializationCompletion.TrySetResult();
-            await NotifyHostInitializationCompletionAsync(succeeded: true, error: null);
-        }
-        catch (Exception exception)
-        {
-            await FailHostInitializationAsync(exception);
-        }
-    }
-
-    private async Task FailHostInitializationAsync(Exception exception)
-    {
-        if (exception is OperationCanceledException cancellationException)
-        {
-            _deferredHostInitializationCompletion.TrySetCanceled(cancellationException.CancellationToken);
-        }
-        else
-        {
-            _deferredHostInitializationCompletion.TrySetException(exception);
-        }
-
-        await NotifyHostInitializationCompletionAsync(
-            succeeded: false,
-            error: GetClientErrorMessage(exception));
-    }
-
-    private async Task NotifyHostInitializationCompletionAsync(bool succeeded, string error)
-    {
-        if (!Client.Connected)
-        {
-            return;
-        }
-
-        try
-        {
-            await Client.SendAsync("JS.EndHostInitialization", succeeded, error);
-        }
-        catch (Exception exception)
-        {
-            Log.CircuitTransmitErrorFailed(_logger, CircuitId, exception);
+            await initializer.InitializeAsync(Services, cancellationToken);
         }
     }
 
@@ -849,65 +778,13 @@ internal partial class CircuitHost : IAsyncDisposable
         }
     }
 
-    internal Task UpdateRootComponents(
+    internal async Task UpdateRootComponents(
         RootComponentOperationBatch operationBatch,
         IClearableStore store,
         bool isRestore,
         CancellationToken cancellation)
     {
         Log.UpdateRootComponentsStarted(_logger);
-
-        Task predecessor;
-        var queueCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        lock (_rootComponentUpdateLock)
-        {
-            predecessor = _rootComponentUpdateQueue;
-            _rootComponentUpdateQueue = queueCompletion.Task;
-        }
-
-        return ProcessQueuedRootComponentUpdate(
-            operationBatch,
-            store,
-            isRestore,
-            cancellation,
-            predecessor,
-            queueCompletion);
-    }
-
-    private async Task ProcessQueuedRootComponentUpdate(
-        RootComponentOperationBatch operationBatch,
-        IClearableStore store,
-        bool isRestore,
-        CancellationToken cancellation,
-        Task predecessor,
-        TaskCompletionSource queueCompletion)
-    {
-        try
-        {
-            await predecessor;
-            await UpdateRootComponentsCore(operationBatch, store, isRestore, cancellation);
-        }
-        finally
-        {
-            queueCompletion.TrySetResult();
-        }
-    }
-
-    private async Task UpdateRootComponentsCore(
-        RootComponentOperationBatch operationBatch,
-        IClearableStore store,
-        bool isRestore,
-        CancellationToken cancellation)
-    {
-        try
-        {
-            await _deferredHostInitializationCompletion.Task.WaitAsync(cancellation);
-        }
-        catch
-        {
-            // InitializeAsync owns reporting host initialization failures.
-            return;
-        }
 
         await Renderer.Dispatcher.InvokeAsync(async () =>
         {
@@ -925,6 +802,16 @@ internal partial class CircuitHost : IAsyncDisposable
                     // the footprint for Blazor Server closer to what it was before.
                     throw new InvalidOperationException("UpdateRootComponents is not supported when components have" +
                         " been provided during circuit start up.");
+                }
+
+                try
+                {
+                    await _deferredHostInitializersTask;
+                }
+                catch
+                {
+                    // InitializeAsync owns reporting host initialization failures.
+                    return;
                 }
 
                 if (store != null)

--- a/src/Components/Server/src/Circuits/CircuitHost.cs
+++ b/src/Components/Server/src/Circuits/CircuitHost.cs
@@ -28,8 +28,7 @@ internal partial class CircuitHost : IAsyncDisposable
     private readonly ILogger _logger;
     private readonly CircuitMetrics _circuitMetrics;
     private readonly CircuitActivitySource _circuitActivitySource;
-    private readonly IHostInitializer[] _deferredHostInitializers;
-    private Task _deferredHostInitializersTask = Task.CompletedTask;
+    private readonly HostInitializerInvoker _hostInitializerInvoker;
     private Func<Func<Task>, Task> _dispatchInboundActivity;
     private CircuitHandler[] _circuitHandlers;
     private bool _initialized;
@@ -57,7 +56,7 @@ internal partial class CircuitHost : IAsyncDisposable
         IReadOnlyList<ComponentDescriptor> descriptors,
         RemoteJSRuntime jsRuntime,
         RemoteNavigationManager navigationManager,
-        IHostInitializer[] deferredHostInitializers,
+        HostInitializerInvoker hostInitializerInvoker,
         CircuitHandler[] circuitHandlers,
         CircuitMetrics circuitMetrics,
         CircuitActivitySource circuitActivitySource,
@@ -77,7 +76,7 @@ internal partial class CircuitHost : IAsyncDisposable
         Descriptors = descriptors ?? throw new ArgumentNullException(nameof(descriptors));
         JSRuntime = jsRuntime ?? throw new ArgumentNullException(nameof(jsRuntime));
         _navigationManager = navigationManager ?? throw new ArgumentNullException(nameof(navigationManager));
-        _deferredHostInitializers = deferredHostInitializers ?? throw new ArgumentNullException(nameof(deferredHostInitializers));
+        _hostInitializerInvoker = hostInitializerInvoker ?? throw new ArgumentNullException(nameof(hostInitializerInvoker));
         _circuitHandlers = circuitHandlers ?? throw new ArgumentNullException(nameof(circuitHandlers));
         _circuitMetrics = circuitMetrics;
         _circuitActivitySource = circuitActivitySource;
@@ -140,8 +139,7 @@ internal partial class CircuitHost : IAsyncDisposable
                 activityHandle = _circuitActivitySource.StartCircuitActivity(CircuitId.Id, httpActivityContext);
                 _startTime = (_circuitMetrics != null && _circuitMetrics.IsDurationEnabled()) ? Stopwatch.GetTimestamp() : 0;
 
-                _deferredHostInitializersTask = RunDeferredHostInitializersAsync(cancellationToken);
-                await _deferredHostInitializersTask;
+                await _hostInitializerInvoker.InitializeBrowserAsync(cancellationToken);
 
                 // We only run the handlers in case we are in a Blazor Server scenario, which renders
                 // the components immediately during start.
@@ -198,14 +196,6 @@ internal partial class CircuitHost : IAsyncDisposable
                 await TryNotifyClientErrorAsync(Client, GetClientErrorMessage(ex), ex);
             }
         }));
-    }
-
-    private async Task RunDeferredHostInitializersAsync(CancellationToken cancellationToken)
-    {
-        foreach (var initializer in _deferredHostInitializers)
-        {
-            await initializer.InitializeAsync(Services, cancellationToken);
-        }
     }
 
     // We handle errors in DisposeAsync because there's no real value in letting it propagate.
@@ -806,7 +796,7 @@ internal partial class CircuitHost : IAsyncDisposable
 
                 try
                 {
-                    await _deferredHostInitializersTask;
+                    await _hostInitializerInvoker.InitializeBrowserAsync(cancellation);
                 }
                 catch
                 {

--- a/src/Components/Server/src/Circuits/ICircuitFactory.cs
+++ b/src/Components/Server/src/Circuits/ICircuitFactory.cs
@@ -15,5 +15,7 @@ internal interface ICircuitFactory
         IReadOnlyDictionary<string, string> startupValues,
         ClaimsPrincipal user,
         IPersistentComponentStateStore store,
-        ResourceAssetCollection resourceCollection);
+        ResourceAssetCollection resourceCollection,
+        bool supportsDeferredHostInitialization,
+        CancellationToken cancellationToken);
 }

--- a/src/Components/Server/src/Circuits/ICircuitFactory.cs
+++ b/src/Components/Server/src/Circuits/ICircuitFactory.cs
@@ -12,6 +12,7 @@ internal interface ICircuitFactory
         CircuitClientProxy client,
         string baseUri,
         string uri,
+        IReadOnlyDictionary<string, string> startupValues,
         ClaimsPrincipal user,
         IPersistentComponentStateStore store,
         ResourceAssetCollection resourceCollection);

--- a/src/Components/Server/src/Circuits/ICircuitFactory.cs
+++ b/src/Components/Server/src/Circuits/ICircuitFactory.cs
@@ -16,6 +16,5 @@ internal interface ICircuitFactory
         ClaimsPrincipal user,
         IPersistentComponentStateStore store,
         ResourceAssetCollection resourceCollection,
-        bool supportsDeferredHostInitialization,
         CancellationToken cancellationToken);
 }

--- a/src/Components/Server/src/Circuits/InteractiveServerContext.cs
+++ b/src/Components/Server/src/Circuits/InteractiveServerContext.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Server.Circuits;
+
+internal sealed class InteractiveServerContext
+{
+    public bool IsInteractive { get; set; }
+}

--- a/src/Components/Server/src/ComponentHub.cs
+++ b/src/Components/Server/src/ComponentHub.cs
@@ -111,12 +111,6 @@ internal sealed partial class ComponentHub : Hub
         => HostStartupValuesJson.SerializeKeys(
             BrowserStartupValueProviderUtilities.GetKeys(_browserStartupValueProviders));
 
-    public async Task CompleteHostInitialization()
-    {
-        var circuitHost = await GetActiveCircuitAsync();
-        circuitHost?.BeginHostInitialization(Context.ConnectionAborted);
-    }
-
     public async ValueTask<string> StartCircuit(
         string startupValuesJson,
         string serializedComponentRecords,
@@ -176,8 +170,8 @@ internal sealed partial class ComponentHub : Hub
             var httpActivityContext = Context.GetHttpContext().Features.Get<IHttpActivityFeature>()?.Activity.Context ?? default;
             _ = circuitHost.InitializeAsync(store, httpActivityContext, Context.ConnectionAborted);
 
-            // Publish before initialization completes so the client can complete deferred host initialization.
-            // Root component rendering remains blocked until that handshake finishes.
+            // Publish before initialization completes so JS interop responses can flow.
+            // Root component rendering remains blocked until host initialization finishes.
             _circuitRegistry.Register(circuitHost);
             _circuitHandleRegistry.SetCircuit(Context.Items, CircuitKey, circuitHost);
 
@@ -469,8 +463,8 @@ internal sealed partial class ComponentHub : Hub
 
             circuitHost.AttachPersistedState(resumedPersistedCircuitState);
 
-            // Publish before initialization completes so the client can complete deferred host initialization.
-            // Root component rendering remains blocked until that handshake finishes.
+            // Publish before initialization completes so JS interop responses can flow.
+            // Root component rendering remains blocked until host initialization finishes.
             _circuitRegistry.Register(circuitHost);
             _circuitHandleRegistry.SetCircuit(Context.Items, CircuitKey, circuitHost);
 

--- a/src/Components/Server/src/ComponentHub.cs
+++ b/src/Components/Server/src/ComponentHub.cs
@@ -107,8 +107,15 @@ internal sealed partial class ComponentHub : Hub
         return Task.CompletedTask;
     }
 
-    public string[] GetStartupValueKeys()
-        => BrowserStartupValueProviderUtilities.GetKeys(_browserStartupValueProviders);
+    public string GetStartupValueKeys()
+        => HostStartupValuesJson.SerializeKeys(
+            BrowserStartupValueProviderUtilities.GetKeys(_browserStartupValueProviders));
+
+    public async Task CompleteHostInitialization()
+    {
+        var circuitHost = await GetActiveCircuitAsync();
+        circuitHost?.BeginHostInitialization(Context.ConnectionAborted);
+    }
 
     public ValueTask<string> StartCircuit(string baseUri, string uri, string serializedComponentRecords, string applicationState)
         => StartCircuitCore(baseUri, uri, serializedComponentRecords, applicationState, null, hasStartupValues: false);
@@ -195,7 +202,9 @@ internal sealed partial class ComponentHub : Hub
                 startupValues,
                 Context.User,
                 store,
-                resourceCollection);
+                resourceCollection,
+                supportsDeferredHostInitialization: hasStartupValues,
+                cancellationToken: Context.ConnectionAborted);
 
             // Fire-and-forget the initialization process, because we can't block the
             // SignalR message loop (we'd get a deadlock if any of the initialization
@@ -204,8 +213,8 @@ internal sealed partial class ComponentHub : Hub
             var httpActivityContext = Context.GetHttpContext().Features.Get<IHttpActivityFeature>()?.Activity.Context ?? default;
             _ = circuitHost.InitializeAsync(store, httpActivityContext, Context.ConnectionAborted);
 
-            // It's safe to *publish* the circuit now because nothing will be able
-            // to run inside it until after InitializeAsync completes.
+            // Publish before initialization completes so new clients can complete deferred host initialization.
+            // Root component rendering remains blocked until that handshake finishes.
             _circuitRegistry.Register(circuitHost);
             _circuitHandleRegistry.SetCircuit(Context.Items, CircuitKey, circuitHost);
 
@@ -552,7 +561,9 @@ internal sealed partial class ComponentHub : Hub
                 startupValues,
                 Context.User,
                 store: null,
-                resourceCollection);
+                resourceCollection,
+                supportsDeferredHostInitialization: hasStartupValues,
+                cancellationToken: Context.ConnectionAborted);
 
             var httpActivityContext = Context.GetHttpContext().Features.Get<IHttpActivityFeature>()?.Activity.Context ?? default;
 
@@ -564,8 +575,8 @@ internal sealed partial class ComponentHub : Hub
 
             circuitHost.AttachPersistedState(resumedPersistedCircuitState);
 
-            // It's safe to *publish* the circuit now because nothing will be able
-            // to run inside it until after InitializeAsync completes.
+            // Publish before initialization completes so new clients can complete deferred host initialization.
+            // Root component rendering remains blocked until that handshake finishes.
             _circuitRegistry.Register(circuitHost);
             _circuitHandleRegistry.SetCircuit(Context.Items, CircuitKey, circuitHost);
 

--- a/src/Components/Server/src/ComponentHub.cs
+++ b/src/Components/Server/src/ComponentHub.cs
@@ -4,6 +4,7 @@
 using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.DataProtection;
@@ -46,6 +47,7 @@ internal sealed partial class ComponentHub : Hub
     private readonly CircuitRegistry _circuitRegistry;
     private readonly CircuitPersistenceManager _circuitPersistenceManager;
     private readonly ICircuitHandleRegistry _circuitHandleRegistry;
+    private readonly IEnumerable<IBrowserStartupValueProvider> _browserStartupValueProviders;
     private readonly ILogger _logger;
 
     public ComponentHub(
@@ -56,6 +58,7 @@ internal sealed partial class ComponentHub : Hub
         CircuitRegistry circuitRegistry,
         CircuitPersistenceManager circuitPersistenceProvider,
         ICircuitHandleRegistry circuitHandleRegistry,
+        IEnumerable<IBrowserStartupValueProvider> browserStartupValueProviders,
         ILogger<ComponentHub> logger)
     {
         _serverComponentSerializer = serializer;
@@ -65,6 +68,7 @@ internal sealed partial class ComponentHub : Hub
         _circuitRegistry = circuitRegistry;
         _circuitPersistenceManager = circuitPersistenceProvider;
         _circuitHandleRegistry = circuitHandleRegistry;
+        _browserStartupValueProviders = browserStartupValueProviders;
         _logger = logger;
     }
 
@@ -103,7 +107,27 @@ internal sealed partial class ComponentHub : Hub
         return Task.CompletedTask;
     }
 
-    public async ValueTask<string> StartCircuit(string baseUri, string uri, string serializedComponentRecords, string applicationState)
+    public string[] GetStartupValueKeys()
+        => BrowserStartupValueProviderUtilities.GetKeys(_browserStartupValueProviders);
+
+    public ValueTask<string> StartCircuit(string baseUri, string uri, string serializedComponentRecords, string applicationState)
+        => StartCircuitCore(baseUri, uri, serializedComponentRecords, applicationState, null, hasStartupValues: false);
+
+    public ValueTask<string> StartCircuitWithStartupValues(
+        string baseUri,
+        string uri,
+        string serializedComponentRecords,
+        string applicationState,
+        string startupValuesJson)
+        => StartCircuitCore(baseUri, uri, serializedComponentRecords, applicationState, startupValuesJson, hasStartupValues: true);
+
+    private async ValueTask<string> StartCircuitCore(
+        string baseUri,
+        string uri,
+        string serializedComponentRecords,
+        string applicationState,
+        string? startupValuesJson,
+        bool hasStartupValues)
     {
         var circuitHost = _circuitHandleRegistry.GetCircuit(Context.Items, CircuitKey);
         if (circuitHost != null)
@@ -132,6 +156,22 @@ internal sealed partial class ComponentHub : Hub
             return null;
         }
 
+        Dictionary<string, string> startupValues;
+        if (hasStartupValues)
+        {
+            if (!TryGetStartupValues(startupValuesJson, baseUri, uri, out startupValues))
+            {
+                Log.InvalidInputData(_logger);
+                await NotifyClientError(Clients.Caller, "The startup values provided are invalid.");
+                Context.Abort();
+                return null;
+            }
+        }
+        else
+        {
+            startupValues = CreateNavigationStartupValues(baseUri, uri);
+        }
+
         if (!_serverComponentSerializer.TryDeserializeComponentDescriptorCollection(serializedComponentRecords, out var components))
         {
             Log.InvalidInputData(_logger);
@@ -152,6 +192,7 @@ internal sealed partial class ComponentHub : Hub
                 circuitClient,
                 baseUri,
                 uri,
+                startupValues,
                 Context.User,
                 store,
                 resourceCollection);
@@ -184,6 +225,61 @@ internal sealed partial class ComponentHub : Hub
             return null;
         }
     }
+
+    private static bool HasConflictingValue(
+        IReadOnlyDictionary<string, string> values,
+        string key,
+        string expectedValue)
+        => values.TryGetValue(key, out var value) && !string.Equals(value, expectedValue, StringComparison.Ordinal);
+
+    private static bool ContainsExactly(
+        IReadOnlyDictionary<string, string> values,
+        IReadOnlyList<string> expectedKeys)
+    {
+        if (values.Count != expectedKeys.Count)
+        {
+            return false;
+        }
+
+        foreach (var key in expectedKeys)
+        {
+            if (!values.ContainsKey(key))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private bool TryGetStartupValues(
+        string? startupValuesJson,
+        string baseUri,
+        string uri,
+        out Dictionary<string, string> startupValues)
+    {
+        if (!HostStartupValuesJson.TryDeserialize(startupValuesJson, out startupValues) ||
+            !ContainsExactly(
+                startupValues,
+                BrowserStartupValueProviderUtilities.GetKeys(_browserStartupValueProviders)) ||
+            HasConflictingValue(startupValues, NavigationBrowserStartupValueProvider.BaseUriKey, baseUri) ||
+            HasConflictingValue(startupValues, NavigationBrowserStartupValueProvider.LocationHrefKey, uri))
+        {
+            return false;
+        }
+
+        startupValues[NavigationBrowserStartupValueProvider.BaseUriKey] = baseUri;
+        startupValues[NavigationBrowserStartupValueProvider.LocationHrefKey] = uri;
+
+        return true;
+    }
+
+    private static Dictionary<string, string> CreateNavigationStartupValues(string baseUri, string uri)
+        => new(StringComparer.Ordinal)
+        {
+            [NavigationBrowserStartupValueProvider.BaseUriKey] = baseUri,
+            [NavigationBrowserStartupValueProvider.LocationHrefKey] = uri,
+        };
 
     public async Task UpdateRootComponents(string serializedComponentOperations, string applicationState)
     {
@@ -297,12 +393,45 @@ internal sealed partial class ComponentHub : Hub
     // On the server we are going to have a public method on Circuit.cs to trigger pausing a circuit from the server
     // that returns the root components and application state as strings data-protected by the data protection provider.
     // Those can be then passed to this method for resuming the circuit.
-    public async ValueTask<string> ResumeCircuit(
+    public ValueTask<string> ResumeCircuit(
         string circuitIdSecret,
         string baseUri,
         string uri,
         string rootComponents,
         string applicationState)
+        => ResumeCircuitCore(
+            circuitIdSecret,
+            baseUri,
+            uri,
+            rootComponents,
+            applicationState,
+            startupValuesJson: null,
+            hasStartupValues: false);
+
+    public ValueTask<string> ResumeCircuitWithStartupValues(
+        string circuitIdSecret,
+        string baseUri,
+        string uri,
+        string rootComponents,
+        string applicationState,
+        string startupValuesJson)
+        => ResumeCircuitCore(
+            circuitIdSecret,
+            baseUri,
+            uri,
+            rootComponents,
+            applicationState,
+            startupValuesJson,
+            hasStartupValues: true);
+
+    private async ValueTask<string> ResumeCircuitCore(
+        string circuitIdSecret,
+        string baseUri,
+        string uri,
+        string rootComponents,
+        string applicationState,
+        string? startupValuesJson,
+        bool hasStartupValues)
     {
         // TryParseCircuitId will not throw.
         if (!_circuitIdFactory.TryParseCircuitId(circuitIdSecret, out var circuitId))
@@ -337,6 +466,22 @@ internal sealed partial class ComponentHub : Hub
             await NotifyClientError(Clients.Caller, "The uris provided are invalid.");
             Context.Abort();
             return null;
+        }
+
+        Dictionary<string, string> startupValues;
+        if (hasStartupValues)
+        {
+            if (!TryGetStartupValues(startupValuesJson, baseUri, uri, out startupValues))
+            {
+                Log.InvalidInputData(_logger);
+                await NotifyClientError(Clients.Caller, "The startup values provided are invalid.");
+                Context.Abort();
+                return null;
+            }
+        }
+        else
+        {
+            startupValues = CreateNavigationStartupValues(baseUri, uri);
         }
 
         PersistedCircuitState? persistedCircuitState;
@@ -404,6 +549,7 @@ internal sealed partial class ComponentHub : Hub
                 circuitClient,
                 baseUri,
                 uri,
+                startupValues,
                 Context.User,
                 store: null,
                 resourceCollection);

--- a/src/Components/Server/src/ComponentHub.cs
+++ b/src/Components/Server/src/ComponentHub.cs
@@ -117,24 +117,10 @@ internal sealed partial class ComponentHub : Hub
         circuitHost?.BeginHostInitialization(Context.ConnectionAborted);
     }
 
-    public ValueTask<string> StartCircuit(string baseUri, string uri, string serializedComponentRecords, string applicationState)
-        => StartCircuitCore(baseUri, uri, serializedComponentRecords, applicationState, null, hasStartupValues: false);
-
-    public ValueTask<string> StartCircuitWithStartupValues(
-        string baseUri,
-        string uri,
+    public async ValueTask<string> StartCircuit(
+        string startupValuesJson,
         string serializedComponentRecords,
-        string applicationState,
-        string startupValuesJson)
-        => StartCircuitCore(baseUri, uri, serializedComponentRecords, applicationState, startupValuesJson, hasStartupValues: true);
-
-    private async ValueTask<string> StartCircuitCore(
-        string baseUri,
-        string uri,
-        string serializedComponentRecords,
-        string applicationState,
-        string? startupValuesJson,
-        bool hasStartupValues)
+        string applicationState)
     {
         var circuitHost = _circuitHandleRegistry.GetCircuit(Context.Items, CircuitKey);
         if (circuitHost != null)
@@ -147,36 +133,14 @@ internal sealed partial class ComponentHub : Hub
             return null;
         }
 
-        if (baseUri == null ||
-            uri == null ||
-            !Uri.TryCreate(baseUri, UriKind.Absolute, out _) ||
-            !Uri.TryCreate(uri, UriKind.Absolute, out _))
+        if (!TryGetStartupValues(startupValuesJson, out var startupValues, out var baseUri, out var uri))
         {
-            // We do some really minimal validation here to prevent obviously wrong data from getting in
-            // without duplicating too much logic.
-            //
             // This is an error condition attempting to initialize the circuit in a way that would fail.
             // We can reject this and terminate the connection.
             Log.InvalidInputData(_logger);
-            await NotifyClientError(Clients.Caller, "The uris provided are invalid.");
+            await NotifyClientError(Clients.Caller, "The startup values provided are invalid.");
             Context.Abort();
             return null;
-        }
-
-        Dictionary<string, string> startupValues;
-        if (hasStartupValues)
-        {
-            if (!TryGetStartupValues(startupValuesJson, baseUri, uri, out startupValues))
-            {
-                Log.InvalidInputData(_logger);
-                await NotifyClientError(Clients.Caller, "The startup values provided are invalid.");
-                Context.Abort();
-                return null;
-            }
-        }
-        else
-        {
-            startupValues = CreateNavigationStartupValues(baseUri, uri);
         }
 
         if (!_serverComponentSerializer.TryDeserializeComponentDescriptorCollection(serializedComponentRecords, out var components))
@@ -203,7 +167,6 @@ internal sealed partial class ComponentHub : Hub
                 Context.User,
                 store,
                 resourceCollection,
-                supportsDeferredHostInitialization: hasStartupValues,
                 cancellationToken: Context.ConnectionAborted);
 
             // Fire-and-forget the initialization process, because we can't block the
@@ -213,7 +176,7 @@ internal sealed partial class ComponentHub : Hub
             var httpActivityContext = Context.GetHttpContext().Features.Get<IHttpActivityFeature>()?.Activity.Context ?? default;
             _ = circuitHost.InitializeAsync(store, httpActivityContext, Context.ConnectionAborted);
 
-            // Publish before initialization completes so new clients can complete deferred host initialization.
+            // Publish before initialization completes so the client can complete deferred host initialization.
             // Root component rendering remains blocked until that handshake finishes.
             _circuitRegistry.Register(circuitHost);
             _circuitHandleRegistry.SetCircuit(Context.Items, CircuitKey, circuitHost);
@@ -234,12 +197,6 @@ internal sealed partial class ComponentHub : Hub
             return null;
         }
     }
-
-    private static bool HasConflictingValue(
-        IReadOnlyDictionary<string, string> values,
-        string key,
-        string expectedValue)
-        => values.TryGetValue(key, out var value) && !string.Equals(value, expectedValue, StringComparison.Ordinal);
 
     private static bool ContainsExactly(
         IReadOnlyDictionary<string, string> values,
@@ -263,32 +220,26 @@ internal sealed partial class ComponentHub : Hub
 
     private bool TryGetStartupValues(
         string? startupValuesJson,
-        string baseUri,
-        string uri,
-        out Dictionary<string, string> startupValues)
+        out Dictionary<string, string> startupValues,
+        out string baseUri,
+        out string uri)
     {
         if (!HostStartupValuesJson.TryDeserialize(startupValuesJson, out startupValues) ||
             !ContainsExactly(
                 startupValues,
                 BrowserStartupValueProviderUtilities.GetKeys(_browserStartupValueProviders)) ||
-            HasConflictingValue(startupValues, NavigationBrowserStartupValueProvider.BaseUriKey, baseUri) ||
-            HasConflictingValue(startupValues, NavigationBrowserStartupValueProvider.LocationHrefKey, uri))
+            !startupValues.TryGetValue(NavigationBrowserStartupValueProvider.BaseUriKey, out baseUri) ||
+            !startupValues.TryGetValue(NavigationBrowserStartupValueProvider.LocationHrefKey, out uri) ||
+            !Uri.TryCreate(baseUri, UriKind.Absolute, out _) ||
+            !Uri.TryCreate(uri, UriKind.Absolute, out _))
         {
+            baseUri = null;
+            uri = null;
             return false;
         }
 
-        startupValues[NavigationBrowserStartupValueProvider.BaseUriKey] = baseUri;
-        startupValues[NavigationBrowserStartupValueProvider.LocationHrefKey] = uri;
-
         return true;
     }
-
-    private static Dictionary<string, string> CreateNavigationStartupValues(string baseUri, string uri)
-        => new(StringComparer.Ordinal)
-        {
-            [NavigationBrowserStartupValueProvider.BaseUriKey] = baseUri,
-            [NavigationBrowserStartupValueProvider.LocationHrefKey] = uri,
-        };
 
     public async Task UpdateRootComponents(string serializedComponentOperations, string applicationState)
     {
@@ -402,45 +353,11 @@ internal sealed partial class ComponentHub : Hub
     // On the server we are going to have a public method on Circuit.cs to trigger pausing a circuit from the server
     // that returns the root components and application state as strings data-protected by the data protection provider.
     // Those can be then passed to this method for resuming the circuit.
-    public ValueTask<string> ResumeCircuit(
+    public async ValueTask<string> ResumeCircuit(
         string circuitIdSecret,
-        string baseUri,
-        string uri,
+        string startupValuesJson,
         string rootComponents,
         string applicationState)
-        => ResumeCircuitCore(
-            circuitIdSecret,
-            baseUri,
-            uri,
-            rootComponents,
-            applicationState,
-            startupValuesJson: null,
-            hasStartupValues: false);
-
-    public ValueTask<string> ResumeCircuitWithStartupValues(
-        string circuitIdSecret,
-        string baseUri,
-        string uri,
-        string rootComponents,
-        string applicationState,
-        string startupValuesJson)
-        => ResumeCircuitCore(
-            circuitIdSecret,
-            baseUri,
-            uri,
-            rootComponents,
-            applicationState,
-            startupValuesJson,
-            hasStartupValues: true);
-
-    private async ValueTask<string> ResumeCircuitCore(
-        string circuitIdSecret,
-        string baseUri,
-        string uri,
-        string rootComponents,
-        string applicationState,
-        string? startupValuesJson,
-        bool hasStartupValues)
     {
         // TryParseCircuitId will not throw.
         if (!_circuitIdFactory.TryParseCircuitId(circuitIdSecret, out var circuitId))
@@ -461,36 +378,14 @@ internal sealed partial class ComponentHub : Hub
             return null;
         }
 
-        if (baseUri == null ||
-            uri == null ||
-            !Uri.TryCreate(baseUri, UriKind.Absolute, out _) ||
-            !Uri.TryCreate(uri, UriKind.Absolute, out _))
+        if (!TryGetStartupValues(startupValuesJson, out var startupValues, out var baseUri, out var uri))
         {
-            // We do some really minimal validation here to prevent obviously wrong data from getting in
-            // without duplicating too much logic.
-            //
             // This is an error condition attempting to initialize the circuit in a way that would fail.
             // We can reject this and terminate the connection.
             Log.InvalidInputData(_logger);
-            await NotifyClientError(Clients.Caller, "The uris provided are invalid.");
+            await NotifyClientError(Clients.Caller, "The startup values provided are invalid.");
             Context.Abort();
             return null;
-        }
-
-        Dictionary<string, string> startupValues;
-        if (hasStartupValues)
-        {
-            if (!TryGetStartupValues(startupValuesJson, baseUri, uri, out startupValues))
-            {
-                Log.InvalidInputData(_logger);
-                await NotifyClientError(Clients.Caller, "The startup values provided are invalid.");
-                Context.Abort();
-                return null;
-            }
-        }
-        else
-        {
-            startupValues = CreateNavigationStartupValues(baseUri, uri);
         }
 
         PersistedCircuitState? persistedCircuitState;
@@ -562,7 +457,6 @@ internal sealed partial class ComponentHub : Hub
                 Context.User,
                 store: null,
                 resourceCollection,
-                supportsDeferredHostInitialization: hasStartupValues,
                 cancellationToken: Context.ConnectionAborted);
 
             var httpActivityContext = Context.GetHttpContext().Features.Get<IHttpActivityFeature>()?.Activity.Context ?? default;
@@ -575,7 +469,7 @@ internal sealed partial class ComponentHub : Hub
 
             circuitHost.AttachPersistedState(resumedPersistedCircuitState);
 
-            // Publish before initialization completes so new clients can complete deferred host initialization.
+            // Publish before initialization completes so the client can complete deferred host initialization.
             // Root component rendering remains blocked until that handshake finishes.
             _circuitRegistry.Register(circuitHost);
             _circuitHandleRegistry.SetCircuit(Context.Items, CircuitKey, circuitHost);

--- a/src/Components/Server/src/DependencyInjection/ComponentServiceCollectionExtensions.cs
+++ b/src/Components/Server/src/DependencyInjection/ComponentServiceCollectionExtensions.cs
@@ -85,16 +85,16 @@ public static class ComponentServiceCollectionExtensions
         services.TryAddScoped<IErrorBoundaryLogger, RemoteErrorBoundaryLogger>();
         services.TryAddScoped<AntiforgeryStateProvider, DefaultAntiforgeryStateProvider>();
         services.TryAddScoped<InteractiveServerContext>();
-        services.TryAddKeyedScoped<InteractiveHostStartupValues>(typeof(ComponentHub));
+        services.TryAddKeyedScoped<InteractiveHostStartupValues>(HostInitializerKey.Server);
         services.TryAddKeyedScoped<IHostStartupValues>(
-            typeof(ComponentHub),
+            HostInitializerKey.Server,
             static (services, key) => services.GetRequiredKeyedService<InteractiveHostStartupValues>(key));
         services.TryAddEnumerable(
-            ServiceDescriptor.Singleton<IHostInitializer, NavigationManagerInitializer>());
+            ServiceDescriptor.KeyedSingleton<IHostInitializer, NavigationManagerInitializer>(HostInitializerKey.Server));
         services.TryAddEnumerable(
-            ServiceDescriptor.Singleton<IHostInitializer, NavigationManagerJSRuntimeInitializer>());
+            ServiceDescriptor.KeyedSingleton<IHostInitializer, NavigationManagerJSRuntimeInitializer>(HostInitializerKey.Server));
         services.TryAddEnumerable(
-            ServiceDescriptor.Singleton<IHostInitializer, NavigationServicesJSRuntimeInitializer>());
+            ServiceDescriptor.KeyedSingleton<IHostInitializer, NavigationServicesJSRuntimeInitializer>(HostInitializerKey.Server));
         services.TryAddSingleton<HostInitializerCollection>();
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IBrowserStartupValueProvider, NavigationBrowserStartupValueProvider>());
@@ -107,11 +107,11 @@ public static class ComponentServiceCollectionExtensions
                 var context = services.GetRequiredService<InteractiveServerContext>();
                 if (context.IsInteractive)
                 {
-                    return services.GetRequiredKeyedService<IHostStartupValues>(typeof(ComponentHub));
+                    return services.GetRequiredKeyedService<IHostStartupValues>(HostInitializerKey.Server);
                 }
 
-                return services.GetKeyedService<IHostStartupValues>(typeof(IHostStartupValues))
-                    ?? services.GetRequiredKeyedService<IHostStartupValues>(typeof(ComponentHub));
+                return services.GetKeyedService<IHostStartupValues>(HostInitializerKey.Static)
+                    ?? services.GetRequiredKeyedService<IHostStartupValues>(HostInitializerKey.Server);
             });
         }
 

--- a/src/Components/Server/src/DependencyInjection/ComponentServiceCollectionExtensions.cs
+++ b/src/Components/Server/src/DependencyInjection/ComponentServiceCollectionExtensions.cs
@@ -90,6 +90,12 @@ public static class ComponentServiceCollectionExtensions
             typeof(ComponentHub),
             static (services, key) => services.GetRequiredKeyedService<InteractiveHostStartupValues>(key));
         services.TryAddEnumerable(
+            ServiceDescriptor.Scoped<IHostInitializer, NavigationManagerInitializer>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Scoped<IHostInitializer, NavigationManagerJSRuntimeInitializer>());
+        services.TryAddEnumerable(
+            ServiceDescriptor.Scoped<IHostInitializer, NavigationServicesJSRuntimeInitializer>());
+        services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IBrowserStartupValueProvider, NavigationBrowserStartupValueProvider>());
 
         if (!HasHostStartupValuesRegistrationMarker(services))

--- a/src/Components/Server/src/DependencyInjection/ComponentServiceCollectionExtensions.cs
+++ b/src/Components/Server/src/DependencyInjection/ComponentServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Endpoints;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Components.Server;
 using Microsoft.AspNetCore.Components.Server.BlazorPack;
@@ -83,6 +84,29 @@ public static class ComponentServiceCollectionExtensions
         services.TryAddScoped<IServerComponentDeserializer, ServerComponentDeserializer>();
         services.TryAddScoped<IErrorBoundaryLogger, RemoteErrorBoundaryLogger>();
         services.TryAddScoped<AntiforgeryStateProvider, DefaultAntiforgeryStateProvider>();
+        services.TryAddScoped<InteractiveServerContext>();
+        services.TryAddKeyedScoped<InteractiveHostStartupValues>(typeof(ComponentHub));
+        services.TryAddKeyedScoped<IHostStartupValues>(
+            typeof(ComponentHub),
+            static (services, key) => services.GetRequiredKeyedService<InteractiveHostStartupValues>(key));
+        services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IBrowserStartupValueProvider, NavigationBrowserStartupValueProvider>());
+
+        if (!HasHostStartupValuesRegistrationMarker(services))
+        {
+            services.AddSingleton<HostStartupValuesRegistrationMarker>();
+            services.AddScoped<IHostStartupValues>(static services =>
+            {
+                var context = services.GetRequiredService<InteractiveServerContext>();
+                if (context.IsInteractive)
+                {
+                    return services.GetRequiredKeyedService<IHostStartupValues>(typeof(ComponentHub));
+                }
+
+                return services.GetKeyedService<IHostStartupValues>(typeof(IHostStartupValues))
+                    ?? services.GetRequiredKeyedService<IHostStartupValues>(typeof(ComponentHub));
+            });
+        }
 
         services.TryAddScoped(s => s.GetRequiredService<ICircuitAccessor>().Circuit);
         services.TryAddScoped<ICircuitAccessor, DefaultCircuitAccessor>();
@@ -132,6 +156,19 @@ public static class ComponentServiceCollectionExtensions
         return builder;
     }
 
+    private static bool HasHostStartupValuesRegistrationMarker(IServiceCollection services)
+    {
+        foreach (var descriptor in services)
+        {
+            if (descriptor.ServiceType == typeof(HostStartupValuesRegistrationMarker))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private sealed class DefaultServerSideBlazorBuilder : IServerSideBlazorBuilder
     {
         public DefaultServerSideBlazorBuilder(IServiceCollection services)
@@ -140,5 +177,9 @@ public static class ComponentServiceCollectionExtensions
         }
 
         public IServiceCollection Services { get; }
+    }
+
+    private sealed class HostStartupValuesRegistrationMarker
+    {
     }
 }

--- a/src/Components/Server/src/DependencyInjection/ComponentServiceCollectionExtensions.cs
+++ b/src/Components/Server/src/DependencyInjection/ComponentServiceCollectionExtensions.cs
@@ -90,11 +90,12 @@ public static class ComponentServiceCollectionExtensions
             typeof(ComponentHub),
             static (services, key) => services.GetRequiredKeyedService<InteractiveHostStartupValues>(key));
         services.TryAddEnumerable(
-            ServiceDescriptor.Scoped<IHostInitializer, NavigationManagerInitializer>());
+            ServiceDescriptor.Singleton<IHostInitializer, NavigationManagerInitializer>());
         services.TryAddEnumerable(
-            ServiceDescriptor.Scoped<IHostInitializer, NavigationManagerJSRuntimeInitializer>());
+            ServiceDescriptor.Singleton<IHostInitializer, NavigationManagerJSRuntimeInitializer>());
         services.TryAddEnumerable(
-            ServiceDescriptor.Scoped<IHostInitializer, NavigationServicesJSRuntimeInitializer>());
+            ServiceDescriptor.Singleton<IHostInitializer, NavigationServicesJSRuntimeInitializer>());
+        services.TryAddSingleton<HostInitializerCollection>();
         services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IBrowserStartupValueProvider, NavigationBrowserStartupValueProvider>());
 

--- a/src/Components/Server/src/Hosting/BrowserStartupValueProviderUtilities.cs
+++ b/src/Components/Server/src/Hosting/BrowserStartupValueProviderUtilities.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+internal static class BrowserStartupValueProviderUtilities
+{
+    internal static string[] GetKeys(IEnumerable<IBrowserStartupValueProvider> providers)
+    {
+        var keys = new List<string>();
+        var uniqueKeys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var provider in providers)
+        {
+            foreach (var key in provider.Keys)
+            {
+                if (key is null)
+                {
+                    throw new InvalidOperationException("A browser startup value provider returned a null key.");
+                }
+
+                if (!uniqueKeys.Add(key))
+                {
+                    throw new InvalidOperationException($"The browser startup value key '{key}' was provided more than once.");
+                }
+
+                keys.Add(key);
+            }
+        }
+
+        return [.. keys];
+    }
+}

--- a/src/Components/Server/src/Hosting/HostStartupValuesJson.cs
+++ b/src/Components/Server/src/Hosting/HostStartupValuesJson.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using System.Text.Json;
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+internal static class HostStartupValuesJson
+{
+    internal static bool TryDeserialize(string? json, out Dictionary<string, string> values)
+    {
+        values = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (json is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
+            if (!reader.Read() || reader.TokenType is not JsonTokenType.StartObject)
+            {
+                return false;
+            }
+
+            while (reader.Read() && reader.TokenType is not JsonTokenType.EndObject)
+            {
+                if (reader.TokenType is not JsonTokenType.PropertyName)
+                {
+                    return false;
+                }
+
+                var key = reader.GetString()!;
+                if (!reader.Read() || reader.TokenType is not JsonTokenType.String)
+                {
+                    return false;
+                }
+
+                if (!values.TryAdd(key, reader.GetString()!))
+                {
+                    return false;
+                }
+            }
+
+            return reader.TokenType is JsonTokenType.EndObject && !reader.Read();
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Components/Server/src/Hosting/HostStartupValuesJson.cs
+++ b/src/Components/Server/src/Hosting/HostStartupValuesJson.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Text;
 using System.Text.Json;
 
@@ -8,6 +9,22 @@ namespace Microsoft.AspNetCore.Components.Hosting;
 
 internal static class HostStartupValuesJson
 {
+    internal static string SerializeKeys(IReadOnlyList<string> keys)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartArray();
+            foreach (var key in keys)
+            {
+                writer.WriteStringValue(key);
+            }
+            writer.WriteEndArray();
+        }
+
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
+    }
+
     internal static bool TryDeserialize(string? json, out Dictionary<string, string> values)
     {
         values = new Dictionary<string, string>(StringComparer.Ordinal);

--- a/src/Components/Server/src/Hosting/IServerHostInitializer.cs
+++ b/src/Components/Server/src/Hosting/IServerHostInitializer.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+internal interface IServerHostInitializer : IHostInitializer
+{
+}

--- a/src/Components/Server/src/Hosting/IServerHostInitializer.cs
+++ b/src/Components/Server/src/Hosting/IServerHostInitializer.cs
@@ -1,8 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
-namespace Microsoft.AspNetCore.Components.Hosting;
-
-internal interface IServerHostInitializer : IHostInitializer
-{
-}

--- a/src/Components/Server/src/Hosting/InteractiveHostStartupValues.cs
+++ b/src/Components/Server/src/Hosting/InteractiveHostStartupValues.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+internal sealed class InteractiveHostStartupValues : IHostStartupValues
+{
+    private IReadOnlyDictionary<string, string>? _values;
+
+    public string? GetValue(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        return _values is not null && _values.TryGetValue(key, out var value) ? value : null;
+    }
+
+    public string GetRequired(string key)
+        => GetValue(key) ?? throw new InvalidOperationException($"Startup value '{key}' was not provided.");
+
+    internal void Initialize(IReadOnlyDictionary<string, string> values)
+        => _values = new Dictionary<string, string>(values, StringComparer.Ordinal);
+}

--- a/src/Components/Server/src/Hosting/NavigationBrowserStartupValueProvider.cs
+++ b/src/Components/Server/src/Hosting/NavigationBrowserStartupValueProvider.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+internal sealed class NavigationBrowserStartupValueProvider : IBrowserStartupValueProvider
+{
+    internal const string BaseUriKey = "document.baseURI";
+    internal const string LocationHrefKey = "location.href";
+
+    public IReadOnlyList<string> Keys { get; } = [BaseUriKey, LocationHrefKey];
+}

--- a/src/Components/Server/src/Hosting/NavigationManagerInitializer.cs
+++ b/src/Components/Server/src/Hosting/NavigationManagerInitializer.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Server.Circuits;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+internal sealed class NavigationManagerInitializer(
+    IServiceProvider services,
+    InteractiveServerContext context) : IServerHostInitializer
+{
+    public int Order => -200;
+
+    public Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!context.IsInteractive)
+        {
+            return Task.CompletedTask;
+        }
+
+        var startupValues = services.GetRequiredService<IHostStartupValues>();
+        var navigationManager = services.GetRequiredService<NavigationManager>();
+        ((RemoteNavigationManager)navigationManager).Initialize(
+            startupValues.GetRequired(NavigationBrowserStartupValueProvider.BaseUriKey),
+            startupValues.GetRequired(NavigationBrowserStartupValueProvider.LocationHrefKey));
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Components/Server/src/Hosting/NavigationManagerInitializer.cs
+++ b/src/Components/Server/src/Hosting/NavigationManagerInitializer.cs
@@ -6,16 +6,15 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Components.Hosting;
 
-internal sealed class NavigationManagerInitializer(
-    IServiceProvider services,
-    InteractiveServerContext context) : IHostInitializer
+internal sealed class NavigationManagerInitializer : IHostInitializer
 {
     public int Order => -200;
 
-    public Task InitializeAsync(CancellationToken cancellationToken = default)
+    public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
+        var context = services.GetRequiredService<InteractiveServerContext>();
         if (!context.IsInteractive)
         {
             return Task.CompletedTask;

--- a/src/Components/Server/src/Hosting/NavigationManagerInitializer.cs
+++ b/src/Components/Server/src/Hosting/NavigationManagerInitializer.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Components.Hosting;
 
 internal sealed class NavigationManagerInitializer(
     IServiceProvider services,
-    InteractiveServerContext context) : IServerHostInitializer
+    InteractiveServerContext context) : IHostInitializer
 {
     public int Order => -200;
 

--- a/src/Components/Server/src/Hosting/NavigationManagerInitializer.cs
+++ b/src/Components/Server/src/Hosting/NavigationManagerInitializer.cs
@@ -10,7 +10,7 @@ internal sealed class NavigationManagerInitializer : IHostInitializer
 {
     public int Order => -200;
 
-    public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+    public Task InitializeHostAsync(IServiceProvider services, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Components/Server/src/Hosting/NavigationManagerJSRuntimeInitializer.cs
+++ b/src/Components/Server/src/Hosting/NavigationManagerJSRuntimeInitializer.cs
@@ -7,18 +7,17 @@ using Microsoft.JSInterop;
 
 namespace Microsoft.AspNetCore.Components.Hosting;
 
-internal sealed class NavigationManagerJSRuntimeInitializer(
-    IServiceProvider services,
-    InteractiveServerContext context) : IHostInitializer
+internal sealed class NavigationManagerJSRuntimeInitializer : IHostInitializer
 {
     public int Order => -150;
 
     public bool RequiresJSInterop => true;
 
-    public Task InitializeAsync(CancellationToken cancellationToken = default)
+    public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
+        var context = services.GetRequiredService<InteractiveServerContext>();
         if (!context.IsInteractive)
         {
             return Task.CompletedTask;

--- a/src/Components/Server/src/Hosting/NavigationManagerJSRuntimeInitializer.cs
+++ b/src/Components/Server/src/Hosting/NavigationManagerJSRuntimeInitializer.cs
@@ -11,9 +11,7 @@ internal sealed class NavigationManagerJSRuntimeInitializer : IHostInitializer
 {
     public int Order => -150;
 
-    public bool RequiresJSInterop => true;
-
-    public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+    public Task InitializeBrowserAsync(IServiceProvider services, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Components/Server/src/Hosting/NavigationManagerJSRuntimeInitializer.cs
+++ b/src/Components/Server/src/Hosting/NavigationManagerJSRuntimeInitializer.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Server.Circuits;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+internal sealed class NavigationManagerJSRuntimeInitializer(
+    IServiceProvider services,
+    InteractiveServerContext context) : IServerHostInitializer
+{
+    public int Order => -150;
+
+    public bool RequiresJSInterop => true;
+
+    public Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!context.IsInteractive)
+        {
+            return Task.CompletedTask;
+        }
+
+        var navigationManager = services.GetRequiredService<NavigationManager>();
+        var jsRuntime = services.GetRequiredService<IJSRuntime>();
+        ((RemoteNavigationManager)navigationManager).AttachJsRuntime(jsRuntime);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Components/Server/src/Hosting/NavigationManagerJSRuntimeInitializer.cs
+++ b/src/Components/Server/src/Hosting/NavigationManagerJSRuntimeInitializer.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Components.Hosting;
 
 internal sealed class NavigationManagerJSRuntimeInitializer(
     IServiceProvider services,
-    InteractiveServerContext context) : IServerHostInitializer
+    InteractiveServerContext context) : IHostInitializer
 {
     public int Order => -150;
 

--- a/src/Components/Server/src/Hosting/NavigationServicesJSRuntimeInitializer.cs
+++ b/src/Components/Server/src/Hosting/NavigationServicesJSRuntimeInitializer.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Components.Hosting;
 
 internal sealed class NavigationServicesJSRuntimeInitializer(
     IServiceProvider services,
-    InteractiveServerContext context) : IServerHostInitializer
+    InteractiveServerContext context) : IHostInitializer
 {
     public int Order => -100;
 

--- a/src/Components/Server/src/Hosting/NavigationServicesJSRuntimeInitializer.cs
+++ b/src/Components/Server/src/Hosting/NavigationServicesJSRuntimeInitializer.cs
@@ -8,18 +8,17 @@ using Microsoft.JSInterop;
 
 namespace Microsoft.AspNetCore.Components.Hosting;
 
-internal sealed class NavigationServicesJSRuntimeInitializer(
-    IServiceProvider services,
-    InteractiveServerContext context) : IHostInitializer
+internal sealed class NavigationServicesJSRuntimeInitializer : IHostInitializer
 {
     public int Order => -100;
 
     public bool RequiresJSInterop => true;
 
-    public Task InitializeAsync(CancellationToken cancellationToken = default)
+    public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
+        var context = services.GetRequiredService<InteractiveServerContext>();
         if (!context.IsInteractive)
         {
             return Task.CompletedTask;

--- a/src/Components/Server/src/Hosting/NavigationServicesJSRuntimeInitializer.cs
+++ b/src/Components/Server/src/Hosting/NavigationServicesJSRuntimeInitializer.cs
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.AspNetCore.Components.Server.Circuits;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+internal sealed class NavigationServicesJSRuntimeInitializer(
+    IServiceProvider services,
+    InteractiveServerContext context) : IServerHostInitializer
+{
+    public int Order => -100;
+
+    public bool RequiresJSInterop => true;
+
+    public Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!context.IsInteractive)
+        {
+            return Task.CompletedTask;
+        }
+
+        var navigationInterception = services.GetRequiredService<INavigationInterception>();
+        var scrollToLocationHash = services.GetRequiredService<IScrollToLocationHash>();
+        var jsRuntime = services.GetRequiredService<IJSRuntime>();
+        ((RemoteNavigationInterception)navigationInterception).AttachJSRuntime(jsRuntime);
+        ((RemoteScrollToLocationHash)scrollToLocationHash).AttachJSRuntime(jsRuntime);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Components/Server/src/Hosting/NavigationServicesJSRuntimeInitializer.cs
+++ b/src/Components/Server/src/Hosting/NavigationServicesJSRuntimeInitializer.cs
@@ -12,9 +12,7 @@ internal sealed class NavigationServicesJSRuntimeInitializer : IHostInitializer
 {
     public int Order => -100;
 
-    public bool RequiresJSInterop => true;
-
-    public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+    public Task InitializeBrowserAsync(IServiceProvider services, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Components/Server/src/Microsoft.AspNetCore.Components.Server.csproj
+++ b/src/Components/Server/src/Microsoft.AspNetCore.Components.Server.csproj
@@ -73,6 +73,7 @@
     <Compile Include="$(ComponentsSharedSourceRoot)src\RootTypeCache.cs" />
     <Compile Include="$(ComponentsSharedSourceRoot)src\DefaultAntiforgeryStateProvider.cs" LinkBase="Forms" />
     <Compile Include="$(ComponentsSharedSourceRoot)src\WebRendererId.cs" />
+    <Compile Include="$(ComponentsSharedSourceRoot)src\Hosting\HostInitializerCollection.cs" />
     <Compile Include="$(SharedSourceRoot)Components\ServerComponentSerializer.cs" LinkBase="DependencyInjection" />
     <Compile Include="$(SharedSourceRoot)Components\ServerComponentInvocationSequence.cs" LinkBase="DependencyInjection" />
 

--- a/src/Components/Server/test/Circuits/CircuitFactoryTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitFactoryTest.cs
@@ -1,0 +1,244 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Security.Claims;
+using Microsoft.AspNetCore.Components.Hosting;
+using Microsoft.AspNetCore.Components.Routing;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Moq;
+
+namespace Microsoft.AspNetCore.Components.Server.Circuits;
+
+public class CircuitFactoryTest
+{
+    [Fact]
+    public async Task LegacyClientRunsNonJSInitializersAndFrameworkAttachmentsInOrder()
+    {
+        var calls = new List<string>();
+        using var provider = CreateServices(
+            new TestHostInitializer("lower", -300, calls),
+            new TestHostInitializer("user-js", -150, calls, requiresJSInterop: true),
+            new TestHostInitializer("later", 0, calls));
+
+        await using var circuitHost = await CreateCircuitHostAsync(
+            provider.GetRequiredService<ICircuitFactory>(),
+            supportsDeferredHostInitialization: false);
+
+        Assert.Equal(["lower", "later"], calls);
+        Assert.Equal("https://localhost/", circuitHost.Services.GetRequiredService<NavigationManager>().BaseUri);
+        Assert.True(((RemoteNavigationManager)circuitHost.Services.GetRequiredService<NavigationManager>()).HasAttachedJSRuntime);
+        Assert.True(((RemoteNavigationInterception)circuitHost.Services.GetRequiredService<INavigationInterception>()).HasAttachedJSRuntime);
+        Assert.True(((RemoteScrollToLocationHash)circuitHost.Services.GetRequiredService<IScrollToLocationHash>()).HasAttachedJSRuntime);
+    }
+
+    [Fact]
+    public async Task NewClientDefersEntireOrderedSuffixAfterFirstJSInitializer()
+    {
+        var calls = new List<string>();
+        using var provider = CreateServices(
+            new TestHostInitializer("lower", -300, calls),
+            new TestHostInitializer("user-js", -150, calls, requiresJSInterop: true),
+            new TestHostInitializer("later-non-js", 0, calls));
+
+        await using var circuitHost = await CreateCircuitHostAsync(
+            provider.GetRequiredService<ICircuitFactory>(),
+            supportsDeferredHostInitialization: true);
+        var navigationManager = (RemoteNavigationManager)circuitHost.Services.GetRequiredService<NavigationManager>();
+        var navigationInterception = (RemoteNavigationInterception)circuitHost.Services.GetRequiredService<INavigationInterception>();
+        var scrollToLocationHash = (RemoteScrollToLocationHash)circuitHost.Services.GetRequiredService<IScrollToLocationHash>();
+
+        Assert.Equal(["lower"], calls);
+        Assert.False(navigationManager.HasAttachedJSRuntime);
+        Assert.False(navigationInterception.HasAttachedJSRuntime);
+        Assert.False(scrollToLocationHash.HasAttachedJSRuntime);
+
+        circuitHost.BeginHostInitialization(CancellationToken.None);
+        circuitHost.BeginHostInitialization(CancellationToken.None);
+        await WaitForAsync(() => calls.Count == 3);
+
+        Assert.Equal(["lower", "user-js", "later-non-js"], calls);
+        Assert.True(navigationManager.HasAttachedJSRuntime);
+        Assert.True(navigationInterception.HasAttachedJSRuntime);
+        Assert.True(scrollToLocationHash.HasAttachedJSRuntime);
+    }
+
+    [Fact]
+    public async Task NewClientPreservesRegistrationOrderForEqualOrderAcrossDeferredBoundary()
+    {
+        var calls = new List<string>();
+        using var provider = CreateServices(
+            new TestHostInitializer("first", -250, calls),
+            new TestHostInitializer("second-js", -250, calls, requiresJSInterop: true),
+            new TestHostInitializer("third", -250, calls));
+
+        await using var circuitHost = await CreateCircuitHostAsync(
+            provider.GetRequiredService<ICircuitFactory>(),
+            supportsDeferredHostInitialization: true);
+
+        Assert.Equal(["first"], calls);
+
+        circuitHost.BeginHostInitialization(CancellationToken.None);
+        await WaitForAsync(() => calls.Count == 3);
+
+        Assert.Equal(["first", "second-js", "third"], calls);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task EndpointInitializerDoesNotActInInteractiveCircuitScope(bool addServerFirst)
+    {
+        using var provider = CreateCombinedServices(addServerFirst);
+
+        await using var circuitHost = await CreateCircuitHostAsync(
+            provider.GetRequiredService<ICircuitFactory>(),
+            supportsDeferredHostInitialization: false);
+
+        var navigationManager = (RemoteNavigationManager)circuitHost.Services.GetRequiredService<NavigationManager>();
+        Assert.Equal("https://localhost/", navigationManager.BaseUri);
+        Assert.Equal("https://localhost/page", navigationManager.Uri);
+        Assert.True(navigationManager.HasAttachedJSRuntime);
+    }
+
+    [Fact]
+    public async Task NonJSInitializerFailureStopsAndSurfaces()
+    {
+        var calls = new List<string>();
+        var exception = new InvalidOperationException("Initializer failed.");
+        using var provider = CreateServices(
+            new TestHostInitializer("failure", -300, calls, exception: exception),
+            new TestHostInitializer("not-run", -200, calls));
+
+        var actualException = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await CreateCircuitHostAsync(
+                provider.GetRequiredService<ICircuitFactory>(),
+                supportsDeferredHostInitialization: true));
+
+        Assert.Same(exception, actualException);
+        Assert.Equal(["failure"], calls);
+    }
+
+    [Fact]
+    public async Task NonJSInitializerCancellationStopsAndSurfaces()
+    {
+        var calls = new List<string>();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        using var provider = CreateServices(
+            new TestHostInitializer("canceled", -300, calls, callback: token =>
+            {
+                cancellationTokenSource.Cancel();
+                token.ThrowIfCancellationRequested();
+            }),
+            new TestHostInitializer("not-run", -200, calls));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await CreateCircuitHostAsync(
+                provider.GetRequiredService<ICircuitFactory>(),
+                supportsDeferredHostInitialization: true,
+                cancellationTokenSource.Token));
+
+        Assert.Equal(["canceled"], calls);
+    }
+
+    private static ServiceProvider CreateServices(params IHostInitializer[] initializers)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddMetrics();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddSingleton<IWebHostEnvironment>(new TestWebHostEnvironment());
+        services.AddServerSideBlazor();
+        foreach (var initializer in initializers)
+        {
+            services.AddSingleton(typeof(IHostInitializer), initializer);
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    private static ServiceProvider CreateCombinedServices(bool addServerFirst)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddMetrics();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddSingleton<IWebHostEnvironment>(new TestWebHostEnvironment());
+        if (addServerFirst)
+        {
+            services.AddServerSideBlazor();
+            services.AddRazorComponents();
+        }
+        else
+        {
+            services.AddRazorComponents();
+            services.AddServerSideBlazor();
+        }
+
+        return services.BuildServiceProvider();
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition)
+    {
+        for (var i = 0; i < 100 && !condition(); i++)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.True(condition());
+    }
+
+    private static ValueTask<CircuitHost> CreateCircuitHostAsync(
+        ICircuitFactory circuitFactory,
+        bool supportsDeferredHostInitialization,
+        CancellationToken cancellationToken = default)
+        => circuitFactory.CreateCircuitHostAsync(
+            [],
+            new CircuitClientProxy(Mock.Of<ISingleClientProxy>(), "connection"),
+            "https://localhost/",
+            "https://localhost/page",
+            new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["document.baseURI"] = "https://localhost/",
+                ["location.href"] = "https://localhost/page",
+            },
+            new ClaimsPrincipal(),
+            store: null,
+            resourceCollection: null,
+            supportsDeferredHostInitialization,
+            cancellationToken);
+
+    private sealed class TestHostInitializer(
+        string name,
+        int order,
+        List<string> calls,
+        bool requiresJSInterop = false,
+        Exception exception = null,
+        Action<CancellationToken> callback = null) : IHostInitializer
+    {
+        public int Order => order;
+
+        public bool RequiresJSInterop => requiresJSInterop;
+
+        public Task InitializeAsync(CancellationToken cancellationToken = default)
+        {
+            calls.Add(name);
+            callback?.Invoke(cancellationToken);
+
+            return exception is null ? Task.CompletedTask : Task.FromException(exception);
+        }
+    }
+
+    private sealed class TestWebHostEnvironment : IWebHostEnvironment
+    {
+        public string ApplicationName { get; set; } = "Test";
+        public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+        public string WebRootPath { get; set; } = "/";
+        public string EnvironmentName { get; set; } = "Test";
+        public string ContentRootPath { get; set; } = "/";
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/src/Components/Server/test/Circuits/CircuitFactoryTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitFactoryTest.cs
@@ -35,9 +35,7 @@ public class CircuitFactoryTest
         Assert.False(navigationInterception.HasAttachedJSRuntime);
         Assert.False(scrollToLocationHash.HasAttachedJSRuntime);
 
-        circuitHost.BeginHostInitialization(CancellationToken.None);
-        circuitHost.BeginHostInitialization(CancellationToken.None);
-        await WaitForAsync(() => calls.Count == 3);
+        await circuitHost.InitializeAsync(null, default, CancellationToken.None);
 
         Assert.Equal(["lower", "user-js", "later-non-js"], calls);
         Assert.True(navigationManager.HasAttachedJSRuntime);
@@ -59,8 +57,7 @@ public class CircuitFactoryTest
 
         Assert.Equal(["first"], calls);
 
-        circuitHost.BeginHostInitialization(CancellationToken.None);
-        await WaitForAsync(() => calls.Count == 3);
+        await circuitHost.InitializeAsync(null, default, CancellationToken.None);
 
         Assert.Equal(["first", "second-js", "third"], calls);
     }
@@ -80,8 +77,7 @@ public class CircuitFactoryTest
         Assert.Equal("https://localhost/page", navigationManager.Uri);
         Assert.False(navigationManager.HasAttachedJSRuntime);
 
-        circuitHost.BeginHostInitialization(CancellationToken.None);
-        await WaitForAsync(() => navigationManager.HasAttachedJSRuntime);
+        await circuitHost.InitializeAsync(null, default, CancellationToken.None);
 
         Assert.True(navigationManager.HasAttachedJSRuntime);
     }
@@ -124,6 +120,24 @@ public class CircuitFactoryTest
         Assert.Equal(["canceled"], calls);
     }
 
+    [Fact]
+    public async Task SingletonInitializerUsesTheActiveCircuitScope()
+    {
+        var initializer = new ScopeRecordingInitializer();
+        using var provider = CreateServices(initializer);
+        var circuitFactory = provider.GetRequiredService<ICircuitFactory>();
+
+        await using var firstCircuit = await CreateCircuitHostAsync(circuitFactory);
+        await using var secondCircuit = await CreateCircuitHostAsync(circuitFactory);
+
+        Assert.Equal(2, initializer.ScopedDependencyIds.Count);
+        Assert.NotEqual(initializer.ScopedDependencyIds[0], initializer.ScopedDependencyIds[1]);
+        Assert.Same(
+            initializer,
+            provider.GetRequiredService<HostInitializerCollection>().Initializers.Single(
+                candidate => candidate is ScopeRecordingInitializer));
+    }
+
     private static ServiceProvider CreateServices(params IHostInitializer[] initializers)
     {
         var services = new ServiceCollection();
@@ -131,6 +145,7 @@ public class CircuitFactoryTest
         services.AddMetrics();
         services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
         services.AddSingleton<IWebHostEnvironment>(new TestWebHostEnvironment());
+        services.AddScoped<ScopedDependency>();
         services.AddServerSideBlazor();
         foreach (var initializer in initializers)
         {
@@ -159,16 +174,6 @@ public class CircuitFactoryTest
         }
 
         return services.BuildServiceProvider();
-    }
-
-    private static async Task WaitForAsync(Func<bool> condition)
-    {
-        for (var i = 0; i < 100 && !condition(); i++)
-        {
-            await Task.Delay(10);
-        }
-
-        Assert.True(condition());
     }
 
     private static ValueTask<CircuitHost> CreateCircuitHostAsync(
@@ -201,13 +206,31 @@ public class CircuitFactoryTest
 
         public bool RequiresJSInterop => requiresJSInterop;
 
-        public Task InitializeAsync(CancellationToken cancellationToken = default)
+        public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
         {
             calls.Add(name);
             callback?.Invoke(cancellationToken);
 
             return exception is null ? Task.CompletedTask : Task.FromException(exception);
         }
+    }
+
+    private sealed class ScopeRecordingInitializer : IHostInitializer
+    {
+        public int Order => -300;
+
+        public List<Guid> ScopedDependencyIds { get; } = [];
+
+        public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+        {
+            ScopedDependencyIds.Add(services.GetRequiredService<ScopedDependency>().Id);
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class ScopedDependency
+    {
+        public Guid Id { get; } = Guid.NewGuid();
     }
 
     private sealed class TestWebHostEnvironment : IWebHostEnvironment

--- a/src/Components/Server/test/Circuits/CircuitFactoryTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitFactoryTest.cs
@@ -16,27 +16,7 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits;
 public class CircuitFactoryTest
 {
     [Fact]
-    public async Task LegacyClientRunsNonJSInitializersAndFrameworkAttachmentsInOrder()
-    {
-        var calls = new List<string>();
-        using var provider = CreateServices(
-            new TestHostInitializer("lower", -300, calls),
-            new TestHostInitializer("user-js", -150, calls, requiresJSInterop: true),
-            new TestHostInitializer("later", 0, calls));
-
-        await using var circuitHost = await CreateCircuitHostAsync(
-            provider.GetRequiredService<ICircuitFactory>(),
-            supportsDeferredHostInitialization: false);
-
-        Assert.Equal(["lower", "later"], calls);
-        Assert.Equal("https://localhost/", circuitHost.Services.GetRequiredService<NavigationManager>().BaseUri);
-        Assert.True(((RemoteNavigationManager)circuitHost.Services.GetRequiredService<NavigationManager>()).HasAttachedJSRuntime);
-        Assert.True(((RemoteNavigationInterception)circuitHost.Services.GetRequiredService<INavigationInterception>()).HasAttachedJSRuntime);
-        Assert.True(((RemoteScrollToLocationHash)circuitHost.Services.GetRequiredService<IScrollToLocationHash>()).HasAttachedJSRuntime);
-    }
-
-    [Fact]
-    public async Task NewClientDefersEntireOrderedSuffixAfterFirstJSInitializer()
+    public async Task DefersEntireOrderedSuffixAfterFirstJSInitializer()
     {
         var calls = new List<string>();
         using var provider = CreateServices(
@@ -45,8 +25,7 @@ public class CircuitFactoryTest
             new TestHostInitializer("later-non-js", 0, calls));
 
         await using var circuitHost = await CreateCircuitHostAsync(
-            provider.GetRequiredService<ICircuitFactory>(),
-            supportsDeferredHostInitialization: true);
+            provider.GetRequiredService<ICircuitFactory>());
         var navigationManager = (RemoteNavigationManager)circuitHost.Services.GetRequiredService<NavigationManager>();
         var navigationInterception = (RemoteNavigationInterception)circuitHost.Services.GetRequiredService<INavigationInterception>();
         var scrollToLocationHash = (RemoteScrollToLocationHash)circuitHost.Services.GetRequiredService<IScrollToLocationHash>();
@@ -67,7 +46,7 @@ public class CircuitFactoryTest
     }
 
     [Fact]
-    public async Task NewClientPreservesRegistrationOrderForEqualOrderAcrossDeferredBoundary()
+    public async Task PreservesRegistrationOrderForEqualOrderAcrossDeferredBoundary()
     {
         var calls = new List<string>();
         using var provider = CreateServices(
@@ -76,8 +55,7 @@ public class CircuitFactoryTest
             new TestHostInitializer("third", -250, calls));
 
         await using var circuitHost = await CreateCircuitHostAsync(
-            provider.GetRequiredService<ICircuitFactory>(),
-            supportsDeferredHostInitialization: true);
+            provider.GetRequiredService<ICircuitFactory>());
 
         Assert.Equal(["first"], calls);
 
@@ -95,12 +73,16 @@ public class CircuitFactoryTest
         using var provider = CreateCombinedServices(addServerFirst);
 
         await using var circuitHost = await CreateCircuitHostAsync(
-            provider.GetRequiredService<ICircuitFactory>(),
-            supportsDeferredHostInitialization: false);
+            provider.GetRequiredService<ICircuitFactory>());
 
         var navigationManager = (RemoteNavigationManager)circuitHost.Services.GetRequiredService<NavigationManager>();
         Assert.Equal("https://localhost/", navigationManager.BaseUri);
         Assert.Equal("https://localhost/page", navigationManager.Uri);
+        Assert.False(navigationManager.HasAttachedJSRuntime);
+
+        circuitHost.BeginHostInitialization(CancellationToken.None);
+        await WaitForAsync(() => navigationManager.HasAttachedJSRuntime);
+
         Assert.True(navigationManager.HasAttachedJSRuntime);
     }
 
@@ -115,8 +97,7 @@ public class CircuitFactoryTest
 
         var actualException = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             await CreateCircuitHostAsync(
-                provider.GetRequiredService<ICircuitFactory>(),
-                supportsDeferredHostInitialization: true));
+                provider.GetRequiredService<ICircuitFactory>()));
 
         Assert.Same(exception, actualException);
         Assert.Equal(["failure"], calls);
@@ -138,7 +119,6 @@ public class CircuitFactoryTest
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
             await CreateCircuitHostAsync(
                 provider.GetRequiredService<ICircuitFactory>(),
-                supportsDeferredHostInitialization: true,
                 cancellationTokenSource.Token));
 
         Assert.Equal(["canceled"], calls);
@@ -193,7 +173,6 @@ public class CircuitFactoryTest
 
     private static ValueTask<CircuitHost> CreateCircuitHostAsync(
         ICircuitFactory circuitFactory,
-        bool supportsDeferredHostInitialization,
         CancellationToken cancellationToken = default)
         => circuitFactory.CreateCircuitHostAsync(
             [],
@@ -208,7 +187,6 @@ public class CircuitFactoryTest
             new ClaimsPrincipal(),
             store: null,
             resourceCollection: null,
-            supportsDeferredHostInitialization,
             cancellationToken);
 
     private sealed class TestHostInitializer(

--- a/src/Components/Server/test/Circuits/CircuitFactoryTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitFactoryTest.cs
@@ -16,13 +16,13 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits;
 public class CircuitFactoryTest
 {
     [Fact]
-    public async Task DefersEntireOrderedSuffixAfterFirstJSInitializer()
+    public async Task RunsHostPhaseBeforeBrowserPhase()
     {
         var calls = new List<string>();
         using var provider = CreateServices(
             new TestHostInitializer("lower", -300, calls),
-            new TestHostInitializer("user-js", -150, calls, requiresJSInterop: true),
-            new TestHostInitializer("later-non-js", 0, calls));
+            new TestHostInitializer("user-browser", -125, calls, browserPhase: true),
+            new TestHostInitializer("later-browser", 0, calls, browserPhase: true));
 
         await using var circuitHost = await CreateCircuitHostAsync(
             provider.GetRequiredService<ICircuitFactory>());
@@ -37,29 +37,32 @@ public class CircuitFactoryTest
 
         await circuitHost.InitializeAsync(null, default, CancellationToken.None);
 
-        Assert.Equal(["lower", "user-js", "later-non-js"], calls);
+        Assert.Equal(["lower", "user-browser", "later-browser"], calls);
         Assert.True(navigationManager.HasAttachedJSRuntime);
         Assert.True(navigationInterception.HasAttachedJSRuntime);
         Assert.True(scrollToLocationHash.HasAttachedJSRuntime);
     }
 
     [Fact]
-    public async Task PreservesRegistrationOrderForEqualOrderAcrossDeferredBoundary()
+    public async Task CircuitUsesSharedAndServerInitializersOnly()
     {
         var calls = new List<string>();
-        using var provider = CreateServices(
-            new TestHostInitializer("first", -250, calls),
-            new TestHostInitializer("second-js", -250, calls, requiresJSInterop: true),
-            new TestHostInitializer("third", -250, calls));
+        var services = CreateBaseServices();
+        services.AddSingleton<IHostInitializer>(new TestHostInitializer("shared", -300, calls));
+        services.AddKeyedSingleton<IHostInitializer>(
+            HostInitializerKey.Static,
+            new TestHostInitializer("static", -250, calls));
+        services.AddKeyedSingleton<IHostInitializer>(
+            HostInitializerKey.Server,
+            new TestHostInitializer("server", -225, calls));
+        services.AddRazorComponents();
+        services.AddServerSideBlazor();
+        using var provider = services.BuildServiceProvider();
 
         await using var circuitHost = await CreateCircuitHostAsync(
             provider.GetRequiredService<ICircuitFactory>());
 
-        Assert.Equal(["first"], calls);
-
-        await circuitHost.InitializeAsync(null, default, CancellationToken.None);
-
-        Assert.Equal(["first", "second-js", "third"], calls);
+        Assert.Equal(["shared", "server"], calls);
     }
 
     [Theory]
@@ -89,7 +92,7 @@ public class CircuitFactoryTest
         var exception = new InvalidOperationException("Initializer failed.");
         using var provider = CreateServices(
             new TestHostInitializer("failure", -300, calls, exception: exception),
-            new TestHostInitializer("not-run", -200, calls));
+            new TestHostInitializer("not-run", -250, calls));
 
         var actualException = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             await CreateCircuitHostAsync(
@@ -110,7 +113,7 @@ public class CircuitFactoryTest
                 cancellationTokenSource.Cancel();
                 token.ThrowIfCancellationRequested();
             }),
-            new TestHostInitializer("not-run", -200, calls));
+            new TestHostInitializer("not-run", -250, calls));
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
             await CreateCircuitHostAsync(
@@ -132,19 +135,12 @@ public class CircuitFactoryTest
 
         Assert.Equal(2, initializer.ScopedDependencyIds.Count);
         Assert.NotEqual(initializer.ScopedDependencyIds[0], initializer.ScopedDependencyIds[1]);
-        Assert.Same(
-            initializer,
-            provider.GetRequiredService<HostInitializerCollection>().Initializers.Single(
-                candidate => candidate is ScopeRecordingInitializer));
+        Assert.Same(initializer, Assert.Single(provider.GetServices<IHostInitializer>()));
     }
 
     private static ServiceProvider CreateServices(params IHostInitializer[] initializers)
     {
-        var services = new ServiceCollection();
-        services.AddLogging();
-        services.AddMetrics();
-        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
-        services.AddSingleton<IWebHostEnvironment>(new TestWebHostEnvironment());
+        var services = CreateBaseServices();
         services.AddScoped<ScopedDependency>();
         services.AddServerSideBlazor();
         foreach (var initializer in initializers)
@@ -153,6 +149,16 @@ public class CircuitFactoryTest
         }
 
         return services.BuildServiceProvider();
+    }
+
+    private static ServiceCollection CreateBaseServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddMetrics();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddSingleton<IWebHostEnvironment>(new TestWebHostEnvironment());
+        return services;
     }
 
     private static ServiceProvider CreateCombinedServices(bool addServerFirst)
@@ -198,15 +204,19 @@ public class CircuitFactoryTest
         string name,
         int order,
         List<string> calls,
-        bool requiresJSInterop = false,
+        bool browserPhase = false,
         Exception exception = null,
         Action<CancellationToken> callback = null) : IHostInitializer
     {
         public int Order => order;
 
-        public bool RequiresJSInterop => requiresJSInterop;
+        public Task InitializeHostAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+            => browserPhase ? Task.CompletedTask : Invoke(cancellationToken);
 
-        public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+        public Task InitializeBrowserAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+            => browserPhase ? Invoke(cancellationToken) : Task.CompletedTask;
+
+        private Task Invoke(CancellationToken cancellationToken)
         {
             calls.Add(name);
             callback?.Invoke(cancellationToken);
@@ -221,7 +231,7 @@ public class CircuitFactoryTest
 
         public List<Guid> ScopedDependencyIds { get; } = [];
 
-        public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+        public Task InitializeHostAsync(IServiceProvider services, CancellationToken cancellationToken = default)
         {
             ScopedDependencyIds.Add(services.GetRequiredService<ScopedDependency>().Id);
             return Task.CompletedTask;

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -24,17 +24,10 @@ public class CircuitHostTest
     private readonly ServerComponentInvocationSequence _invocationSequence = new();
 
     [Fact]
-    public async Task DeferredHostInitializersCompleteOnceBeforeRootComponentsRender()
+    public async Task DeferredHostInitializersCompleteBeforeRootComponentsRender()
     {
         var calls = new List<string>();
-        var completionNotification = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var proxy = new Mock<ISingleClientProxy>();
-        proxy.Setup(client => client.SendCoreAsync(
-                "JS.EndHostInitialization",
-                It.IsAny<object[]>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<string, object[], CancellationToken>((_, _, _) => completionNotification.TrySetResult())
-            .Returns(Task.CompletedTask);
         DeferredInitializerRootComponent.Reset();
         var circuitHost = TestCircuitHost.Create(
             clientProxy: new CircuitClientProxy(proxy.Object, "connection"),
@@ -57,38 +50,20 @@ public class CircuitHostTest
             new ProtectedPrerenderComponentApplicationStore(Mock.Of<IDataProtectionProvider>()),
             default,
             CancellationToken.None);
-        await Task.Yield();
-        Assert.False(DeferredInitializerRootComponent.Rendered.Task.IsCompleted);
-
-        circuitHost.BeginHostInitialization(CancellationToken.None);
-        circuitHost.BeginHostInitialization(CancellationToken.None);
-        await completionNotification.Task;
         await initializeTask;
         await DeferredInitializerRootComponent.Rendered.Task;
 
         Assert.Equal(["first", "second"], calls);
-        proxy.Verify(client => client.SendCoreAsync(
-            "JS.EndHostInitialization",
-            It.Is<object[]>(arguments => (bool)arguments[0] && ReferenceEquals(arguments[1], null)),
-            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task DeferredHostInitializerFailureStopsExecutionAndUnblocksInitialization()
+    public async Task DeferredHostInitializerFailureStopsExecutionAndIsReportedByInitialization()
     {
         var calls = new List<string>();
         var exception = new InvalidOperationException("Initializer failed.");
         var reportedException = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var completionNotification = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var proxy = new Mock<ISingleClientProxy>();
         proxy.Setup(client => client.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-            .Callback<string, object[], CancellationToken>((method, _, _) =>
-            {
-                if (method == "JS.EndHostInitialization")
-                {
-                    completionNotification.TrySetResult();
-                }
-            })
             .Returns(Task.CompletedTask);
         var circuitHost = TestCircuitHost.Create(
             clientProxy: new CircuitClientProxy(proxy.Object, "connection"),
@@ -101,35 +76,20 @@ public class CircuitHostTest
             reportedException.TrySetResult((Exception)eventArgs.ExceptionObject);
 
         var initializeTask = circuitHost.InitializeAsync(null, default, CancellationToken.None);
-        circuitHost.BeginHostInitialization(CancellationToken.None);
-        circuitHost.BeginHostInitialization(CancellationToken.None);
-        await completionNotification.Task;
         await initializeTask;
 
         Assert.Same(exception, await reportedException.Task);
         Assert.Equal(["failure"], calls);
-        proxy.Verify(client => client.SendCoreAsync(
-            "JS.EndHostInitialization",
-            It.Is<object[]>(arguments => !(bool)arguments[0]),
-            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task DeferredHostInitializerCancellationStopsExecutionAndUnblocksInitialization()
+    public async Task DeferredHostInitializerCancellationStopsExecutionAndIsReportedByInitialization()
     {
         var calls = new List<string>();
         using var cancellationTokenSource = new CancellationTokenSource();
         var reportedException = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
-        var completionNotification = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var proxy = new Mock<ISingleClientProxy>();
         proxy.Setup(client => client.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
-            .Callback<string, object[], CancellationToken>((method, _, _) =>
-            {
-                if (method == "JS.EndHostInitialization")
-                {
-                    completionNotification.TrySetResult();
-                }
-            })
             .Returns(Task.CompletedTask);
         var circuitHost = TestCircuitHost.Create(
             clientProxy: new CircuitClientProxy(proxy.Object, "connection"),
@@ -146,16 +106,10 @@ public class CircuitHostTest
             reportedException.TrySetResult((Exception)eventArgs.ExceptionObject);
 
         var initializeTask = circuitHost.InitializeAsync(null, default, cancellationTokenSource.Token);
-        circuitHost.BeginHostInitialization(cancellationTokenSource.Token);
-        await completionNotification.Task;
         await initializeTask;
 
         Assert.IsAssignableFrom<OperationCanceledException>(await reportedException.Task);
         Assert.Equal(["canceled"], calls);
-        proxy.Verify(client => client.SendCoreAsync(
-            "JS.EndHostInitialization",
-            It.Is<object[]>(arguments => !(bool)arguments[0]),
-            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -173,8 +127,16 @@ public class CircuitHostTest
         var services = new ServiceCollection()
             .AddSingleton(handler.Object)
             .BuildServiceProvider();
+        var completedBatches = new List<long>();
         var proxy = new Mock<ISingleClientProxy>();
         proxy.Setup(client => client.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, arguments, _) =>
+            {
+                if (method == "JS.EndUpdateRootComponents")
+                {
+                    completedBatches.Add((long)arguments[0]);
+                }
+            })
             .Returns(Task.CompletedTask);
         DeferredInitializerRootComponent.Reset();
         var circuitHost = TestCircuitHost.Create(
@@ -194,25 +156,28 @@ public class CircuitHostTest
             ]);
 
         var initializeTask = circuitHost.InitializeAsync(null, default, CancellationToken.None);
-        var updateTask = AddComponentAsync<DeferredInitializerRootComponent>(circuitHost, 1);
+        var firstUpdateTask = AddComponentAsync<DeferredInitializerRootComponent>(circuitHost, 1, batchId: 1);
+        var secondUpdateTask = AddComponentAsync<DeferredInitializerRootComponent>(circuitHost, 2, batchId: 2);
         await Task.Yield();
 
-        Assert.False(updateTask.IsCompleted);
+        Assert.False(firstUpdateTask.IsCompleted);
+        Assert.False(secondUpdateTask.IsCompleted);
         Assert.False(DeferredInitializerRootComponent.Rendered.Task.IsCompleted);
         handler.Verify(
             instance => instance.OnCircuitOpenedAsync(It.IsAny<Circuit>(), It.IsAny<CancellationToken>()),
             Times.Never);
 
-        circuitHost.BeginHostInitialization(CancellationToken.None);
         await initializerStarted.Task;
-        Assert.False(updateTask.IsCompleted);
+        Assert.False(firstUpdateTask.IsCompleted);
+        Assert.False(secondUpdateTask.IsCompleted);
         Assert.False(DeferredInitializerRootComponent.Rendered.Task.IsCompleted);
 
         continueInitializer.SetResult();
         await initializeTask;
-        await updateTask;
+        await Task.WhenAll(firstUpdateTask, secondUpdateTask);
 
         Assert.Equal(["deferred"], calls);
+        Assert.Equal([1L, 2L], completedBatches);
         Assert.True(DeferredInitializerRootComponent.Rendered.Task.IsCompletedSuccessfully);
         handler.Verify(
             instance => instance.OnCircuitOpenedAsync(It.IsAny<Circuit>(), It.IsAny<CancellationToken>()),
@@ -220,94 +185,6 @@ public class CircuitHostTest
         handler.Verify(
             instance => instance.OnConnectionUpAsync(It.IsAny<Circuit>(), It.IsAny<CancellationToken>()),
             Times.Once);
-    }
-
-    [Fact]
-    public async Task UpdateRootComponentsPreservesArrivalOrderWhileWaitingForDeferredHostInitialization()
-    {
-        var calls = new List<string>();
-        var initializerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var continueInitializer = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var handler = new Mock<CircuitHandler>();
-        SetupMockInboundActivityHandler(handler);
-        handler.Setup(instance => instance.OnCircuitOpenedAsync(It.IsAny<Circuit>(), It.IsAny<CancellationToken>()))
-            .Callback(() => calls.Add("circuit-opened"))
-            .Returns(Task.CompletedTask);
-        handler.Setup(instance => instance.OnConnectionUpAsync(It.IsAny<Circuit>(), It.IsAny<CancellationToken>()))
-            .Callback(() => calls.Add("connection-up"))
-            .Returns(Task.CompletedTask);
-        var services = new ServiceCollection()
-            .AddSingleton(handler.Object)
-            .BuildServiceProvider();
-        var proxy = new Mock<ISingleClientProxy>();
-        proxy.Setup(client => client.SendCoreAsync(
-                "JS.EndUpdateRootComponents",
-                It.IsAny<object[]>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<string, object[], CancellationToken>((_, arguments, _) => calls.Add($"batch-{arguments[0]}"))
-            .Returns(Task.CompletedTask);
-        var circuitHost = TestCircuitHost.Create(
-            clientProxy: new CircuitClientProxy(proxy.Object, "connection"),
-            remoteRenderer: GetRemoteRenderer(),
-            serviceScope: services.CreateAsyncScope(),
-            deferredHostInitializers:
-            [
-                new TestHostInitializer("initializer", calls, asyncCallback: _ =>
-                {
-                    initializerStarted.SetResult();
-                    return continueInitializer.Task;
-                }),
-            ]);
-
-        var initializeTask = circuitHost.InitializeAsync(null, default, CancellationToken.None);
-        var firstUpdate = AddComponentAsync<DynamicallyAddedComponent>(circuitHost, 1, batchId: 1);
-        var secondUpdate = AddComponentAsync<DynamicallyAddedComponent>(circuitHost, 2, batchId: 2);
-
-        circuitHost.BeginHostInitialization(CancellationToken.None);
-        await initializerStarted.Task;
-        Assert.Equal(["initializer"], calls);
-
-        continueInitializer.SetResult();
-        await Task.WhenAll(initializeTask, firstUpdate, secondUpdate);
-
-        Assert.Equal(["initializer", "circuit-opened", "connection-up", "batch-1", "batch-2"], calls);
-    }
-
-    [Fact]
-    public async Task UpdateRootComponentsQueueAdvancesAfterCanceledUpdate()
-    {
-        var calls = new List<string>();
-        var proxy = new Mock<ISingleClientProxy>();
-        proxy.Setup(client => client.SendCoreAsync(
-                "JS.EndUpdateRootComponents",
-                It.IsAny<object[]>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<string, object[], CancellationToken>((_, arguments, _) => calls.Add($"batch-{arguments[0]}"))
-            .Returns(Task.CompletedTask);
-        var circuitHost = TestCircuitHost.Create(
-            clientProxy: new CircuitClientProxy(proxy.Object, "connection"),
-            remoteRenderer: GetRemoteRenderer(),
-            serviceScope: new ServiceCollection().BuildServiceProvider().CreateAsyncScope(),
-            deferredHostInitializers:
-            [
-                new TestHostInitializer("initializer", calls),
-            ]);
-        using var cancellationTokenSource = new CancellationTokenSource();
-
-        var initializeTask = circuitHost.InitializeAsync(null, default, CancellationToken.None);
-        var canceledUpdate = AddComponentAsync<DynamicallyAddedComponent>(
-            circuitHost,
-            1,
-            batchId: 1,
-            cancellationToken: cancellationTokenSource.Token);
-        var succeedingUpdate = AddComponentAsync<DynamicallyAddedComponent>(circuitHost, 2, batchId: 2);
-
-        cancellationTokenSource.Cancel();
-        circuitHost.BeginHostInitialization(CancellationToken.None);
-        await Task.WhenAll(initializeTask, canceledUpdate, succeedingUpdate).WaitAsync(TimeSpan.FromSeconds(10));
-
-        Assert.Equal(["initializer", "batch-2"], calls);
-        Assert.Single(circuitHost.Renderer.GetOrCreateWebRootComponentManager().GetRootComponents());
     }
 
     [Fact]
@@ -1716,7 +1593,7 @@ public class CircuitHostTest
         Action<CancellationToken> callback = null,
         Func<CancellationToken, Task> asyncCallback = null) : IHostInitializer
     {
-        public Task InitializeAsync(CancellationToken cancellationToken = default)
+        public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
         {
             calls.Add(name);
             callback?.Invoke(cancellationToken);

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -40,10 +40,10 @@ public class CircuitHostTest
                     Sequence = 0,
                 },
             ],
-            deferredHostInitializers:
+            browserHostInitializers:
             [
-                new TestHostInitializer("first", calls),
-                new TestHostInitializer("second", calls),
+                new TestHostInitializer("first", calls, order: -10),
+                new TestHostInitializer("second", calls, order: 10),
             ]);
 
         var initializeTask = circuitHost.InitializeAsync(
@@ -67,10 +67,10 @@ public class CircuitHostTest
             .Returns(Task.CompletedTask);
         var circuitHost = TestCircuitHost.Create(
             clientProxy: new CircuitClientProxy(proxy.Object, "connection"),
-            deferredHostInitializers:
+            browserHostInitializers:
             [
-                new TestHostInitializer("failure", calls, exception),
-                new TestHostInitializer("not-run", calls),
+                new TestHostInitializer("failure", calls, exception, order: -10),
+                new TestHostInitializer("not-run", calls, order: 10),
             ]);
         circuitHost.UnhandledException += (_, eventArgs) =>
             reportedException.TrySetResult((Exception)eventArgs.ExceptionObject);
@@ -93,14 +93,14 @@ public class CircuitHostTest
             .Returns(Task.CompletedTask);
         var circuitHost = TestCircuitHost.Create(
             clientProxy: new CircuitClientProxy(proxy.Object, "connection"),
-            deferredHostInitializers:
+            browserHostInitializers:
             [
                 new TestHostInitializer("canceled", calls, callback: token =>
                 {
                     cancellationTokenSource.Cancel();
                     token.ThrowIfCancellationRequested();
-                }),
-                new TestHostInitializer("not-run", calls),
+                }, order: -10),
+                new TestHostInitializer("not-run", calls, order: 10),
             ]);
         circuitHost.UnhandledException += (_, eventArgs) =>
             reportedException.TrySetResult((Exception)eventArgs.ExceptionObject);
@@ -143,7 +143,7 @@ public class CircuitHostTest
             clientProxy: new CircuitClientProxy(proxy.Object, "connection"),
             remoteRenderer: GetRemoteRenderer(),
             serviceScope: services.CreateAsyncScope(),
-            deferredHostInitializers:
+            browserHostInitializers:
             [
                 new TestHostInitializer(
                     "deferred",
@@ -1591,9 +1591,12 @@ public class CircuitHostTest
         List<string> calls,
         Exception exception = null,
         Action<CancellationToken> callback = null,
-        Func<CancellationToken, Task> asyncCallback = null) : IHostInitializer
+        Func<CancellationToken, Task> asyncCallback = null,
+        int order = 0) : IHostInitializer
     {
-        public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+        public int Order => order;
+
+        public Task InitializeBrowserAsync(IServiceProvider services, CancellationToken cancellationToken = default)
         {
             calls.Add(name);
             callback?.Invoke(cancellationToken);

--- a/src/Components/Server/test/Circuits/CircuitHostTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitHostTest.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Text.Json;
 using Microsoft.AspNetCore.Components.Endpoints;
+using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.SignalR;
@@ -21,6 +22,293 @@ public class CircuitHostTest
 {
     private readonly IDataProtectionProvider _ephemeralDataProtectionProvider = new EphemeralDataProtectionProvider();
     private readonly ServerComponentInvocationSequence _invocationSequence = new();
+
+    [Fact]
+    public async Task DeferredHostInitializersCompleteOnceBeforeRootComponentsRender()
+    {
+        var calls = new List<string>();
+        var completionNotification = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(client => client.SendCoreAsync(
+                "JS.EndHostInitialization",
+                It.IsAny<object[]>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => completionNotification.TrySetResult())
+            .Returns(Task.CompletedTask);
+        DeferredInitializerRootComponent.Reset();
+        var circuitHost = TestCircuitHost.Create(
+            clientProxy: new CircuitClientProxy(proxy.Object, "connection"),
+            descriptors:
+            [
+                new ComponentDescriptor
+                {
+                    ComponentType = typeof(DeferredInitializerRootComponent),
+                    Parameters = ParameterView.Empty,
+                    Sequence = 0,
+                },
+            ],
+            deferredHostInitializers:
+            [
+                new TestHostInitializer("first", calls),
+                new TestHostInitializer("second", calls),
+            ]);
+
+        var initializeTask = circuitHost.InitializeAsync(
+            new ProtectedPrerenderComponentApplicationStore(Mock.Of<IDataProtectionProvider>()),
+            default,
+            CancellationToken.None);
+        await Task.Yield();
+        Assert.False(DeferredInitializerRootComponent.Rendered.Task.IsCompleted);
+
+        circuitHost.BeginHostInitialization(CancellationToken.None);
+        circuitHost.BeginHostInitialization(CancellationToken.None);
+        await completionNotification.Task;
+        await initializeTask;
+        await DeferredInitializerRootComponent.Rendered.Task;
+
+        Assert.Equal(["first", "second"], calls);
+        proxy.Verify(client => client.SendCoreAsync(
+            "JS.EndHostInitialization",
+            It.Is<object[]>(arguments => (bool)arguments[0] && ReferenceEquals(arguments[1], null)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeferredHostInitializerFailureStopsExecutionAndUnblocksInitialization()
+    {
+        var calls = new List<string>();
+        var exception = new InvalidOperationException("Initializer failed.");
+        var reportedException = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completionNotification = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(client => client.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, _, _) =>
+            {
+                if (method == "JS.EndHostInitialization")
+                {
+                    completionNotification.TrySetResult();
+                }
+            })
+            .Returns(Task.CompletedTask);
+        var circuitHost = TestCircuitHost.Create(
+            clientProxy: new CircuitClientProxy(proxy.Object, "connection"),
+            deferredHostInitializers:
+            [
+                new TestHostInitializer("failure", calls, exception),
+                new TestHostInitializer("not-run", calls),
+            ]);
+        circuitHost.UnhandledException += (_, eventArgs) =>
+            reportedException.TrySetResult((Exception)eventArgs.ExceptionObject);
+
+        var initializeTask = circuitHost.InitializeAsync(null, default, CancellationToken.None);
+        circuitHost.BeginHostInitialization(CancellationToken.None);
+        circuitHost.BeginHostInitialization(CancellationToken.None);
+        await completionNotification.Task;
+        await initializeTask;
+
+        Assert.Same(exception, await reportedException.Task);
+        Assert.Equal(["failure"], calls);
+        proxy.Verify(client => client.SendCoreAsync(
+            "JS.EndHostInitialization",
+            It.Is<object[]>(arguments => !(bool)arguments[0]),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeferredHostInitializerCancellationStopsExecutionAndUnblocksInitialization()
+    {
+        var calls = new List<string>();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var reportedException = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completionNotification = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(client => client.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((method, _, _) =>
+            {
+                if (method == "JS.EndHostInitialization")
+                {
+                    completionNotification.TrySetResult();
+                }
+            })
+            .Returns(Task.CompletedTask);
+        var circuitHost = TestCircuitHost.Create(
+            clientProxy: new CircuitClientProxy(proxy.Object, "connection"),
+            deferredHostInitializers:
+            [
+                new TestHostInitializer("canceled", calls, callback: token =>
+                {
+                    cancellationTokenSource.Cancel();
+                    token.ThrowIfCancellationRequested();
+                }),
+                new TestHostInitializer("not-run", calls),
+            ]);
+        circuitHost.UnhandledException += (_, eventArgs) =>
+            reportedException.TrySetResult((Exception)eventArgs.ExceptionObject);
+
+        var initializeTask = circuitHost.InitializeAsync(null, default, cancellationTokenSource.Token);
+        circuitHost.BeginHostInitialization(cancellationTokenSource.Token);
+        await completionNotification.Task;
+        await initializeTask;
+
+        Assert.IsAssignableFrom<OperationCanceledException>(await reportedException.Task);
+        Assert.Equal(["canceled"], calls);
+        proxy.Verify(client => client.SendCoreAsync(
+            "JS.EndHostInitialization",
+            It.Is<object[]>(arguments => !(bool)arguments[0]),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateRootComponentsWaitsForDeferredHostInitializationWithoutDescriptors()
+    {
+        var calls = new List<string>();
+        var initializerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueInitializer = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new Mock<CircuitHandler>();
+        SetupMockInboundActivityHandler(handler);
+        handler.Setup(instance => instance.OnCircuitOpenedAsync(It.IsAny<Circuit>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        handler.Setup(instance => instance.OnConnectionUpAsync(It.IsAny<Circuit>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var services = new ServiceCollection()
+            .AddSingleton(handler.Object)
+            .BuildServiceProvider();
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(client => client.SendCoreAsync(It.IsAny<string>(), It.IsAny<object[]>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        DeferredInitializerRootComponent.Reset();
+        var circuitHost = TestCircuitHost.Create(
+            clientProxy: new CircuitClientProxy(proxy.Object, "connection"),
+            remoteRenderer: GetRemoteRenderer(),
+            serviceScope: services.CreateAsyncScope(),
+            deferredHostInitializers:
+            [
+                new TestHostInitializer(
+                    "deferred",
+                    calls,
+                    asyncCallback: _ =>
+                    {
+                        initializerStarted.TrySetResult();
+                        return continueInitializer.Task;
+                    }),
+            ]);
+
+        var initializeTask = circuitHost.InitializeAsync(null, default, CancellationToken.None);
+        var updateTask = AddComponentAsync<DeferredInitializerRootComponent>(circuitHost, 1);
+        await Task.Yield();
+
+        Assert.False(updateTask.IsCompleted);
+        Assert.False(DeferredInitializerRootComponent.Rendered.Task.IsCompleted);
+        handler.Verify(
+            instance => instance.OnCircuitOpenedAsync(It.IsAny<Circuit>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        circuitHost.BeginHostInitialization(CancellationToken.None);
+        await initializerStarted.Task;
+        Assert.False(updateTask.IsCompleted);
+        Assert.False(DeferredInitializerRootComponent.Rendered.Task.IsCompleted);
+
+        continueInitializer.SetResult();
+        await initializeTask;
+        await updateTask;
+
+        Assert.Equal(["deferred"], calls);
+        Assert.True(DeferredInitializerRootComponent.Rendered.Task.IsCompletedSuccessfully);
+        handler.Verify(
+            instance => instance.OnCircuitOpenedAsync(It.IsAny<Circuit>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        handler.Verify(
+            instance => instance.OnConnectionUpAsync(It.IsAny<Circuit>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateRootComponentsPreservesArrivalOrderWhileWaitingForDeferredHostInitialization()
+    {
+        var calls = new List<string>();
+        var initializerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueInitializer = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var handler = new Mock<CircuitHandler>();
+        SetupMockInboundActivityHandler(handler);
+        handler.Setup(instance => instance.OnCircuitOpenedAsync(It.IsAny<Circuit>(), It.IsAny<CancellationToken>()))
+            .Callback(() => calls.Add("circuit-opened"))
+            .Returns(Task.CompletedTask);
+        handler.Setup(instance => instance.OnConnectionUpAsync(It.IsAny<Circuit>(), It.IsAny<CancellationToken>()))
+            .Callback(() => calls.Add("connection-up"))
+            .Returns(Task.CompletedTask);
+        var services = new ServiceCollection()
+            .AddSingleton(handler.Object)
+            .BuildServiceProvider();
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(client => client.SendCoreAsync(
+                "JS.EndUpdateRootComponents",
+                It.IsAny<object[]>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, arguments, _) => calls.Add($"batch-{arguments[0]}"))
+            .Returns(Task.CompletedTask);
+        var circuitHost = TestCircuitHost.Create(
+            clientProxy: new CircuitClientProxy(proxy.Object, "connection"),
+            remoteRenderer: GetRemoteRenderer(),
+            serviceScope: services.CreateAsyncScope(),
+            deferredHostInitializers:
+            [
+                new TestHostInitializer("initializer", calls, asyncCallback: _ =>
+                {
+                    initializerStarted.SetResult();
+                    return continueInitializer.Task;
+                }),
+            ]);
+
+        var initializeTask = circuitHost.InitializeAsync(null, default, CancellationToken.None);
+        var firstUpdate = AddComponentAsync<DynamicallyAddedComponent>(circuitHost, 1, batchId: 1);
+        var secondUpdate = AddComponentAsync<DynamicallyAddedComponent>(circuitHost, 2, batchId: 2);
+
+        circuitHost.BeginHostInitialization(CancellationToken.None);
+        await initializerStarted.Task;
+        Assert.Equal(["initializer"], calls);
+
+        continueInitializer.SetResult();
+        await Task.WhenAll(initializeTask, firstUpdate, secondUpdate);
+
+        Assert.Equal(["initializer", "circuit-opened", "connection-up", "batch-1", "batch-2"], calls);
+    }
+
+    [Fact]
+    public async Task UpdateRootComponentsQueueAdvancesAfterCanceledUpdate()
+    {
+        var calls = new List<string>();
+        var proxy = new Mock<ISingleClientProxy>();
+        proxy.Setup(client => client.SendCoreAsync(
+                "JS.EndUpdateRootComponents",
+                It.IsAny<object[]>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, arguments, _) => calls.Add($"batch-{arguments[0]}"))
+            .Returns(Task.CompletedTask);
+        var circuitHost = TestCircuitHost.Create(
+            clientProxy: new CircuitClientProxy(proxy.Object, "connection"),
+            remoteRenderer: GetRemoteRenderer(),
+            serviceScope: new ServiceCollection().BuildServiceProvider().CreateAsyncScope(),
+            deferredHostInitializers:
+            [
+                new TestHostInitializer("initializer", calls),
+            ]);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        var initializeTask = circuitHost.InitializeAsync(null, default, CancellationToken.None);
+        var canceledUpdate = AddComponentAsync<DynamicallyAddedComponent>(
+            circuitHost,
+            1,
+            batchId: 1,
+            cancellationToken: cancellationTokenSource.Token);
+        var succeedingUpdate = AddComponentAsync<DynamicallyAddedComponent>(circuitHost, 2, batchId: 2);
+
+        cancellationTokenSource.Cancel();
+        circuitHost.BeginHostInitialization(CancellationToken.None);
+        await Task.WhenAll(initializeTask, canceledUpdate, succeedingUpdate).WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Equal(["initializer", "batch-2"], calls);
+        Assert.Single(circuitHost.Renderer.GetOrCreateWebRootComponentManager().GetRootComponents());
+    }
 
     [Fact]
     public async Task DisposeAsync_DisposesResources()
@@ -1327,7 +1615,13 @@ public class CircuitHostTest
         Assert.Equal(2, testRenderer.GetOrCreateWebRootComponentManager().GetRootComponents().Count());
     }
 
-    private async Task AddComponentAsync<TComponent>(CircuitHost circuitHost, int ssrComponentId, Dictionary<string, object> parameters = null, string componentKey = "")
+    private Task AddComponentAsync<TComponent>(
+        CircuitHost circuitHost,
+        int ssrComponentId,
+        Dictionary<string, object> parameters = null,
+        string componentKey = "",
+        long batchId = 0,
+        CancellationToken cancellationToken = default)
         where TComponent : IComponent
     {
         var addOperation = new RootComponentOperation
@@ -1341,7 +1635,11 @@ public class CircuitHostTest
         };
 
         // Add component
-        await circuitHost.UpdateRootComponents(new() { Operations = [addOperation] }, null, false, CancellationToken.None);
+        return circuitHost.UpdateRootComponents(
+            new() { BatchId = batchId, Operations = [addOperation] },
+            null,
+            false,
+            cancellationToken);
     }
 
     private async Task UpdateComponentAsync<TComponent>(CircuitHost circuitHost, int ssrComponentId, Dictionary<string, object> parameters = null, string componentKey = "")
@@ -1409,6 +1707,42 @@ public class CircuitHostTest
             .Setup(h => h.CreateInboundActivityHandler(It.IsAny<Func<CircuitInboundActivityContext, Task>>()))
             .Returns((Func<CircuitInboundActivityContext, Task> next) => next)
             .Verifiable();
+    }
+
+    private sealed class TestHostInitializer(
+        string name,
+        List<string> calls,
+        Exception exception = null,
+        Action<CancellationToken> callback = null,
+        Func<CancellationToken, Task> asyncCallback = null) : IHostInitializer
+    {
+        public Task InitializeAsync(CancellationToken cancellationToken = default)
+        {
+            calls.Add(name);
+            callback?.Invoke(cancellationToken);
+
+            return exception is not null
+                ? Task.FromException(exception)
+                : asyncCallback?.Invoke(cancellationToken) ?? Task.CompletedTask;
+        }
+    }
+
+    private sealed class DeferredInitializerRootComponent : IComponent
+    {
+        public static TaskCompletionSource Rendered { get; private set; }
+
+        public static void Reset()
+            => Rendered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Attach(RenderHandle renderHandle)
+        {
+        }
+
+        public Task SetParametersAsync(ParameterView parameters)
+        {
+            Rendered.TrySetResult();
+            return Task.CompletedTask;
+        }
     }
 
     private ComponentMarker CreateMarker(Type type, string locationHash, Dictionary<string, object> parameters = null, string componentKey = "")

--- a/src/Components/Server/test/Circuits/CircuitPersistenceManagerTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitPersistenceManagerTest.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Components.Endpoints;
 using Microsoft.AspNetCore.Components.Infrastructure;
+using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.InternalTesting;
@@ -437,7 +438,7 @@ public class CircuitPersistenceManagerTest
             [],
             jsRuntime,
             navigationManager,
-            [],
+            new HostInitializerInvoker([], scope.ServiceProvider),
             circuitHandlers,
             circuitMetrics,
             componentsActivitySource,

--- a/src/Components/Server/test/Circuits/CircuitPersistenceManagerTest.cs
+++ b/src/Components/Server/test/Circuits/CircuitPersistenceManagerTest.cs
@@ -437,6 +437,7 @@ public class CircuitPersistenceManagerTest
             [],
             jsRuntime,
             navigationManager,
+            [],
             circuitHandlers,
             circuitMetrics,
             componentsActivitySource,

--- a/src/Components/Server/test/Circuits/ComponentHubTest.cs
+++ b/src/Components/Server/test/Circuits/ComponentHubTest.cs
@@ -114,13 +114,22 @@ public class ComponentHubTest
     }
 
     [Fact]
-    public async Task CompleteHostInitializationReturnsBeforeDeferredInitializerCompletes()
+    public async Task StartCircuitReturnsWhileDeferredInitializerAndRenderingRemainIncomplete()
     {
         var initializerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var continueInitializer = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        var completionNotification = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        DeferredInitializerRootComponent.Reset();
         var circuitFactory = new TestCircuitFactory
         {
+            Descriptors =
+            [
+                new ComponentDescriptor
+                {
+                    ComponentType = typeof(DeferredInitializerRootComponent),
+                    Parameters = ParameterView.Empty,
+                    Sequence = 0,
+                },
+            ],
             DeferredHostInitializers =
             [
                 new TestHostInitializer(() =>
@@ -130,27 +139,16 @@ public class ComponentHubTest
                 }),
             ],
         };
-        var (client, hub) = InitializeComponentHub(circuitFactory: circuitFactory);
-        client.Setup(proxy => proxy.SendCoreAsync(
-                "JS.EndHostInitialization",
-                It.IsAny<object[]>(),
-                It.IsAny<CancellationToken>()))
-            .Callback<string, object[], CancellationToken>((_, _, _) => completionNotification.TrySetResult())
-            .Returns(Task.CompletedTask);
-        await hub.StartCircuit(NavigationStartupValuesJson, "{}", null);
-
-        var hubInvocation = hub.CompleteHostInitialization();
+        var (_, hub) = InitializeComponentHub(circuitFactory: circuitFactory);
+        var circuitSecret = await hub.StartCircuit(NavigationStartupValuesJson, "{}", null);
         await initializerStarted.Task;
 
-        Assert.True(hubInvocation.IsCompletedSuccessfully);
-        Assert.False(completionNotification.Task.IsCompleted);
+        Assert.NotNull(circuitSecret);
+        Assert.False(continueInitializer.Task.IsCompleted);
+        Assert.False(DeferredInitializerRootComponent.Rendered.Task.IsCompleted);
 
         continueInitializer.SetResult();
-        await completionNotification.Task;
-        client.Verify(proxy => proxy.SendCoreAsync(
-            "JS.EndHostInitialization",
-            It.Is<object[]>(arguments => (bool)arguments[0] && ReferenceEquals(arguments[1], null)),
-            It.IsAny<CancellationToken>()), Times.Once);
+        await DeferredInitializerRootComponent.Rendered.Task;
     }
 
     [Theory]
@@ -760,6 +758,8 @@ public class ComponentHubTest
 
         public IHostInitializer[] DeferredHostInitializers { get; init; } = [];
 
+        public IReadOnlyList<ComponentDescriptor> Descriptors { get; init; } = [];
+
         // Implement a `CreateCircuitHostAsync` that mocks the construction
         // of the CircuitHost.
         public ValueTask<CircuitHost> CreateCircuitHostAsync(
@@ -779,6 +779,7 @@ public class ComponentHubTest
                 circuitId: TestCircuitIdFactory.Instance.CreateCircuitId(),
                 serviceScope: new AsyncServiceScope(serviceScope.Object),
                 clientProxy: client,
+                descriptors: Descriptors,
                 deferredHostInitializers: DeferredHostInitializers);
             return ValueTask.FromResult(circuitHost);
         }
@@ -786,12 +787,30 @@ public class ComponentHubTest
 
     private sealed class TestHostInitializer(Func<Task> initialize) : IHostInitializer
     {
-        public Task InitializeAsync(CancellationToken cancellationToken = default)
+        public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
             => initialize();
     }
 
     private sealed class TestBrowserStartupValueProvider(params string[] keys) : IBrowserStartupValueProvider
     {
         public IReadOnlyList<string> Keys { get; } = keys;
+    }
+
+    private sealed class DeferredInitializerRootComponent : IComponent
+    {
+        public static TaskCompletionSource Rendered { get; private set; }
+
+        public static void Reset()
+            => Rendered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Attach(RenderHandle renderHandle)
+        {
+        }
+
+        public Task SetParametersAsync(ParameterView parameters)
+        {
+            Rendered.TrySetResult();
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/Components/Server/test/Circuits/ComponentHubTest.cs
+++ b/src/Components/Server/test/Circuits/ComponentHubTest.cs
@@ -24,14 +24,17 @@ namespace Microsoft.AspNetCore.Components.Server;
 
 public class ComponentHubTest
 {
+    private const string NavigationStartupValuesJson =
+        """{"document.baseURI":"https://localhost:5000/","location.href":"https://localhost:5000/subdir"}""";
+
     [Fact]
     public async Task CannotStartMultipleCircuits()
     {
         var (mockClientProxy, hub) = InitializeComponentHub();
-        var circuitSecret = await hub.StartCircuit("https://localhost:5000", "https://localhost:5000/subdir", "{}", null);
+        var circuitSecret = await StartCircuitAsync(hub);
         Assert.NotNull(circuitSecret);
 
-        var circuit2Secret = await hub.StartCircuit("https://localhost:5000", "https://localhost:5000/subdir", "{}", null);
+        var circuit2Secret = await StartCircuitAsync(hub);
         Assert.Null(circuit2Secret);
 
         var errorMessage = "The circuit host '.*?' has already been initialized.";
@@ -42,10 +45,10 @@ public class ComponentHubTest
     public async Task StartCircuitFailsWithNullData()
     {
         var (mockClientProxy, hub) = InitializeComponentHub();
-        var circuitSecret = await hub.StartCircuit(null, null, "foo", null);
+        var circuitSecret = await hub.StartCircuit(null, "foo", null);
 
         Assert.Null(circuitSecret);
-        var errorMessage = "The uris provided are invalid.";
+        var errorMessage = "The startup values provided are invalid.";
         mockClientProxy.Verify(m => m.SendCoreAsync("JS.Error", new[] { errorMessage }, It.IsAny<CancellationToken>()), Times.Once());
     }
 
@@ -77,26 +80,21 @@ public class ComponentHubTest
     }
 
     [Fact]
-    public async Task StartCircuitLegacyPathSeedsNavigationStartupValues()
+    public async Task StartCircuitPassesNavigationStartupValues()
     {
         var circuitFactory = new TestCircuitFactory();
         var (_, hub) = InitializeComponentHub(circuitFactory: circuitFactory);
 
-        var circuitSecret = await hub.StartCircuit(
-            "https://localhost:5000/",
-            "https://localhost:5000/page",
-            "{}",
-            null);
+        var circuitSecret = await hub.StartCircuit(NavigationStartupValuesJson, "{}", null);
 
         Assert.NotNull(circuitSecret);
         Assert.Equal("https://localhost:5000/", circuitFactory.StartupValues["document.baseURI"]);
-        Assert.Equal("https://localhost:5000/page", circuitFactory.StartupValues["location.href"]);
+        Assert.Equal("https://localhost:5000/subdir", circuitFactory.StartupValues["location.href"]);
         Assert.Equal(2, circuitFactory.StartupValues.Count);
-        Assert.False(circuitFactory.SupportsDeferredHostInitialization);
     }
 
     [Fact]
-    public async Task StartCircuitWithStartupValuesPassesValidatedValues()
+    public async Task StartCircuitPassesValidatedCustomValues()
     {
         var circuitFactory = new TestCircuitFactory();
         var (_, hub) = InitializeComponentHub(
@@ -106,16 +104,13 @@ public class ComponentHubTest
                 new TestBrowserStartupValueProvider("document.baseURI", "location.href", "custom.value"),
             ]);
 
-        var circuitSecret = await hub.StartCircuitWithStartupValues(
-            "https://localhost:5000/",
-            "https://localhost:5000/page",
+        var circuitSecret = await hub.StartCircuit(
+            """{"document.baseURI":"https://localhost:5000/","location.href":"https://localhost:5000/page","custom.value":"expected"}""",
             "{}",
-            null,
-            """{"document.baseURI":"https://localhost:5000/","location.href":"https://localhost:5000/page","custom.value":"expected"}""");
+            null);
 
         Assert.NotNull(circuitSecret);
         Assert.Equal("expected", circuitFactory.StartupValues["custom.value"]);
-        Assert.True(circuitFactory.SupportsDeferredHostInitialization);
     }
 
     [Fact]
@@ -142,12 +137,7 @@ public class ComponentHubTest
                 It.IsAny<CancellationToken>()))
             .Callback<string, object[], CancellationToken>((_, _, _) => completionNotification.TrySetResult())
             .Returns(Task.CompletedTask);
-        await hub.StartCircuitWithStartupValues(
-            "https://localhost:5000/",
-            "https://localhost:5000/page",
-            "{}",
-            null,
-            "{}");
+        await hub.StartCircuit(NavigationStartupValuesJson, "{}", null);
 
         var hubInvocation = hub.CompleteHostInitialization();
         await initializerStarted.Task;
@@ -167,11 +157,11 @@ public class ComponentHubTest
     [InlineData("not json")]
     [InlineData("""{"value":"first","value":"second"}""")]
     [InlineData("""{"value":42}""")]
-    [InlineData("""{"document.baseURI":"https://other.example/","location.href":"https://localhost:5000/page"}""")]
-    [InlineData("""{"document.baseURI":"https://localhost:5000/","location.href":"https://localhost:5000/other"}""")]
+    [InlineData("""{"document.baseURI":"relative","location.href":"https://localhost:5000/page"}""")]
+    [InlineData("""{"document.baseURI":"https://localhost:5000/","location.href":"relative"}""")]
     [InlineData("""{"document.baseURI":"https://localhost:5000/"}""")]
     [InlineData("""{"document.baseURI":"https://localhost:5000/","location.href":"https://localhost:5000/page","unexpected":"value"}""")]
-    public async Task StartCircuitWithStartupValuesRejectsInvalidValues(string startupValuesJson)
+    public async Task StartCircuitRejectsInvalidStartupValues(string startupValuesJson)
     {
         var (mockClientProxy, hub) = InitializeComponentHub(
             browserStartupValueProviders:
@@ -179,12 +169,7 @@ public class ComponentHubTest
                 new TestBrowserStartupValueProvider("document.baseURI", "location.href"),
             ]);
 
-        var circuitSecret = await hub.StartCircuitWithStartupValues(
-            "https://localhost:5000/",
-            "https://localhost:5000/page",
-            "{}",
-            null,
-            startupValuesJson);
+        var circuitSecret = await hub.StartCircuit(startupValuesJson, "{}", null);
 
         Assert.Null(circuitSecret);
         mockClientProxy.Verify(
@@ -276,7 +261,7 @@ public class ComponentHubTest
                 return true;
             };
         var (mockClientProxy, hub) = InitializeComponentHub(deserializer);
-        var circuitSecret = await hub.StartCircuit("https://localhost:5000", "https://localhost:5000/subdir", "[]", null);
+        var circuitSecret = await StartCircuitAsync(hub, "[]");
         Assert.NotNull(circuitSecret);
         await hub.UpdateRootComponents("""{ batchId: 1, operations: [] }""", "");
         Assert.True(called);
@@ -318,9 +303,9 @@ public class ComponentHubTest
             });
 
         var (mockClientProxy, hub) = InitializeComponentHub(deserializer, handleRegistryMock.Object, providerMock.Object);
-        var circuitSecret = await hub.StartCircuit("https://localhost:5000", "https://localhost:5000/subdir", "[]", null);
+        var circuitSecret = await StartCircuitAsync(hub, "[]");
         lastCircuit = null;
-        var result = await hub.ResumeCircuit(circuitSecret, "https://localhost:5000", "https://localhost:5000/subdir", "[]", "");
+        var result = await ResumeCircuitAsync(hub, circuitSecret, "[]", "");
         await hub.UpdateRootComponents("""{ batchId: 1, operations: [] }""", "");
         Assert.False(lastCircuit.HasPendingPersistedCircuitState);
     }
@@ -330,7 +315,7 @@ public class ComponentHubTest
     {
         var (mockClientProxy, hub) = InitializeComponentHub();
         var invalidCircuitId = "invalid-circuit-id";
-        var result = await hub.ResumeCircuit(invalidCircuitId, null, null, null, null);
+        var result = await hub.ResumeCircuit(invalidCircuitId, null, null, null);
         Assert.Null(result);
     }
 
@@ -338,23 +323,23 @@ public class ComponentHubTest
     public async Task CannotResumeConnectedCircuit()
     {
         var (mockClientProxy, hub) = InitializeComponentHub();
-        var circuitSecret = await hub.StartCircuit("https://localhost:5000", "https://localhost:5000/subdir", "{}", null);
+        var circuitSecret = await StartCircuitAsync(hub);
         Assert.NotNull(circuitSecret);
-        var result = await hub.ResumeCircuit(circuitSecret, null, null, null, null);
+        var result = await hub.ResumeCircuit(circuitSecret, null, null, null);
         Assert.Null(result);
         var errorMessage = "The circuit host '.*?' has already been initialized.";
         mockClientProxy.Verify(m => m.SendCoreAsync("JS.Error", It.Is<object[]>(s => Regex.Match((string)s[0], errorMessage).Success), It.IsAny<CancellationToken>()), Times.Once());
     }
 
     [Fact]
-    public async Task CannotResumeInvalidUrls()
+    public async Task CannotResumeInvalidStartupValues()
     {
         var handleRegistryMock = new Mock<ICircuitHandleRegistry>();
         var (mockClientProxy, hub) = InitializeComponentHub(null, handleRegistryMock.Object);
-        var circuitSecret = await hub.StartCircuit("https://localhost:5000", "https://localhost:5000/subdir", "{}", null);
-        var result = await hub.ResumeCircuit(circuitSecret, null, null, null, null);
+        var circuitSecret = await StartCircuitAsync(hub);
+        var result = await hub.ResumeCircuit(circuitSecret, null, null, null);
         Assert.Null(result);
-        var errorMessage = "The uris provided are invalid.";
+        var errorMessage = "The startup values provided are invalid.";
         mockClientProxy.Verify(m => m.SendCoreAsync("JS.Error", new[] { errorMessage }, It.IsAny<CancellationToken>()), Times.Once());
     }
 
@@ -365,8 +350,8 @@ public class ComponentHubTest
     {
         var handleRegistryMock = new Mock<ICircuitHandleRegistry>();
         var (mockClientProxy, hub) = InitializeComponentHub(null, handleRegistryMock.Object);
-        var circuitSecret = await hub.StartCircuit("https://localhost:5000", "https://localhost:5000/subdir", "{}", null);
-        var result = await hub.ResumeCircuit(circuitSecret, "https://localhost:5000", "https://localhost:5000/subdir", "unused", appState);
+        var circuitSecret = await StartCircuitAsync(hub);
+        var result = await ResumeCircuitAsync(hub, circuitSecret, "unused", appState);
         Assert.Null(result);
         var errorMessage = "The application state provided is invalid.";
         mockClientProxy.Verify(m => m.SendCoreAsync("JS.Error", new[] { errorMessage }, It.IsAny<CancellationToken>()), Times.Once());
@@ -380,8 +365,8 @@ public class ComponentHubTest
     {
         var handleRegistryMock = new Mock<ICircuitHandleRegistry>();
         var (mockClientProxy, hub) = InitializeComponentHub(null, handleRegistryMock.Object);
-        var circuitSecret = await hub.StartCircuit("https://localhost:5000", "https://localhost:5000/subdir", "{}", null);
-        var result = await hub.ResumeCircuit(circuitSecret, "https://localhost:5000", "https://localhost:5000/subdir", rootComponents, "app-state");
+        var circuitSecret = await StartCircuitAsync(hub);
+        var result = await ResumeCircuitAsync(hub, circuitSecret, rootComponents, "app-state");
         Assert.Null(result);
         var errorMessage = "The root components provided are invalid.";
         mockClientProxy.Verify(m => m.SendCoreAsync("JS.Error", new[] { errorMessage }, It.IsAny<CancellationToken>()), Times.Once());
@@ -392,8 +377,8 @@ public class ComponentHubTest
     {
         var handleRegistryMock = new Mock<ICircuitHandleRegistry>();
         var (mockClientProxy, hub) = InitializeComponentHub(null, handleRegistryMock.Object);
-        var circuitSecret = await hub.StartCircuit("https://localhost:5000", "https://localhost:5000/subdir", "{}", null);
-        var result = await hub.ResumeCircuit(circuitSecret, "https://localhost:5000", "https://localhost:5000/subdir", "[]", "");
+        var circuitSecret = await StartCircuitAsync(hub);
+        var result = await ResumeCircuitAsync(hub, circuitSecret, "[]", "");
         Assert.Null(result);
     }
 
@@ -416,15 +401,15 @@ public class ComponentHubTest
             });
 
         var (mockClientProxy, hub) = InitializeComponentHub(null, handleRegistryMock.Object, providerMock.Object);
-        var circuitSecret = await hub.StartCircuit("https://localhost:5000", "https://localhost:5000/subdir", "{}", null);
-        var result = await hub.ResumeCircuit(circuitSecret, "https://localhost:5000", "https://localhost:5000/subdir", "[]", "");
+        var circuitSecret = await StartCircuitAsync(hub);
+        var result = await ResumeCircuitAsync(hub, circuitSecret, "[]", "");
         Assert.NotNull(result);
         Assert.NotEqual(circuitSecret, result);
         Assert.True(lastCircuit.HasPendingPersistedCircuitState);
     }
 
     [Fact]
-    public async Task ResumeCircuitWithStartupValuesPassesValidatedValues()
+    public async Task ResumeCircuitPassesValidatedValues()
     {
         var handleRegistryMock = new Mock<ICircuitHandleRegistry>();
         var providerMock = new Mock<ICircuitPersistenceProvider>();
@@ -444,33 +429,29 @@ public class ComponentHubTest
                 new TestBrowserStartupValueProvider("document.baseURI", "location.href", "custom.value"),
             ]);
         var circuitSecret = await hub.StartCircuit(
-            "https://localhost:5000/",
-            "https://localhost:5000/page",
+            """{"document.baseURI":"https://localhost:5000/","location.href":"https://localhost:5000/page","custom.value":"initial"}""",
             "{}",
             null);
 
-        var result = await hub.ResumeCircuitWithStartupValues(
+        var result = await hub.ResumeCircuit(
             circuitSecret,
-            "https://localhost:5000/",
-            "https://localhost:5000/page",
+            """{"document.baseURI":"https://localhost:5000/","location.href":"https://localhost:5000/page","custom.value":"expected"}""",
             "[]",
-            "",
-            """{"document.baseURI":"https://localhost:5000/","location.href":"https://localhost:5000/page","custom.value":"expected"}""");
+            "");
 
         Assert.NotNull(result);
         Assert.Equal("expected", circuitFactory.StartupValues["custom.value"]);
-        Assert.True(circuitFactory.SupportsDeferredHostInitialization);
     }
 
     [Theory]
     [InlineData("not json")]
     [InlineData("""{"value":"first","value":"second"}""")]
     [InlineData("""{"value":42}""")]
-    [InlineData("""{"document.baseURI":"https://other.example/","location.href":"https://localhost:5000/page"}""")]
-    [InlineData("""{"document.baseURI":"https://localhost:5000/","location.href":"https://localhost:5000/other"}""")]
+    [InlineData("""{"document.baseURI":"relative","location.href":"https://localhost:5000/page"}""")]
+    [InlineData("""{"document.baseURI":"https://localhost:5000/","location.href":"relative"}""")]
     [InlineData("""{"document.baseURI":"https://localhost:5000/"}""")]
     [InlineData("""{"document.baseURI":"https://localhost:5000/","location.href":"https://localhost:5000/page","unexpected":"value"}""")]
-    public async Task ResumeCircuitWithStartupValuesRejectsInvalidValues(string startupValuesJson)
+    public async Task ResumeCircuitRejectsInvalidStartupValues(string startupValuesJson)
     {
         var handleRegistryMock = new Mock<ICircuitHandleRegistry>();
         var (mockClientProxy, hub) = InitializeComponentHub(
@@ -480,18 +461,15 @@ public class ComponentHubTest
                 new TestBrowserStartupValueProvider("document.baseURI", "location.href"),
             ]);
         var circuitSecret = await hub.StartCircuit(
-            "https://localhost:5000/",
-            "https://localhost:5000/page",
+            """{"document.baseURI":"https://localhost:5000/","location.href":"https://localhost:5000/page"}""",
             "{}",
             null);
 
-        var result = await hub.ResumeCircuitWithStartupValues(
+        var result = await hub.ResumeCircuit(
             circuitSecret,
-            "https://localhost:5000/",
-            "https://localhost:5000/page",
+            startupValuesJson,
             "[]",
-            "",
-            startupValuesJson);
+            "");
 
         Assert.Null(result);
         mockClientProxy.Verify(
@@ -516,12 +494,11 @@ public class ComponentHubTest
                 It.IsAny<ClaimsPrincipal>(),
                 It.IsAny<IPersistentComponentStateStore>(),
                 It.IsAny<ResourceAssetCollection>(),
-                It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Unable to resolve service for type 'IMyUnresolvedDependency'."));
 
         var (mockClientProxy, hub) = InitializeComponentHub(circuitFactory: circuitFactoryMock.Object);
-        var circuitSecret = await hub.StartCircuit("https://localhost:5000", "https://localhost:5000/subdir", "{}", null);
+        var circuitSecret = await StartCircuitAsync(hub);
 
         Assert.Null(circuitSecret);
         var errorMessage = "The circuit failed to initialize. See the server logs for more information.";
@@ -551,7 +528,6 @@ public class ComponentHubTest
                 It.IsAny<ClaimsPrincipal>(),
                 It.IsAny<IPersistentComponentStateStore>(),
                 It.IsAny<ResourceAssetCollection>(),
-                It.IsAny<bool>(),
                 It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Unable to resolve service for type 'IMyUnresolvedDependency'."));
 
@@ -560,8 +536,8 @@ public class ComponentHubTest
             handleRegistry: handleRegistryMock.Object,
             provider: providerMock.Object,
             circuitFactory: circuitFactoryMock.Object);
-        var circuitSecret = await hub.StartCircuit("https://localhost:5000", "https://localhost:5000/subdir", "{}", null);
-        var result = await hub.ResumeCircuit(circuitSecret, "https://localhost:5000", "https://localhost:5000/subdir", "[]", "");
+        var circuitSecret = await StartCircuitAsync(hub);
+        var result = await ResumeCircuitAsync(hub, circuitSecret, "[]", "");
 
         Assert.Null(result);
         var errorMessage = "The circuit failed to initialize. See the server logs for more information.";
@@ -659,7 +635,10 @@ public class ComponentHubTest
             circuitRegistry: circuitRegistry,
             circuitPersistenceProvider: circuitPersistenceManager,
             circuitHandleRegistry: circuitHandleRegistry,
-            browserStartupValueProviders: browserStartupValueProviders ?? [],
+            browserStartupValueProviders: browserStartupValueProviders ??
+            [
+                new TestBrowserStartupValueProvider("document.baseURI", "location.href"),
+            ],
             logger: NullLogger<ComponentHub>.Instance);
 
         // Here we mock out elements of the Hub that are typically configured
@@ -686,6 +665,19 @@ public class ComponentHubTest
 
         return (mockClientProxy, hub);
     }
+
+    private static ValueTask<string> StartCircuitAsync(
+        ComponentHub hub,
+        string serializedComponentRecords = "{}",
+        string applicationState = null)
+        => hub.StartCircuit(NavigationStartupValuesJson, serializedComponentRecords, applicationState);
+
+    private static ValueTask<string> ResumeCircuitAsync(
+        ComponentHub hub,
+        string circuitId,
+        string rootComponents,
+        string applicationState)
+        => hub.ResumeCircuit(circuitId, NavigationStartupValuesJson, rootComponents, applicationState);
 
     private class TestCircuitHandleRegistry : ICircuitHandleRegistry
     {
@@ -766,8 +758,6 @@ public class ComponentHubTest
         public IReadOnlyDictionary<string, string> StartupValues { get; private set; } =
             new Dictionary<string, string>();
 
-        public bool SupportsDeferredHostInitialization { get; private set; }
-
         public IHostInitializer[] DeferredHostInitializers { get; init; } = [];
 
         // Implement a `CreateCircuitHostAsync` that mocks the construction
@@ -781,11 +771,9 @@ public class ComponentHubTest
             ClaimsPrincipal user,
             IPersistentComponentStateStore store,
             ResourceAssetCollection resourceCollection,
-            bool supportsDeferredHostInitialization,
             CancellationToken cancellationToken)
         {
             StartupValues = startupValues;
-            SupportsDeferredHostInitialization = supportsDeferredHostInitialization;
             var serviceScope = new Mock<IServiceScope>();
             var circuitHost = TestCircuitHost.Create(
                 circuitId: TestCircuitIdFactory.Instance.CreateCircuitId(),

--- a/src/Components/Server/test/Circuits/ComponentHubTest.cs
+++ b/src/Components/Server/test/Circuits/ComponentHubTest.cs
@@ -59,7 +59,7 @@ public class ComponentHubTest
         };
         var (_, hub) = InitializeComponentHub(browserStartupValueProviders: providers);
 
-        Assert.Equal(["first.value", "second.value"], hub.GetStartupValueKeys());
+        Assert.Equal("""["first.value","second.value"]""", hub.GetStartupValueKeys());
     }
 
     [Fact]
@@ -92,6 +92,7 @@ public class ComponentHubTest
         Assert.Equal("https://localhost:5000/", circuitFactory.StartupValues["document.baseURI"]);
         Assert.Equal("https://localhost:5000/page", circuitFactory.StartupValues["location.href"]);
         Assert.Equal(2, circuitFactory.StartupValues.Count);
+        Assert.False(circuitFactory.SupportsDeferredHostInitialization);
     }
 
     [Fact]
@@ -114,6 +115,52 @@ public class ComponentHubTest
 
         Assert.NotNull(circuitSecret);
         Assert.Equal("expected", circuitFactory.StartupValues["custom.value"]);
+        Assert.True(circuitFactory.SupportsDeferredHostInitialization);
+    }
+
+    [Fact]
+    public async Task CompleteHostInitializationReturnsBeforeDeferredInitializerCompletes()
+    {
+        var initializerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueInitializer = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var completionNotification = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var circuitFactory = new TestCircuitFactory
+        {
+            DeferredHostInitializers =
+            [
+                new TestHostInitializer(() =>
+                {
+                    initializerStarted.TrySetResult();
+                    return continueInitializer.Task;
+                }),
+            ],
+        };
+        var (client, hub) = InitializeComponentHub(circuitFactory: circuitFactory);
+        client.Setup(proxy => proxy.SendCoreAsync(
+                "JS.EndHostInitialization",
+                It.IsAny<object[]>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, object[], CancellationToken>((_, _, _) => completionNotification.TrySetResult())
+            .Returns(Task.CompletedTask);
+        await hub.StartCircuitWithStartupValues(
+            "https://localhost:5000/",
+            "https://localhost:5000/page",
+            "{}",
+            null,
+            "{}");
+
+        var hubInvocation = hub.CompleteHostInitialization();
+        await initializerStarted.Task;
+
+        Assert.True(hubInvocation.IsCompletedSuccessfully);
+        Assert.False(completionNotification.Task.IsCompleted);
+
+        continueInitializer.SetResult();
+        await completionNotification.Task;
+        client.Verify(proxy => proxy.SendCoreAsync(
+            "JS.EndHostInitialization",
+            It.Is<object[]>(arguments => (bool)arguments[0] && ReferenceEquals(arguments[1], null)),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Theory]
@@ -412,6 +459,7 @@ public class ComponentHubTest
 
         Assert.NotNull(result);
         Assert.Equal("expected", circuitFactory.StartupValues["custom.value"]);
+        Assert.True(circuitFactory.SupportsDeferredHostInitialization);
     }
 
     [Theory]
@@ -467,7 +515,9 @@ public class ComponentHubTest
                 It.IsAny<IReadOnlyDictionary<string, string>>(),
                 It.IsAny<ClaimsPrincipal>(),
                 It.IsAny<IPersistentComponentStateStore>(),
-                It.IsAny<ResourceAssetCollection>()))
+                It.IsAny<ResourceAssetCollection>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Unable to resolve service for type 'IMyUnresolvedDependency'."));
 
         var (mockClientProxy, hub) = InitializeComponentHub(circuitFactory: circuitFactoryMock.Object);
@@ -500,7 +550,9 @@ public class ComponentHubTest
                 It.IsAny<IReadOnlyDictionary<string, string>>(),
                 It.IsAny<ClaimsPrincipal>(),
                 It.IsAny<IPersistentComponentStateStore>(),
-                It.IsAny<ResourceAssetCollection>()))
+                It.IsAny<ResourceAssetCollection>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Unable to resolve service for type 'IMyUnresolvedDependency'."));
 
         var (mockClientProxy, hub) = InitializeComponentHub(
@@ -714,6 +766,10 @@ public class ComponentHubTest
         public IReadOnlyDictionary<string, string> StartupValues { get; private set; } =
             new Dictionary<string, string>();
 
+        public bool SupportsDeferredHostInitialization { get; private set; }
+
+        public IHostInitializer[] DeferredHostInitializers { get; init; } = [];
+
         // Implement a `CreateCircuitHostAsync` that mocks the construction
         // of the CircuitHost.
         public ValueTask<CircuitHost> CreateCircuitHostAsync(
@@ -724,18 +780,26 @@ public class ComponentHubTest
             IReadOnlyDictionary<string, string> startupValues,
             ClaimsPrincipal user,
             IPersistentComponentStateStore store,
-            ResourceAssetCollection resourceCollection)
+            ResourceAssetCollection resourceCollection,
+            bool supportsDeferredHostInitialization,
+            CancellationToken cancellationToken)
         {
             StartupValues = startupValues;
-            var clientProxy = new CircuitClientProxy(Mock.Of<ISingleClientProxy>(), "123");
-
+            SupportsDeferredHostInitialization = supportsDeferredHostInitialization;
             var serviceScope = new Mock<IServiceScope>();
             var circuitHost = TestCircuitHost.Create(
                 circuitId: TestCircuitIdFactory.Instance.CreateCircuitId(),
                 serviceScope: new AsyncServiceScope(serviceScope.Object),
-                clientProxy: clientProxy);
+                clientProxy: client,
+                deferredHostInitializers: DeferredHostInitializers);
             return ValueTask.FromResult(circuitHost);
         }
+    }
+
+    private sealed class TestHostInitializer(Func<Task> initialize) : IHostInitializer
+    {
+        public Task InitializeAsync(CancellationToken cancellationToken = default)
+            => initialize();
     }
 
     private sealed class TestBrowserStartupValueProvider(params string[] keys) : IBrowserStartupValueProvider

--- a/src/Components/Server/test/Circuits/ComponentHubTest.cs
+++ b/src/Components/Server/test/Circuits/ComponentHubTest.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.DataProtection;
@@ -46,6 +47,105 @@ public class ComponentHubTest
         Assert.Null(circuitSecret);
         var errorMessage = "The uris provided are invalid.";
         mockClientProxy.Verify(m => m.SendCoreAsync("JS.Error", new[] { errorMessage }, It.IsAny<CancellationToken>()), Times.Once());
+    }
+
+    [Fact]
+    public void GetStartupValueKeysReturnsProviderKeysInRegistrationOrder()
+    {
+        var providers = new IBrowserStartupValueProvider[]
+        {
+            new TestBrowserStartupValueProvider("first.value"),
+            new TestBrowserStartupValueProvider("second.value"),
+        };
+        var (_, hub) = InitializeComponentHub(browserStartupValueProviders: providers);
+
+        Assert.Equal(["first.value", "second.value"], hub.GetStartupValueKeys());
+    }
+
+    [Fact]
+    public void GetStartupValueKeysRejectsDuplicates()
+    {
+        var providers = new IBrowserStartupValueProvider[]
+        {
+            new TestBrowserStartupValueProvider("duplicate.value"),
+            new TestBrowserStartupValueProvider("duplicate.value"),
+        };
+        var (_, hub) = InitializeComponentHub(browserStartupValueProviders: providers);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => hub.GetStartupValueKeys());
+        Assert.Equal("The browser startup value key 'duplicate.value' was provided more than once.", exception.Message);
+    }
+
+    [Fact]
+    public async Task StartCircuitLegacyPathSeedsNavigationStartupValues()
+    {
+        var circuitFactory = new TestCircuitFactory();
+        var (_, hub) = InitializeComponentHub(circuitFactory: circuitFactory);
+
+        var circuitSecret = await hub.StartCircuit(
+            "https://localhost:5000/",
+            "https://localhost:5000/page",
+            "{}",
+            null);
+
+        Assert.NotNull(circuitSecret);
+        Assert.Equal("https://localhost:5000/", circuitFactory.StartupValues["document.baseURI"]);
+        Assert.Equal("https://localhost:5000/page", circuitFactory.StartupValues["location.href"]);
+        Assert.Equal(2, circuitFactory.StartupValues.Count);
+    }
+
+    [Fact]
+    public async Task StartCircuitWithStartupValuesPassesValidatedValues()
+    {
+        var circuitFactory = new TestCircuitFactory();
+        var (_, hub) = InitializeComponentHub(
+            circuitFactory: circuitFactory,
+            browserStartupValueProviders:
+            [
+                new TestBrowserStartupValueProvider("document.baseURI", "location.href", "custom.value"),
+            ]);
+
+        var circuitSecret = await hub.StartCircuitWithStartupValues(
+            "https://localhost:5000/",
+            "https://localhost:5000/page",
+            "{}",
+            null,
+            """{"document.baseURI":"https://localhost:5000/","location.href":"https://localhost:5000/page","custom.value":"expected"}""");
+
+        Assert.NotNull(circuitSecret);
+        Assert.Equal("expected", circuitFactory.StartupValues["custom.value"]);
+    }
+
+    [Theory]
+    [InlineData("not json")]
+    [InlineData("""{"value":"first","value":"second"}""")]
+    [InlineData("""{"value":42}""")]
+    [InlineData("""{"document.baseURI":"https://other.example/","location.href":"https://localhost:5000/page"}""")]
+    [InlineData("""{"document.baseURI":"https://localhost:5000/","location.href":"https://localhost:5000/other"}""")]
+    [InlineData("""{"document.baseURI":"https://localhost:5000/"}""")]
+    [InlineData("""{"document.baseURI":"https://localhost:5000/","location.href":"https://localhost:5000/page","unexpected":"value"}""")]
+    public async Task StartCircuitWithStartupValuesRejectsInvalidValues(string startupValuesJson)
+    {
+        var (mockClientProxy, hub) = InitializeComponentHub(
+            browserStartupValueProviders:
+            [
+                new TestBrowserStartupValueProvider("document.baseURI", "location.href"),
+            ]);
+
+        var circuitSecret = await hub.StartCircuitWithStartupValues(
+            "https://localhost:5000/",
+            "https://localhost:5000/page",
+            "{}",
+            null,
+            startupValuesJson);
+
+        Assert.Null(circuitSecret);
+        mockClientProxy.Verify(
+            proxy => proxy.SendCoreAsync(
+                "JS.Error",
+                new[] { "The startup values provided are invalid." },
+                It.IsAny<CancellationToken>()),
+            Times.Once());
     }
 
     [Fact]
@@ -277,6 +377,84 @@ public class ComponentHubTest
     }
 
     [Fact]
+    public async Task ResumeCircuitWithStartupValuesPassesValidatedValues()
+    {
+        var handleRegistryMock = new Mock<ICircuitHandleRegistry>();
+        var providerMock = new Mock<ICircuitPersistenceProvider>();
+        providerMock.Setup(m => m.RestoreCircuitAsync(It.IsAny<CircuitId>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PersistedCircuitState
+            {
+                RootComponents = [.. """{}"""u8],
+                ApplicationState = ReadOnlyDictionary<string, byte[]>.Empty,
+            });
+        var circuitFactory = new TestCircuitFactory();
+        var (_, hub) = InitializeComponentHub(
+            handleRegistry: handleRegistryMock.Object,
+            provider: providerMock.Object,
+            circuitFactory: circuitFactory,
+            browserStartupValueProviders:
+            [
+                new TestBrowserStartupValueProvider("document.baseURI", "location.href", "custom.value"),
+            ]);
+        var circuitSecret = await hub.StartCircuit(
+            "https://localhost:5000/",
+            "https://localhost:5000/page",
+            "{}",
+            null);
+
+        var result = await hub.ResumeCircuitWithStartupValues(
+            circuitSecret,
+            "https://localhost:5000/",
+            "https://localhost:5000/page",
+            "[]",
+            "",
+            """{"document.baseURI":"https://localhost:5000/","location.href":"https://localhost:5000/page","custom.value":"expected"}""");
+
+        Assert.NotNull(result);
+        Assert.Equal("expected", circuitFactory.StartupValues["custom.value"]);
+    }
+
+    [Theory]
+    [InlineData("not json")]
+    [InlineData("""{"value":"first","value":"second"}""")]
+    [InlineData("""{"value":42}""")]
+    [InlineData("""{"document.baseURI":"https://other.example/","location.href":"https://localhost:5000/page"}""")]
+    [InlineData("""{"document.baseURI":"https://localhost:5000/","location.href":"https://localhost:5000/other"}""")]
+    [InlineData("""{"document.baseURI":"https://localhost:5000/"}""")]
+    [InlineData("""{"document.baseURI":"https://localhost:5000/","location.href":"https://localhost:5000/page","unexpected":"value"}""")]
+    public async Task ResumeCircuitWithStartupValuesRejectsInvalidValues(string startupValuesJson)
+    {
+        var handleRegistryMock = new Mock<ICircuitHandleRegistry>();
+        var (mockClientProxy, hub) = InitializeComponentHub(
+            handleRegistry: handleRegistryMock.Object,
+            browserStartupValueProviders:
+            [
+                new TestBrowserStartupValueProvider("document.baseURI", "location.href"),
+            ]);
+        var circuitSecret = await hub.StartCircuit(
+            "https://localhost:5000/",
+            "https://localhost:5000/page",
+            "{}",
+            null);
+
+        var result = await hub.ResumeCircuitWithStartupValues(
+            circuitSecret,
+            "https://localhost:5000/",
+            "https://localhost:5000/page",
+            "[]",
+            "",
+            startupValuesJson);
+
+        Assert.Null(result);
+        mockClientProxy.Verify(
+            proxy => proxy.SendCoreAsync(
+                "JS.Error",
+                new[] { "The startup values provided are invalid." },
+                It.IsAny<CancellationToken>()),
+            Times.Once());
+    }
+
+    [Fact]
     public async Task StartCircuitFailsWithUnresolvedCircuitHandlerDependency_NotifiesClientToCheckServerLogs()
     {
         var circuitFactoryMock = new Mock<ICircuitFactory>();
@@ -286,6 +464,7 @@ public class ComponentHubTest
                 It.IsAny<CircuitClientProxy>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(),
                 It.IsAny<ClaimsPrincipal>(),
                 It.IsAny<IPersistentComponentStateStore>(),
                 It.IsAny<ResourceAssetCollection>()))
@@ -318,6 +497,7 @@ public class ComponentHubTest
                 It.IsAny<CircuitClientProxy>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                It.IsAny<IReadOnlyDictionary<string, string>>(),
                 It.IsAny<ClaimsPrincipal>(),
                 It.IsAny<IPersistentComponentStateStore>(),
                 It.IsAny<ResourceAssetCollection>()))
@@ -397,7 +577,8 @@ public class ComponentHubTest
         ICircuitPersistenceProvider provider = null,
         ICircuitFactory circuitFactory = null,
         ClaimsPrincipal user = null,
-        IConnectionAuthenticationRefreshFeature userRefreshFeature = null)
+        IConnectionAuthenticationRefreshFeature userRefreshFeature = null,
+        IEnumerable<IBrowserStartupValueProvider> browserStartupValueProviders = null)
     {
         deserializer ??= new TestServerComponentDeserializer();
         var ephemeralDataProtectionProvider = new EphemeralDataProtectionProvider();
@@ -426,6 +607,7 @@ public class ComponentHubTest
             circuitRegistry: circuitRegistry,
             circuitPersistenceProvider: circuitPersistenceManager,
             circuitHandleRegistry: circuitHandleRegistry,
+            browserStartupValueProviders: browserStartupValueProviders ?? [],
             logger: NullLogger<ComponentHub>.Instance);
 
         // Here we mock out elements of the Hub that are typically configured
@@ -518,12 +700,19 @@ public class ComponentHubTest
 
     private class TestCircuitFactory : ICircuitFactory
     {
+        public TestCircuitFactory()
+        {
+        }
+
         public TestCircuitFactory(
         IServiceScopeFactory scopeFactory,
         ILoggerFactory loggerFactory,
         CircuitIdFactory circuitIdFactory,
         IOptions<CircuitOptions> options)
         { }
+
+        public IReadOnlyDictionary<string, string> StartupValues { get; private set; } =
+            new Dictionary<string, string>();
 
         // Implement a `CreateCircuitHostAsync` that mocks the construction
         // of the CircuitHost.
@@ -532,10 +721,12 @@ public class ComponentHubTest
             CircuitClientProxy client,
             string baseUri,
             string uri,
+            IReadOnlyDictionary<string, string> startupValues,
             ClaimsPrincipal user,
             IPersistentComponentStateStore store,
             ResourceAssetCollection resourceCollection)
         {
+            StartupValues = startupValues;
             var clientProxy = new CircuitClientProxy(Mock.Of<ISingleClientProxy>(), "123");
 
             var serviceScope = new Mock<IServiceScope>();
@@ -545,5 +736,10 @@ public class ComponentHubTest
                 clientProxy: clientProxy);
             return ValueTask.FromResult(circuitHost);
         }
+    }
+
+    private sealed class TestBrowserStartupValueProvider(params string[] keys) : IBrowserStartupValueProvider
+    {
+        public IReadOnlyList<string> Keys { get; } = keys;
     }
 }

--- a/src/Components/Server/test/Circuits/ComponentHubTest.cs
+++ b/src/Components/Server/test/Circuits/ComponentHubTest.cs
@@ -130,7 +130,7 @@ public class ComponentHubTest
                     Sequence = 0,
                 },
             ],
-            DeferredHostInitializers =
+            BrowserHostInitializers =
             [
                 new TestHostInitializer(() =>
                 {
@@ -756,7 +756,7 @@ public class ComponentHubTest
         public IReadOnlyDictionary<string, string> StartupValues { get; private set; } =
             new Dictionary<string, string>();
 
-        public IHostInitializer[] DeferredHostInitializers { get; init; } = [];
+        public IHostInitializer[] BrowserHostInitializers { get; init; } = [];
 
         public IReadOnlyList<ComponentDescriptor> Descriptors { get; init; } = [];
 
@@ -780,14 +780,14 @@ public class ComponentHubTest
                 serviceScope: new AsyncServiceScope(serviceScope.Object),
                 clientProxy: client,
                 descriptors: Descriptors,
-                deferredHostInitializers: DeferredHostInitializers);
+                browserHostInitializers: BrowserHostInitializers);
             return ValueTask.FromResult(circuitHost);
         }
     }
 
     private sealed class TestHostInitializer(Func<Task> initialize) : IHostInitializer
     {
-        public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+        public Task InitializeBrowserAsync(IServiceProvider services, CancellationToken cancellationToken = default)
             => initialize();
     }
 

--- a/src/Components/Server/test/Circuits/TestCircuitHost.cs
+++ b/src/Components/Server/test/Circuits/TestCircuitHost.cs
@@ -18,8 +18,8 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits;
 
 internal class TestCircuitHost : CircuitHost
 {
-    private TestCircuitHost(CircuitId circuitId, AsyncServiceScope scope, CircuitOptions options, CircuitClientProxy client, RemoteRenderer renderer, IReadOnlyList<ComponentDescriptor> descriptors, RemoteJSRuntime jsRuntime, RemoteNavigationManager navigationManager, IHostInitializer[] deferredHostInitializers, CircuitHandler[] circuitHandlers, CircuitMetrics circuitMetrics, CircuitActivitySource circuitActivitySource, ILogger logger)
-        : base(circuitId, scope, options, client, renderer, descriptors, jsRuntime, navigationManager, deferredHostInitializers, circuitHandlers, circuitMetrics, circuitActivitySource, logger)
+    private TestCircuitHost(CircuitId circuitId, AsyncServiceScope scope, CircuitOptions options, CircuitClientProxy client, RemoteRenderer renderer, IReadOnlyList<ComponentDescriptor> descriptors, RemoteJSRuntime jsRuntime, RemoteNavigationManager navigationManager, HostInitializerInvoker hostInitializerInvoker, CircuitHandler[] circuitHandlers, CircuitMetrics circuitMetrics, CircuitActivitySource circuitActivitySource, ILogger logger)
+        : base(circuitId, scope, options, client, renderer, descriptors, jsRuntime, navigationManager, hostInitializerInvoker, circuitHandlers, circuitMetrics, circuitActivitySource, logger)
     {
     }
 
@@ -28,7 +28,7 @@ internal class TestCircuitHost : CircuitHost
         AsyncServiceScope? serviceScope = null,
         RemoteRenderer remoteRenderer = null,
         IReadOnlyList<ComponentDescriptor> descriptors = null,
-        IHostInitializer[] deferredHostInitializers = null,
+        IHostInitializer[] browserHostInitializers = null,
         CircuitHandler[] handlers = null,
         CircuitClientProxy clientProxy = null)
     {
@@ -76,7 +76,7 @@ internal class TestCircuitHost : CircuitHost
             descriptors ?? new List<ComponentDescriptor>(),
             jsRuntime,
             navigationManager,
-            deferredHostInitializers ?? [],
+            new HostInitializerInvoker([.. browserHostInitializers ?? []], serviceScope.Value.ServiceProvider),
             handlers,
             circuitMetrics,
             circuitActivitySource,

--- a/src/Components/Server/test/Circuits/TestCircuitHost.cs
+++ b/src/Components/Server/test/Circuits/TestCircuitHost.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.AspNetCore.SignalR;
@@ -17,8 +18,8 @@ namespace Microsoft.AspNetCore.Components.Server.Circuits;
 
 internal class TestCircuitHost : CircuitHost
 {
-    private TestCircuitHost(CircuitId circuitId, AsyncServiceScope scope, CircuitOptions options, CircuitClientProxy client, RemoteRenderer renderer, IReadOnlyList<ComponentDescriptor> descriptors, RemoteJSRuntime jsRuntime, RemoteNavigationManager navigationManager, CircuitHandler[] circuitHandlers, CircuitMetrics circuitMetrics, CircuitActivitySource circuitActivitySource, ILogger logger)
-        : base(circuitId, scope, options, client, renderer, descriptors, jsRuntime, navigationManager, circuitHandlers, circuitMetrics, circuitActivitySource, logger)
+    private TestCircuitHost(CircuitId circuitId, AsyncServiceScope scope, CircuitOptions options, CircuitClientProxy client, RemoteRenderer renderer, IReadOnlyList<ComponentDescriptor> descriptors, RemoteJSRuntime jsRuntime, RemoteNavigationManager navigationManager, IHostInitializer[] deferredHostInitializers, CircuitHandler[] circuitHandlers, CircuitMetrics circuitMetrics, CircuitActivitySource circuitActivitySource, ILogger logger)
+        : base(circuitId, scope, options, client, renderer, descriptors, jsRuntime, navigationManager, deferredHostInitializers, circuitHandlers, circuitMetrics, circuitActivitySource, logger)
     {
     }
 
@@ -27,6 +28,7 @@ internal class TestCircuitHost : CircuitHost
         AsyncServiceScope? serviceScope = null,
         RemoteRenderer remoteRenderer = null,
         IReadOnlyList<ComponentDescriptor> descriptors = null,
+        IHostInitializer[] deferredHostInitializers = null,
         CircuitHandler[] handlers = null,
         CircuitClientProxy clientProxy = null)
     {
@@ -74,6 +76,7 @@ internal class TestCircuitHost : CircuitHost
             descriptors ?? new List<ComponentDescriptor>(),
             jsRuntime,
             navigationManager,
+            deferredHostInitializers ?? [],
             handlers,
             circuitMetrics,
             circuitActivitySource,

--- a/src/Components/Server/test/DependencyInjection/ComponentServiceCollectionExtensionsTest.cs
+++ b/src/Components/Server/test/DependencyInjection/ComponentServiceCollectionExtensionsTest.cs
@@ -1,17 +1,72 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
 using Microsoft.AspNetCore.Components.Server;
 using Microsoft.AspNetCore.Components.Server.BlazorPack;
 using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Options;
+using Microsoft.JSInterop;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
 public class ComponentServiceCollectionExtensionsTest
 {
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void EqualOrderInitializersPreserveServiceRegistrationOrder(bool registerUserFirst)
+    {
+        var services = new ServiceCollection();
+        var userInitializer = new TestHostInitializer();
+        if (registerUserFirst)
+        {
+            services.AddSingleton<IHostInitializer>(userInitializer);
+        }
+
+        services.AddServerSideBlazor();
+
+        if (!registerUserFirst)
+        {
+            services.AddSingleton<IHostInitializer>(userInitializer);
+        }
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var initializers = scope.ServiceProvider.GetServices<IHostInitializer>()
+            .OrderBy(initializer => initializer.Order)
+            .ToArray();
+        var navigationInitializerIndex = Array.FindIndex(
+            initializers,
+            initializer => initializer.GetType() == typeof(NavigationManagerInitializer));
+        var userInitializerIndex = Array.IndexOf(initializers, userInitializer);
+
+        Assert.Equal(registerUserFirst, userInitializerIndex < navigationInitializerIndex);
+    }
+
+    [Fact]
+    public async Task ServerInitializersDoNotResolveInteractiveServicesInStaticScope()
+    {
+        var services = new ServiceCollection();
+        services.AddServerSideBlazor();
+        services.AddScoped<NavigationManager>(_ => throw new InvalidOperationException("Unexpected resolution."));
+        services.AddScoped<INavigationInterception>(_ => throw new InvalidOperationException("Unexpected resolution."));
+        services.AddScoped<IScrollToLocationHash>(_ => throw new InvalidOperationException("Unexpected resolution."));
+        services.AddScoped<IJSRuntime>(_ => throw new InvalidOperationException("Unexpected resolution."));
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var initializers = scope.ServiceProvider.GetServices<IHostInitializer>();
+
+        foreach (var initializer in initializers)
+        {
+            await initializer.InitializeAsync();
+        }
+    }
+
     [Fact]
     public void AddServerSideSignalR_RegistersBlazorPack()
     {
@@ -142,5 +197,14 @@ public class ComponentServiceCollectionExtensionsTest
         Assert.Equal(
             countAfterFirstCall,
             services.Count(descriptor => descriptor.ServiceType == typeof(IHostStartupValues)));
+        Assert.Equal(3, services.Count(descriptor => descriptor.ServiceType == typeof(IHostInitializer)));
+    }
+
+    private sealed class TestHostInitializer : IHostInitializer
+    {
+        public int Order => -200;
+
+        public Task InitializeAsync(CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
     }
 }

--- a/src/Components/Server/test/DependencyInjection/ComponentServiceCollectionExtensionsTest.cs
+++ b/src/Components/Server/test/DependencyInjection/ComponentServiceCollectionExtensionsTest.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.AspNetCore.Components.Server;
 using Microsoft.AspNetCore.Components.Server.BlazorPack;
+using Microsoft.AspNetCore.Components.Server.Circuits;
+using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Options;
 
@@ -75,5 +77,70 @@ public class ComponentServiceCollectionExtensionsTest
 
         // Configuring Blazor options is kept separate from the global options.
         Assert.Equal(TimeSpan.FromMinutes(10), globalOptions.Value.HandshakeTimeout);
+    }
+
+    [Theory]
+    [InlineData("Endpoints")]
+    [InlineData("Server")]
+    [InlineData("EndpointsThenServer")]
+    [InlineData("ServerThenEndpoints")]
+    public void HostStartupValuesRegistrationUsesTheExpectedNonInteractiveHolder(string registrations)
+    {
+        var services = new ServiceCollection();
+        switch (registrations)
+        {
+            case "Endpoints":
+                services.AddRazorComponents();
+                break;
+            case "Server":
+                services.AddServerSideBlazor();
+                break;
+            case "EndpointsThenServer":
+                services.AddRazorComponents();
+                services.AddServerSideBlazor();
+                break;
+            case "ServerThenEndpoints":
+                services.AddServerSideBlazor();
+                services.AddRazorComponents();
+                break;
+        }
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        var startupValues = scope.ServiceProvider.GetRequiredService<IHostStartupValues>();
+        var expectedAssembly = registrations is "Server"
+            ? "Microsoft.AspNetCore.Components.Server"
+            : "Microsoft.AspNetCore.Components.Endpoints";
+
+        Assert.Equal(expectedAssembly, startupValues.GetType().Assembly.GetName().Name);
+    }
+
+    [Fact]
+    public void HostStartupValuesRegistrationSelectsServerHolderForInteractiveScope()
+    {
+        var services = new ServiceCollection();
+        services.AddRazorComponents();
+        services.AddServerSideBlazor();
+
+        using var provider = services.BuildServiceProvider();
+        using var scope = provider.CreateScope();
+        scope.ServiceProvider.GetRequiredService<InteractiveServerContext>().IsInteractive = true;
+
+        var startupValues = scope.ServiceProvider.GetRequiredService<IHostStartupValues>();
+        Assert.IsType<InteractiveHostStartupValues>(startupValues);
+    }
+
+    [Fact]
+    public void AddServerSideBlazorRepeatedlyDoesNotDuplicateHostStartupValueRegistrations()
+    {
+        var services = new ServiceCollection();
+        services.AddServerSideBlazor();
+        var countAfterFirstCall = services.Count(descriptor => descriptor.ServiceType == typeof(IHostStartupValues));
+
+        services.AddServerSideBlazor();
+
+        Assert.Equal(
+            countAfterFirstCall,
+            services.Count(descriptor => descriptor.ServiceType == typeof(IHostStartupValues)));
     }
 }

--- a/src/Components/Server/test/DependencyInjection/ComponentServiceCollectionExtensionsTest.cs
+++ b/src/Components/Server/test/DependencyInjection/ComponentServiceCollectionExtensionsTest.cs
@@ -15,35 +15,20 @@ namespace Microsoft.Extensions.DependencyInjection;
 
 public class ComponentServiceCollectionExtensionsTest
 {
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void EqualOrderInitializersPreserveServiceRegistrationOrder(bool registerUserFirst)
+    [Fact]
+    public void FrameworkInitializersAreKeyedAndUserInitializersAreShared()
     {
         var services = new ServiceCollection();
         var userInitializer = new TestHostInitializer();
-        if (registerUserFirst)
-        {
-            services.AddSingleton<IHostInitializer>(userInitializer);
-        }
-
+        services.AddSingleton<IHostInitializer>(userInitializer);
         services.AddServerSideBlazor();
-
-        if (!registerUserFirst)
-        {
-            services.AddSingleton<IHostInitializer>(userInitializer);
-        }
 
         using var provider = services.BuildServiceProvider();
         using var scope = provider.CreateScope();
         var collection = provider.GetRequiredService<HostInitializerCollection>();
-        var initializers = collection.Initializers;
-        var navigationInitializerIndex = Array.FindIndex(
-            initializers.ToArray(),
-            initializer => initializer.GetType() == typeof(NavigationManagerInitializer));
-        var userInitializerIndex = initializers.IndexOf(userInitializer);
 
-        Assert.Equal(registerUserFirst, userInitializerIndex < navigationInitializerIndex);
+        Assert.Same(userInitializer, Assert.Single(provider.GetServices<IHostInitializer>()));
+        Assert.Equal(3, provider.GetKeyedServices<IHostInitializer>(HostInitializerKey.Server).Count());
         Assert.Same(collection, scope.ServiceProvider.GetRequiredService<HostInitializerCollection>());
         Assert.Equal(1, userInitializer.OrderAccessCount);
     }
@@ -60,12 +45,9 @@ public class ComponentServiceCollectionExtensionsTest
 
         using var provider = services.BuildServiceProvider();
         using var scope = provider.CreateScope();
-        var initializers = scope.ServiceProvider.GetServices<IHostInitializer>();
-
-        foreach (var initializer in initializers)
-        {
-            await initializer.InitializeAsync(scope.ServiceProvider);
-        }
+        await scope.ServiceProvider.GetRequiredService<HostInitializerCollection>()
+            .GetInitializerInvoker(scope.ServiceProvider)
+            .InitializeBrowserAsync();
     }
 
     [Fact]
@@ -214,13 +196,13 @@ public class ComponentServiceCollectionExtensionsTest
             get
             {
                 OrderAccessCount++;
-                return -200;
+                return 0;
             }
         }
 
         public int OrderAccessCount { get; private set; }
 
-        public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+        public Task InitializeHostAsync(IServiceProvider services, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
     }
 }

--- a/src/Components/Server/test/DependencyInjection/ComponentServiceCollectionExtensionsTest.cs
+++ b/src/Components/Server/test/DependencyInjection/ComponentServiceCollectionExtensionsTest.cs
@@ -36,15 +36,16 @@ public class ComponentServiceCollectionExtensionsTest
 
         using var provider = services.BuildServiceProvider();
         using var scope = provider.CreateScope();
-        var initializers = scope.ServiceProvider.GetServices<IHostInitializer>()
-            .OrderBy(initializer => initializer.Order)
-            .ToArray();
+        var collection = provider.GetRequiredService<HostInitializerCollection>();
+        var initializers = collection.Initializers;
         var navigationInitializerIndex = Array.FindIndex(
-            initializers,
+            initializers.ToArray(),
             initializer => initializer.GetType() == typeof(NavigationManagerInitializer));
-        var userInitializerIndex = Array.IndexOf(initializers, userInitializer);
+        var userInitializerIndex = initializers.IndexOf(userInitializer);
 
         Assert.Equal(registerUserFirst, userInitializerIndex < navigationInitializerIndex);
+        Assert.Same(collection, scope.ServiceProvider.GetRequiredService<HostInitializerCollection>());
+        Assert.Equal(1, userInitializer.OrderAccessCount);
     }
 
     [Fact]
@@ -63,7 +64,7 @@ public class ComponentServiceCollectionExtensionsTest
 
         foreach (var initializer in initializers)
         {
-            await initializer.InitializeAsync();
+            await initializer.InitializeAsync(scope.ServiceProvider);
         }
     }
 
@@ -198,13 +199,28 @@ public class ComponentServiceCollectionExtensionsTest
             countAfterFirstCall,
             services.Count(descriptor => descriptor.ServiceType == typeof(IHostStartupValues)));
         Assert.Equal(3, services.Count(descriptor => descriptor.ServiceType == typeof(IHostInitializer)));
+        Assert.All(
+            services.Where(descriptor => descriptor.ServiceType == typeof(IHostInitializer)),
+            descriptor => Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime));
+        Assert.Equal(
+            ServiceLifetime.Singleton,
+            Assert.Single(services.Where(descriptor => descriptor.ServiceType == typeof(HostInitializerCollection))).Lifetime);
     }
 
     private sealed class TestHostInitializer : IHostInitializer
     {
-        public int Order => -200;
+        public int Order
+        {
+            get
+            {
+                OrderAccessCount++;
+                return -200;
+            }
+        }
 
-        public Task InitializeAsync(CancellationToken cancellationToken = default)
+        public int OrderAccessCount { get; private set; }
+
+        public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
             => Task.CompletedTask;
     }
 }

--- a/src/Components/Server/test/Hosting/InteractiveHostStartupValuesTest.cs
+++ b/src/Components/Server/test/Hosting/InteractiveHostStartupValuesTest.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+public class InteractiveHostStartupValuesTest
+{
+    [Fact]
+    public void GetValueRejectsNullKeyBeforeInitialization()
+    {
+        var startupValues = new InteractiveHostStartupValues();
+
+        Assert.Throws<ArgumentNullException>(() => startupValues.GetValue(null!));
+    }
+
+    [Fact]
+    public void GetsInitializedValues()
+    {
+        var startupValues = new InteractiveHostStartupValues();
+        startupValues.Initialize(new Dictionary<string, string>
+        {
+            ["key"] = "value",
+        });
+
+        Assert.Equal("value", startupValues.GetValue("key"));
+        Assert.Equal("value", startupValues.GetRequired("key"));
+        Assert.Null(startupValues.GetValue("missing"));
+        var exception = Assert.Throws<InvalidOperationException>(() => startupValues.GetRequired("missing"));
+        Assert.Equal("Startup value 'missing' was not provided.", exception.Message);
+    }
+}

--- a/src/Components/Server/test/Microsoft.AspNetCore.Components.Server.Tests.csproj
+++ b/src/Components/Server/test/Microsoft.AspNetCore.Components.Server.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Reference Include="Microsoft.AspNetCore.Antiforgery" />
     <Reference Include="Microsoft.AspNetCore.Hosting" />
     <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions" />
     <Reference Include="Microsoft.AspNetCore.Http" />

--- a/src/Components/Shared/src/Hosting/HostInitializerCollection.cs
+++ b/src/Components/Shared/src/Hosting/HostInitializerCollection.cs
@@ -3,17 +3,108 @@
 
 using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Components.Hosting;
 
+internal static class HostInitializerKey
+{
+    public const string Static = "Static";
+    public const string Server = "Server";
+}
+
 internal sealed class HostInitializerCollection
 {
-    public HostInitializerCollection(IEnumerable<IHostInitializer> initializers)
+    private readonly ImmutableArray<IHostInitializer> _sharedInitializers;
+    private readonly ImmutableArray<IHostInitializer> _staticInitializers;
+    private readonly ImmutableArray<IHostInitializer> _serverInitializers;
+
+    public HostInitializerCollection(IServiceProvider services)
     {
-        Initializers = initializers
-            .OrderBy(initializer => initializer.Order)
+        var sharedInitializers = GetOrderedInitializers(services.GetServices<IHostInitializer>());
+        var staticInitializers = GetOrderedInitializers(
+            services.GetKeyedServices<IHostInitializer>(HostInitializerKey.Static));
+        var serverInitializers = GetOrderedInitializers(
+            services.GetKeyedServices<IHostInitializer>(HostInitializerKey.Server));
+
+        _sharedInitializers = CreateEffectiveSet(sharedInitializers, []);
+        _staticInitializers = CreateEffectiveSet(sharedInitializers, staticInitializers);
+        _serverInitializers = CreateEffectiveSet(sharedInitializers, serverInitializers);
+    }
+
+    public HostInitializerInvoker GetInitializerInvoker(IServiceProvider services)
+        => new(_sharedInitializers, services);
+
+    public HostInitializerInvoker GetInitializerInvoker(IServiceProvider services, string key)
+        => new(key switch
+        {
+            HostInitializerKey.Static => _staticInitializers,
+            HostInitializerKey.Server => _serverInitializers,
+            _ => throw new ArgumentException($"Unknown host initializer key '{key}'.", nameof(key)),
+        }, services);
+
+    private static ImmutableArray<OrderedInitializer> GetOrderedInitializers(
+        IEnumerable<IHostInitializer> initializers)
+        => initializers
+            .Select(static initializer => new OrderedInitializer(initializer, initializer.Order))
+            .ToImmutableArray();
+
+    private static ImmutableArray<IHostInitializer> CreateEffectiveSet(
+        ImmutableArray<OrderedInitializer> sharedInitializers,
+        ImmutableArray<OrderedInitializer> keyedInitializers)
+    {
+        var initializers = sharedInitializers.AddRange(keyedInitializers);
+        var orderedInitializers = initializers.Sort(
+            static (left, right) => left.Order.CompareTo(right.Order));
+
+        for (var i = 1; i < orderedInitializers.Length; i++)
+        {
+            var previous = orderedInitializers[i - 1];
+            var current = orderedInitializers[i];
+            if (previous.Order == current.Order)
+            {
+                throw new InvalidOperationException(
+                    $"Host initializers '{previous.Initializer.GetType()}' and '{current.Initializer.GetType()}' " +
+                    $"both use Order '{current.Order}'. Order values must be unique within each host.");
+            }
+        }
+
+        return orderedInitializers
+            .Select(static initializer => initializer.Initializer)
             .ToImmutableArray();
     }
 
-    public ImmutableArray<IHostInitializer> Initializers { get; }
+    private readonly record struct OrderedInitializer(IHostInitializer Initializer, int Order);
+}
+
+internal sealed class HostInitializerInvoker(
+    ImmutableArray<IHostInitializer> initializers,
+    IServiceProvider services)
+{
+    private Task? _hostInitializationTask;
+    private Task? _browserInitializationTask;
+
+    public Task InitializeHostAsync(CancellationToken cancellationToken = default)
+        => _hostInitializationTask ??= InitializeHostCoreAsync(cancellationToken);
+
+    public Task InitializeBrowserAsync(CancellationToken cancellationToken = default)
+        => _browserInitializationTask ??= InitializeBrowserCoreAsync(cancellationToken);
+
+    private async Task InitializeHostCoreAsync(CancellationToken cancellationToken)
+    {
+        foreach (var initializer in initializers)
+        {
+            await initializer.InitializeHostAsync(services, cancellationToken);
+        }
+    }
+
+    private async Task InitializeBrowserCoreAsync(CancellationToken cancellationToken)
+    {
+        await InitializeHostAsync(cancellationToken);
+
+        foreach (var initializer in initializers)
+        {
+            await initializer.InitializeBrowserAsync(services, cancellationToken);
+        }
+    }
 }

--- a/src/Components/Shared/src/Hosting/HostInitializerCollection.cs
+++ b/src/Components/Shared/src/Hosting/HostInitializerCollection.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Linq;
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+internal sealed class HostInitializerCollection
+{
+    public HostInitializerCollection(IEnumerable<IHostInitializer> initializers)
+    {
+        Initializers = initializers
+            .OrderBy(initializer => initializer.Order)
+            .ToImmutableArray();
+    }
+
+    public ImmutableArray<IHostInitializer> Initializers { get; }
+}

--- a/src/Components/Web.JS/src/Boot.WebAssembly.Common.ts
+++ b/src/Components/Web.JS/src/Boot.WebAssembly.Common.ts
@@ -19,6 +19,7 @@ import { DotNet } from '@microsoft/dotnet-js-interop';
 import { MonoConfig } from '@microsoft/dotnet-runtime';
 import { RootComponentManager } from './Services/RootComponentManager';
 import { WebRendererId } from './Rendering/WebRendererId';
+import { evaluateHostStartupValuesJson } from './Services/HostStartupValues';
 
 let options: Partial<WebAssemblyStartOptions> | undefined;
 let platformLoadPromise: Promise<void> | undefined;
@@ -104,6 +105,7 @@ async function startCore(components: RootComponentManager<WebAssemblyComponentDe
   Blazor._internal.endInvokeDotNetFromJS = endInvokeDotNetFromJS;
   Blazor._internal.receiveWebAssemblyDotNetDataStream = receiveWebAssemblyDotNetDataStream;
   Blazor._internal.receiveByteArray = receiveByteArray;
+  Blazor._internal.getHostStartupValues = evaluateHostStartupValuesJson;
 
   // Configure environment for execution under Mono WebAssembly with shared-memory rendering
   const platform = Environment.setPlatform(monoPlatform);

--- a/src/Components/Web.JS/src/GlobalExports.ts
+++ b/src/Components/Web.JS/src/GlobalExports.ts
@@ -79,6 +79,7 @@ export interface IBlazor {
     getConfig?: (fileName: string) => Uint8Array | undefined;
     getApplicationEnvironment?: () => string;
     getApplicationCulture?: () => string;
+    getHostStartupValues?: (keysJson: string) => string;
     dotNetCriticalError?: any;
     loadLazyAssembly?: any;
     loadSatelliteAssemblies?: any;

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
@@ -67,8 +67,6 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
 
   private _activePauseDeferral?: AbortController;
 
-  private _hostInitializationCompletion?: HostInitializationCompletion;
-
   public constructor(
     componentManager: RootComponentManager<ServerComponentDescriptor>,
     appState: string,
@@ -127,8 +125,6 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     if (!this._circuitId) {
       return false;
     }
-
-    await this.completeHostInitialization();
 
     for (const handler of this._options.circuitHandlers) {
       if (handler.onCircuitOpened) {
@@ -208,20 +204,6 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     connection.on('JS.EndUpdateRootComponents', (batchId: number) => {
       this._componentManager.onAfterUpdateRootComponents?.(batchId);
     });
-    connection.on('JS.EndHostInitialization', (succeeded: boolean, error: string | null) => {
-      const completion = this._hostInitializationCompletion;
-      if (!completion) {
-        return;
-      }
-
-      this._hostInitializationCompletion = undefined;
-      if (succeeded) {
-        completion.resolve();
-      } else {
-        completion.reject(new Error(error || 'The circuit failed to initialize.'));
-      }
-    });
-
     connection.on('JS.RequestPause', async () => {
       try {
         await this.handleServerInitiatedPause();
@@ -231,7 +213,6 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     });
     connection.on('JS.EndLocationChanging', Blazor._internal.navigationManager.endLocationChanging);
     connection.onclose(error => {
-      this.rejectHostInitialization(error || new Error('The connection closed during host initialization.'));
       this._interopMethodsForReconnection = detachWebRendererInterop(WebRendererId.Server);
 
       this.handleConnectionDown();
@@ -248,7 +229,6 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
       }
     });
     connection.on('JS.Error', error => {
-      this.rejectHostInitialization(new Error(error));
       this._renderingFailed = true;
       this.unhandledError(error);
       showErrorNotification();
@@ -287,31 +267,6 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     }
 
     return connection;
-  }
-
-  private async completeHostInitialization(): Promise<void> {
-    const completionPromise = new Promise<void>((resolve, reject) => {
-      this._hostInitializationCompletion = { resolve, reject };
-    });
-    completionPromise.catch(() => { /* The invocation is awaited before this promise. */ });
-
-    try {
-      await this._connection!.invoke('CompleteHostInitialization');
-    } catch (error) {
-      this.rejectHostInitialization(error);
-    }
-
-    await completionPromise;
-  }
-
-  private rejectHostInitialization(error: unknown): void {
-    const completion = this._hostInitializationCompletion;
-    if (!completion) {
-      return;
-    }
-
-    this._hostInitializationCompletion = undefined;
-    completion.reject(error instanceof Error ? error : new Error(`${error}`));
   }
 
   public async disconnect(): Promise<void> {
@@ -530,8 +485,6 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
         return resumingPromise;
       }
 
-      await this.completeHostInitialization();
-
       this._pausingState.transitionTo(false);
       this._resumingState.complete(true);
 
@@ -716,11 +669,6 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
       }
     }
   }
-}
-
-interface HostInitializationCompletion {
-  resolve(): void;
-  reject(error: Error): void;
 }
 
 class CircuitState<T> {

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
@@ -19,6 +19,7 @@ import { Blazor } from '../../GlobalExports';
 import { showErrorNotification } from '../../BootErrors';
 import { attachWebRendererInterop, detachWebRendererInterop, isRendererAttached } from '../../Rendering/WebRendererInteropMethods';
 import { sendJSDataStream } from './CircuitStreamingInterop';
+import { evaluateHostStartupValues } from '../../Services/HostStartupValues';
 
 export class CircuitManager implements DotNet.DotNetCallDispatcher {
 
@@ -112,13 +113,28 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     }
 
     const componentsJson = JSON.stringify(this._componentManager.initialComponents.map(c => descriptorToMarker(c)));
-    this._circuitId = await this._connection.invoke<string>(
-      'StartCircuit',
-      navigationManagerFunctions.getBaseURI(),
-      navigationManagerFunctions.getLocationHref(),
-      componentsJson,
-      this._applicationState || ''
-    );
+    const baseUri = navigationManagerFunctions.getBaseURI();
+    const uri = navigationManagerFunctions.getLocationHref();
+    const applicationState = this._applicationState || '';
+    const startupValuesJson = await this.getStartupValuesJson();
+    if (startupValuesJson === undefined) {
+      this._circuitId = await this._connection.invoke<string>(
+        'StartCircuit',
+        baseUri,
+        uri,
+        componentsJson,
+        applicationState
+      );
+    } else {
+      this._circuitId = await this._connection.invoke<string>(
+        'StartCircuitWithStartupValues',
+        baseUri,
+        uri,
+        componentsJson,
+        applicationState,
+        startupValuesJson
+      );
+    }
 
     if (!this._circuitId) {
       return false;
@@ -131,6 +147,19 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     }
 
     return true;
+  }
+
+  private async getStartupValuesJson(): Promise<string | undefined> {
+    try {
+      const keys = await this._connection!.invoke<string[]>('GetStartupValueKeys');
+      return JSON.stringify(evaluateHostStartupValues(keys));
+    } catch (error) {
+      if (error instanceof Error && error.message.endsWith('HubException: Method does not exist.')) {
+        return undefined;
+      }
+
+      throw error;
+    }
   }
 
   private async startConnection(): Promise<HubConnection> {
@@ -466,14 +495,25 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
       const persistedCircuitState = this._persistedCircuitState;
       this._persistedCircuitState = undefined;
 
-      const newCircuitId = await this._connection!.invoke<string>(
-        'ResumeCircuit',
-        this._circuitId,
-        navigationManagerFunctions.getBaseURI(),
-        navigationManagerFunctions.getLocationHref(),
-        persistedCircuitState?.components ?? '[]',
-        persistedCircuitState?.applicationState ?? '',
-      );
+      const startupValuesJson = await this.getStartupValuesJson();
+      const newCircuitId = startupValuesJson === undefined
+        ? await this._connection!.invoke<string>(
+          'ResumeCircuit',
+          this._circuitId,
+          navigationManagerFunctions.getBaseURI(),
+          navigationManagerFunctions.getLocationHref(),
+          persistedCircuitState?.components ?? '[]',
+          persistedCircuitState?.applicationState ?? '',
+        )
+        : await this._connection!.invoke<string>(
+          'ResumeCircuitWithStartupValues',
+          this._circuitId,
+          navigationManagerFunctions.getBaseURI(),
+          navigationManagerFunctions.getLocationHref(),
+          persistedCircuitState?.components ?? '[]',
+          persistedCircuitState?.applicationState ?? '',
+          startupValuesJson,
+        );
       if (!newCircuitId) {
         this._resumingState.complete(false);
         return resumingPromise;

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
@@ -115,36 +115,20 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     }
 
     const componentsJson = JSON.stringify(this._componentManager.initialComponents.map(c => descriptorToMarker(c)));
-    const baseUri = navigationManagerFunctions.getBaseURI();
-    const uri = navigationManagerFunctions.getLocationHref();
     const applicationState = this._applicationState || '';
     const startupValuesJson = await this.getStartupValuesJson();
-    if (startupValuesJson === undefined) {
-      this._circuitId = await this._connection.invoke<string>(
-        'StartCircuit',
-        baseUri,
-        uri,
-        componentsJson,
-        applicationState
-      );
-    } else {
-      this._circuitId = await this._connection.invoke<string>(
-        'StartCircuitWithStartupValues',
-        baseUri,
-        uri,
-        componentsJson,
-        applicationState,
-        startupValuesJson
-      );
-    }
+    this._circuitId = await this._connection.invoke<string>(
+      'StartCircuit',
+      startupValuesJson,
+      componentsJson,
+      applicationState
+    );
 
     if (!this._circuitId) {
       return false;
     }
 
-    if (startupValuesJson !== undefined) {
-      await this.completeHostInitialization();
-    }
+    await this.completeHostInitialization();
 
     for (const handler of this._options.circuitHandlers) {
       if (handler.onCircuitOpened) {
@@ -155,17 +139,9 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     return true;
   }
 
-  private async getStartupValuesJson(): Promise<string | undefined> {
-    try {
-      const keysJson = await this._connection!.invoke<string>('GetStartupValueKeys');
-      return JSON.stringify(evaluateHostStartupValues(keysJson));
-    } catch (error) {
-      if (error instanceof Error && error.message.endsWith('HubException: Method does not exist.')) {
-        return undefined;
-      }
-
-      throw error;
-    }
+  private async getStartupValuesJson(): Promise<string> {
+    const keysJson = await this._connection!.invoke<string>('GetStartupValueKeys');
+    return JSON.stringify(evaluateHostStartupValues(keysJson));
   }
 
   private async startConnection(): Promise<HubConnection> {
@@ -542,32 +518,19 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
       this._persistedCircuitState = undefined;
 
       const startupValuesJson = await this.getStartupValuesJson();
-      const newCircuitId = startupValuesJson === undefined
-        ? await this._connection!.invoke<string>(
-          'ResumeCircuit',
-          this._circuitId,
-          navigationManagerFunctions.getBaseURI(),
-          navigationManagerFunctions.getLocationHref(),
-          persistedCircuitState?.components ?? '[]',
-          persistedCircuitState?.applicationState ?? '',
-        )
-        : await this._connection!.invoke<string>(
-          'ResumeCircuitWithStartupValues',
-          this._circuitId,
-          navigationManagerFunctions.getBaseURI(),
-          navigationManagerFunctions.getLocationHref(),
-          persistedCircuitState?.components ?? '[]',
-          persistedCircuitState?.applicationState ?? '',
-          startupValuesJson,
-        );
+      const newCircuitId = await this._connection!.invoke<string>(
+        'ResumeCircuit',
+        this._circuitId,
+        startupValuesJson,
+        persistedCircuitState?.components ?? '[]',
+        persistedCircuitState?.applicationState ?? '',
+      );
       if (!newCircuitId) {
         this._resumingState.complete(false);
         return resumingPromise;
       }
 
-      if (startupValuesJson !== undefined) {
-        await this.completeHostInitialization();
-      }
+      await this.completeHostInitialization();
 
       this._pausingState.transitionTo(false);
       this._resumingState.complete(true);

--- a/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
+++ b/src/Components/Web.JS/src/Platform/Circuits/CircuitManager.ts
@@ -67,6 +67,8 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
 
   private _activePauseDeferral?: AbortController;
 
+  private _hostInitializationCompletion?: HostInitializationCompletion;
+
   public constructor(
     componentManager: RootComponentManager<ServerComponentDescriptor>,
     appState: string,
@@ -140,6 +142,10 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
       return false;
     }
 
+    if (startupValuesJson !== undefined) {
+      await this.completeHostInitialization();
+    }
+
     for (const handler of this._options.circuitHandlers) {
       if (handler.onCircuitOpened) {
         handler.onCircuitOpened();
@@ -151,8 +157,8 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
 
   private async getStartupValuesJson(): Promise<string | undefined> {
     try {
-      const keys = await this._connection!.invoke<string[]>('GetStartupValueKeys');
-      return JSON.stringify(evaluateHostStartupValues(keys));
+      const keysJson = await this._connection!.invoke<string>('GetStartupValueKeys');
+      return JSON.stringify(evaluateHostStartupValues(keysJson));
     } catch (error) {
       if (error instanceof Error && error.message.endsWith('HubException: Method does not exist.')) {
         return undefined;
@@ -226,6 +232,19 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     connection.on('JS.EndUpdateRootComponents', (batchId: number) => {
       this._componentManager.onAfterUpdateRootComponents?.(batchId);
     });
+    connection.on('JS.EndHostInitialization', (succeeded: boolean, error: string | null) => {
+      const completion = this._hostInitializationCompletion;
+      if (!completion) {
+        return;
+      }
+
+      this._hostInitializationCompletion = undefined;
+      if (succeeded) {
+        completion.resolve();
+      } else {
+        completion.reject(new Error(error || 'The circuit failed to initialize.'));
+      }
+    });
 
     connection.on('JS.RequestPause', async () => {
       try {
@@ -236,6 +255,7 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     });
     connection.on('JS.EndLocationChanging', Blazor._internal.navigationManager.endLocationChanging);
     connection.onclose(error => {
+      this.rejectHostInitialization(error || new Error('The connection closed during host initialization.'));
       this._interopMethodsForReconnection = detachWebRendererInterop(WebRendererId.Server);
 
       this.handleConnectionDown();
@@ -252,6 +272,7 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
       }
     });
     connection.on('JS.Error', error => {
+      this.rejectHostInitialization(new Error(error));
       this._renderingFailed = true;
       this.unhandledError(error);
       showErrorNotification();
@@ -290,6 +311,31 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
     }
 
     return connection;
+  }
+
+  private async completeHostInitialization(): Promise<void> {
+    const completionPromise = new Promise<void>((resolve, reject) => {
+      this._hostInitializationCompletion = { resolve, reject };
+    });
+    completionPromise.catch(() => { /* The invocation is awaited before this promise. */ });
+
+    try {
+      await this._connection!.invoke('CompleteHostInitialization');
+    } catch (error) {
+      this.rejectHostInitialization(error);
+    }
+
+    await completionPromise;
+  }
+
+  private rejectHostInitialization(error: unknown): void {
+    const completion = this._hostInitializationCompletion;
+    if (!completion) {
+      return;
+    }
+
+    this._hostInitializationCompletion = undefined;
+    completion.reject(error instanceof Error ? error : new Error(`${error}`));
   }
 
   public async disconnect(): Promise<void> {
@@ -519,6 +565,10 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
         return resumingPromise;
       }
 
+      if (startupValuesJson !== undefined) {
+        await this.completeHostInitialization();
+      }
+
       this._pausingState.transitionTo(false);
       this._resumingState.complete(true);
 
@@ -703,6 +753,11 @@ export class CircuitManager implements DotNet.DotNetCallDispatcher {
       }
     }
   }
+}
+
+interface HostInitializationCompletion {
+  resolve(): void;
+  reject(error: Error): void;
 }
 
 class CircuitState<T> {

--- a/src/Components/Web.JS/src/Services/HostStartupValues.ts
+++ b/src/Components/Web.JS/src/Services/HostStartupValues.ts
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+const identifierPattern = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+const dangerousSegments = new Set([
+  '__proto__',
+  'prototype',
+  'constructor',
+]);
+
+export function evaluateHostStartupValues(keysOrJson: readonly string[] | string): Record<string, string> {
+  const keys = parseKeys(keysOrJson);
+  const uniqueKeys = new Set<string>();
+
+  for (const key of keys) {
+    validateKey(key);
+    if (uniqueKeys.has(key)) {
+      throw new Error(`The browser startup value key '${key}' was provided more than once.`);
+    }
+
+    uniqueKeys.add(key);
+  }
+
+  const values: Record<string, string> = Object.create(null);
+  for (const key of keys) {
+    let value: unknown = globalThis;
+    for (const segment of key.split('.')) {
+      if (value === null || value === undefined) {
+        throw new Error(`The browser startup value '${key}' could not be resolved.`);
+      }
+
+      value = (value as Record<string, unknown>)[segment];
+    }
+
+    if (typeof value !== 'string') {
+      throw new Error(`The browser startup value '${key}' must resolve to a string.`);
+    }
+
+    values[key] = value;
+  }
+
+  return values;
+}
+
+export function evaluateHostStartupValuesJson(keysJson: string): string {
+  return JSON.stringify(evaluateHostStartupValues(keysJson));
+}
+
+function parseKeys(keysOrJson: readonly string[] | string): readonly string[] {
+  let keys: unknown;
+  try {
+    keys = typeof keysOrJson === 'string' ? JSON.parse(keysOrJson) : keysOrJson;
+  } catch {
+    throw new Error('Browser startup value keys must be an array of strings.');
+  }
+
+  if (!Array.isArray(keys) || keys.some(key => typeof key !== 'string')) {
+    throw new Error('Browser startup value keys must be an array of strings.');
+  }
+
+  return keys;
+}
+
+function validateKey(key: string): void {
+  const segments = key.split('.');
+  if (segments.some(segment => !identifierPattern.test(segment) || dangerousSegments.has(segment))) {
+    throw new Error(`The browser startup value key '${key}' is not a valid property path.`);
+  }
+}

--- a/src/Components/Web.JS/test/HostStartupValues.test.ts
+++ b/src/Components/Web.JS/test/HostStartupValues.test.ts
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+import { afterEach, describe, expect, test } from '@jest/globals';
+import { evaluateHostStartupValues, evaluateHostStartupValuesJson } from '../src/Services/HostStartupValues';
+
+const globals = globalThis as unknown as Record<string, unknown>;
+
+describe('HostStartupValues', () => {
+  afterEach(() => {
+    delete globals.testStartupValues;
+    delete globals.duplicateStartupValue;
+  });
+
+  test('evaluates property paths from an array or JSON array', () => {
+    globals.testStartupValues = { nested: { value: 'expected' } };
+
+    expect(evaluateHostStartupValues(['testStartupValues.nested.value']))
+      .toEqual({ 'testStartupValues.nested.value': 'expected' });
+    expect(JSON.parse(evaluateHostStartupValuesJson('["testStartupValues.nested.value"]')))
+      .toEqual({ 'testStartupValues.nested.value': 'expected' });
+  });
+
+  test('rejects duplicate keys before evaluating them', () => {
+    let evaluations = 0;
+    Object.defineProperty(globalThis, 'duplicateStartupValue', {
+      configurable: true,
+      get: () => {
+        evaluations++;
+        return 'value';
+      },
+    });
+
+    expect(() => evaluateHostStartupValues(['duplicateStartupValue', 'duplicateStartupValue']))
+      .toThrow("The browser startup value key 'duplicateStartupValue' was provided more than once.");
+    expect(evaluations).toBe(0);
+  });
+
+  test.each([
+    '',
+    'location.href()',
+    'location["href"]',
+    'location..href',
+    '__proto__.value',
+    'value.prototype.name',
+    'value.constructor.name',
+  ])('rejects invalid property path %s', key => {
+    expect(() => evaluateHostStartupValues([key]))
+      .toThrow(`The browser startup value key '${key}' is not a valid property path.`);
+  });
+
+  test.each([
+    [null, 'testStartupValues.nullValue'],
+    [undefined, 'testStartupValues.undefinedValue'],
+    [42, 'testStartupValues.numberValue'],
+    [() => 'value', 'testStartupValues.functionValue'],
+  ])('rejects non-string leaf %p', (value, key) => {
+    globals.testStartupValues = {
+      [key.substring(key.indexOf('.') + 1)]: value,
+    };
+
+    expect(() => evaluateHostStartupValues([key]))
+      .toThrow(`The browser startup value '${key}' must resolve to a string.`);
+  });
+
+  test('rejects an unresolved intermediate path', () => {
+    globals.testStartupValues = null;
+
+    expect(() => evaluateHostStartupValues(['testStartupValues.value']))
+      .toThrow("The browser startup value 'testStartupValues.value' could not be resolved.");
+  });
+
+  test('rejects a JSON value that is not an array of strings', () => {
+    expect(() => evaluateHostStartupValues('{"key":"value"}'))
+      .toThrow('Browser startup value keys must be an array of strings.');
+    expect(() => evaluateHostStartupValues('["key",42]'))
+      .toThrow('Browser startup value keys must be an array of strings.');
+  });
+});

--- a/src/Components/Web.JS/test/Platform/Circuits/CircuitManagerStartupValues.test.ts
+++ b/src/Components/Web.JS/test/Platform/Circuits/CircuitManagerStartupValues.test.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { afterEach, describe, expect, jest, test } from '@jest/globals';
-import { HubConnection, HubConnectionState } from '@microsoft/signalr';
+import { HubConnection, HubConnectionBuilder, HubConnectionState } from '@microsoft/signalr';
 import { CircuitManager } from '../../../src/Platform/Circuits/CircuitManager';
 import { resolveOptions } from '../../../src/Platform/Circuits/CircuitStartOptions';
 import { JSEventRegistry } from '../../../src/Services/JSEventRegistry';
@@ -26,7 +26,7 @@ describe('CircuitManager startup values', () => {
     globals.testCircuitStartup = { value: 'expected' };
     const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
       if (method === 'GetStartupValueKeys') {
-        return ['testCircuitStartup.value'];
+        return '["testCircuitStartup.value"]';
       }
 
       return 'circuit-id';
@@ -35,10 +35,100 @@ describe('CircuitManager startup values', () => {
 
     await expect(circuit.start()).resolves.toBe(true);
 
-    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke.mock.calls.map(call => call[0])).toEqual([
+      'GetStartupValueKeys',
+      'StartCircuitWithStartupValues',
+      'CompleteHostInitialization',
+    ]);
     expect(invoke.mock.calls[1][0]).toBe('StartCircuitWithStartupValues');
     expect(JSON.parse(invoke.mock.calls[1][5] as string))
       .toEqual({ 'testCircuitStartup.value': 'expected' });
+  });
+
+  test('completes host initialization before reporting the circuit as opened', async () => {
+    const events: string[] = [];
+    const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
+      events.push(method);
+      return method === 'GetStartupValueKeys' ? '[]' : 'circuit-id';
+    });
+    const circuit = createCircuit(
+      invoke,
+      () => events.push('opened'),
+      notify => {
+        events.push('server completion');
+        notify(true, null);
+      });
+
+    await expect(circuit.start()).resolves.toBe(true);
+
+    expect(events).toEqual([
+      'GetStartupValueKeys',
+      'StartCircuitWithStartupValues',
+      'CompleteHostInitialization',
+      'server completion',
+      'opened',
+    ]);
+  });
+
+  test('waits for server completion after the trigger invocation returns', async () => {
+    let notifyCompletion: ((succeeded: boolean, error: string | null) => void) | undefined;
+    let startCompleted = false;
+    const invoke = jest.fn(async (method: string, ..._args: unknown[]) =>
+      method === 'GetStartupValueKeys' ? '[]' : 'circuit-id');
+    const circuit = createCircuit(
+      invoke,
+      undefined,
+      notify => {
+        notifyCompletion = notify;
+      });
+
+    const startPromise = circuit.start().then(result => {
+      startCompleted = true;
+      return result;
+    });
+    await waitFor(() => notifyCompletion !== undefined);
+
+    expect(invoke.mock.calls.map(call => call[0])).toEqual([
+      'GetStartupValueKeys',
+      'StartCircuitWithStartupValues',
+      'CompleteHostInitialization',
+    ]);
+    expect(startCompleted).toBe(false);
+
+    notifyCompletion!(true, null);
+    await expect(startPromise).resolves.toBe(true);
+  });
+
+  test('rejects when server host initialization fails without falling back', async () => {
+    const invoke = jest.fn(async (method: string, ..._args: unknown[]) =>
+      method === 'GetStartupValueKeys' ? '[]' : 'circuit-id');
+    const circuit = createCircuit(
+      invoke,
+      undefined,
+      notify => notify(false, 'Initializer failed.'));
+
+    await expect(circuit.start()).rejects.toThrow('Initializer failed.');
+    expect(invoke.mock.calls.map(call => call[0])).toEqual([
+      'GetStartupValueKeys',
+      'StartCircuitWithStartupValues',
+      'CompleteHostInitialization',
+    ]);
+  });
+
+  test('rejects host initialization when the circuit fails before completion notification', async () => {
+    const invoke = jest.fn(async (method: string, ..._args: unknown[]) =>
+      method === 'GetStartupValueKeys' ? [] : 'circuit-id');
+    const circuit = createCircuit(
+      invoke,
+      undefined,
+      (_notify, notifyError) => notifyError('Initializer failed through circuit error.'));
+
+    await expect(circuit.start()).rejects.toThrow('Initializer failed through circuit error.');
+    expect(invoke.mock.calls.map(call => call[0])).toEqual([
+      'GetStartupValueKeys',
+      'StartCircuitWithStartupValues',
+      'CompleteHostInitialization',
+    ]);
   });
 
   test('uses legacy start only when the capability method is absent', async () => {
@@ -60,7 +150,7 @@ describe('CircuitManager startup values', () => {
   test('does not fall back after startup-values capability succeeds', async () => {
     const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
       if (method === 'GetStartupValueKeys') {
-        return [];
+        return '[]';
       }
 
       throw new Error('New start failed.');
@@ -77,7 +167,7 @@ describe('CircuitManager startup values', () => {
     globals.testCircuitStartup = { value: 'expected' };
     const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
       if (method === 'GetStartupValueKeys') {
-        return ['testCircuitStartup.value'];
+        return '["testCircuitStartup.value"]';
       }
 
       return method === 'ResumeCircuitWithStartupValues' ? 'resumed-circuit-id' : 'circuit-id';
@@ -92,10 +182,12 @@ describe('CircuitManager startup values', () => {
     expect(invoke.mock.calls.map(call => call[0])).toEqual([
       'GetStartupValueKeys',
       'StartCircuitWithStartupValues',
+      'CompleteHostInitialization',
       'GetStartupValueKeys',
       'ResumeCircuitWithStartupValues',
+      'CompleteHostInitialization',
     ]);
-    expect(JSON.parse(invoke.mock.calls[3][6] as string))
+    expect(JSON.parse(invoke.mock.calls[4][6] as string))
       .toEqual({ 'testCircuitStartup.value': 'changed' });
   });
 
@@ -121,7 +213,7 @@ describe('CircuitManager startup values', () => {
   test('does not fall back when startup-values resume fails', async () => {
     const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
       if (method === 'GetStartupValueKeys') {
-        return [];
+        return '[]';
       }
 
       if (method === 'ResumeCircuitWithStartupValues') {
@@ -139,17 +231,70 @@ describe('CircuitManager startup values', () => {
     expect(invoke.mock.calls.map(call => call[0])).toEqual([
       'GetStartupValueKeys',
       'StartCircuitWithStartupValues',
+      'CompleteHostInitialization',
       'GetStartupValueKeys',
       'ResumeCircuitWithStartupValues',
     ]);
   });
+
+  test('rejects resume when server host initialization fails without falling back', async () => {
+    let initializationCount = 0;
+    const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
+      if (method === 'GetStartupValueKeys') {
+        return '[]';
+      }
+
+      return method === 'ResumeCircuitWithStartupValues' ? 'resumed-circuit-id' : 'circuit-id';
+    });
+    const circuit = createCircuit(
+      invoke,
+      undefined,
+      notify => {
+        initializationCount++;
+        notify(initializationCount === 1, initializationCount === 1 ? null : 'Resume initializer failed.');
+      });
+    await circuit.start();
+    setPaused(circuit);
+
+    await expect(circuit.resume()).rejects.toThrow('Resume initializer failed.');
+    expect(invoke.mock.calls.map(call => call[0])).toEqual([
+      'GetStartupValueKeys',
+      'StartCircuitWithStartupValues',
+      'CompleteHostInitialization',
+      'GetStartupValueKeys',
+      'ResumeCircuitWithStartupValues',
+      'CompleteHostInitialization',
+    ]);
+  });
 });
 
-function createCircuit(invoke: (method: string, ...args: unknown[]) => Promise<unknown>): CircuitManager {
+function createCircuit(
+  invoke: (method: string, ...args: unknown[]) => Promise<unknown>,
+  onCircuitOpened?: () => void,
+  onHostInitialization: (
+    notify: (succeeded: boolean, error: string | null) => void,
+    notifyError: (error: string) => void,
+  ) => void = notify => notify(true, null),
+): CircuitManager {
+  const handlers = new Map<string, (...args: any[]) => void>();
   const connection = {
     state: HubConnectionState.Connected,
-    invoke,
+    on: (method: string, handler: (...args: any[]) => void) => handlers.set(method, handler),
+    onclose: () => { /* no-op */ },
+    start: () => Promise.resolve(),
+    stop: () => Promise.resolve(),
+    send: () => Promise.resolve(),
+    invoke: async (method: string, ...args: unknown[]) => {
+      const result = await invoke(method, ...args);
+      if (method === 'CompleteHostInitialization') {
+        onHostInitialization(
+          (succeeded, error) => handlers.get('JS.EndHostInitialization')!(succeeded, error),
+          error => handlers.get('JS.Error')!(error));
+      }
+      return result;
+    },
   } as unknown as HubConnection;
+  jest.spyOn(HubConnectionBuilder.prototype, 'build').mockReturnValue(connection);
   const circuit = new CircuitManager(
     { initialComponents: [] } as never,
     '',
@@ -158,13 +303,20 @@ function createCircuit(invoke: (method: string, ...args: unknown[]) => Promise<u
         onConnectionDown: () => { /* no-op */ },
         onConnectionUp: () => { /* no-op */ },
       },
+      circuitHandlers: onCircuitOpened ? [{ onCircuitOpened }] : [],
     }),
     { log: () => { /* no-op */ } } as never,
     new JSEventRegistry());
-  (circuit as unknown as InternalCircuitManager).startConnection = () => Promise.resolve(connection);
   return circuit;
 }
 
 function setPaused(circuit: CircuitManager): void {
   (circuit as unknown as InternalCircuitManager)._pausingState.transitionTo(true);
+}
+
+async function waitFor(condition: () => boolean): Promise<void> {
+  for (let i = 0; i < 100 && !condition(); i++) {
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+  expect(condition()).toBe(true);
 }

--- a/src/Components/Web.JS/test/Platform/Circuits/CircuitManagerStartupValues.test.ts
+++ b/src/Components/Web.JS/test/Platform/Circuits/CircuitManagerStartupValues.test.ts
@@ -38,7 +38,6 @@ describe('CircuitManager startup values', () => {
     expect(invoke.mock.calls.map(call => call[0])).toEqual([
       'GetStartupValueKeys',
       'StartCircuit',
-      'CompleteHostInitialization',
     ]);
     expect(JSON.parse(invoke.mock.calls[1][1] as string))
       .toEqual({
@@ -46,92 +45,6 @@ describe('CircuitManager startup values', () => {
         'location.href': location.href,
         'testCircuitStartup.value': 'expected',
       });
-  });
-
-  test('completes host initialization before reporting the circuit as opened', async () => {
-    const events: string[] = [];
-    const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
-      events.push(method);
-      return method === 'GetStartupValueKeys' ? '[]' : 'circuit-id';
-    });
-    const circuit = createCircuit(
-      invoke,
-      () => events.push('opened'),
-      notify => {
-        events.push('server completion');
-        notify(true, null);
-      });
-
-    await expect(circuit.start()).resolves.toBe(true);
-
-    expect(events).toEqual([
-      'GetStartupValueKeys',
-      'StartCircuit',
-      'CompleteHostInitialization',
-      'server completion',
-      'opened',
-    ]);
-  });
-
-  test('waits for server completion after the trigger invocation returns', async () => {
-    let notifyCompletion: ((succeeded: boolean, error: string | null) => void) | undefined;
-    let startCompleted = false;
-    const invoke = jest.fn(async (method: string, ..._args: unknown[]) =>
-      method === 'GetStartupValueKeys' ? '[]' : 'circuit-id');
-    const circuit = createCircuit(
-      invoke,
-      undefined,
-      notify => {
-        notifyCompletion = notify;
-      });
-
-    const startPromise = circuit.start().then(result => {
-      startCompleted = true;
-      return result;
-    });
-    await waitFor(() => notifyCompletion !== undefined);
-
-    expect(invoke.mock.calls.map(call => call[0])).toEqual([
-      'GetStartupValueKeys',
-      'StartCircuit',
-      'CompleteHostInitialization',
-    ]);
-    expect(startCompleted).toBe(false);
-
-    notifyCompletion!(true, null);
-    await expect(startPromise).resolves.toBe(true);
-  });
-
-  test('rejects when server host initialization fails without falling back', async () => {
-    const invoke = jest.fn(async (method: string, ..._args: unknown[]) =>
-      method === 'GetStartupValueKeys' ? '[]' : 'circuit-id');
-    const circuit = createCircuit(
-      invoke,
-      undefined,
-      notify => notify(false, 'Initializer failed.'));
-
-    await expect(circuit.start()).rejects.toThrow('Initializer failed.');
-    expect(invoke.mock.calls.map(call => call[0])).toEqual([
-      'GetStartupValueKeys',
-      'StartCircuit',
-      'CompleteHostInitialization',
-    ]);
-  });
-
-  test('rejects host initialization when the circuit fails before completion notification', async () => {
-    const invoke = jest.fn(async (method: string, ..._args: unknown[]) =>
-      method === 'GetStartupValueKeys' ? '[]' : 'circuit-id');
-    const circuit = createCircuit(
-      invoke,
-      undefined,
-      (_notify, notifyError) => notifyError('Initializer failed through circuit error.'));
-
-    await expect(circuit.start()).rejects.toThrow('Initializer failed through circuit error.');
-    expect(invoke.mock.calls.map(call => call[0])).toEqual([
-      'GetStartupValueKeys',
-      'StartCircuit',
-      'CompleteHostInitialization',
-    ]);
   });
 
   test('fails when the required key query is unavailable without invoking start', async () => {
@@ -185,12 +98,10 @@ describe('CircuitManager startup values', () => {
     expect(invoke.mock.calls.map(call => call[0])).toEqual([
       'GetStartupValueKeys',
       'StartCircuit',
-      'CompleteHostInitialization',
       'GetStartupValueKeys',
       'ResumeCircuit',
-      'CompleteHostInitialization',
     ]);
-    expect(JSON.parse(invoke.mock.calls[4][2] as string))
+    expect(JSON.parse(invoke.mock.calls[3][2] as string))
       .toEqual({ 'testCircuitStartup.value': 'changed' });
   });
 
@@ -215,7 +126,7 @@ describe('CircuitManager startup values', () => {
     await expect(circuit.resume()).rejects.toThrow('Method does not exist.');
 
     expect(invoke.mock.calls.map(call => call[0]))
-      .toEqual(['GetStartupValueKeys', 'StartCircuit', 'CompleteHostInitialization', 'GetStartupValueKeys']);
+      .toEqual(['GetStartupValueKeys', 'StartCircuit', 'GetStartupValueKeys']);
   });
 
   test('does not fall back when resume fails', async () => {
@@ -239,39 +150,8 @@ describe('CircuitManager startup values', () => {
     expect(invoke.mock.calls.map(call => call[0])).toEqual([
       'GetStartupValueKeys',
       'StartCircuit',
-      'CompleteHostInitialization',
       'GetStartupValueKeys',
       'ResumeCircuit',
-    ]);
-  });
-
-  test('rejects resume when server host initialization fails without falling back', async () => {
-    let initializationCount = 0;
-    const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
-      if (method === 'GetStartupValueKeys') {
-        return '[]';
-      }
-
-      return method === 'ResumeCircuit' ? 'resumed-circuit-id' : 'circuit-id';
-    });
-    const circuit = createCircuit(
-      invoke,
-      undefined,
-      notify => {
-        initializationCount++;
-        notify(initializationCount === 1, initializationCount === 1 ? null : 'Resume initializer failed.');
-      });
-    await circuit.start();
-    setPaused(circuit);
-
-    await expect(circuit.resume()).rejects.toThrow('Resume initializer failed.');
-    expect(invoke.mock.calls.map(call => call[0])).toEqual([
-      'GetStartupValueKeys',
-      'StartCircuit',
-      'CompleteHostInitialization',
-      'GetStartupValueKeys',
-      'ResumeCircuit',
-      'CompleteHostInitialization',
     ]);
   });
 });
@@ -279,10 +159,6 @@ describe('CircuitManager startup values', () => {
 function createCircuit(
   invoke: (method: string, ...args: unknown[]) => Promise<unknown>,
   onCircuitOpened?: () => void,
-  onHostInitialization: (
-    notify: (succeeded: boolean, error: string | null) => void,
-    notifyError: (error: string) => void,
-  ) => void = notify => notify(true, null),
 ): CircuitManager {
   const handlers = new Map<string, (...args: any[]) => void>();
   const connection = {
@@ -292,15 +168,7 @@ function createCircuit(
     start: () => Promise.resolve(),
     stop: () => Promise.resolve(),
     send: () => Promise.resolve(),
-    invoke: async (method: string, ...args: unknown[]) => {
-      const result = await invoke(method, ...args);
-      if (method === 'CompleteHostInitialization') {
-        onHostInitialization(
-          (succeeded, error) => handlers.get('JS.EndHostInitialization')!(succeeded, error),
-          error => handlers.get('JS.Error')!(error));
-      }
-      return result;
-    },
+    invoke: (method: string, ...args: unknown[]) => invoke(method, ...args),
   } as unknown as HubConnection;
   jest.spyOn(HubConnectionBuilder.prototype, 'build').mockReturnValue(connection);
   const circuit = new CircuitManager(
@@ -320,11 +188,4 @@ function createCircuit(
 
 function setPaused(circuit: CircuitManager): void {
   (circuit as unknown as InternalCircuitManager)._pausingState.transitionTo(true);
-}
-
-async function waitFor(condition: () => boolean): Promise<void> {
-  for (let i = 0; i < 100 && !condition(); i++) {
-    await new Promise(resolve => setTimeout(resolve, 0));
-  }
-  expect(condition()).toBe(true);
 }

--- a/src/Components/Web.JS/test/Platform/Circuits/CircuitManagerStartupValues.test.ts
+++ b/src/Components/Web.JS/test/Platform/Circuits/CircuitManagerStartupValues.test.ts
@@ -1,0 +1,170 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
+import { HubConnection, HubConnectionState } from '@microsoft/signalr';
+import { CircuitManager } from '../../../src/Platform/Circuits/CircuitManager';
+import { resolveOptions } from '../../../src/Platform/Circuits/CircuitStartOptions';
+import { JSEventRegistry } from '../../../src/Services/JSEventRegistry';
+
+interface InternalCircuitManager {
+  startConnection(): Promise<HubConnection>;
+  _pausingState: {
+    transitionTo(value: boolean): void;
+  };
+}
+
+const globals = globalThis as unknown as Record<string, unknown>;
+
+describe('CircuitManager startup values', () => {
+  afterEach(() => {
+    delete globals.testCircuitStartup;
+    jest.restoreAllMocks();
+  });
+
+  test('queries keys and starts with evaluated startup values', async () => {
+    globals.testCircuitStartup = { value: 'expected' };
+    const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
+      if (method === 'GetStartupValueKeys') {
+        return ['testCircuitStartup.value'];
+      }
+
+      return 'circuit-id';
+    });
+    const circuit = createCircuit(invoke);
+
+    await expect(circuit.start()).resolves.toBe(true);
+
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke.mock.calls[1][0]).toBe('StartCircuitWithStartupValues');
+    expect(JSON.parse(invoke.mock.calls[1][5] as string))
+      .toEqual({ 'testCircuitStartup.value': 'expected' });
+  });
+
+  test('uses legacy start only when the capability method is absent', async () => {
+    const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
+      if (method === 'GetStartupValueKeys') {
+        throw new Error(
+          "Failed to invoke 'GetStartupValueKeys' due to an error on the server. HubException: Method does not exist.");
+      }
+
+      return 'circuit-id';
+    });
+    const circuit = createCircuit(invoke);
+
+    await expect(circuit.start()).resolves.toBe(true);
+
+    expect(invoke.mock.calls.map(call => call[0])).toEqual(['GetStartupValueKeys', 'StartCircuit']);
+  });
+
+  test('does not fall back after startup-values capability succeeds', async () => {
+    const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
+      if (method === 'GetStartupValueKeys') {
+        return [];
+      }
+
+      throw new Error('New start failed.');
+    });
+    const circuit = createCircuit(invoke);
+
+    await expect(circuit.start()).rejects.toThrow('New start failed.');
+
+    expect(invoke.mock.calls.map(call => call[0]))
+      .toEqual(['GetStartupValueKeys', 'StartCircuitWithStartupValues']);
+  });
+
+  test('renegotiates and reevaluates startup values when resuming', async () => {
+    globals.testCircuitStartup = { value: 'expected' };
+    const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
+      if (method === 'GetStartupValueKeys') {
+        return ['testCircuitStartup.value'];
+      }
+
+      return method === 'ResumeCircuitWithStartupValues' ? 'resumed-circuit-id' : 'circuit-id';
+    });
+    const circuit = createCircuit(invoke);
+    await circuit.start();
+    globals.testCircuitStartup = { value: 'changed' };
+    setPaused(circuit);
+
+    await expect(circuit.resume()).resolves.toBe(true);
+
+    expect(invoke.mock.calls.map(call => call[0])).toEqual([
+      'GetStartupValueKeys',
+      'StartCircuitWithStartupValues',
+      'GetStartupValueKeys',
+      'ResumeCircuitWithStartupValues',
+    ]);
+    expect(JSON.parse(invoke.mock.calls[3][6] as string))
+      .toEqual({ 'testCircuitStartup.value': 'changed' });
+  });
+
+  test('uses legacy resume when startup values are unsupported', async () => {
+    const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
+      if (method === 'GetStartupValueKeys') {
+        throw new Error(
+          "Failed to invoke 'GetStartupValueKeys' due to an error on the server. HubException: Method does not exist.");
+      }
+
+      return method === 'ResumeCircuit' ? 'resumed-circuit-id' : 'circuit-id';
+    });
+    const circuit = createCircuit(invoke);
+    await circuit.start();
+    setPaused(circuit);
+
+    await expect(circuit.resume()).resolves.toBe(true);
+
+    expect(invoke.mock.calls.map(call => call[0]))
+      .toEqual(['GetStartupValueKeys', 'StartCircuit', 'GetStartupValueKeys', 'ResumeCircuit']);
+  });
+
+  test('does not fall back when startup-values resume fails', async () => {
+    const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
+      if (method === 'GetStartupValueKeys') {
+        return [];
+      }
+
+      if (method === 'ResumeCircuitWithStartupValues') {
+        throw new Error('New resume failed.');
+      }
+
+      return 'circuit-id';
+    });
+    const circuit = createCircuit(invoke);
+    await circuit.start();
+    setPaused(circuit);
+
+    await expect(circuit.resume()).rejects.toThrow('New resume failed.');
+
+    expect(invoke.mock.calls.map(call => call[0])).toEqual([
+      'GetStartupValueKeys',
+      'StartCircuitWithStartupValues',
+      'GetStartupValueKeys',
+      'ResumeCircuitWithStartupValues',
+    ]);
+  });
+});
+
+function createCircuit(invoke: (method: string, ...args: unknown[]) => Promise<unknown>): CircuitManager {
+  const connection = {
+    state: HubConnectionState.Connected,
+    invoke,
+  } as unknown as HubConnection;
+  const circuit = new CircuitManager(
+    { initialComponents: [] } as never,
+    '',
+    resolveOptions({
+      reconnectionHandler: {
+        onConnectionDown: () => { /* no-op */ },
+        onConnectionUp: () => { /* no-op */ },
+      },
+    }),
+    { log: () => { /* no-op */ } } as never,
+    new JSEventRegistry());
+  (circuit as unknown as InternalCircuitManager).startConnection = () => Promise.resolve(connection);
+  return circuit;
+}
+
+function setPaused(circuit: CircuitManager): void {
+  (circuit as unknown as InternalCircuitManager)._pausingState.transitionTo(true);
+}

--- a/src/Components/Web.JS/test/Platform/Circuits/CircuitManagerStartupValues.test.ts
+++ b/src/Components/Web.JS/test/Platform/Circuits/CircuitManagerStartupValues.test.ts
@@ -26,7 +26,7 @@ describe('CircuitManager startup values', () => {
     globals.testCircuitStartup = { value: 'expected' };
     const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
       if (method === 'GetStartupValueKeys') {
-        return '["testCircuitStartup.value"]';
+        return '["document.baseURI","location.href","testCircuitStartup.value"]';
       }
 
       return 'circuit-id';
@@ -37,12 +37,15 @@ describe('CircuitManager startup values', () => {
 
     expect(invoke.mock.calls.map(call => call[0])).toEqual([
       'GetStartupValueKeys',
-      'StartCircuitWithStartupValues',
+      'StartCircuit',
       'CompleteHostInitialization',
     ]);
-    expect(invoke.mock.calls[1][0]).toBe('StartCircuitWithStartupValues');
-    expect(JSON.parse(invoke.mock.calls[1][5] as string))
-      .toEqual({ 'testCircuitStartup.value': 'expected' });
+    expect(JSON.parse(invoke.mock.calls[1][1] as string))
+      .toEqual({
+        'document.baseURI': document.baseURI,
+        'location.href': location.href,
+        'testCircuitStartup.value': 'expected',
+      });
   });
 
   test('completes host initialization before reporting the circuit as opened', async () => {
@@ -63,7 +66,7 @@ describe('CircuitManager startup values', () => {
 
     expect(events).toEqual([
       'GetStartupValueKeys',
-      'StartCircuitWithStartupValues',
+      'StartCircuit',
       'CompleteHostInitialization',
       'server completion',
       'opened',
@@ -90,7 +93,7 @@ describe('CircuitManager startup values', () => {
 
     expect(invoke.mock.calls.map(call => call[0])).toEqual([
       'GetStartupValueKeys',
-      'StartCircuitWithStartupValues',
+      'StartCircuit',
       'CompleteHostInitialization',
     ]);
     expect(startCompleted).toBe(false);
@@ -110,14 +113,14 @@ describe('CircuitManager startup values', () => {
     await expect(circuit.start()).rejects.toThrow('Initializer failed.');
     expect(invoke.mock.calls.map(call => call[0])).toEqual([
       'GetStartupValueKeys',
-      'StartCircuitWithStartupValues',
+      'StartCircuit',
       'CompleteHostInitialization',
     ]);
   });
 
   test('rejects host initialization when the circuit fails before completion notification', async () => {
     const invoke = jest.fn(async (method: string, ..._args: unknown[]) =>
-      method === 'GetStartupValueKeys' ? [] : 'circuit-id');
+      method === 'GetStartupValueKeys' ? '[]' : 'circuit-id');
     const circuit = createCircuit(
       invoke,
       undefined,
@@ -126,12 +129,12 @@ describe('CircuitManager startup values', () => {
     await expect(circuit.start()).rejects.toThrow('Initializer failed through circuit error.');
     expect(invoke.mock.calls.map(call => call[0])).toEqual([
       'GetStartupValueKeys',
-      'StartCircuitWithStartupValues',
+      'StartCircuit',
       'CompleteHostInitialization',
     ]);
   });
 
-  test('uses legacy start only when the capability method is absent', async () => {
+  test('fails when the required key query is unavailable without invoking start', async () => {
     const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
       if (method === 'GetStartupValueKeys') {
         throw new Error(
@@ -142,12 +145,12 @@ describe('CircuitManager startup values', () => {
     });
     const circuit = createCircuit(invoke);
 
-    await expect(circuit.start()).resolves.toBe(true);
+    await expect(circuit.start()).rejects.toThrow('Method does not exist.');
 
-    expect(invoke.mock.calls.map(call => call[0])).toEqual(['GetStartupValueKeys', 'StartCircuit']);
+    expect(invoke.mock.calls.map(call => call[0])).toEqual(['GetStartupValueKeys']);
   });
 
-  test('does not fall back after startup-values capability succeeds', async () => {
+  test('does not fall back after start fails', async () => {
     const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
       if (method === 'GetStartupValueKeys') {
         return '[]';
@@ -160,17 +163,17 @@ describe('CircuitManager startup values', () => {
     await expect(circuit.start()).rejects.toThrow('New start failed.');
 
     expect(invoke.mock.calls.map(call => call[0]))
-      .toEqual(['GetStartupValueKeys', 'StartCircuitWithStartupValues']);
+      .toEqual(['GetStartupValueKeys', 'StartCircuit']);
   });
 
-  test('renegotiates and reevaluates startup values when resuming', async () => {
+  test('queries and reevaluates startup values when resuming', async () => {
     globals.testCircuitStartup = { value: 'expected' };
     const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
       if (method === 'GetStartupValueKeys') {
         return '["testCircuitStartup.value"]';
       }
 
-      return method === 'ResumeCircuitWithStartupValues' ? 'resumed-circuit-id' : 'circuit-id';
+      return method === 'ResumeCircuit' ? 'resumed-circuit-id' : 'circuit-id';
     });
     const circuit = createCircuit(invoke);
     await circuit.start();
@@ -181,42 +184,47 @@ describe('CircuitManager startup values', () => {
 
     expect(invoke.mock.calls.map(call => call[0])).toEqual([
       'GetStartupValueKeys',
-      'StartCircuitWithStartupValues',
+      'StartCircuit',
       'CompleteHostInitialization',
       'GetStartupValueKeys',
-      'ResumeCircuitWithStartupValues',
+      'ResumeCircuit',
       'CompleteHostInitialization',
     ]);
-    expect(JSON.parse(invoke.mock.calls[4][6] as string))
+    expect(JSON.parse(invoke.mock.calls[4][2] as string))
       .toEqual({ 'testCircuitStartup.value': 'changed' });
   });
 
-  test('uses legacy resume when startup values are unsupported', async () => {
+  test('fails resume when the required key query is unavailable without invoking resume', async () => {
+    let startupValueQueryCount = 0;
     const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
       if (method === 'GetStartupValueKeys') {
-        throw new Error(
-          "Failed to invoke 'GetStartupValueKeys' due to an error on the server. HubException: Method does not exist.");
+        startupValueQueryCount++;
+        if (startupValueQueryCount > 1) {
+          throw new Error(
+            "Failed to invoke 'GetStartupValueKeys' due to an error on the server. HubException: Method does not exist.");
+        }
+        return '[]';
       }
 
-      return method === 'ResumeCircuit' ? 'resumed-circuit-id' : 'circuit-id';
+      return 'circuit-id';
     });
     const circuit = createCircuit(invoke);
     await circuit.start();
     setPaused(circuit);
 
-    await expect(circuit.resume()).resolves.toBe(true);
+    await expect(circuit.resume()).rejects.toThrow('Method does not exist.');
 
     expect(invoke.mock.calls.map(call => call[0]))
-      .toEqual(['GetStartupValueKeys', 'StartCircuit', 'GetStartupValueKeys', 'ResumeCircuit']);
+      .toEqual(['GetStartupValueKeys', 'StartCircuit', 'CompleteHostInitialization', 'GetStartupValueKeys']);
   });
 
-  test('does not fall back when startup-values resume fails', async () => {
+  test('does not fall back when resume fails', async () => {
     const invoke = jest.fn(async (method: string, ..._args: unknown[]) => {
       if (method === 'GetStartupValueKeys') {
         return '[]';
       }
 
-      if (method === 'ResumeCircuitWithStartupValues') {
+      if (method === 'ResumeCircuit') {
         throw new Error('New resume failed.');
       }
 
@@ -230,10 +238,10 @@ describe('CircuitManager startup values', () => {
 
     expect(invoke.mock.calls.map(call => call[0])).toEqual([
       'GetStartupValueKeys',
-      'StartCircuitWithStartupValues',
+      'StartCircuit',
       'CompleteHostInitialization',
       'GetStartupValueKeys',
-      'ResumeCircuitWithStartupValues',
+      'ResumeCircuit',
     ]);
   });
 
@@ -244,7 +252,7 @@ describe('CircuitManager startup values', () => {
         return '[]';
       }
 
-      return method === 'ResumeCircuitWithStartupValues' ? 'resumed-circuit-id' : 'circuit-id';
+      return method === 'ResumeCircuit' ? 'resumed-circuit-id' : 'circuit-id';
     });
     const circuit = createCircuit(
       invoke,
@@ -259,10 +267,10 @@ describe('CircuitManager startup values', () => {
     await expect(circuit.resume()).rejects.toThrow('Resume initializer failed.');
     expect(invoke.mock.calls.map(call => call[0])).toEqual([
       'GetStartupValueKeys',
-      'StartCircuitWithStartupValues',
+      'StartCircuit',
       'CompleteHostInitialization',
       'GetStartupValueKeys',
-      'ResumeCircuitWithStartupValues',
+      'ResumeCircuit',
       'CompleteHostInitialization',
     ]);
   });

--- a/src/Components/Web/src/Hosting/IBrowserStartupValueProvider.cs
+++ b/src/Components/Web/src/Hosting/IBrowserStartupValueProvider.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+/// <summary>
+/// Declares startup values to collect from the browser.
+/// </summary>
+/// <remarks>
+/// Keys are dot-separated JavaScript property paths resolved from <c>globalThis</c>.
+/// Each path must resolve to a string value. Duplicate keys across providers are rejected.
+/// </remarks>
+public interface IBrowserStartupValueProvider
+{
+    /// <summary>
+    /// Gets the JavaScript property paths to collect from the browser.
+    /// </summary>
+    IReadOnlyList<string> Keys { get; }
+}

--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -1,5 +1,7 @@
 #nullable enable
 Microsoft.AspNetCore.Components.Web.AssetPathAttributes
+Microsoft.AspNetCore.Components.Hosting.IBrowserStartupValueProvider
+Microsoft.AspNetCore.Components.Hosting.IBrowserStartupValueProvider.Keys.get -> System.Collections.Generic.IReadOnlyList<string!>!
 Microsoft.AspNetCore.Components.Web.EnvironmentView
 Microsoft.AspNetCore.Components.Web.EnvironmentView.ChildContent.get -> Microsoft.AspNetCore.Components.RenderFragment?
 Microsoft.AspNetCore.Components.Web.EnvironmentView.ChildContent.set -> void

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/BrowserStartupValueProviderUtilities.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/BrowserStartupValueProviderUtilities.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+internal static class BrowserStartupValueProviderUtilities
+{
+    internal static string[] GetKeys(IEnumerable<IBrowserStartupValueProvider> providers)
+    {
+        var keys = new List<string>();
+        var uniqueKeys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var provider in providers)
+        {
+            foreach (var key in provider.Keys)
+            {
+                if (key is null)
+                {
+                    throw new InvalidOperationException("A browser startup value provider returned a null key.");
+                }
+
+                if (!uniqueKeys.Add(key))
+                {
+                    throw new InvalidOperationException($"The browser startup value key '{key}' was provided more than once.");
+                }
+
+                keys.Add(key);
+            }
+        }
+
+        return [.. keys];
+    }
+}

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/HostStartupValuesJson.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/HostStartupValuesJson.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+internal static class HostStartupValuesJson
+{
+    internal static string SerializeKeys(IReadOnlyList<string> keys)
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            writer.WriteStartArray();
+            foreach (var key in keys)
+            {
+                writer.WriteStringValue(key);
+            }
+            writer.WriteEndArray();
+        }
+
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
+    }
+
+    internal static bool TryDeserialize(string? json, out Dictionary<string, string> values)
+    {
+        values = new Dictionary<string, string>(StringComparer.Ordinal);
+        if (json is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
+            if (!reader.Read() || reader.TokenType is not JsonTokenType.StartObject)
+            {
+                return false;
+            }
+
+            while (reader.Read() && reader.TokenType is not JsonTokenType.EndObject)
+            {
+                if (reader.TokenType is not JsonTokenType.PropertyName)
+                {
+                    return false;
+                }
+
+                var key = reader.GetString()!;
+                if (!reader.Read() || reader.TokenType is not JsonTokenType.String)
+                {
+                    return false;
+                }
+
+                if (!values.TryAdd(key, reader.GetString()!))
+                {
+                    return false;
+                }
+            }
+
+            return reader.TokenType is JsonTokenType.EndObject && !reader.Read();
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/InteractiveHostStartupValues.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/InteractiveHostStartupValues.cs
@@ -1,0 +1,22 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+internal sealed class InteractiveHostStartupValues : IHostStartupValues
+{
+    private IReadOnlyDictionary<string, string>? _values;
+
+    public string? GetValue(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+
+        return _values is not null && _values.TryGetValue(key, out var value) ? value : null;
+    }
+
+    public string GetRequired(string key)
+        => GetValue(key) ?? throw new InvalidOperationException($"Startup value '{key}' was not provided.");
+
+    internal void Initialize(IReadOnlyDictionary<string, string> values)
+        => _values = new Dictionary<string, string>(values, StringComparer.Ordinal);
+}

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/NavigationBrowserStartupValueProvider.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/NavigationBrowserStartupValueProvider.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+internal sealed class NavigationBrowserStartupValueProvider : IBrowserStartupValueProvider
+{
+    internal const string BaseUriKey = "document.baseURI";
+    internal const string LocationHrefKey = "location.href";
+
+    public IReadOnlyList<string> Keys { get; } = [BaseUriKey, LocationHrefKey];
+}

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/NavigationManagerInitializer.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/NavigationManagerInitializer.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.WebAssembly.Services;
+
+namespace Microsoft.AspNetCore.Components.Hosting;
+
+internal sealed class NavigationManagerInitializer(
+    IHostStartupValues startupValues,
+    NavigationManager navigationManager) : IHostInitializer
+{
+    public int Order => -200;
+
+    public Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        ((WebAssemblyNavigationManager)navigationManager).InitializeNavigation(
+            startupValues.GetRequired(NavigationBrowserStartupValueProvider.BaseUriKey),
+            startupValues.GetRequired(NavigationBrowserStartupValueProvider.LocationHrefKey));
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/NavigationManagerInitializer.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/NavigationManagerInitializer.cs
@@ -2,19 +2,20 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Components.WebAssembly.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Components.Hosting;
 
-internal sealed class NavigationManagerInitializer(
-    IHostStartupValues startupValues,
-    NavigationManager navigationManager) : IHostInitializer
+internal sealed class NavigationManagerInitializer : IHostInitializer
 {
     public int Order => -200;
 
-    public Task InitializeAsync(CancellationToken cancellationToken = default)
+    public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
+        var startupValues = services.GetRequiredService<IHostStartupValues>();
+        var navigationManager = services.GetRequiredService<NavigationManager>();
         ((WebAssemblyNavigationManager)navigationManager).InitializeNavigation(
             startupValues.GetRequired(NavigationBrowserStartupValueProvider.BaseUriKey),
             startupValues.GetRequired(NavigationBrowserStartupValueProvider.LocationHrefKey));

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/NavigationManagerInitializer.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/NavigationManagerInitializer.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.AspNetCore.Components.WebAssembly.Services;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,16 +9,24 @@ namespace Microsoft.AspNetCore.Components.Hosting;
 
 internal sealed class NavigationManagerInitializer : IHostInitializer
 {
-    public int Order => -200;
+    public int Order => int.MinValue;
 
-    public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+    public Task InitializeHostAsync(IServiceProvider services, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         var startupValues = services.GetRequiredService<IHostStartupValues>();
-        var navigationManager = services.GetRequiredService<NavigationManager>();
-        ((WebAssemblyNavigationManager)navigationManager).InitializeNavigation(
-            startupValues.GetRequired(NavigationBrowserStartupValueProvider.BaseUriKey),
+        var baseUri = startupValues.GetRequired(NavigationBrowserStartupValueProvider.BaseUriKey);
+        var baseAddress = WebAssemblyNavigationManager.NormalizeBaseUriForHostEnvironment(baseUri);
+        var hostEnvironment = services.GetRequiredService<IWebAssemblyHostEnvironment>();
+        if (!string.Equals(baseAddress, hostEnvironment.BaseAddress, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("The browser base URI changed during host initialization.");
+        }
+
+        var navigationManager = services.GetRequiredService<WebAssemblyNavigationManager>();
+        navigationManager.InitializeNavigation(
+            baseUri,
             startupValues.GetRequired(NavigationBrowserStartupValueProvider.LocationHrefKey));
 
         return Task.CompletedTask;

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHost.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHost.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Web;
@@ -137,6 +138,13 @@ public sealed class WebAssemblyHost : IAsyncDisposable
         _started = true;
 
         InitializeHostStartupValues();
+
+        var hostInitializers = Services.GetServices<IHostInitializer>()
+            .OrderBy(initializer => initializer.Order);
+        foreach (var initializer in hostInitializers)
+        {
+            await initializer.InitializeAsync(cancellationToken);
+        }
 
         var manager = Services.GetRequiredService<ComponentStatePersistenceManager>();
         var store = !string.IsNullOrEmpty(_persistedState) ?

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHost.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHost.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Web;
@@ -139,11 +138,10 @@ public sealed class WebAssemblyHost : IAsyncDisposable
 
         InitializeHostStartupValues();
 
-        var hostInitializers = Services.GetServices<IHostInitializer>()
-            .OrderBy(initializer => initializer.Order);
-        foreach (var initializer in hostInitializers)
+        var hostInitializers = Services.GetRequiredService<HostInitializerCollection>();
+        foreach (var initializer in hostInitializers.Initializers)
         {
-            await initializer.InitializeAsync(cancellationToken);
+            await initializer.InitializeAsync(Services, cancellationToken);
         }
 
         var manager = Services.GetRequiredService<ComponentStatePersistenceManager>();

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHost.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHost.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.ExceptionServices;
 using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Web;
@@ -26,6 +27,11 @@ public sealed class WebAssemblyHost : IAsyncDisposable
     private readonly IConfiguration _configuration;
     private readonly RootComponentMappingCollection _rootComponents;
     private readonly string? _persistedState;
+    private readonly CancellationTokenSource _hostCancellationTokenSource;
+    private readonly Task _browserInitializationTask;
+    private readonly object _lifecycleLock = new();
+    private CancellationTokenRegistration _externalCancellationRegistration;
+    private Task? _runTask;
 
     // NOTE: the host is disposable because it OWNs references to disposable things.
     //
@@ -45,7 +51,8 @@ public sealed class WebAssemblyHost : IAsyncDisposable
         WebAssemblyHostBuilder builder,
         IServiceProvider services,
         AsyncServiceScope scope,
-        string? persistedState)
+        string? persistedState,
+        CancellationTokenSource hostCancellationTokenSource)
     {
         // To ensure JS-invoked methods don't get linked out, have a reference to their enclosing types
         GC.KeepAlive(typeof(JSInteropMethods));
@@ -55,6 +62,18 @@ public sealed class WebAssemblyHost : IAsyncDisposable
         _configuration = builder.Configuration;
         _rootComponents = builder.RootComponents;
         _persistedState = persistedState;
+        _hostCancellationTokenSource = hostCancellationTokenSource;
+
+        InitializeHostStartupValues();
+        var hostInitializerInvoker = Services
+            .GetRequiredService<HostInitializerCollection>()
+            .GetInitializerInvoker(Services);
+        _browserInitializationTask = hostInitializerInvoker.InitializeBrowserAsync(
+            _hostCancellationTokenSource.Token);
+        if (_browserInitializationTask.IsCompleted)
+        {
+            _browserInitializationTask.GetAwaiter().GetResult();
+        }
     }
 
     /// <summary>
@@ -73,40 +92,82 @@ public sealed class WebAssemblyHost : IAsyncDisposable
     /// <returns>A <see cref="ValueTask"/> which represents the completion of disposal.</returns>
     public async ValueTask DisposeAsync()
     {
-        if (_disposed)
+        Task taskToAwait;
+        CancellationToken hostCancellationToken;
+        Exception? runException = null;
+        lock (_lifecycleLock)
         {
-            return;
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            _externalCancellationRegistration.Dispose();
+            _externalCancellationRegistration = default;
+            taskToAwait = _runTask ?? _browserInitializationTask;
+            hostCancellationToken = _hostCancellationTokenSource.Token;
+            try
+            {
+                _hostCancellationTokenSource.Cancel();
+            }
+            catch (Exception exception)
+            {
+                runException = exception;
+            }
         }
 
-        _disposed = true;
-
-        // Stop hosted services first
-        if (_hostedServiceExecutor is not null)
+        try
         {
             try
             {
-                await _hostedServiceExecutor.StopAsync(CancellationToken.None);
+                await taskToAwait;
             }
-            catch
+            catch (OperationCanceledException exception) when (exception.CancellationToken == hostCancellationToken)
             {
-                // Ignore errors when stopping hosted services during disposal
+            }
+            catch (Exception exception)
+            {
+                runException ??= exception;
+            }
+
+            // Stop hosted services first
+            if (_hostedServiceExecutor is not null)
+            {
+                try
+                {
+                    await _hostedServiceExecutor.StopAsync(CancellationToken.None);
+                }
+                catch
+                {
+                    // Ignore errors when stopping hosted services during disposal
+                }
+            }
+
+            if (_renderer is not null)
+            {
+                await _renderer.DisposeAsync();
+            }
+
+            await _scope.DisposeAsync();
+
+            if (_services is IAsyncDisposable asyncDisposableServices)
+            {
+                await asyncDisposableServices.DisposeAsync();
+            }
+            else if (_services is IDisposable disposableServices)
+            {
+                disposableServices.Dispose();
             }
         }
-
-        if (_renderer is not null)
+        finally
         {
-            await _renderer.DisposeAsync();
+            _hostCancellationTokenSource.Dispose();
         }
 
-        await _scope.DisposeAsync();
-
-        if (_services is IAsyncDisposable asyncDisposableServices)
+        if (runException is not null)
         {
-            await asyncDisposableServices.DisposeAsync();
-        }
-        else if (_services is IDisposable disposableServices)
-        {
-            disposableServices.Dispose();
+            ExceptionDispatchInfo.Capture(runException).Throw();
         }
     }
 
@@ -127,113 +188,135 @@ public sealed class WebAssemblyHost : IAsyncDisposable
     }
 
     // Internal for testing.
-    internal async Task RunAsyncCore(CancellationToken cancellationToken, WebAssemblyCultureProvider? cultureProvider = null)
+    internal Task RunAsyncCore(CancellationToken cancellationToken, WebAssemblyCultureProvider? cultureProvider = null)
     {
-        if (_started)
+        lock (_lifecycleLock)
         {
-            throw new InvalidOperationException("The host has already started.");
-        }
-
-        _started = true;
-
-        InitializeHostStartupValues();
-
-        var hostInitializers = Services.GetRequiredService<HostInitializerCollection>();
-        foreach (var initializer in hostInitializers.Initializers)
-        {
-            await initializer.InitializeAsync(Services, cancellationToken);
-        }
-
-        var manager = Services.GetRequiredService<ComponentStatePersistenceManager>();
-        var store = !string.IsNullOrEmpty(_persistedState) ?
-            new PrerenderComponentApplicationStore(_persistedState) :
-            new PrerenderComponentApplicationStore();
-
-        manager.SetPlatformRenderMode(RenderMode.InteractiveWebAssembly);
-        await manager.RestoreStateAsync(store, RestoreContext.InitialValue);
-
-        cultureProvider ??= WebAssemblyCultureProvider.Instance!;
-        cultureProvider.ThrowIfCultureChangeIsUnsupported();
-
-        if (Services.GetService<CultureStateProvider>() is CultureStateProvider cultureStateProvider)
-        {
-            cultureStateProvider.ApplyStoredCulture();
-        }
-
-        // Application developers might have configured the culture based on some ambient state
-        // such as local storage, url etc as part of their Program.Main(Async).
-        // This is the earliest opportunity to fetch satellite assemblies for this selection.
-        await cultureProvider.LoadCurrentCultureResourcesAsync();
-
-        // Start hosted services after culture is fully applied,
-        // so services that depend on culture see the correct values.
-        _hostedServiceExecutor = Services.GetRequiredService<HostedServiceExecutor>();
-        await _hostedServiceExecutor.StartAsync(cancellationToken);
-
-        var tcs = new TaskCompletionSource();
-        using (cancellationToken.Register(() => tcs.TrySetResult()))
-        {
-            var loggerFactory = Services.GetRequiredService<ILoggerFactory>();
-            var jsComponentInterop = new JSComponentInterop(_rootComponents.JSComponents);
-            var collectionProvider = Services.GetRequiredService<ResourceCollectionProvider>();
-            var collection = await collectionProvider.GetResourceCollection();
-            var useOutOfProcessRenderer = Environment.GetEnvironmentVariable("__BLAZOR_WEBASSEMBLY_OUT_OF_PROCESS_RENDERER") == "true";
-            _renderer = new WebAssemblyRenderer(Services, collection, loggerFactory, jsComponentInterop, useOutOfProcessRenderer);
-
-            WebAssemblyNavigationManager.Instance.CreateLogger(loggerFactory);
-
-            RootComponentOperationBatch? initialOperationBatch = null;
-            if (Environment.GetEnvironmentVariable("__BLAZOR_WEBASSEMBLY_WAIT_FOR_ROOT_COMPONENTS") == "true")
+            if (_started)
             {
-                // In Blazor web, we wait for the JS side to tell us about the components available
-                // before we render the initial set of components. Any additional update goes through
-                // UpdateRootComponents.
-                // We do it this way to ensure that the persistent component state is only used the first time
-                // the wasm runtime is initialized and is done in the same way for both webassembly and blazor
-                // web.
-                initialOperationBatch = await InternalJSImportMethods.GetInitialComponentUpdate();
+                throw new InvalidOperationException("The host has already started.");
             }
 
-            var initializationTcs = new TaskCompletionSource();
-            WebAssemblyCallQueue.Schedule((_rootComponents, _renderer, initializationTcs), async state =>
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            _started = true;
+            _externalCancellationRegistration = cancellationToken.Register(
+                static state => ((CancellationTokenSource)state!).Cancel(),
+                _hostCancellationTokenSource);
+            _runTask = RunAsyncCoreInternal(_hostCancellationTokenSource.Token, cultureProvider);
+
+            return _runTask;
+        }
+    }
+
+    private async Task RunAsyncCoreInternal(
+        CancellationToken hostCancellationToken,
+        WebAssemblyCultureProvider? cultureProvider)
+    {
+        try
+        {
+            await _browserInitializationTask;
+            hostCancellationToken.ThrowIfCancellationRequested();
+
+            var manager = Services.GetRequiredService<ComponentStatePersistenceManager>();
+            var store = !string.IsNullOrEmpty(_persistedState) ?
+                new PrerenderComponentApplicationStore(_persistedState) :
+                new PrerenderComponentApplicationStore();
+
+            manager.SetPlatformRenderMode(RenderMode.InteractiveWebAssembly);
+            await manager.RestoreStateAsync(store, RestoreContext.InitialValue);
+
+            cultureProvider ??= WebAssemblyCultureProvider.Instance!;
+            cultureProvider.ThrowIfCultureChangeIsUnsupported();
+
+            if (Services.GetService<CultureStateProvider>() is CultureStateProvider cultureStateProvider)
             {
-                var (rootComponents, renderer, initializationTcs) = state;
-                try
+                cultureStateProvider.ApplyStoredCulture();
+            }
+
+            // Application developers might have configured the culture based on some ambient state
+            // such as local storage, url etc as part of their Program.Main(Async).
+            // This is the earliest opportunity to fetch satellite assemblies for this selection.
+            await cultureProvider.LoadCurrentCultureResourcesAsync();
+
+            // Start hosted services after culture is fully applied,
+            // so services that depend on culture see the correct values.
+            _hostedServiceExecutor = Services.GetRequiredService<HostedServiceExecutor>();
+            await _hostedServiceExecutor.StartAsync(hostCancellationToken);
+
+            var tcs = new TaskCompletionSource();
+            using (hostCancellationToken.Register(() => tcs.TrySetResult()))
+            {
+                var loggerFactory = Services.GetRequiredService<ILoggerFactory>();
+                var jsComponentInterop = new JSComponentInterop(_rootComponents.JSComponents);
+                var collectionProvider = Services.GetRequiredService<ResourceCollectionProvider>();
+                var collection = await collectionProvider.GetResourceCollection();
+                var useOutOfProcessRenderer = Environment.GetEnvironmentVariable("__BLAZOR_WEBASSEMBLY_OUT_OF_PROCESS_RENDERER") == "true";
+                _renderer = new WebAssemblyRenderer(Services, collection, loggerFactory, jsComponentInterop, useOutOfProcessRenderer);
+
+                WebAssemblyNavigationManager.Instance.CreateLogger(loggerFactory);
+
+                RootComponentOperationBatch? initialOperationBatch = null;
+                if (Environment.GetEnvironmentVariable("__BLAZOR_WEBASSEMBLY_WAIT_FOR_ROOT_COMPONENTS") == "true")
                 {
-                    // Here, we add each root component but don't await the returned tasks so that the
-                    // components can be processed in parallel.
-                    var count = rootComponents.Count;
-                    var initialOperationCount = initialOperationBatch?.Operations.Length ?? 0;
-                    var pendingRenders = new List<Task>(count + initialOperationCount);
-                    for (var i = 0; i < count; i++)
-                    {
-                        var rootComponent = rootComponents[i];
-                        pendingRenders.Add(renderer.AddComponentAsync(
-                            rootComponent.ComponentType,
-                            rootComponent.Parameters,
-                            rootComponent.Selector));
-                    }
-
-                    if (initialOperationBatch is not null)
-                    {
-                        AddWebRootComponents(renderer, initialOperationBatch, pendingRenders);
-                    }
-
-                    // Now we wait for all components to finish rendering.
-                    await Task.WhenAll(pendingRenders);
-
-                    initializationTcs.SetResult();
+                    // In Blazor web, we wait for the JS side to tell us about the components available
+                    // before we render the initial set of components. Any additional update goes through
+                    // UpdateRootComponents.
+                    // We do it this way to ensure that the persistent component state is only used the first time
+                    // the wasm runtime is initialized and is done in the same way for both webassembly and blazor
+                    // web.
+                    initialOperationBatch = await InternalJSImportMethods.GetInitialComponentUpdate();
                 }
-                catch (Exception ex)
+
+                var initializationTcs = new TaskCompletionSource();
+                WebAssemblyCallQueue.Schedule((_rootComponents, _renderer, initializationTcs), async state =>
                 {
-                    initializationTcs.SetException(ex);
-                }
-            });
+                    var (rootComponents, renderer, initializationTcs) = state;
+                    try
+                    {
+                        // Here, we add each root component but don't await the returned tasks so that the
+                        // components can be processed in parallel.
+                        var count = rootComponents.Count;
+                        var initialOperationCount = initialOperationBatch?.Operations.Length ?? 0;
+                        var pendingRenders = new List<Task>(count + initialOperationCount);
+                        for (var i = 0; i < count; i++)
+                        {
+                            var rootComponent = rootComponents[i];
+                            pendingRenders.Add(renderer.AddComponentAsync(
+                                rootComponent.ComponentType,
+                                rootComponent.Parameters,
+                                rootComponent.Selector));
+                        }
 
-            await initializationTcs.Task;
-            store.ExistingState.Clear();
+                        if (initialOperationBatch is not null)
+                        {
+                            AddWebRootComponents(renderer, initialOperationBatch, pendingRenders);
+                        }
 
-            await tcs.Task;
+                        // Now we wait for all components to finish rendering.
+                        await Task.WhenAll(pendingRenders);
+
+                        initializationTcs.SetResult();
+                    }
+                    catch (Exception ex)
+                    {
+                        initializationTcs.SetException(ex);
+                    }
+                });
+
+                await initializationTcs.Task;
+                store.ExistingState.Clear();
+
+                await tcs.Task;
+            }
+        }
+        finally
+        {
+            lock (_lifecycleLock)
+            {
+                _externalCancellationRegistration.Dispose();
+                _externalCancellationRegistration = default;
+            }
         }
     }
 

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHost.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHost.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.Web.Infrastructure;
@@ -135,6 +136,8 @@ public sealed class WebAssemblyHost : IAsyncDisposable
 
         _started = true;
 
+        InitializeHostStartupValues();
+
         var manager = Services.GetRequiredService<ComponentStatePersistenceManager>();
         var store = !string.IsNullOrEmpty(_persistedState) ?
             new PrerenderComponentApplicationStore(_persistedState) :
@@ -226,6 +229,39 @@ public sealed class WebAssemblyHost : IAsyncDisposable
 
             await tcs.Task;
         }
+    }
+
+    private void InitializeHostStartupValues()
+    {
+        var keys = BrowserStartupValueProviderUtilities.GetKeys(
+            Services.GetServices<IBrowserStartupValueProvider>());
+        var keysJson = HostStartupValuesJson.SerializeKeys(keys);
+        var valuesJson = Services.GetRequiredService<IInternalJSImportMethods>().GetHostStartupValues(keysJson);
+        if (!HostStartupValuesJson.TryDeserialize(valuesJson, out var values) ||
+            !ContainsExactly(values, keys))
+        {
+            throw new InvalidOperationException("The browser returned invalid host startup values.");
+        }
+
+        Services.GetRequiredService<InteractiveHostStartupValues>().Initialize(values);
+    }
+
+    private static bool ContainsExactly(IReadOnlyDictionary<string, string> values, IReadOnlyList<string> keys)
+    {
+        if (values.Count != keys.Count)
+        {
+            return false;
+        }
+
+        foreach (var key in keys)
+        {
+            if (!values.ContainsKey(key))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2072", Justification = "These are root components which belong to the user and are in assemblies that don't get trimmed.")]

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostBuilder.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostBuilder.cs
@@ -340,6 +340,7 @@ public sealed class WebAssemblyHostBuilder
             static services => services.GetRequiredService<InteractiveHostStartupValues>());
         Services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IHostInitializer, NavigationManagerInitializer>());
+        Services.TryAddSingleton<HostInitializerCollection>();
         Services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IBrowserStartupValueProvider, NavigationBrowserStartupValueProvider>());
         Services.AddSingleton<IJSRuntime>(DefaultWebAssemblyJSRuntime.Instance);

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostBuilder.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostBuilder.cs
@@ -190,6 +190,7 @@ public sealed class WebAssemblyHostBuilder
         var baseUri = _jsMethods.NavigationManager_GetBaseUri();
         var uri = _jsMethods.NavigationManager_GetLocationHref();
 
+        // NavigationManager is available between Build and RunAsync for compatibility with existing applications.
         WebAssemblyNavigationManager.Instance = new WebAssemblyNavigationManager(baseUri, uri);
     }
 
@@ -337,6 +338,8 @@ public sealed class WebAssemblyHostBuilder
         Services.AddSingleton<InteractiveHostStartupValues>();
         Services.TryAddSingleton<IHostStartupValues>(
             static services => services.GetRequiredService<InteractiveHostStartupValues>());
+        Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IHostInitializer, NavigationManagerInitializer>());
         Services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IBrowserStartupValueProvider, NavigationBrowserStartupValueProvider>());
         Services.AddSingleton<IJSRuntime>(DefaultWebAssemblyJSRuntime.Instance);

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostBuilder.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostBuilder.cs
@@ -96,12 +96,12 @@ public sealed class WebAssemblyHostBuilder
         InitializeWebAssemblyRenderer();
 
         // Retrieve required attributes from JSRuntimeInvoker
-        InitializeNavigationManager();
+        var baseAddress = GetNormalizedBaseAddress();
         InitializeRegisteredRootComponents();
         InitializePersistedState();
         InitializeDefaultServices();
 
-        var hostEnvironment = InitializeEnvironment();
+        var hostEnvironment = InitializeEnvironment(baseAddress);
         HostEnvironment = hostEnvironment;
 
         _createServiceProvider = () =>
@@ -185,19 +185,14 @@ public sealed class WebAssemblyHostBuilder
         _persistedState = _jsMethods.GetPersistedState();
     }
 
-    private void InitializeNavigationManager()
-    {
-        var baseUri = _jsMethods.NavigationManager_GetBaseUri();
-        var uri = _jsMethods.NavigationManager_GetLocationHref();
+    private string GetNormalizedBaseAddress()
+        => WebAssemblyNavigationManager.NormalizeBaseUriForHostEnvironment(
+            _jsMethods.NavigationManager_GetBaseUri());
 
-        // NavigationManager is available between Build and RunAsync for compatibility with existing applications.
-        WebAssemblyNavigationManager.Instance = new WebAssemblyNavigationManager(baseUri, uri);
-    }
-
-    private WebAssemblyHostEnvironment InitializeEnvironment()
+    private WebAssemblyHostEnvironment InitializeEnvironment(string baseAddress)
     {
         var applicationEnvironment = _jsMethods.GetApplicationEnvironment();
-        var hostEnvironment = new WebAssemblyHostEnvironment(applicationEnvironment, WebAssemblyNavigationManager.Instance.BaseUri);
+        var hostEnvironment = new WebAssemblyHostEnvironment(applicationEnvironment, baseAddress);
 
         Services.AddSingleton<IWebAssemblyHostEnvironment>(hostEnvironment);
         Services.AddSingleton<IHostEnvironment>(sp => new WebAssemblyHostEnvironmentAdapter(sp.GetRequiredService<IWebAssemblyHostEnvironment>()));
@@ -326,9 +321,73 @@ public sealed class WebAssemblyHostBuilder
         // to configure services inside *that scope* inside their startup code, we create *both* the
         // service provider and the scope here.
         var services = _createServiceProvider();
-        var scope = services.GetRequiredService<IServiceScopeFactory>().CreateAsyncScope();
+        AsyncServiceScope? scope = null;
+        CancellationTokenSource? hostCancellationTokenSource = null;
+        try
+        {
+            scope = services.GetRequiredService<IServiceScopeFactory>().CreateAsyncScope();
+            hostCancellationTokenSource = new CancellationTokenSource();
 
-        return new WebAssemblyHost(this, services, scope, _persistedState);
+            return new WebAssemblyHost(
+                this,
+                services,
+                scope.Value,
+                _persistedState,
+                hostCancellationTokenSource);
+        }
+        catch
+        {
+            _ = DisposeFailedBuildAsync(scope, services, hostCancellationTokenSource);
+            throw;
+        }
+    }
+
+    private static async Task DisposeFailedBuildAsync(
+        AsyncServiceScope? scope,
+        IServiceProvider services,
+        CancellationTokenSource? hostCancellationTokenSource)
+    {
+        try
+        {
+            hostCancellationTokenSource?.Cancel();
+        }
+        catch
+        {
+        }
+
+        try
+        {
+            if (scope is not null)
+            {
+                await scope.Value.DisposeAsync();
+            }
+        }
+        catch
+        {
+        }
+
+        try
+        {
+            if (services is IAsyncDisposable asyncDisposableServices)
+            {
+                await asyncDisposableServices.DisposeAsync();
+            }
+            else if (services is IDisposable disposableServices)
+            {
+                disposableServices.Dispose();
+            }
+        }
+        catch
+        {
+        }
+
+        try
+        {
+            hostCancellationTokenSource?.Dispose();
+        }
+        catch
+        {
+        }
     }
 
     [DynamicDependency(JsonSerialized, typeof(DefaultAntiforgeryStateProvider))]
@@ -344,7 +403,14 @@ public sealed class WebAssemblyHostBuilder
         Services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IBrowserStartupValueProvider, NavigationBrowserStartupValueProvider>());
         Services.AddSingleton<IJSRuntime>(DefaultWebAssemblyJSRuntime.Instance);
-        Services.AddSingleton<NavigationManager>(WebAssemblyNavigationManager.Instance);
+        Services.AddSingleton(static services =>
+        {
+            var navigationManager = new WebAssemblyNavigationManager();
+            WebAssemblyNavigationManager.Instance = navigationManager;
+            return navigationManager;
+        });
+        Services.AddSingleton<NavigationManager>(
+            static services => services.GetRequiredService<WebAssemblyNavigationManager>());
         Services.AddSingleton<INavigationInterception>(WebAssemblyNavigationInterception.Instance);
         Services.AddSingleton<IScrollToLocationHash>(WebAssemblyScrollToLocationHash.Instance);
         Services.AddSingleton(_jsMethods);

--- a/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostBuilder.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyHostBuilder.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Infrastructure;
 using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.AspNetCore.Components.Routing;
@@ -15,6 +16,7 @@ using Microsoft.AspNetCore.Components.WebAssembly.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Json;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
@@ -332,6 +334,11 @@ public sealed class WebAssemblyHostBuilder
     [DynamicDependency(JsonSerialized, typeof(AntiforgeryRequestToken))]
     internal void InitializeDefaultServices()
     {
+        Services.AddSingleton<InteractiveHostStartupValues>();
+        Services.TryAddSingleton<IHostStartupValues>(
+            static services => services.GetRequiredService<InteractiveHostStartupValues>());
+        Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IBrowserStartupValueProvider, NavigationBrowserStartupValueProvider>());
         Services.AddSingleton<IJSRuntime>(DefaultWebAssemblyJSRuntime.Instance);
         Services.AddSingleton<NavigationManager>(WebAssemblyNavigationManager.Instance);
         Services.AddSingleton<INavigationInterception>(WebAssemblyNavigationInterception.Instance);

--- a/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
+++ b/src/Components/WebAssembly/WebAssembly/src/Microsoft.AspNetCore.Components.WebAssembly.csproj
@@ -69,6 +69,7 @@
     <Compile Include="$(ComponentsSharedSourceRoot)src\DefaultAntiforgeryStateProvider.cs" LinkBase="Forms" />
     <Compile Include="$(ComponentsSharedSourceRoot)src\ResourceCollectionProvider.cs" Link="Shared\ResourceCollectionProvider.cs" />
     <Compile Include="$(ComponentsSharedSourceRoot)src\CultureStateProvider.cs" Link="Shared\CultureStateProvider.cs" />
+    <Compile Include="$(ComponentsSharedSourceRoot)src\Hosting\HostInitializerCollection.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Components/WebAssembly/WebAssembly/src/Services/IInternalJSImportMethods.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/IInternalJSImportMethods.cs
@@ -11,6 +11,8 @@ internal interface IInternalJSImportMethods
     
     string GetApplicationCulture();
 
+    string GetHostStartupValues(string keysJson);
+
     void AttachRootComponentToElement(string domElementSelector, int componentId, int rendererId);
 
     void EndUpdateRootComponents(long batchId);

--- a/src/Components/WebAssembly/WebAssembly/src/Services/InternalJSImportMethods.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/InternalJSImportMethods.cs
@@ -30,6 +30,9 @@ internal partial class InternalJSImportMethods : IInternalJSImportMethods
     public string GetApplicationCulture()
         => GetApplicationCultureCore();
 
+    public string GetHostStartupValues(string keysJson)
+        => GetHostStartupValuesCore(keysJson);
+
     public void AttachRootComponentToElement(string domElementSelector, int componentId, int rendererId)
         => AttachRootComponentToElementCore(domElementSelector, componentId, rendererId);
 
@@ -77,6 +80,9 @@ internal partial class InternalJSImportMethods : IInternalJSImportMethods
 
     [JSImport("Blazor._internal.getApplicationCulture", "blazor-internal")]
     private static partial string GetApplicationCultureCore();
+
+    [JSImport("Blazor._internal.getHostStartupValues", "blazor-internal")]
+    private static partial string GetHostStartupValuesCore(string keysJson);
 
     [JSImport("Blazor._internal.attachRootComponentToElement", "blazor-internal")]
     private static partial void AttachRootComponentToElementCore(string domElementSelector, int componentId, int rendererId);

--- a/src/Components/WebAssembly/WebAssembly/src/Services/WebAssemblyNavigationManager.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/WebAssemblyNavigationManager.cs
@@ -26,6 +26,17 @@ internal sealed partial class WebAssemblyNavigationManager : NavigationManager
         Initialize(baseUri, uri);
     }
 
+    internal void InitializeNavigation(string baseUri, string uri)
+    {
+        var lastSlashIndex = baseUri.LastIndexOf('/');
+        var normalizedBaseUri = lastSlashIndex >= 0 ? baseUri[..(lastSlashIndex + 1)] : baseUri;
+        if (!string.Equals(BaseUri, normalizedBaseUri, StringComparison.Ordinal) ||
+            !string.Equals(Uri, uri, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("The browser navigation values changed during host initialization.");
+        }
+    }
+
     public void CreateLogger(ILoggerFactory loggerFactory)
     {
         if (_logger is not null)

--- a/src/Components/WebAssembly/WebAssembly/src/Services/WebAssemblyNavigationManager.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Services/WebAssemblyNavigationManager.cs
@@ -21,20 +21,18 @@ internal sealed partial class WebAssemblyNavigationManager : NavigationManager
     /// </summary>
     public static WebAssemblyNavigationManager Instance { get; set; } = default!;
 
-    public WebAssemblyNavigationManager(string baseUri, string uri)
-    {
-        Initialize(baseUri, uri);
-    }
-
     internal void InitializeNavigation(string baseUri, string uri)
+        => Initialize(baseUri, uri);
+
+    internal static string NormalizeBaseUriForHostEnvironment(string baseUri)
     {
         var lastSlashIndex = baseUri.LastIndexOf('/');
-        var normalizedBaseUri = lastSlashIndex >= 0 ? baseUri[..(lastSlashIndex + 1)] : baseUri;
-        if (!string.Equals(BaseUri, normalizedBaseUri, StringComparison.Ordinal) ||
-            !string.Equals(Uri, uri, StringComparison.Ordinal))
+        if (lastSlashIndex >= 0)
         {
-            throw new InvalidOperationException("The browser navigation values changed during host initialization.");
+            baseUri = baseUri[..(lastSlashIndex + 1)];
         }
+
+        return baseUri;
     }
 
     public void CreateLogger(ILoggerFactory loggerFactory)

--- a/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyHostBuilderTest.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyHostBuilderTest.cs
@@ -133,7 +133,7 @@ public class WebAssemblyHostBuilderTest
     }
 
     [Fact]
-    public void Builder_CreatesNavigationManager()
+    public void Builder_CreatesNavigationManagerThatIsUsableBeforeRunAsync()
     {
         // Arrange
         var builder = new WebAssemblyHostBuilder(new TestInternalJSImportMethods(environment: "Development"));
@@ -143,8 +143,8 @@ public class WebAssemblyHostBuilderTest
 
         // Assert
         var navigationManager = host.Services.GetRequiredService<NavigationManager>();
-        Assert.NotNull(navigationManager);
         Assert.Equal("https://www.example.com/", navigationManager.BaseUri);
+        Assert.Equal(navigationManager.BaseUri, builder.HostEnvironment.BaseAddress);
         Assert.Equal("https://www.example.com/awesome-part-that-will-be-truncated-in-tests/cool", navigationManager.Uri);
     }
 

--- a/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyHostTest.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyHostTest.cs
@@ -131,10 +131,12 @@ public class WebAssemblyHostTest
             }));
         var host = builder.Build();
         navigationManager = host.Services.GetRequiredService<NavigationManager>();
+        var initializerCollection = host.Services.GetRequiredService<HostInitializerCollection>();
 
         await host.RunAsyncCore(cancellationTokenSource.Token, new TestSatelliteResourcesLoader());
 
         Assert.Equal(["lower", "first-tie", "second-tie", "navigation"], calls);
+        Assert.Same(initializerCollection, host.Services.GetRequiredService<HostInitializerCollection>());
     }
 
     [Fact]
@@ -439,7 +441,7 @@ public class WebAssemblyHostTest
 
         public bool RequiresJSInterop => requiresJSInterop;
 
-        public Task InitializeAsync(CancellationToken cancellationToken = default)
+        public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
         {
             calls.Add(name);
             callback?.Invoke(cancellationToken);

--- a/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyHostTest.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyHostTest.cs
@@ -4,6 +4,7 @@
 using System.Globalization;
 using System.Text.Json;
 using Microsoft.AspNetCore.Components.Hosting;
+using Microsoft.AspNetCore.Components.WebAssembly.Services;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -23,7 +24,7 @@ public class WebAssemblyHostTest
     }
 
     [Fact]
-    public async Task RunAsyncCollectsAndInitializesBrowserStartupValues()
+    public async Task BuildCollectsStartupValuesAndInitializesNavigationBeforeReturning()
     {
         var jsMethods = new TestInternalJSImportMethods
         {
@@ -35,38 +36,60 @@ public class WebAssemblyHostTest
         builder.Services.AddSingleton<IBrowserStartupValueProvider>(
             new TestBrowserStartupValueProvider("custom.value"));
         var host = builder.Build();
-        var cts = new CancellationTokenSource();
-
-        var task = host.RunAsyncCore(cts.Token, new TestSatelliteResourcesLoader());
-        cts.Cancel();
-        await task.TimeoutAfter(TimeSpan.FromSeconds(3));
-
         var keys = JsonSerializer.Deserialize<string[]>(jsMethods.HostStartupValueKeysJson);
         Assert.Equal(["document.baseURI", "location.href", "custom.value"], keys);
         Assert.Equal(
             "expected",
             host.Services.GetRequiredService<IHostStartupValues>().GetRequired("custom.value"));
+        var navigationManager = host.Services.GetRequiredService<NavigationManager>();
+        Assert.Equal("https://www.example.com/", navigationManager.BaseUri);
+        Assert.Equal(
+            "https://www.example.com/awesome-part-that-will-be-truncated-in-tests/cool",
+            navigationManager.Uri);
+        Assert.Same(WebAssemblyNavigationManager.Instance, navigationManager);
+
+        await host.DisposeAsync();
     }
 
     [Fact]
-    public async Task RunAsyncRejectsNavigationValuesThatChangedAfterBuild()
+    public async Task BuildStartsAsyncInitializerAndRunAwaitsIt()
     {
-        var jsMethods = new TestInternalJSImportMethods
-        {
-            HostStartupValuesJson =
-                """{"document.baseURI":"https://www.example.com/other/","location.href":"https://www.example.com/other/page"}""",
-        };
-        var builder = new WebAssemblyHostBuilder(jsMethods);
+        var initializerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueInitializer = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var calls = new List<string>();
+        var builder = new WebAssemblyHostBuilder(new TestInternalJSImportMethods());
+        builder.Services.AddSingleton(Mock.Of<IJSRuntime>());
+        builder.Services.AddSingleton<IHostInitializer>(
+            new TestHostInitializer(
+                "async",
+                0,
+                calls,
+                asyncCallback: _ =>
+                {
+                    initializerStarted.SetResult();
+                    return continueInitializer.Task;
+                }));
+
         var host = builder.Build();
+        await initializerStarted.Task;
+        var navigationManager = host.Services.GetRequiredService<NavigationManager>();
+        using var cancellationTokenSource = new CancellationTokenSource();
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => host.RunAsyncCore(CancellationToken.None, new TestSatelliteResourcesLoader()));
+        var runTask = host.RunAsyncCore(
+            cancellationTokenSource.Token,
+            new TestSatelliteResourcesLoader());
 
-        Assert.Equal("The browser navigation values changed during host initialization.", exception.Message);
+        Assert.False(runTask.IsCompleted);
+        Assert.Equal("https://www.example.com/", navigationManager.BaseUri);
+        continueInitializer.SetResult();
+        await Task.Yield();
+        cancellationTokenSource.Cancel();
+        await runTask.TimeoutAfter(TimeSpan.FromSeconds(3));
+        Assert.Equal(["async"], calls);
     }
 
     [Fact]
-    public async Task RunAsyncRejectsDuplicateBrowserStartupValueKeysBeforeJSImport()
+    public void BuildRejectsDuplicateBrowserStartupValueKeysBeforeJSImport()
     {
         var jsMethods = new TestInternalJSImportMethods();
         var builder = new WebAssemblyHostBuilder(jsMethods);
@@ -74,10 +97,7 @@ public class WebAssemblyHostTest
             new TestBrowserStartupValueProvider("duplicate.value"));
         builder.Services.AddSingleton<IBrowserStartupValueProvider>(
             new TestBrowserStartupValueProvider("duplicate.value"));
-        var host = builder.Build();
-
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => host.RunAsyncCore(CancellationToken.None, new TestSatelliteResourcesLoader()));
+        var exception = Assert.Throws<InvalidOperationException>(builder.Build);
 
         Assert.Equal(
             "The browser startup value key 'duplicate.value' was provided more than once.",
@@ -90,57 +110,38 @@ public class WebAssemblyHostTest
     [InlineData("""{"document.baseURI":"base"}""")]
     [InlineData("""{"document.baseURI":42,"location.href":"uri"}""")]
     [InlineData("""{"document.baseURI":"first","document.baseURI":"second","location.href":"uri"}""")]
-    public async Task RunAsyncRejectsInvalidBrowserStartupValues(string startupValuesJson)
+    public void BuildRejectsInvalidBrowserStartupValues(string startupValuesJson)
     {
         var jsMethods = new TestInternalJSImportMethods
         {
             HostStartupValuesJson = startupValuesJson,
         };
         var builder = new WebAssemblyHostBuilder(jsMethods);
-        var host = builder.Build();
-
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => host.RunAsyncCore(CancellationToken.None, new TestSatelliteResourcesLoader()));
+        var exception = Assert.Throws<InvalidOperationException>(builder.Build);
 
         Assert.Equal("The browser returned invalid host startup values.", exception.Message);
     }
 
     [Fact]
-    public async Task RunAsyncRunsHostInitializersInStableOrderIncludingJSInterop()
+    public async Task BuildRunsHostThenBrowserPhasesInOrder()
     {
         var calls = new List<string>();
-        using var cancellationTokenSource = new CancellationTokenSource();
-        NavigationManager navigationManager = null;
         var builder = new WebAssemblyHostBuilder(new TestInternalJSImportMethods());
         builder.Services.AddSingleton(Mock.Of<IJSRuntime>());
         builder.Services.AddSingleton<IHostInitializer>(
             new TestHostInitializer("lower", -100, calls));
         builder.Services.AddSingleton<IHostInitializer>(
-            new TestHostInitializer("first-tie", 0, calls));
+            new TestHostInitializer("middle", 0, calls));
         builder.Services.AddSingleton<IHostInitializer>(
-            new TestHostInitializer("second-tie", 0, calls, requiresJSInterop: true));
-        builder.Services.AddSingleton<IHostInitializer>(
-            new TestHostInitializer("navigation", 100, calls, callback: token =>
-            {
-                Assert.Equal(cancellationTokenSource.Token, token);
-                Assert.Equal("https://www.example.com/", navigationManager!.BaseUri);
-                Assert.Equal(
-                    "https://www.example.com/awesome-part-that-will-be-truncated-in-tests/cool",
-                    navigationManager.Uri);
-                cancellationTokenSource.Cancel();
-            }));
+            new TestHostInitializer("browser", 100, calls, browserPhase: true));
         var host = builder.Build();
-        navigationManager = host.Services.GetRequiredService<NavigationManager>();
-        var initializerCollection = host.Services.GetRequiredService<HostInitializerCollection>();
 
-        await host.RunAsyncCore(cancellationTokenSource.Token, new TestSatelliteResourcesLoader());
-
-        Assert.Equal(["lower", "first-tie", "second-tie", "navigation"], calls);
-        Assert.Same(initializerCollection, host.Services.GetRequiredService<HostInitializerCollection>());
+        Assert.Equal(["lower", "middle", "browser"], calls);
+        await host.DisposeAsync();
     }
 
     [Fact]
-    public async Task RunAsyncStopsAndSurfacesHostInitializerFailure()
+    public void BuildSurfacesSynchronousHostInitializerFailure()
     {
         var calls = new List<string>();
         var builder = new WebAssemblyHostBuilder(new TestInternalJSImportMethods());
@@ -148,39 +149,195 @@ public class WebAssemblyHostTest
             new TestHostInitializer("failure", -300, calls, exception: new InvalidOperationException("Initializer failed.")));
         builder.Services.AddSingleton<IHostInitializer>(
             new TestHostInitializer("not-run", -200, calls));
-        var host = builder.Build();
-
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            host.RunAsyncCore(CancellationToken.None, new TestSatelliteResourcesLoader()));
+        var exception = Assert.Throws<InvalidOperationException>(builder.Build);
 
         Assert.Equal("Initializer failed.", exception.Message);
         Assert.Equal(["failure"], calls);
     }
 
     [Fact]
-    public async Task RunAsyncStopsAndSurfacesHostInitializerCancellation()
+    public async Task BuildFailureCancelsInitializationAndDisposesCreatedServicesAsynchronously()
+    {
+        var cleanupFailure = new InvalidOperationException("Cleanup failed.");
+        var scopedDisposable = new AsyncOnlyDisposableService(cleanupFailure);
+        var singletonDisposable = new AsyncOnlyDisposableService();
+        var failure = new InvalidOperationException("Initializer failed.");
+        CancellationToken initializationToken = default;
+        var builder = new WebAssemblyHostBuilder(new TestInternalJSImportMethods());
+        builder.Services.AddScoped(_ => scopedDisposable);
+        builder.Services.AddSingleton(_ => singletonDisposable);
+        builder.Services.AddSingleton<IHostInitializer>(
+            new TestHostInitializer(
+                "failure",
+                0,
+                [],
+                exception: failure,
+                servicesCallback: (services, token) =>
+                {
+                    initializationToken = token;
+                    _ = services.GetServices<AsyncOnlyDisposableService>().ToArray();
+                }));
+
+        var exception = Assert.Throws<InvalidOperationException>(builder.Build);
+
+        Assert.Same(failure, exception);
+        Assert.True(initializationToken.IsCancellationRequested);
+
+        await scopedDisposable.DisposeStarted.Task.TimeoutAfter(TimeSpan.FromSeconds(3));
+        Assert.False(singletonDisposable.DisposeStarted.Task.IsCompleted);
+        scopedDisposable.ContinueDisposal();
+        await scopedDisposable.DisposeCompleted.Task.TimeoutAfter(TimeSpan.FromSeconds(3));
+
+        await singletonDisposable.DisposeStarted.Task.TimeoutAfter(TimeSpan.FromSeconds(3));
+        singletonDisposable.ContinueDisposal();
+        await singletonDisposable.DisposeCompleted.Task.TimeoutAfter(TimeSpan.FromSeconds(3));
+    }
+
+    [Fact]
+    public void BuildRejectsBaseUriThatChangedSinceBuilderCreation()
+    {
+        var jsMethods = new TestInternalJSImportMethods();
+        var builder = new WebAssemblyHostBuilder(jsMethods);
+        jsMethods.HostStartupValuesJson =
+            """{"document.baseURI":"https://www.example.com/other/","location.href":"https://www.example.com/other/page"}""";
+
+        var exception = Assert.Throws<InvalidOperationException>(builder.Build);
+
+        Assert.Equal("The browser base URI changed during host initialization.", exception.Message);
+    }
+
+    [Fact]
+    public async Task RunCancellationCancelsBuildTimeInitialization()
     {
         var calls = new List<string>();
         using var cancellationTokenSource = new CancellationTokenSource();
         var builder = new WebAssemblyHostBuilder(new TestInternalJSImportMethods());
+        var initializerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         builder.Services.AddSingleton<IHostInitializer>(
-            new TestHostInitializer("canceled", -300, calls, callback: token =>
-            {
-                cancellationTokenSource.Cancel();
-                token.ThrowIfCancellationRequested();
-            }));
-        builder.Services.AddSingleton<IHostInitializer>(
-            new TestHostInitializer("not-run", -200, calls));
+            new TestHostInitializer(
+                "canceled",
+                -300,
+                calls,
+                asyncCallback: async token =>
+                {
+                    initializerStarted.SetResult();
+                    await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                }));
         var host = builder.Build();
+        await initializerStarted.Task;
+        var runTask = host.RunAsyncCore(
+            cancellationTokenSource.Token,
+            new TestSatelliteResourcesLoader());
 
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
-            host.RunAsyncCore(cancellationTokenSource.Token, new TestSatelliteResourcesLoader()));
+        cancellationTokenSource.Cancel();
 
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => runTask);
         Assert.Equal(["canceled"], calls);
+        await host.DisposeAsync();
     }
 
     [Fact]
-    public void HostEnvironmentBaseAddressIsAvailableBeforeRunAsync()
+    public async Task DisposeCancelsAndObservesBuildTimeInitialization()
+    {
+        var initializerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        CancellationToken initializationToken = default;
+        var builder = new WebAssemblyHostBuilder(new TestInternalJSImportMethods());
+        builder.Services.AddSingleton<IHostInitializer>(
+            new TestHostInitializer(
+                "initializer",
+                0,
+                [],
+                asyncCallback: async token =>
+                {
+                    initializationToken = token;
+                    initializerStarted.SetResult();
+                    await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                }));
+
+        var host = builder.Build();
+        await initializerStarted.Task;
+
+        await host.DisposeAsync();
+
+        Assert.True(initializationToken.IsCancellationRequested);
+    }
+
+    [Fact]
+    public async Task DisposeWaitsForCancellationIgnoringInitializationBeforeDisposingServices()
+    {
+        var initializerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueInitializer = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        CancellationToken initializationToken = default;
+        var hostedServiceResolved = false;
+        var hostedService = new TestHostedService();
+        var builder = new WebAssemblyHostBuilder(new TestInternalJSImportMethods());
+        builder.Services.AddSingleton(Mock.Of<IJSRuntime>());
+        builder.Services.AddSingleton<IHostInitializer>(
+            new TestHostInitializer(
+                "initializer",
+                0,
+                [],
+                asyncCallback: token =>
+                {
+                    initializationToken = token;
+                    initializerStarted.SetResult();
+                    return continueInitializer.Task;
+                }));
+        builder.Services.AddScoped<IHostedService>(_ =>
+        {
+            hostedServiceResolved = true;
+            return hostedService;
+        });
+
+        var host = builder.Build();
+        await initializerStarted.Task;
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var runTask = host.RunAsyncCore(
+            cancellationTokenSource.Token,
+            new TestSatelliteResourcesLoader());
+
+        var disposeTask = host.DisposeAsync().AsTask();
+
+        Assert.True(initializationToken.IsCancellationRequested);
+        Assert.False(disposeTask.IsCompleted);
+        Assert.False(hostedServiceResolved);
+        Assert.False(hostedService.StartCalled);
+
+        continueInitializer.SetResult();
+        await disposeTask.TimeoutAfter(TimeSpan.FromSeconds(3));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => runTask);
+
+        Assert.False(hostedServiceResolved);
+        Assert.False(hostedService.StartCalled);
+
+        cancellationTokenSource.Cancel();
+    }
+
+    [Fact]
+    public async Task RunAndDisposeSurfaceAsynchronousInitializationFailure()
+    {
+        var failInitializer = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var failure = new InvalidOperationException("Initializer failed asynchronously.");
+        var builder = new WebAssemblyHostBuilder(new TestInternalJSImportMethods());
+        builder.Services.AddSingleton<IHostInitializer>(
+            new TestHostInitializer(
+                "initializer",
+                0,
+                [],
+                asyncCallback: _ => failInitializer.Task));
+        var host = builder.Build();
+        var runTask = host.RunAsyncCore(CancellationToken.None, new TestSatelliteResourcesLoader());
+
+        failInitializer.SetException(failure);
+
+        Assert.Same(failure, await Assert.ThrowsAsync<InvalidOperationException>(() => runTask));
+        Assert.Same(
+            failure,
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await host.DisposeAsync()));
+    }
+
+    [Fact]
+    public void HostEnvironmentBaseAddressIsNormalizedBeforeBuild()
     {
         var builder = new WebAssemblyHostBuilder(new TestInternalJSImportMethods());
 
@@ -283,7 +440,8 @@ public class WebAssemblyHostTest
 
         // Assert
         Assert.True(testHostedService.StartCalled);
-        Assert.Equal(cts.Token, testHostedService.StartToken);
+        Assert.NotEqual(cts.Token, testHostedService.StartToken);
+        Assert.True(testHostedService.StartToken.IsCancellationRequested);
     }
 
     [Fact]
@@ -433,20 +591,55 @@ public class WebAssemblyHostTest
         string name,
         int order,
         List<string> calls,
-        bool requiresJSInterop = false,
+        bool browserPhase = false,
         Exception exception = null,
-        Action<CancellationToken> callback = null) : IHostInitializer
+        Action<CancellationToken> callback = null,
+        Func<CancellationToken, Task> asyncCallback = null,
+        Action<IServiceProvider, CancellationToken> servicesCallback = null) : IHostInitializer
     {
         public int Order => order;
 
-        public bool RequiresJSInterop => requiresJSInterop;
+        public Task InitializeHostAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+            => browserPhase ? Task.CompletedTask : Invoke(services, cancellationToken);
 
-        public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+        public Task InitializeBrowserAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+            => browserPhase ? Invoke(services, cancellationToken) : Task.CompletedTask;
+
+        private Task Invoke(IServiceProvider services, CancellationToken cancellationToken)
         {
             calls.Add(name);
             callback?.Invoke(cancellationToken);
+            servicesCallback?.Invoke(services, cancellationToken);
 
-            return exception is null ? Task.CompletedTask : Task.FromException(exception);
+            return exception is not null
+                ? Task.FromException(exception)
+                : asyncCallback?.Invoke(cancellationToken) ?? Task.CompletedTask;
+        }
+    }
+
+    private sealed class AsyncOnlyDisposableService(Exception disposeException = null) : IAsyncDisposable
+    {
+        private readonly TaskCompletionSource _continueDisposal =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource DisposeStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource DisposeCompleted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void ContinueDisposal() => _continueDisposal.SetResult();
+
+        public async ValueTask DisposeAsync()
+        {
+            DisposeStarted.SetResult();
+            await _continueDisposal.Task;
+            DisposeCompleted.SetResult();
+
+            if (disposeException is not null)
+            {
+                throw disposeException;
+            }
         }
     }
 

--- a/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyHostTest.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyHostTest.cs
@@ -3,6 +3,7 @@
 
 using System.Globalization;
 using System.Text.Json;
+using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -13,6 +14,80 @@ namespace Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 
 public class WebAssemblyHostTest
 {
+    [Fact]
+    public void HostStartupValuesRejectsNullKeyBeforeInitialization()
+    {
+        var startupValues = new InteractiveHostStartupValues();
+
+        Assert.Throws<ArgumentNullException>(() => startupValues.GetValue(null!));
+    }
+
+    [Fact]
+    public async Task RunAsyncCollectsAndInitializesBrowserStartupValues()
+    {
+        var jsMethods = new TestInternalJSImportMethods
+        {
+            HostStartupValuesJson =
+                """{"document.baseURI":"https://www.example.com/","location.href":"https://www.example.com/page","custom.value":"expected"}""",
+        };
+        var builder = new WebAssemblyHostBuilder(jsMethods);
+        builder.Services.AddSingleton(Mock.Of<IJSRuntime>());
+        builder.Services.AddSingleton<IBrowserStartupValueProvider>(
+            new TestBrowserStartupValueProvider("custom.value"));
+        var host = builder.Build();
+        var cts = new CancellationTokenSource();
+
+        var task = host.RunAsyncCore(cts.Token, new TestSatelliteResourcesLoader());
+        cts.Cancel();
+        await task.TimeoutAfter(TimeSpan.FromSeconds(3));
+
+        var keys = JsonSerializer.Deserialize<string[]>(jsMethods.HostStartupValueKeysJson);
+        Assert.Equal(["document.baseURI", "location.href", "custom.value"], keys);
+        Assert.Equal(
+            "expected",
+            host.Services.GetRequiredService<IHostStartupValues>().GetRequired("custom.value"));
+    }
+
+    [Fact]
+    public async Task RunAsyncRejectsDuplicateBrowserStartupValueKeysBeforeJSImport()
+    {
+        var jsMethods = new TestInternalJSImportMethods();
+        var builder = new WebAssemblyHostBuilder(jsMethods);
+        builder.Services.AddSingleton<IBrowserStartupValueProvider>(
+            new TestBrowserStartupValueProvider("duplicate.value"));
+        builder.Services.AddSingleton<IBrowserStartupValueProvider>(
+            new TestBrowserStartupValueProvider("duplicate.value"));
+        var host = builder.Build();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => host.RunAsyncCore(CancellationToken.None, new TestSatelliteResourcesLoader()));
+
+        Assert.Equal(
+            "The browser startup value key 'duplicate.value' was provided more than once.",
+            exception.Message);
+        Assert.Empty(jsMethods.HostStartupValueKeysJson);
+    }
+
+    [Theory]
+    [InlineData("""{"document.baseURI":"base","location.href":"uri","unexpected":"value"}""")]
+    [InlineData("""{"document.baseURI":"base"}""")]
+    [InlineData("""{"document.baseURI":42,"location.href":"uri"}""")]
+    [InlineData("""{"document.baseURI":"first","document.baseURI":"second","location.href":"uri"}""")]
+    public async Task RunAsyncRejectsInvalidBrowserStartupValues(string startupValuesJson)
+    {
+        var jsMethods = new TestInternalJSImportMethods
+        {
+            HostStartupValuesJson = startupValuesJson,
+        };
+        var builder = new WebAssemblyHostBuilder(jsMethods);
+        var host = builder.Build();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => host.RunAsyncCore(CancellationToken.None, new TestSatelliteResourcesLoader()));
+
+        Assert.Equal("The browser returned invalid host startup values.", exception.Message);
+    }
+
     // This won't happen in the product code, but we need to be able to safely call RunAsync
     // to be able to test a few of the other details.
     [Fact]
@@ -208,6 +283,11 @@ public class WebAssemblyHostTest
         var testService = hostedServices.First();
         Assert.IsType<TestHostedService>(testService);
         Assert.True(((TestHostedService)testService).StartCalled);
+    }
+
+    private sealed class TestBrowserStartupValueProvider(params string[] keys) : IBrowserStartupValueProvider
+    {
+        public IReadOnlyList<string> Keys { get; } = keys;
     }
 
     private class TestHostedService : IHostedService

--- a/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyHostTest.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/Hosting/WebAssemblyHostTest.cs
@@ -28,7 +28,7 @@ public class WebAssemblyHostTest
         var jsMethods = new TestInternalJSImportMethods
         {
             HostStartupValuesJson =
-                """{"document.baseURI":"https://www.example.com/","location.href":"https://www.example.com/page","custom.value":"expected"}""",
+                """{"document.baseURI":"https://www.example.com/awesome-part-that-will-be-truncated-in-tests","location.href":"https://www.example.com/awesome-part-that-will-be-truncated-in-tests/cool","custom.value":"expected"}""",
         };
         var builder = new WebAssemblyHostBuilder(jsMethods);
         builder.Services.AddSingleton(Mock.Of<IJSRuntime>());
@@ -46,6 +46,23 @@ public class WebAssemblyHostTest
         Assert.Equal(
             "expected",
             host.Services.GetRequiredService<IHostStartupValues>().GetRequired("custom.value"));
+    }
+
+    [Fact]
+    public async Task RunAsyncRejectsNavigationValuesThatChangedAfterBuild()
+    {
+        var jsMethods = new TestInternalJSImportMethods
+        {
+            HostStartupValuesJson =
+                """{"document.baseURI":"https://www.example.com/other/","location.href":"https://www.example.com/other/page"}""",
+        };
+        var builder = new WebAssemblyHostBuilder(jsMethods);
+        var host = builder.Build();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => host.RunAsyncCore(CancellationToken.None, new TestSatelliteResourcesLoader()));
+
+        Assert.Equal("The browser navigation values changed during host initialization.", exception.Message);
     }
 
     [Fact]
@@ -86,6 +103,86 @@ public class WebAssemblyHostTest
             () => host.RunAsyncCore(CancellationToken.None, new TestSatelliteResourcesLoader()));
 
         Assert.Equal("The browser returned invalid host startup values.", exception.Message);
+    }
+
+    [Fact]
+    public async Task RunAsyncRunsHostInitializersInStableOrderIncludingJSInterop()
+    {
+        var calls = new List<string>();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        NavigationManager navigationManager = null;
+        var builder = new WebAssemblyHostBuilder(new TestInternalJSImportMethods());
+        builder.Services.AddSingleton(Mock.Of<IJSRuntime>());
+        builder.Services.AddSingleton<IHostInitializer>(
+            new TestHostInitializer("lower", -100, calls));
+        builder.Services.AddSingleton<IHostInitializer>(
+            new TestHostInitializer("first-tie", 0, calls));
+        builder.Services.AddSingleton<IHostInitializer>(
+            new TestHostInitializer("second-tie", 0, calls, requiresJSInterop: true));
+        builder.Services.AddSingleton<IHostInitializer>(
+            new TestHostInitializer("navigation", 100, calls, callback: token =>
+            {
+                Assert.Equal(cancellationTokenSource.Token, token);
+                Assert.Equal("https://www.example.com/", navigationManager!.BaseUri);
+                Assert.Equal(
+                    "https://www.example.com/awesome-part-that-will-be-truncated-in-tests/cool",
+                    navigationManager.Uri);
+                cancellationTokenSource.Cancel();
+            }));
+        var host = builder.Build();
+        navigationManager = host.Services.GetRequiredService<NavigationManager>();
+
+        await host.RunAsyncCore(cancellationTokenSource.Token, new TestSatelliteResourcesLoader());
+
+        Assert.Equal(["lower", "first-tie", "second-tie", "navigation"], calls);
+    }
+
+    [Fact]
+    public async Task RunAsyncStopsAndSurfacesHostInitializerFailure()
+    {
+        var calls = new List<string>();
+        var builder = new WebAssemblyHostBuilder(new TestInternalJSImportMethods());
+        builder.Services.AddSingleton<IHostInitializer>(
+            new TestHostInitializer("failure", -300, calls, exception: new InvalidOperationException("Initializer failed.")));
+        builder.Services.AddSingleton<IHostInitializer>(
+            new TestHostInitializer("not-run", -200, calls));
+        var host = builder.Build();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            host.RunAsyncCore(CancellationToken.None, new TestSatelliteResourcesLoader()));
+
+        Assert.Equal("Initializer failed.", exception.Message);
+        Assert.Equal(["failure"], calls);
+    }
+
+    [Fact]
+    public async Task RunAsyncStopsAndSurfacesHostInitializerCancellation()
+    {
+        var calls = new List<string>();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var builder = new WebAssemblyHostBuilder(new TestInternalJSImportMethods());
+        builder.Services.AddSingleton<IHostInitializer>(
+            new TestHostInitializer("canceled", -300, calls, callback: token =>
+            {
+                cancellationTokenSource.Cancel();
+                token.ThrowIfCancellationRequested();
+            }));
+        builder.Services.AddSingleton<IHostInitializer>(
+            new TestHostInitializer("not-run", -200, calls));
+        var host = builder.Build();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            host.RunAsyncCore(cancellationTokenSource.Token, new TestSatelliteResourcesLoader()));
+
+        Assert.Equal(["canceled"], calls);
+    }
+
+    [Fact]
+    public void HostEnvironmentBaseAddressIsAvailableBeforeRunAsync()
+    {
+        var builder = new WebAssemblyHostBuilder(new TestInternalJSImportMethods());
+
+        Assert.Equal("https://www.example.com/", builder.HostEnvironment.BaseAddress);
     }
 
     // This won't happen in the product code, but we need to be able to safely call RunAsync
@@ -327,6 +424,27 @@ public class WebAssemblyHostTest
         {
             StopCalled = true;
             throw new InvalidOperationException("Simulated hosted service stop error");
+        }
+    }
+
+    private sealed class TestHostInitializer(
+        string name,
+        int order,
+        List<string> calls,
+        bool requiresJSInterop = false,
+        Exception exception = null,
+        Action<CancellationToken> callback = null) : IHostInitializer
+    {
+        public int Order => order;
+
+        public bool RequiresJSInterop => requiresJSInterop;
+
+        public Task InitializeAsync(CancellationToken cancellationToken = default)
+        {
+            calls.Add(name);
+            callback?.Invoke(cancellationToken);
+
+            return exception is null ? Task.CompletedTask : Task.FromException(exception);
         }
     }
 

--- a/src/Components/WebAssembly/WebAssembly/test/TestInternalJSImportMethods.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/TestInternalJSImportMethods.cs
@@ -9,6 +9,11 @@ internal sealed class TestInternalJSImportMethods : IInternalJSImportMethods
 {
     private readonly string _environment;
 
+    public string HostStartupValuesJson { get; set; } =
+        """{"document.baseURI":"https://www.example.com/awesome-part-that-will-be-truncated-in-tests","location.href":"https://www.example.com/awesome-part-that-will-be-truncated-in-tests/cool"}""";
+
+    public string HostStartupValueKeysJson { get; private set; } = string.Empty;
+
     public TestInternalJSImportMethods(string environment = "Production")
     {
         _environment = environment;
@@ -19,6 +24,12 @@ internal sealed class TestInternalJSImportMethods : IInternalJSImportMethods
     
     public string GetApplicationCulture()
         => "en-US";
+
+    public string GetHostStartupValues(string keysJson)
+    {
+        HostStartupValueKeysJson = keysJson;
+        return HostStartupValuesJson;
+    }
 
     public string GetPersistedState()
         => null;

--- a/src/Components/test/E2ETest/ServerRenderingTests/InteractivityTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/InteractivityTest.cs
@@ -42,6 +42,25 @@ public class InteractivityTest : ServerTestBase<BasicTestAppServerSiteFixture<Ra
     }
 
     [Fact]
+    public void HostInitializersRunBeforeInteractiveServerRendering()
+    {
+        Navigate($"{ServerPathBase}/host-initialization");
+
+        Browser.Equal("Server:True", () => Browser.FindElement(By.Id("host-initialization-renderer")).Text);
+        Browser.True(() =>
+        {
+            var events = Browser.FindElements(By.CssSelector("#host-initialization-events li"));
+            return events.Count == 2 &&
+                events[0].Text.StartsWith("values:", StringComparison.Ordinal) &&
+                events[0].Text != "values:-" &&
+                events[1].Text == "js-ready";
+        });
+
+        Browser.Click(By.Id("host-initialization-click"));
+        Browser.Equal("1", () => Browser.FindElement(By.Id("host-initialization-click-count")).Text);
+    }
+
+    [Fact]
     public void CanRenderInteractiveServerComponentFromRazorClassLibrary()
     {
         // '3' configures the increment amount.

--- a/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
@@ -13,6 +13,7 @@ using Components.TestServer.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Endpoints;
+using Microsoft.AspNetCore.Components.Hosting;
 using Microsoft.AspNetCore.Components.Server.Circuits;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Localization;
@@ -127,6 +128,10 @@ public class RazorComponentEndpointsStartup<TRootComponent>
         services.AddScoped<InteractiveWebAssemblyService>();
         services.AddScoped<InteractiveServerService>();
         services.AddScoped<InteractiveAutoService>();
+        services.AddScoped<HostInitializationState>();
+        services.AddScoped<IBrowserStartupValueProvider, TestBrowserStartupValueProvider>();
+        services.AddScoped<IHostInitializer, StartupValuesHostInitializer>();
+        services.AddScoped<IHostInitializer, JSReadyHostInitializer>();
 
         // Register custom serializer for E2E testing of persistent component state serialization extensibility
         services.AddSingleton<PersistentComponentStateSerializer<int>, CustomIntSerializer>();

--- a/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponentEndpointsStartup.cs
@@ -129,9 +129,9 @@ public class RazorComponentEndpointsStartup<TRootComponent>
         services.AddScoped<InteractiveServerService>();
         services.AddScoped<InteractiveAutoService>();
         services.AddScoped<HostInitializationState>();
-        services.AddScoped<IBrowserStartupValueProvider, TestBrowserStartupValueProvider>();
-        services.AddScoped<IHostInitializer, StartupValuesHostInitializer>();
-        services.AddScoped<IHostInitializer, JSReadyHostInitializer>();
+        services.AddSingleton<IBrowserStartupValueProvider, TestBrowserStartupValueProvider>();
+        services.AddSingleton<IHostInitializer, StartupValuesHostInitializer>();
+        services.AddSingleton<IHostInitializer, JSReadyHostInitializer>();
 
         // Register custom serializer for E2E testing of persistent component state serialization extensibility
         services.AddSingleton<PersistentComponentStateSerializer<int>, CustomIntSerializer>();

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/HostInitializationServices.cs
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/HostInitializationServices.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Components.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Components.TestServer.RazorComponents;
 
@@ -16,29 +17,30 @@ internal sealed class TestBrowserStartupValueProvider : IBrowserStartupValueProv
     public IReadOnlyList<string> Keys { get; } = ["navigator.language"];
 }
 
-internal sealed class StartupValuesHostInitializer(
-    IHostStartupValues startupValues,
-    HostInitializationState state) : IHostInitializer
+internal sealed class StartupValuesHostInitializer : IHostInitializer
 {
     public int Order => -100;
 
-    public Task InitializeAsync(CancellationToken cancellationToken = default)
+    public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        var startupValues = services.GetRequiredService<IHostStartupValues>();
+        var state = services.GetRequiredService<HostInitializationState>();
         state.Events.Add($"values:{startupValues.GetValue("navigator.language") ?? "-"}");
 
         return Task.CompletedTask;
     }
 }
 
-internal sealed class JSReadyHostInitializer(HostInitializationState state) : IHostInitializer
+internal sealed class JSReadyHostInitializer : IHostInitializer
 {
     public int Order => 100;
     public bool RequiresJSInterop => true;
 
-    public Task InitializeAsync(CancellationToken cancellationToken = default)
+    public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
+        var state = services.GetRequiredService<HostInitializationState>();
         state.Events.Add("js-ready");
 
         return Task.CompletedTask;

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/HostInitializationServices.cs
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/HostInitializationServices.cs
@@ -19,9 +19,9 @@ internal sealed class TestBrowserStartupValueProvider : IBrowserStartupValueProv
 
 internal sealed class StartupValuesHostInitializer : IHostInitializer
 {
-    public int Order => -100;
+    public int Order => -75;
 
-    public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+    public Task InitializeHostAsync(IServiceProvider services, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         var startupValues = services.GetRequiredService<IHostStartupValues>();
@@ -35,9 +35,8 @@ internal sealed class StartupValuesHostInitializer : IHostInitializer
 internal sealed class JSReadyHostInitializer : IHostInitializer
 {
     public int Order => 100;
-    public bool RequiresJSInterop => true;
 
-    public Task InitializeAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+    public Task InitializeBrowserAsync(IServiceProvider services, CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         var state = services.GetRequiredService<HostInitializationState>();

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/HostInitializationServices.cs
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/HostInitializationServices.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Components.Hosting;
+
+namespace Components.TestServer.RazorComponents;
+
+public sealed class HostInitializationState
+{
+    public List<string> Events { get; } = [];
+    public int ClickCount { get; set; }
+}
+
+internal sealed class TestBrowserStartupValueProvider : IBrowserStartupValueProvider
+{
+    public IReadOnlyList<string> Keys { get; } = ["navigator.language"];
+}
+
+internal sealed class StartupValuesHostInitializer(
+    IHostStartupValues startupValues,
+    HostInitializationState state) : IHostInitializer
+{
+    public int Order => -100;
+
+    public Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        state.Events.Add($"values:{startupValues.GetValue("navigator.language") ?? "-"}");
+
+        return Task.CompletedTask;
+    }
+}
+
+internal sealed class JSReadyHostInitializer(HostInitializationState state) : IHostInitializer
+{
+    public int Order => 100;
+    public bool RequiresJSInterop => true;
+
+    public Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        state.Events.Add("js-ready");
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/HostInitialization.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/HostInitialization.razor
@@ -1,0 +1,22 @@
+@page "/host-initialization"
+@rendermode RenderMode.InteractiveServer
+@inject HostInitializationState State
+
+<h1>Host initialization</h1>
+
+<p id="host-initialization-renderer">@RendererInfo.Name:@RendererInfo.IsInteractive</p>
+<ol id="host-initialization-events">
+    @foreach (var entry in State.Events)
+    {
+        <li>@entry</li>
+    }
+</ol>
+<p id="host-initialization-click-count">@State.ClickCount</p>
+<button id="host-initialization-click" @onclick="Increment">Increment</button>
+
+@code {
+    private void Increment()
+    {
+        State.ClickCount++;
+    }
+}


### PR DESCRIPTION
## Summary

- generalize browser and HTTP startup values behind host-neutral provider/consumer interfaces
- use singleton host initializers with explicit host and browser phases
- bind a singleton preordered collection to each active request, circuit, or WebAssembly scope through an internal invoker
- migrate navigation initialization and Server navigation-service JS-runtime attachment to the pipeline
- use one synchronized JS/.NET startup protocol with mandatory startup values

## API status

The final public API is approved in #68957 and implemented in this PR.

```diff
namespace Microsoft.AspNetCore.Components.Hosting;

+public interface IHostInitializer
+{
+    int Order { get; }
+    Task InitializeHostAsync(
+        IServiceProvider services,
+        CancellationToken cancellationToken = default);
+    Task InitializeBrowserAsync(
+        IServiceProvider services,
+        CancellationToken cancellationToken = default);
+}
+
+public interface IHostStartupValues
+{
+    string? GetValue(string key);
+    string GetRequired(string key);
+}
+
+public interface IBrowserStartupValueProvider
+{
+    IReadOnlyList<string> Keys { get; }
+}
+
+public interface IHttpContextStartupValueProvider
+{
+    IReadOnlyDictionary<string, string> GetValues(HttpContext httpContext);
+}
```

Both initializer methods default to `Task.CompletedTask`. Implementations are singleton services. The supplied `IServiceProvider` is the active host scope and must not be retained.

## Initialization model

- `HostInitializerCollection` is internal and singleton
- shared initializers are non-keyed; framework server-side initializers use internal `Static` and `Server` keys; WebAssembly uses its separate non-keyed container
- each effective host set is sorted once; initializer `Order` values must be unique and duplicate orders fail deterministically
- `GetInitializerInvoker` creates an internal per-host invoker bound to the active scope
- the invoker privately caches both initialization tasks
- `InitializeBrowserAsync` always awaits the exact cached `InitializeHostAsync` task before invoking browser methods
- one initializer may participate in both phases

Static SSR invokes only host initialization. Interactive Server runs host initialization during circuit creation and browser initialization after `StartCircuit` can return, while component rendering/root updates await the cached browser task.

WebAssembly starts browser initialization during `Build()`. The navigation initializer uses `int.MinValue`, runs synchronously in the host phase, and initializes `NavigationManager` exactly once before `Build()` returns. `RunAsync` awaits the stored browser task. A host-owned cancellation source coordinates Build-time initialization, Run cancellation, and disposal.

## Startup values and protocol

- JavaScript queries the server for required browser property paths, evaluates them safely, and sends one mandatory startup-values payload to `StartCircuit` or `ResumeCircuit`
- no legacy overloads, capability negotiation, or fallback paths are retained because JavaScript and .NET assets evolve together
- browser keys are validated dot-separated property paths and are resolved without `eval`; duplicate, dangerous, missing, or non-string values are rejected
- returned value sets must contain exactly the requested keys
- HTTP startup values remain request-local and are never emitted to the browser

## Scope

Intentionally excludes ESM bundle architecture, Rollup configuration, render-mode plugins, `JSModuleRegistry`, component migrations, script-mode E2E infrastructure, pipeline YAML, `SsrBrowserOptions.EnableEnhancedNavigation`, and unrelated prototype changes.

## Validation

- `Microsoft.AspNetCore.Components.Tests`: 1,304 passed, 8 skipped
- `Microsoft.AspNetCore.Components.Endpoints.Tests`: 893 passed
- `Microsoft.AspNetCore.Components.Server.Tests`: 435 passed
- `Microsoft.AspNetCore.Components.WebAssembly.Tests`: 70 passed
- Web.JS focused tests/build remained green from the synchronized protocol change; this final commit contains no TypeScript changes
- Components E2E: `HostInitializersRunBeforeInteractiveServerRendering` passed
- WebAssembly regressions cover Build-time navigation, unique-order rejection, cached host/browser tasks, cancellation, construction cleanup, changed base URI, async-only disposal, and concurrent Run/disposal

The repository-wide `eng\build.cmd` reached installer packaging but could not complete because `wix.exe` is unavailable in the local environment; affected Components projects and focused tests build successfully.