### PR TITLE
Add generic ConsumesAttribute<T>

### DIFF
--- a/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
+++ b/src/Mvc/Mvc.ApiExplorer/test/EndpointMetadataApiDescriptionProviderTest.cs
@@ -104,7 +104,7 @@ public partial class EndpointMetadataApiDescriptionProviderTest
     public void AddsMultipleRequestFormatsFromMetadataWithRequestTypeAndOptionalBodyParameter()
     {
         var apiDescription = GetApiDescription(
-            [Consumes(typeof(InferredJsonClass), "application/custom0", "application/custom1", IsOptional = true)]
+            [Consumes<InferredJsonClass>("application/custom0", "application/custom1", IsOptional = true)]
         () =>
             { });
 
@@ -119,7 +119,7 @@ public partial class EndpointMetadataApiDescriptionProviderTest
     public void AddsMultipleRequestFormatsFromMetadataWithRequiredBodyParameter()
     {
         var apiDescription = GetApiDescription(
-            [Consumes(typeof(InferredJsonClass), "application/custom0", "application/custom1", IsOptional = false)]
+            [Consumes<InferredJsonClass>("application/custom0", "application/custom1", IsOptional = false)]
         (InferredJsonClass fromBody) =>
             { }, httpMethods: ["POST"]);
 

--- a/src/Mvc/Mvc.Core/src/ConsumesOfTAttribute.cs
+++ b/src/Mvc/Mvc.Core/src/ConsumesOfTAttribute.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Mvc;
+
+/// <inheritdoc />
+/// <typeparam name="T">The <see cref="Type"/> of object that is going to be read from the request.</typeparam>
+public class ConsumesAttribute<T> : ConsumesAttribute
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="ConsumesAttribute{T}"/>.
+    /// </summary>
+    /// <param name="contentType">The request content type.</param>
+    /// <param name="otherContentTypes">The additional list of allowed request content types.</param>
+    public ConsumesAttribute(string contentType, params string[] otherContentTypes)
+        : base(typeof(T), contentType, otherContentTypes)
+    {
+    }
+}

--- a/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
+++ b/src/Mvc/Mvc.Core/src/PublicAPI.Unshipped.txt
@@ -16,3 +16,5 @@
 *REMOVED*static Microsoft.Extensions.DependencyInjection.MvcCoreMvcBuilderExtensions.SetCompatibilityVersion(this Microsoft.Extensions.DependencyInjection.IMvcBuilder! builder, Microsoft.AspNetCore.Mvc.CompatibilityVersion version) -> Microsoft.Extensions.DependencyInjection.IMvcBuilder!
 *REMOVED*static Microsoft.Extensions.DependencyInjection.MvcCoreMvcCoreBuilderExtensions.SetCompatibilityVersion(this Microsoft.Extensions.DependencyInjection.IMvcCoreBuilder! builder, Microsoft.AspNetCore.Mvc.CompatibilityVersion version) -> Microsoft.Extensions.DependencyInjection.IMvcCoreBuilder!
 *REMOVED*virtual Microsoft.AspNetCore.Mvc.Infrastructure.ConfigureCompatibilityOptions<TOptions>.PostConfigure(string? name, TOptions! options) -> void
+Microsoft.AspNetCore.Mvc.ConsumesAttribute<T>
+Microsoft.AspNetCore.Mvc.ConsumesAttribute<T>.ConsumesAttribute(string! contentType, params string![]! otherContentTypes) -> void

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.RequestBody.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiDocumentService/OpenApiDocumentServiceTests.RequestBody.cs
@@ -241,7 +241,7 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
         var builder = CreateBuilder();
 
         // Act
-        builder.MapPost("/", [Consumes(typeof(IFormFile), "application/magic-foo-content-type")] (IFormFile formFile) => { });
+        builder.MapPost("/", [Consumes<IFormFile>("application/magic-foo-content-type")] (IFormFile formFile) => { });
 
         // Assert
         await VerifyOpenApiDocument(builder, document =>
@@ -364,7 +364,7 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
         var builder = CreateBuilder();
 
         // Act
-        builder.MapPost("/", [Consumes(typeof(string), "application/magic-foo-content-type")] (string name) => { });
+        builder.MapPost("/", [Consumes<string>("application/magic-foo-content-type")] (string name) => { });
 
         // Assert
         await VerifyOpenApiDocument(builder, document =>
@@ -1245,7 +1245,7 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
         var builder = CreateBuilder();
 
         // Act
-        builder.MapPatch("/", [Consumes(typeof(JsonPatchDocument), "application/vnd.github.patch+json")] (JsonPatchDocument patch) => { });
+        builder.MapPatch("/", [Consumes<JsonPatchDocument>("application/vnd.github.patch+json")] (JsonPatchDocument patch) => { });
 
         // Assert
         await VerifyOpenApiDocument(builder, document =>
@@ -1375,7 +1375,7 @@ public partial class OpenApiDocumentServiceTests : OpenApiDocumentServiceTestBas
         var builder = CreateBuilder();
 
         // Act
-        builder.MapPatch("/", [Consumes(typeof(JsonPatchDocument<JsonPatchModel>), "application/vnd.github.patch+json")] (JsonPatchDocument<JsonPatchModel> patch) => { });
+        builder.MapPatch("/", [Consumes<JsonPatchDocument<JsonPatchModel>>("application/vnd.github.patch+json")] (JsonPatchDocument<JsonPatchModel> patch) => { });
 
         // Assert
         await VerifyOpenApiDocument(builder, document =>

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiGeneratorTests.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiGeneratorTests.cs
@@ -113,7 +113,7 @@ public class OpenApiOperationGeneratorTests
     public void AddsMultipleRequestFormatsFromMetadataWithRequestTypeAndOptionalBodyParameter()
     {
         var operation = GetOpenApiOperation(
-            [Consumes(typeof(InferredJsonClass), "application/custom0", "application/custom1", IsOptional = true)] () => { });
+            [Consumes<InferredJsonClass>("application/custom0", "application/custom1", IsOptional = true)] () => { });
         var request = operation.RequestBody;
         Assert.NotNull(request);
         Assert.Equal(2, request.Content.Count);
@@ -131,7 +131,7 @@ public class OpenApiOperationGeneratorTests
     public void AddsMultipleRequestFormatsFromMetadataWithRequiredBodyParameter()
     {
         var operation = GetOpenApiOperation(
-            [Consumes(typeof(InferredJsonClass), "application/custom0", "application/custom1", IsOptional = false)] (InferredJsonClass fromBody) => { });
+            [Consumes<InferredJsonClass>("application/custom0", "application/custom1", IsOptional = false)] (InferredJsonClass fromBody) => { });
 
         var request = operation.RequestBody;
         Assert.NotNull(request);


### PR DESCRIPTION
- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Add a generic ConsumesAttribute<T>

## Description

Adds `ConsumesAttribute<T>`, a generic variant of `ConsumesAttribute` that lets the request type be specified as a type parameter instead of through the `Type requestType` constructor overload, mirroring the existing `ProducesResponseTypeAttribute<T>` pattern:

```csharp
[Consumes<Todo>("application/x-www-form-urlencoded")]
async Task<IResult> AddTodo(Todo todo, TodoDb db)
```

`ConsumesAttribute<T>` inherits from `ConsumesAttribute` and forwards to the existing `ConsumesAttribute(Type requestType, string contentType, params string[] otherContentTypes)` constructor with `typeof(T)`. It automatically picks up the base class's `[AttributeUsage(Class | Method)]` as well as `IAcceptsMetadata`/`IConsumesActionConstraint` behavior, so no additional wiring is needed for either MVC controllers or minimal API endpoints.

No new tests were added. Instead, existing tests that already exercised `ConsumesAttribute` with an explicit request type were updated to use the new `Consumes<T>` syntax, which confirms the generic form behaves identically to the non-generic one:
- `EndpointMetadataApiDescriptionProviderTest`
- `OpenApiDocumentServiceTests.RequestBody`
- `OpenApiGeneratorTests`

Fixes #67701