### PR TITLE
Handle zero size hints in Http1OutputProducer

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http/Http1OutputProducer.cs
@@ -668,6 +668,13 @@ internal class Http1OutputProducer : IHttpOutputProducer, IDisposable
 
     internal Memory<byte> GetFakeMemory(int minSize)
     {
+        if (minSize == 0)
+        {
+            // MemoryPool.Rent(0) may return empty memory;
+            // use Kestrel's minimum segment size to satisfy the IBufferWriter contract.
+            minSize = _memoryPool.GetMinimumSegmentSize();
+        }
+
         // Try to reuse _fakeMemoryOwner
         if (_fakeMemoryOwner != null)
         {
@@ -735,6 +742,13 @@ internal class Http1OutputProducer : IHttpOutputProducer, IDisposable
 
     private void AddSegment(int sizeHint = 0)
     {
+        if (sizeHint == 0)
+        {
+            // MemoryPool.Rent(0) may return empty memory;
+            // use Kestrel's minimum segment size to satisfy the IBufferWriter contract.
+            sizeHint = _memoryPool.GetMinimumSegmentSize();
+        }
+
         if (_currentSegment.Length != 0)
         {
             // We're adding a segment to the list

--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2OutputProducer.cs
@@ -658,6 +658,13 @@ internal sealed class Http2OutputProducer : IHttpOutputProducer, IHttpOutputAbor
 
     internal Memory<byte> GetFakeMemory(int minSize)
     {
+        if (minSize == 0)
+        {
+            // MemoryPool.Rent(0) may return empty memory;
+            // use Kestrel's minimum segment size to satisfy the IBufferWriter contract.
+            minSize = _memoryPool.GetMinimumSegmentSize();
+        }
+
         // Try to reuse _fakeMemoryOwner
         if (_fakeMemoryOwner != null)
         {

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3OutputProducer.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3OutputProducer.cs
@@ -225,6 +225,13 @@ internal sealed class Http3OutputProducer : IHttpOutputProducer, IHttpOutputAbor
 
     internal Memory<byte> GetFakeMemory(int minSize)
     {
+        if (minSize == 0)
+        {
+            // MemoryPool.Rent(0) may return empty memory;
+            // use Kestrel's minimum segment size to satisfy the IBufferWriter contract.
+            minSize = _memoryPool.GetMinimumSegmentSize();
+        }
+
         // Try to reuse _fakeMemoryOwner
         if (_fakeMemoryOwner != null)
         {

--- a/src/Servers/Kestrel/Core/test/Http1/Http1OutputProducerTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1OutputProducerTests.cs
@@ -138,6 +138,35 @@ public class Http1OutputProducerTests : IDisposable
     }
 
     [Fact]
+    public void GetMemoryAndGetSpanWithZeroSizeHintReturnNonEmptyBuffers()
+    {
+        var memoryPool = new Mock<MemoryPool<byte>>();
+        memoryPool.SetupGet(pool => pool.MaxBufferSize).Returns(MemoryPool<byte>.Shared.MaxBufferSize);
+        memoryPool.Setup(pool => pool.Rent(0)).Returns(Mock.Of<IMemoryOwner<byte>>());
+        memoryPool.Setup(pool => pool.Rent(It.Is<int>(size => size > 0)))
+            .Returns((int size) => MemoryPool<byte>.Shared.Rent(size));
+
+        using var output = CreateOutputProducer(memoryPool: memoryPool.Object);
+
+        var beforeStartMemoryLength = output.GetMemory(0).Length;
+        var beforeStartSpanLength = output.GetSpan(0).Length;
+
+        output.Dispose();
+
+        var completedMemoryLength = output.GetMemory(0).Length;
+        var completedSpanLength = output.GetSpan(0).Length;
+
+        Assert.All(
+            [
+                (Operation: "GetMemory before response start", Length: beforeStartMemoryLength),
+                (Operation: "GetSpan before response start", Length: beforeStartSpanLength),
+                (Operation: "GetMemory after completion", Length: completedMemoryLength),
+                (Operation: "GetSpan after completion", Length: completedSpanLength),
+            ],
+            result => Assert.True(result.Length > 0, $"{result.Operation} returned an empty buffer."));
+    }
+
+    [Fact]
     public void AllocatesFakeMemorySmallerThanMaxBufferSize()
     {
         var pipeOptions = new PipeOptions
@@ -223,7 +252,8 @@ public class Http1OutputProducerTests : IDisposable
     private TestHttpOutputProducer CreateOutputProducer(
         PipeOptions pipeOptions = null,
         ConnectionContext connectionContext = null,
-        ConnectionMetricsContext metricsContext = null)
+        ConnectionMetricsContext metricsContext = null,
+        MemoryPool<byte> memoryPool = null)
     {
         pipeOptions = pipeOptions ?? new PipeOptions();
         connectionContext = connectionContext ?? Mock.Of<ConnectionContext>();
@@ -234,7 +264,7 @@ public class Http1OutputProducerTests : IDisposable
             pipe,
             "0",
             connectionContext,
-            _memoryPool,
+            memoryPool ?? _memoryPool,
             serviceContext.Log,
             Mock.Of<ITimeoutControl>(),
             Mock.Of<IHttpMinResponseDataRateFeature>(),

--- a/src/Servers/Kestrel/Core/test/Http1/Http1OutputProducerTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1OutputProducerTests.cs
@@ -151,7 +151,7 @@ public class Http1OutputProducerTests : IDisposable
         var beforeStartMemoryLength = output.GetMemory(0).Length;
         var beforeStartSpanLength = output.GetSpan(0).Length;
 
-        output.Dispose();
+        output.Stop();
 
         var completedMemoryLength = output.GetMemory(0).Length;
         var completedSpanLength = output.GetSpan(0).Length;

--- a/src/Servers/Kestrel/Core/test/Http1/Http1OutputProducerTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http1/Http1OutputProducerTests.cs
@@ -140,13 +140,7 @@ public class Http1OutputProducerTests : IDisposable
     [Fact]
     public void GetMemoryAndGetSpanWithZeroSizeHintReturnNonEmptyBuffers()
     {
-        var memoryPool = new Mock<MemoryPool<byte>>();
-        memoryPool.SetupGet(pool => pool.MaxBufferSize).Returns(MemoryPool<byte>.Shared.MaxBufferSize);
-        memoryPool.Setup(pool => pool.Rent(0)).Returns(Mock.Of<IMemoryOwner<byte>>());
-        memoryPool.Setup(pool => pool.Rent(It.Is<int>(size => size > 0)))
-            .Returns((int size) => MemoryPool<byte>.Shared.Rent(size));
-
-        using var output = CreateOutputProducer(memoryPool: memoryPool.Object);
+        using var output = CreateOutputProducer(memoryPool: MemoryPool<byte>.Shared);
 
         var beforeStartMemoryLength = output.GetMemory(0).Length;
         var beforeStartSpanLength = output.GetSpan(0).Length;

--- a/src/Servers/Kestrel/Core/test/Http2/Http2OutputProducerTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http2/Http2OutputProducerTests.cs
@@ -3,9 +3,7 @@
 
 using System.Buffers;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
-using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.InternalTesting;
-using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
@@ -15,33 +13,15 @@ public class Http2OutputProducerTests
     [Fact]
     public void GetFakeMemoryWithZeroSizeHintReturnsNonEmptyMemory()
     {
-        var memoryPool = CreateMemoryPool();
         var context = TestContextFactory.CreateHttp2StreamContext(
             serviceContext: new TestServiceContext(),
-            memoryPool: memoryPool.Object,
-            timeoutControl: Mock.Of<ITimeoutControl>());
+            memoryPool: MemoryPool<byte>.Shared);
         using var stream = new TestHttp2Stream(context);
         var output = Assert.IsType<Http2OutputProducer>(stream.Output);
 
         var memory = output.GetFakeMemory(0);
 
         Assert.True(memory.Length > 0);
-    }
-
-    private static Mock<MemoryPool<byte>> CreateMemoryPool()
-    {
-        var memoryPool = new Mock<MemoryPool<byte>>();
-        memoryPool.SetupGet(pool => pool.MaxBufferSize).Returns(MemoryPool<byte>.Shared.MaxBufferSize);
-        memoryPool.Setup(pool => pool.Rent(0)).Returns(Mock.Of<IMemoryOwner<byte>>());
-        memoryPool.Setup(pool => pool.Rent(It.Is<int>(size => size > 0)))
-            .Returns((int size) =>
-            {
-                var memoryOwner = new Mock<IMemoryOwner<byte>>();
-                memoryOwner.SetupGet(owner => owner.Memory).Returns(new byte[size]);
-                return memoryOwner.Object;
-            });
-
-        return memoryPool;
     }
 
     private sealed class TestHttp2Stream : Http2Stream

--- a/src/Servers/Kestrel/Core/test/Http2/Http2OutputProducerTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http2/Http2OutputProducerTests.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http2;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+using Microsoft.AspNetCore.InternalTesting;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
+
+public class Http2OutputProducerTests
+{
+    [Fact]
+    public void GetFakeMemoryWithZeroSizeHintReturnsNonEmptyMemory()
+    {
+        var memoryPool = CreateMemoryPool();
+        var context = TestContextFactory.CreateHttp2StreamContext(
+            serviceContext: new TestServiceContext(),
+            memoryPool: memoryPool.Object,
+            timeoutControl: Mock.Of<ITimeoutControl>());
+        using var stream = new TestHttp2Stream(context);
+        var output = Assert.IsType<Http2OutputProducer>(stream.Output);
+
+        var memory = output.GetFakeMemory(0);
+
+        Assert.True(memory.Length > 0);
+    }
+
+    private static Mock<MemoryPool<byte>> CreateMemoryPool()
+    {
+        var memoryPool = new Mock<MemoryPool<byte>>();
+        memoryPool.SetupGet(pool => pool.MaxBufferSize).Returns(MemoryPool<byte>.Shared.MaxBufferSize);
+        memoryPool.Setup(pool => pool.Rent(0)).Returns(Mock.Of<IMemoryOwner<byte>>());
+        memoryPool.Setup(pool => pool.Rent(It.Is<int>(size => size > 0)))
+            .Returns((int size) =>
+            {
+                var memoryOwner = new Mock<IMemoryOwner<byte>>();
+                memoryOwner.SetupGet(owner => owner.Memory).Returns(new byte[size]);
+                return memoryOwner.Object;
+            });
+
+        return memoryPool;
+    }
+
+    private sealed class TestHttp2Stream : Http2Stream
+    {
+        public TestHttp2Stream(Http2StreamContext context)
+        {
+            Initialize(context);
+        }
+
+        public override void Execute()
+        {
+        }
+    }
+}

--- a/src/Servers/Kestrel/Core/test/Http3/Http3OutputProducerTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http3/Http3OutputProducerTests.cs
@@ -1,0 +1,101 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.IO.Pipelines;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
+using Microsoft.AspNetCore.InternalTesting;
+using Moq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
+
+public class Http3OutputProducerTests
+{
+    [Fact]
+    public void GetFakeMemoryWithZeroSizeHintReturnsNonEmptyMemory()
+    {
+        var memoryPool = CreateMemoryPool();
+        var connectionFeatures = new TestConnectionFeatures().FeatureCollection;
+        var streamContext = TestContextFactory.CreateHttp3StreamContext(
+            transport: DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions()).Application,
+            connectionFeatures: connectionFeatures,
+            memoryPool: memoryPool.Object);
+        var stream = new TestHttp3Stream();
+        stream.Initialize(streamContext);
+        var output = Assert.IsType<Http3OutputProducer>(stream.Output);
+
+        try
+        {
+            var memory = output.GetFakeMemory(0);
+
+            Assert.True(memory.Length > 0);
+        }
+        finally
+        {
+            output.Dispose();
+        }
+    }
+
+    private static Mock<MemoryPool<byte>> CreateMemoryPool()
+    {
+        var memoryPool = new Mock<MemoryPool<byte>>();
+        memoryPool.SetupGet(pool => pool.MaxBufferSize).Returns(MemoryPool<byte>.Shared.MaxBufferSize);
+        memoryPool.Setup(pool => pool.Rent(0)).Returns(Mock.Of<IMemoryOwner<byte>>());
+        memoryPool.Setup(pool => pool.Rent(It.Is<int>(size => size > 0)))
+            .Returns((int size) =>
+            {
+                var memoryOwner = new Mock<IMemoryOwner<byte>>();
+                memoryOwner.SetupGet(owner => owner.Memory).Returns(new byte[size]);
+                return memoryOwner.Object;
+            });
+
+        return memoryPool;
+    }
+
+    private sealed class TestHttp3Stream : Http3Stream
+    {
+        public override void Execute()
+        {
+        }
+    }
+
+    private sealed class TestConnectionFeatures : IProtocolErrorCodeFeature, IStreamIdFeature, IStreamAbortFeature, IStreamClosedFeature, IConnectionMetricsContextFeature
+    {
+        public TestConnectionFeatures()
+        {
+            var featureCollection = new FeatureCollection();
+            featureCollection.Set<IProtocolErrorCodeFeature>(this);
+            featureCollection.Set<IStreamIdFeature>(this);
+            featureCollection.Set<IStreamAbortFeature>(this);
+            featureCollection.Set<IStreamClosedFeature>(this);
+            featureCollection.Set<IConnectionMetricsContextFeature>(this);
+
+            FeatureCollection = featureCollection;
+        }
+
+        public IFeatureCollection FeatureCollection { get; }
+        public ConnectionMetricsContext MetricsContext { get; }
+        long IProtocolErrorCodeFeature.Error { get; set; }
+        long IStreamIdFeature.StreamId { get; }
+
+        void IStreamAbortFeature.AbortRead(long errorCode, ConnectionAbortedException abortReason)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IStreamAbortFeature.AbortWrite(long errorCode, ConnectionAbortedException abortReason)
+        {
+            throw new NotImplementedException();
+        }
+
+        void IStreamClosedFeature.OnClosed(Action<object> callback, object state)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Servers/Kestrel/Core/test/Http3/Http3OutputProducerTests.cs
+++ b/src/Servers/Kestrel/Core/test/Http3/Http3OutputProducerTests.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http3;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Infrastructure;
 using Microsoft.AspNetCore.InternalTesting;
-using Moq;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.Kestrel.Core.Tests;
@@ -19,12 +18,11 @@ public class Http3OutputProducerTests
     [Fact]
     public void GetFakeMemoryWithZeroSizeHintReturnsNonEmptyMemory()
     {
-        var memoryPool = CreateMemoryPool();
         var connectionFeatures = new TestConnectionFeatures().FeatureCollection;
         var streamContext = TestContextFactory.CreateHttp3StreamContext(
             transport: DuplexPipe.CreateConnectionPair(new PipeOptions(), new PipeOptions()).Application,
             connectionFeatures: connectionFeatures,
-            memoryPool: memoryPool.Object);
+            memoryPool: MemoryPool<byte>.Shared);
         var stream = new TestHttp3Stream();
         stream.Initialize(streamContext);
         var output = Assert.IsType<Http3OutputProducer>(stream.Output);
@@ -39,22 +37,6 @@ public class Http3OutputProducerTests
         {
             output.Dispose();
         }
-    }
-
-    private static Mock<MemoryPool<byte>> CreateMemoryPool()
-    {
-        var memoryPool = new Mock<MemoryPool<byte>>();
-        memoryPool.SetupGet(pool => pool.MaxBufferSize).Returns(MemoryPool<byte>.Shared.MaxBufferSize);
-        memoryPool.Setup(pool => pool.Rent(0)).Returns(Mock.Of<IMemoryOwner<byte>>());
-        memoryPool.Setup(pool => pool.Rent(It.Is<int>(size => size > 0)))
-            .Returns((int size) =>
-            {
-                var memoryOwner = new Mock<IMemoryOwner<byte>>();
-                memoryOwner.SetupGet(owner => owner.Memory).Returns(new byte[size]);
-                return memoryOwner.Object;
-            });
-
-        return memoryPool;
     }
 
     private sealed class TestHttp3Stream : Http3Stream


### PR DESCRIPTION
`IBufferWriter<byte>.GetMemory(0)` and `GetSpan(0)` must return non-empty buffers, but `Http1OutputProducer` passed zero directly to `MemoryPool<byte>.Rent()`. `MemoryPool<byte>.Rent(0)` only guarantees memory with at least zero elements, and `MemoryPool<byte>.Shared` returns empty memory for that request. This conflicts with the stronger `IBufferWriter<byte>` contract, which requires `GetMemory(0)` and `GetSpan(0)` to return non-empty buffers.

This change normalizes zero size hints to Kestrel's minimum segment size before renting memory in the pre-start buffering and completed-output scratch-memory paths. Using the existing minimum segment size keeps allocation behavior consistent with Kestrel's pipe configuration and avoids inefficient tiny buffers.

Fixes #58644