### PR TITLE
Use diagnostics IPC for non-Windows hang dump capture

### DIFF
--- a/eng/scripts/CaptureHangDumps.sh
+++ b/eng/scripts/CaptureHangDumps.sh
@@ -12,15 +12,15 @@
 # upload-cores.sh already collects (dotnet-<pid>.core in the working directory),
 # so no additional upload wiring is required.
 #
-# We deliberately capture *minidumps* (--normal) rather than full dumps. A full
+# We deliberately capture *minidumps* rather than full dumps. A full
 # dump of a hung .NET process can be several GB; capturing several of them and
 # then uploading them as artifacts does not fit inside the cancelTimeout grace
 # window, so the upload is killed and no dump is ever published. A minidump is a
-# few tens of MB, captures in seconds, and uploads comfortably. createdump is
-# .NET-aware and includes the thread stacks and runtime/module memory the DAC
-# needs, so `clrthreads` / `clrstack` still work to identify the hung process and
-# its managed stack -- which is all a hang investigation needs (heap inspection
-# such as `dumpheap` is not).
+# few tens of MB, captures in seconds, and uploads comfortably. The runtime
+# diagnostics IPC channel requests a .NET-aware dump containing the thread
+# stacks and runtime/module memory the DAC needs, so `clrthreads` / `clrstack`
+# still work to identify the hung process and its managed stack -- which is all
+# a hang investigation needs (heap inspection such as `dumpheap` is not).
 
 set -uo pipefail
 
@@ -34,37 +34,101 @@ __warn() {
   fi
 }
 
+# A 24-byte Server/OK response with a zero HRESULT.
+serverOkResponse="444f544e45545f4950435f5631001800ff00000000000000"
+
+byte() {
+  printf "\\$(printf '%03o' "$1")"
+}
+
+u16le() {
+  byte "$(($1 & 255))"
+  byte "$((($1 >> 8) & 255))"
+}
+
+u32le() {
+  byte "$(($1 & 255))"
+  byte "$((($1 >> 8) & 255))"
+  byte "$((($1 >> 16) & 255))"
+  byte "$((($1 >> 24) & 255))"
+}
+
+capture_dump() {
+  local pid="$1"
+  local dump_path="$2"
+  local socket=""
+  local candidate
+  local path_bytes
+  local path_chars
+  local packet_size
+  local response
+
+  for candidate in "${TMPDIR:-/tmp}"/dotnet-diagnostic-"${pid}"-*-socket; do
+    if [ -S "$candidate" ]; then
+      socket="$candidate"
+      break
+    fi
+  done
+
+  if [ -z "$socket" ]; then
+    echo "Could not find the diagnostics IPC socket for PID $pid." >&2
+    return 1
+  fi
+
+  if ! path_bytes="$(printf '%s' "$dump_path" | iconv -f UTF-8 -t UTF-16LE | wc -c)"; then
+    echo "Could not encode the dump path for PID $pid." >&2
+    return 1
+  fi
+  path_bytes="$(printf '%s' "$path_bytes" | tr -d '[:space:]')"
+  path_chars="$((path_bytes / 2 + 1))"
+  packet_size="$((20 + 4 + path_bytes + 2 + 4 + 4))"
+
+  if [ "$packet_size" -gt 65535 ]; then
+    echo "The diagnostics IPC packet for PID $pid is too large." >&2
+    return 1
+  fi
+
+  if ! response="$({
+    printf 'DOTNET_IPC_V1\0'
+    u16le "$packet_size"
+    byte 1 # Dump command set
+    byte 1 # CreateCoreDump command
+    u16le 0 # Reserved
+
+    u32le "$path_chars"
+    printf '%s' "$dump_path" | iconv -f UTF-8 -t UTF-16LE
+    printf '\0\0'
+
+    u32le 1 # Normal/minidump
+    u32le 1 # Enable generation diagnostics
+  } | nc -U "$socket" | od -An -v -tx1 | tr -d '[:space:]')"; then
+    echo "The diagnostics IPC request for PID $pid failed." >&2
+    return 1
+  fi
+
+  if [ "$response" != "$serverOkResponse" ]; then
+    echo "The diagnostics IPC request for PID $pid returned an unexpected response: ${response:-<empty>}." >&2
+    return 1
+  fi
+}
+
 # Limit how many processes we dump so that a build hang with many MSBuild nodes
 # cannot blow past the cancel-timeout grace window or the artifact size budget.
 maxDumps="${HANG_DUMP_MAX:-8}"
 
 wd="${SYSTEM_DEFAULTWORKINGDIRECTORY:-$(pwd -P)}"
-repoRoot="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 
 # Candidate process names to dump. "dotnet" covers the build host, the MSBuild
 # worker nodes, and the in-proc/out-of-proc C# compiler (csc) child processes,
 # which all run as `dotnet exec ...`. VBCSCompiler/csc are listed defensively.
 candidateNames=("dotnet" "VBCSCompiler" "csc")
 
