### PR TITLE
Disable runtime-async for ppc64le, s390x, and Mono runtimes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -121,6 +121,11 @@
     <CrossgenOutput Condition="'$(DotNetBuildUseMonoRuntime)' == 'true'">false</CrossgenOutput>
   </PropertyGroup>
 
+  <!-- Disable runtime-async on ppc64le, s390x, and Mono builds where the JIT/runtime does not support the new .NET 11 async IL format. -->
+  <PropertyGroup>
+    <UseRuntimeAsync Condition="'$(TargetArchitecture)' == 'ppc64le' or '$(TargetArchitecture)' == 's390x' or '$(DotNetBuildUseMonoRuntime)' == 'true'">false</UseRuntimeAsync>
+  </PropertyGroup>
+
   <!-- Warnings and errors -->
   <PropertyGroup>
     <!-- Ensure API docs are available. -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -171,6 +171,15 @@
     <Features>$(Features);runtime-async=on</Features>
   </PropertyGroup>
 
+  <!-- Ensure runtime-async=off is explicitly set when disabled -->
+  <PropertyGroup Condition="('$(UseRuntimeAsync)' == 'false' or '$(DotNetBuildUseMonoRuntime)' == 'true') AND
+     $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0')) AND
+     '$(TargetOS)' != 'browser' AND
+     !$(RuntimeIdentifier.StartsWith('browser-'))">
+   <Features Condition="!$(Features.Contains('runtime-async='))">$(Features);runtime-async=off</Features>
+   <Features Condition="$(Features.Contains('runtime-async=on'))">$(Features.Replace('runtime-async=on', 'runtime-async=off'))</Features>
+  </PropertyGroup>
+
   <!-- Properties for Package Validation -->
   <PropertyGroup Condition="'$(ExcludeFromSourceOnlyBuild)' != 'true'">
     <EnablePackageValidation Condition="'$(EnablePackageValidation)' == ''">true</EnablePackageValidation>


### PR DESCRIPTION
# [ppc64le][s390x][Mono] Disable `runtime-async` feature on unsupported architectures

Disable `runtime-async` for `ppc64le`, `s390x`, and Mono builds to resolve `InvalidProgramException` test failures.

## Description

ASP.NET Core enables the experimental `runtime-async` feature (`<Features>$(Features);runtime-async=on</Features>`) for `net11.0` framework and test assemblies.

The Mono runtime and JIT backends for `ppc64le` and `s390x` do not support this new async IL format. This causes widespread `System.InvalidProgramException: Invalid IL code ... ret` failures at runtime (such as in `GenericWebHostService:StartAsync`), breaking test execution.

### Changes

- Defined `<UseRuntimeAsync>false</UseRuntimeAsync>` in `Directory.Build.props` when `TargetArchitecture` is `ppc64le` or `s390x`, or when `DotNetBuildUseMonoRuntime` is `true`.
- Guarded `runtime-async=on` in `Directory.Build.targets` with `'$(UseRuntimeAsync)' != 'false'` to ensure it is not passed on unsupported targets.

Fixes #68067

Cc: @tmds @omajid