-# Locate a createdump that matches the build architecture. createdump ships
-# alongside the runtime under the repo-local .dotnet, so it is the correct
-# architecture for the (single-architecture) job that produced the hang.
-createdump="$(find "$repoRoot/.dotnet" -name createdump -type f 2>/dev/null | sort -V | tail -n 1)"
-if [ -z "${createdump:-}" ] && [ -n "${DOTNET_ROOT:-}" ]; then
-  createdump="$(find "$DOTNET_ROOT" -name createdump -type f 2>/dev/null | sort -V | tail -n 1)"
-fi
-
-if [ -z "${createdump:-}" ]; then
-  __warn "Could not find createdump under '$repoRoot/.dotnet'. No hang dumps will be captured."
-  exit 0
-fi
-echo "Using createdump from '$createdump'."
-
-# On macOS, attaching to another process requires elevated privileges.
-sudo=""
-if [ "$(uname -s)" = "Darwin" ]; then
-  sudo="sudo"
-fi
+for requiredCommand in iconv nc od; do
+  if ! command -v "$requiredCommand" >/dev/null 2>&1; then
+    __warn "Could not find $requiredCommand on PATH. No hang dumps will be captured."
+    exit 0
+  fi
+done
 
 # Gather candidate pids (excluding this script's own process tree is unnecessary
 # because the script itself is bash, not dotnet).
@@ -96,13 +160,10 @@ for pid in $ordered; do
   fi
   out="$wd/dotnet-${pid}.core"
   echo "Capturing minidump for PID $pid -> $out"
-  if $sudo "$createdump" --normal --name "$out" "$pid"; then
-    # createdump may run under sudo and write a root-owned file; ensure the
-    # agent account can read it for artifact upload.
-    $sudo chmod 0644 "$out" 2>/dev/null || true
+  if capture_dump "$pid" "$out"; then
     count=$((count + 1))
   else
-    __warn "createdump failed for PID $pid."
+    __warn "Diagnostics IPC minidump request failed for PID $pid."
   fi
 done
 

--- a/eng/scripts/CaptureHangDumps.sh
+++ b/eng/scripts/CaptureHangDumps.sh
@@ -37,6 +37,33 @@ __warn() {
 # A 24-byte Server/OK response with a zero HRESULT.
 serverOkResponse="444f544e45545f4950435f5631001800ff00000000000000"
 
+# Use a watchdog when timeout is unavailable, as on a default macOS installation.
+run_with_timeout() {
+  local seconds="$1"
+  local inputFile="$2"
+  shift 2
+
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$seconds" "$@" < "$inputFile"
+    return
+  fi
+
+  "$@" < "$inputFile" &
+  local commandPid=$!
+  (
+    sleep "$seconds"
+    kill "$commandPid" 2>/dev/null
+  ) &
+  local watchdogPid=$!
+  local status=0
+
+  wait "$commandPid" || status=$?
+  kill "$watchdogPid" 2>/dev/null || true
+  wait "$watchdogPid" 2>/dev/null || true
+
+  return "$status"
+}
+
 byte() {
   printf "\\$(printf '%03o' "$1")"
 }
@@ -61,6 +88,7 @@ capture_dump() {
   local path_bytes
   local path_chars
   local packet_size
+  local packet_file
   local response
 
   for candidate in "${TMPDIR:-/tmp}"/dotnet-diagnostic-"${pid}"-*-socket; do
@@ -88,7 +116,13 @@ capture_dump() {
     return 1
   fi
 
-  if ! response="$({
+  # A file preserves the packet as stdin when the fallback runs nc in the background.
+  if ! packet_file="$(mktemp "${TMPDIR:-/tmp}/capture-hang-dump.XXXXXX")"; then
+    echo "Could not create the diagnostics IPC packet for PID $pid." >&2
+    return 1
+  fi
+
+  if ! {
     printf 'DOTNET_IPC_V1\0'
     u16le "$packet_size"
     byte 1 # Dump command set
@@ -101,10 +135,18 @@ capture_dump() {
 
     u32le 1 # Normal/minidump
     u32le 1 # Enable generation diagnostics
-  } | nc -U "$socket" | od -An -v -tx1 | tr -d '[:space:]')"; then
+  } > "$packet_file"; then
+    rm -f "$packet_file"
+    echo "Could not create the diagnostics IPC packet for PID $pid." >&2
+    return 1
+  fi
+
+  if ! response="$(run_with_timeout "$dumpTimeoutSeconds" "$packet_file" nc -U "$socket" | od -An -v -tx1 | tr -d '[:space:]')"; then
+    rm -f "$packet_file"
     echo "The diagnostics IPC request for PID $pid failed." >&2
     return 1
   fi
+  rm -f "$packet_file"
 
   if [ "$response" != "$serverOkResponse" ]; then
     echo "The diagnostics IPC request for PID $pid returned an unexpected response: ${response:-<empty>}." >&2
@@ -115,6 +157,7 @@ capture_dump() {
 # Limit how many processes we dump so that a build hang with many MSBuild nodes
 # cannot blow past the cancel-timeout grace window or the artifact size budget.
 maxDumps="${HANG_DUMP_MAX:-8}"
+dumpTimeoutSeconds="${HANG_DUMP_TIMEOUT_SECONDS:-60}"
 
 wd="${SYSTEM_DEFAULTWORKINGDIRECTORY:-$(pwd -P)}"
 


### PR DESCRIPTION
## Summary

Update `CaptureHangDumps.sh` to request minidumps through the runtime diagnostics IPC socket, avoiding dependencies on external tooling.

The script now:

- Locates each process's `dotnet-diagnostic-<pid>-*-socket`.
- Sends the legacy `CreateCoreDump` (`0x0101`) IPC command using `nc -U`.
- Encodes the output path as UTF-16LE and requests a normal/minidump.
- Validates the 24-byte Server/OK response and zero HRESULT before counting the dump as captured.
- Reports missing tools, sockets, transport failures, and nonzero HRESULT responses as warnings.
- Preserves the existing process selection, dump limits, filenames, and artifact upload behavior.

## Validation

 - Produced an ELF minidump, loaded the dump with `dotnet-dump analyze`, SOS reported three managed threads and resolved `Program.<Main>` on the captured stack.