### PR TITLE
Fix skill evaluation authentication and runtime

### DIFF
--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -304,11 +304,93 @@ jobs:
             echo 'should_eval=true'
           } >> "$GITHUB_OUTPUT"
 
-  run:
-    name: Run skill evaluations
+  pat_pool:
+    name: Select Copilot token
     needs: gate
     if: >-
       always() &&
+      ((github.event_name == 'workflow_dispatch' &&
+        inputs.action == 'Run' &&
+        inputs.pr_number == '') ||
+       (needs.gate.result == 'success' &&
+        needs.gate.outputs.should_eval == 'true'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: copilot-pat-pool
+    permissions: {}
+    outputs:
+      pat_number: ${{ steps.select-pat-number.outputs.copilot_pat_number }}
+    steps:
+      - name: Require default branch control plane
+        id: control-plane
+        shell: bash
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          SELECTED_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+
+          EXPECTED_REF="refs/heads/$DEFAULT_BRANCH"
+          if [[ "$SELECTED_REF" != "$EXPECTED_REF" ]]; then
+            echo "::error::PAT-backed evaluations require the trusted default branch '$EXPECTED_REF', not '$SELECTED_REF'."
+            exit 1
+          fi
+          echo 'trusted=true' >> "$GITHUB_OUTPUT"
+
+      - name: Select Copilot token from pool
+        id: select-pat-number
+        if: steps.control-plane.outputs.trusted == 'true'
+        shell: bash
+        env:
+          COPILOT_PAT_0: ${{ secrets.COPILOT_PAT_0 }}
+          COPILOT_PAT_1: ${{ secrets.COPILOT_PAT_1 }}
+          COPILOT_PAT_2: ${{ secrets.COPILOT_PAT_2 }}
+          COPILOT_PAT_3: ${{ secrets.COPILOT_PAT_3 }}
+          COPILOT_PAT_4: ${{ secrets.COPILOT_PAT_4 }}
+          COPILOT_PAT_5: ${{ secrets.COPILOT_PAT_5 }}
+          COPILOT_PAT_6: ${{ secrets.COPILOT_PAT_6 }}
+          COPILOT_PAT_7: ${{ secrets.COPILOT_PAT_7 }}
+          COPILOT_PAT_8: ${{ secrets.COPILOT_PAT_8 }}
+          COPILOT_PAT_9: ${{ secrets.COPILOT_PAT_9 }}
+        run: |
+          set -euo pipefail
+
+          PAT_NUMBERS=()
+          POOL_INDICATORS=(➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖ ➖)
+
+          for i in $(seq 0 9); do
+            var="COPILOT_PAT_${i}"
+            val="${!var}"
+            if [[ -n "$val" ]]; then
+              PAT_NUMBERS+=("$i")
+              POOL_INDICATORS[i]="🟪"
+            fi
+          done
+
+          if [[ "${#PAT_NUMBERS[@]}" -eq 0 ]]; then
+            echo "::warning::None of the PAT pool entries had values (checked COPILOT_PAT_0 through COPILOT_PAT_9)."
+            exit 0
+          fi
+
+          PAT_INDEX=$((RANDOM % ${#PAT_NUMBERS[@]}))
+          PAT_NUMBER="${PAT_NUMBERS[$PAT_INDEX]}"
+          POOL_INDICATORS[PAT_NUMBER]="✅"
+
+          echo "Pool size: ${#PAT_NUMBERS[@]}"
+          echo "Selected PAT number $PAT_NUMBER (index: $PAT_INDEX)"
+          echo "|0|1|2|3|4|5|6|7|8|9|" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-|-|-|-|-|-|-|-|-|-|" >> "$GITHUB_STEP_SUMMARY"
+          (IFS='|'; printf '|%s' "${POOL_INDICATORS[@]}"; printf '|\n') >> "$GITHUB_STEP_SUMMARY"
+          echo "copilot_pat_number=$PAT_NUMBER" >> "$GITHUB_OUTPUT"
+
+  run:
+    name: Run skill evaluations
+    needs:
+      - gate
+      - pat_pool
+    if: >-
+      always() &&
+      needs.pat_pool.result == 'success' &&
       ((github.event_name == 'workflow_dispatch' &&
         inputs.action == 'Run' &&
         inputs.pr_number == '') ||
@@ -448,7 +530,7 @@ jobs:
         if: steps.claim.outputs.claimed == 'true'
         shell: pwsh
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT_0 || secrets.COPILOT_PAT_1 || secrets.COPILOT_PAT_2 || secrets.COPILOT_PAT_3 || secrets.COPILOT_PAT_4 || secrets.COPILOT_PAT_5 || secrets.COPILOT_PAT_6 || secrets.COPILOT_PAT_7 || secrets.COPILOT_PAT_8 || secrets.COPILOT_PAT_9 || secrets.COPILOT_GITHUB_TOKEN }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets[format('COPILOT_PAT_{0}', needs.pat_pool.outputs.pat_number)] || secrets.COPILOT_GITHUB_TOKEN }}
           EVALS_JSON: ${{ needs.gate.outputs.evals || format('["{0}"]', inputs.eval) }}
           RUN_TYPE: ${{ needs.gate.outputs.run_type || inputs.run_type }}
           STAGING_ROOT: ${{ runner.temp }}/skill-eval-execution

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -448,14 +448,14 @@ jobs:
         if: steps.claim.outputs.claimed == 'true'
         shell: pwsh
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT_0 }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT_0 || secrets.COPILOT_PAT_1 || secrets.COPILOT_PAT_2 || secrets.COPILOT_PAT_3 || secrets.COPILOT_PAT_4 || secrets.COPILOT_PAT_5 || secrets.COPILOT_PAT_6 || secrets.COPILOT_PAT_7 || secrets.COPILOT_PAT_8 || secrets.COPILOT_PAT_9 || secrets.COPILOT_GITHUB_TOKEN }}
           EVALS_JSON: ${{ needs.gate.outputs.evals || format('["{0}"]', inputs.eval) }}
           RUN_TYPE: ${{ needs.gate.outputs.run_type || inputs.run_type }}
           STAGING_ROOT: ${{ runner.temp }}/skill-eval-execution
         run: |
           $ErrorActionPreference = 'Stop'
           if ([string]::IsNullOrWhiteSpace($env:COPILOT_GITHUB_TOKEN)) {
-              throw 'COPILOT_PAT_0 is not configured in the copilot-pat-pool environment.'
+              throw 'No Copilot credential is configured in COPILOT_PAT_0..9 or COPILOT_GITHUB_TOKEN.'
           }
 
           $failedEvals = @()

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -73,10 +73,33 @@ jobs:
         with:
           node-version: 24.x
 
+      - name: Install evaluation tools
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          printf '' > "$RUNNER_TEMP/evaluation.npmrc"
+          rm -rf "$RUNNER_TEMP/evaluation-tools"
+          mkdir -p "$RUNNER_TEMP/evaluation-tools"
+          cp eng/skill-evals/evaluation-tools/package.json \
+            eng/skill-evals/evaluation-tools/package-lock.json \
+            "$RUNNER_TEMP/evaluation-tools/"
+          npm ci \
+            --prefix "$RUNNER_TEMP/evaluation-tools" \
+            --userconfig "$RUNNER_TEMP/evaluation.npmrc" \
+            --registry https://packagefeedproxy.microsoft.io/npm/
+          "$RUNNER_TEMP/evaluation-tools/node_modules/.bin/vally" --version
+          "$RUNNER_TEMP/evaluation-tools/node_modules/.bin/copilot" --version
+          (
+            cd "$RUNNER_TEMP/evaluation-tools/node_modules/@github/copilot-sdk/dist"
+            node --input-type=module -e "import.meta.resolve('@github/copilot-linux-x64/sdk')"
+          )
+
       - name: Run skill eval checks
         shell: pwsh
         env:
           ACTION: ${{ github.event_name == 'workflow_dispatch' && inputs.action || 'Validate' }}
+          SKILL_EVAL_VALLY: ${{ runner.temp }}/evaluation-tools/node_modules/.bin/vally
         run: ./eng/skill-evals/run.ps1 -Action $env:ACTION
 
       - name: Test trusted staging boundary
@@ -490,6 +513,29 @@ jobs:
         with:
           node-version: 24.x
 
+      - name: Install evaluation tools
+        if: steps.claim.outputs.claimed == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          printf '' > "$RUNNER_TEMP/evaluation.npmrc"
+          rm -rf "$RUNNER_TEMP/evaluation-tools"
+          mkdir -p "$RUNNER_TEMP/evaluation-tools"
+          cp _trusted-control-plane/eng/skill-evals/evaluation-tools/package.json \
+            _trusted-control-plane/eng/skill-evals/evaluation-tools/package-lock.json \
+            "$RUNNER_TEMP/evaluation-tools/"
+          npm ci \
+            --prefix "$RUNNER_TEMP/evaluation-tools" \
+            --userconfig "$RUNNER_TEMP/evaluation.npmrc" \
+            --registry https://packagefeedproxy.microsoft.io/npm/
+          "$RUNNER_TEMP/evaluation-tools/node_modules/.bin/vally" --version
+          "$RUNNER_TEMP/evaluation-tools/node_modules/.bin/copilot" --version
+          (
+            cd "$RUNNER_TEMP/evaluation-tools/node_modules/@github/copilot-sdk/dist"
+            node --input-type=module -e "import.meta.resolve('@github/copilot-linux-x64/sdk')"
+          )
+
       - name: Stage trusted skill eval inputs
         if: steps.claim.outputs.claimed == 'true'
         shell: pwsh
@@ -533,6 +579,7 @@ jobs:
           COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7, needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8, needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9, secrets.COPILOT_GITHUB_TOKEN) }}
           EVALS_JSON: ${{ needs.gate.outputs.evals || format('["{0}"]', inputs.eval) }}
           RUN_TYPE: ${{ needs.gate.outputs.run_type || inputs.run_type }}
+          SKILL_EVAL_VALLY: ${{ runner.temp }}/evaluation-tools/node_modules/.bin/vally
           STAGING_ROOT: ${{ runner.temp }}/skill-eval-execution
         run: |
           $ErrorActionPreference = 'Stop'

--- a/.github/workflows/skill-evals.yml
+++ b/.github/workflows/skill-evals.yml
@@ -530,7 +530,7 @@ jobs:
         if: steps.claim.outputs.claimed == 'true'
         shell: pwsh
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets[format('COPILOT_PAT_{0}', needs.pat_pool.outputs.pat_number)] || secrets.COPILOT_GITHUB_TOKEN }}
+          COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7, needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8, needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9, secrets.COPILOT_GITHUB_TOKEN) }}
           EVALS_JSON: ${{ needs.gate.outputs.evals || format('["{0}"]', inputs.eval) }}
           RUN_TYPE: ${{ needs.gate.outputs.run_type || inputs.run_type }}
           STAGING_ROOT: ${{ runner.temp }}/skill-eval-execution

--- a/eng/skill-evals/README.md
+++ b/eng/skill-evals/README.md
@@ -59,16 +59,18 @@ model-bearing `Run` action requires selecting one standard skill and defaults to
 the one-run-per-stimulus smoke experiment. Full runs retain the standard spec's
 trial count. Both modes use the repository-scoped `copilot-pat-pool`
 environment with one worker, serialize model-bearing runs, and retain the raw
-Vally output as a workflow artifact for seven days. The shared environment
-provides `COPILOT_PAT_0`; same-repository `write`, `maintain`, or `admin` access
-is the authorization boundary for selecting and running a host workflow
-revision. The in-file default-ref checks prevent accidental non-default
+Vally output as a workflow artifact for seven days. The workflow uses the first
+configured `COPILOT_PAT_0` through `COPILOT_PAT_9` pool entry, then falls back to
+the repository `COPILOT_GITHUB_TOKEN`; same-repository `write`, `maintain`, or
+`admin` access is the authorization boundary for selecting and running a host
+workflow revision. The in-file default-ref checks prevent accidental non-default
 dispatches of the unmodified workflow, but a trusted writer could deliberately
 change those checks in a branch-selected workflow revision.
-The fine-grained PAT grants only `Copilot Requests (Read)` for public
-repositories and expires after eight days. It materializes only in the Vally
-execution step as `COPILOT_GITHUB_TOKEN`; checkout, target resolution, staging,
-artifact upload, and reporting never receive it.
+Pool entries are fine-grained PATs that grant only `Copilot Requests (Read)` for
+public repositories and expire after eight days. The selected credential
+materializes only in the Vally execution step as `COPILOT_GITHUB_TOKEN`;
+checkout, target resolution, staging, artifact upload, and reporting never
+receive it.
 
 After the workflow is present on the repository's default branch, maintainers
 with `write`, `maintain`, or `admin` permission can request a smoke evaluation

--- a/eng/skill-evals/README.md
+++ b/eng/skill-evals/README.md
@@ -137,19 +137,28 @@ authorize PAT use. Because `copilot-pat-pool` is shared, apply that decision
 consistently across all workflows that consume the environment rather than
 uniquely to this workflow.
 
-`Validate`, `Lint`, and `Run` use the exact
-`@microsoft/vally-cli@0.13.0` package through `npx` and the Microsoft package
-feed proxy. Pass `-Vally <command> -VallyPrefix <arguments>` only to
-intentionally override that invocation. The runner prints the resolved command
-and reported version for provenance. Additional Vally arguments can be appended
-to the command. If the package is not already cached, `npx` downloads that
-exact version from the proxy; validation is model-free, not offline. It does not
-install a package into the repository or modify dependency manifests. Run
+Hosted `Validate`, `Lint`, and `Run` operations use the toolchain pinned by
+`evaluation-tools/package-lock.json`, including `@microsoft/vally-cli@0.14.0`
+and `@github/copilot@1.0.80`. The manifest also constrains transitive Copilot
+packages to that compatible version so the SDK and native platform package
+retain the same `./sdk` entry point. The workflow installs that lockfile with
+`npm ci` before any Copilot credential enters scope and verifies the Vally,
+Copilot, and Linux x64 platform entry points.
+
+The local runner defaults to the installed pinned toolchain when present.
+Local model-bearing `Run` operations require
+`npm ci --prefix eng/skill-evals/evaluation-tools` first. Model-free validation
+can still download the exact Vally version through `npx` and the Microsoft
+package feed proxy without modifying the checked-in manifests. Set
+`SKILL_EVAL_VALLY` to another installed Vally executable, or pass
+`-Vally <command> -VallyPrefix <arguments>`, to intentionally override that
+invocation. The runner prints the resolved command and reported version for
+provenance. Additional Vally arguments can be appended to the command. Run
 output defaults to `artifacts/skill-evals`.
 
-Standard runs use Vally's experiment `--compare` mode. Vally 0.13 removed the
-old per-stimulus `pairwise` grader, so comparison is owned by the experiment
-rather than repeated in each eval spec.
+Standard runs use Vally's experiment `--compare` mode. Vally 0.13 and later do
+not use the old per-stimulus `pairwise` grader, so comparison is owned by the
+experiment rather than repeated in each eval spec.
 
 ## Result interpretation and provenance
 

--- a/eng/skill-evals/README.md
+++ b/eng/skill-evals/README.md
@@ -59,13 +59,16 @@ model-bearing `Run` action requires selecting one standard skill and defaults to
 the one-run-per-stimulus smoke experiment. Full runs retain the standard spec's
 trial count. Both modes use the repository-scoped `copilot-pat-pool`
 environment with one worker, serialize model-bearing runs, and retain the raw
-Vally output as a workflow artifact for seven days. The workflow uses the first
-configured `COPILOT_PAT_0` through `COPILOT_PAT_9` pool entry, then falls back to
-the repository `COPILOT_GITHUB_TOKEN`; same-repository `write`, `maintain`, or
-`admin` access is the authorization boundary for selecting and running a host
-workflow revision. The in-file default-ref checks prevent accidental non-default
-dispatches of the unmodified workflow, but a trusted writer could deliberately
-change those checks in a branch-selected workflow revision.
+Vally output as a workflow artifact for seven days. A dedicated trusted job
+finds the configured `COPILOT_PAT_0` through `COPILOT_PAT_9` pool entries,
+randomly selects one, and exposes only its numeric slot to the worker. The Vally
+step resolves that slot to the selected secret, or uses the repository
+`COPILOT_GITHUB_TOKEN` when the pool is empty. Same-repository `write`,
+`maintain`, or `admin` access is the authorization boundary for selecting and
+running a host workflow revision. The in-file default-ref checks prevent
+accidental non-default dispatches of the unmodified workflow, but a trusted
+writer could deliberately change those checks in a branch-selected workflow
+revision.
 Pool entries are fine-grained PATs that grant only `Copilot Requests (Read)` for
 public repositories and expire after eight days. The selected credential
 materializes only in the Vally execution step as `COPILOT_GITHUB_TOKEN`;

--- a/eng/skill-evals/evaluation-tools/package-lock.json
+++ b/eng/skill-evals/evaluation-tools/package-lock.json
@@ -1,0 +1,1766 @@
+{
+  "name": "aspnetcore-skill-evaluation-tools",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "aspnetcore-skill-evaluation-tools",
+      "version": "0.0.1",
+      "dependencies": {
+        "@github/copilot": "1.0.80",
+        "@microsoft/vally-cli": "0.14.0"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.2.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha1-k+DoKwGGLn6jtbaZWHGdPz/SyKw=",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.11.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-auth/-/core-auth-1.11.0.tgz",
+      "integrity": "sha1-Ha7/32LRqHHSK4ZfnzFkpj6h9XU=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.11.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-client/-/core-client-1.11.0.tgz",
+      "integrity": "sha1-5z0JrHl33l17QVaWt+1F0/3rZ7A=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.25.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-rest-pipeline/-/core-rest-pipeline-1.25.0.tgz",
+      "integrity": "sha1-kupJEu27H3OV9IKaMAYxF0qoLwg=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.4.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-tracing/-/core-tracing-1.4.0.tgz",
+      "integrity": "sha1-1lenAOJNJW0ZXmKKeV22qMxHXqs=",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.14.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/core-util/-/core-util-1.14.0.tgz",
+      "integrity": "sha1-fOn+V5WPEy3UIlc4VuWkXHIyuwQ=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.4.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/logger/-/logger-1.4.0.tgz",
+      "integrity": "sha1-PVpif+WaJ27OdIenndkq1cUIwzk=",
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@azure/monitor-opentelemetry-exporter": {
+      "version": "1.0.0-beta.32",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@azure/monitor-opentelemetry-exporter/-/monitor-opentelemetry-exporter-1.0.0-beta.32.tgz",
+      "integrity": "sha1-ncv2m4X9D4XAOTPEuxNtZDNSxRw=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.19.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.200.0",
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/resources": "^2.0.0",
+        "@opentelemetry/sdk-logs": "^0.200.0",
+        "@opentelemetry/sdk-metrics": "^2.0.0",
+        "@opentelemetry/sdk-trace-base": "^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.32.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@github/copilot": {
+      "version": "1.0.80",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot/-/copilot-1.0.80.tgz",
+      "integrity": "sha1-Xxj+QlK/5wzoak0Yb2yt/fkg+uE=",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "detect-libc": "^2.1.2"
+      },
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.80",
+        "@github/copilot-darwin-x64": "1.0.80",
+        "@github/copilot-linux-arm64": "1.0.80",
+        "@github/copilot-linux-x64": "1.0.80",
+        "@github/copilot-linuxmusl-arm64": "1.0.80",
+        "@github/copilot-linuxmusl-x64": "1.0.80",
+        "@github/copilot-win32-arm64": "1.0.80",
+        "@github/copilot-win32-x64": "1.0.80"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.80",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.80.tgz",
+      "integrity": "sha1-O7PeMg8QNrLVmr2oJJ2VVGyswmI=",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.80",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.80.tgz",
+      "integrity": "sha1-7p1769kE+APGKTfiFFStYxhq0xg=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.80",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.80.tgz",
+      "integrity": "sha1-Aq/J59Sy7gw5xSPPD201cxauzgs=",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.80",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.80.tgz",
+      "integrity": "sha1-hBj2Ns8VJ3vRw0l9Uuv51CSad84=",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-arm64": {
+      "version": "1.0.80",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.80.tgz",
+      "integrity": "sha1-Cwqw4hKkb4ZD6w5JXIjbPwTN4+8=",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linuxmusl-x64": {
+      "version": "1.0.80",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.80.tgz",
+      "integrity": "sha1-xdoO4YxkEVl6+VCxg6L5MoqyKVQ=",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linuxmusl-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "1.0.11",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-sdk/-/copilot-sdk-1.0.11.tgz",
+      "integrity": "sha1-ZgXSGhM2QbIIDM5cbqFETwCSVzI=",
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^1.0.79",
+        "koffi": "^3.1.0",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.80",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.80.tgz",
+      "integrity": "sha1-2yqFs2UqUisEYq5kix1sxHVykhA=",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.80",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.80.tgz",
+      "integrity": "sha1-MS+ioPfBrZNg2EVr9z3CXfR14Ug=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha1-nPqGSensvNSO31BbEDACQC6lHnA=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-arm64": {
+      "version": "3.1.6",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-darwin-arm64/-/koffi-darwin-arm64-3.1.6.tgz",
+      "integrity": "sha1-UMiG7oa1oXi04Jhx3kSECoKdmcc=",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-darwin-x64": {
+      "version": "3.1.6",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-darwin-x64/-/koffi-darwin-x64-3.1.6.tgz",
+      "integrity": "sha1-t/Dr9d2/AMNajDxpxy8jCChMb3o=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-arm64": {
+      "version": "3.1.6",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-freebsd-arm64/-/koffi-freebsd-arm64-3.1.6.tgz",
+      "integrity": "sha1-cPZgX/tAshlHokDpzkeW3PaQnyA=",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-ia32": {
+      "version": "3.1.6",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-freebsd-ia32/-/koffi-freebsd-ia32-3.1.6.tgz",
+      "integrity": "sha1-G85tcqXWJCPQaGfux2R62HcEPfI=",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-freebsd-x64": {
+      "version": "3.1.6",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-freebsd-x64/-/koffi-freebsd-x64-3.1.6.tgz",
+      "integrity": "sha1-q3QcGMMyVzkvP4pLHG3AIz1b8zw=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-arm64": {
+      "version": "3.1.6",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-linux-arm64/-/koffi-linux-arm64-3.1.6.tgz",
+      "integrity": "sha1-viXY4wKkqiPiVUe6K7QFDsfVzbo=",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-ia32": {
+      "version": "3.1.6",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-linux-ia32/-/koffi-linux-ia32-3.1.6.tgz",
+      "integrity": "sha1-xusbXfU5cDijCAUksx2wHjpOvUs=",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-loong64": {
+      "version": "3.1.6",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-linux-loong64/-/koffi-linux-loong64-3.1.6.tgz",
+      "integrity": "sha1-K0ePdLxqnpuQ7H8D17l1BPUycJ0=",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-riscv64": {
+      "version": "3.1.6",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-linux-riscv64/-/koffi-linux-riscv64-3.1.6.tgz",
+      "integrity": "sha1-fnm/m4pCWeNEtURSnZf4lOls88s=",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-linux-x64": {
+      "version": "3.1.6",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-linux-x64/-/koffi-linux-x64-3.1.6.tgz",
+      "integrity": "sha1-9AiJQ3mygZLONdWyKg7GkD3jR8U=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-ia32": {
+      "version": "3.1.6",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-openbsd-ia32/-/koffi-openbsd-ia32-3.1.6.tgz",
+      "integrity": "sha1-GuGU40x3a20a1YIROLhJDdBgmpc=",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-openbsd-x64": {
+      "version": "3.1.6",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-openbsd-x64/-/koffi-openbsd-x64-3.1.6.tgz",
+      "integrity": "sha1-oCYmp0wYKOlY5o8ZyWoY+XTlU8s=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-arm64": {
+      "version": "3.1.6",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-win32-arm64/-/koffi-win32-arm64-3.1.6.tgz",
+      "integrity": "sha1-AU3bMCcCRp7qmtUe3UCRNE8+T8k=",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-ia32": {
+      "version": "3.1.6",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-win32-ia32/-/koffi-win32-ia32-3.1.6.tgz",
+      "integrity": "sha1-rQVtnYNT4zfkuz7G1Cq4sTYLsDU=",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@koromix/koffi-win32-x64": {
+      "version": "3.1.6",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@koromix/koffi-win32-x64/-/koffi-win32-x64-3.1.6.tgz",
+      "integrity": "sha1-bSJ5S+lFTNK4fxsSjrx99b46HEA=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/@microsoft/vally": {
+      "version": "0.14.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/vally/-/vally-0.14.0.tgz",
+      "integrity": "sha1-m6h5RBbRXhqHw/UjU1EXLDwAF18=",
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot-sdk": "^1.0.7",
+        "@opentelemetry/api": "^1.9.1",
+        "js-tiktoken": "^1.0.21",
+        "mdast-util-from-markdown": "^2.0.3",
+        "picomatch": "^4.0.5",
+        "yaml": "^2.9.0",
+        "zod": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@microsoft/vally-cli": {
+      "version": "0.14.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/vally-cli/-/vally-cli-0.14.0.tgz",
+      "integrity": "sha1-kp2aELnDzM1eR1F9oL0WxTN4LIg=",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.32",
+        "@microsoft/vally": "^0.14.0",
+        "@microsoft/vally-server": "^0.14.0",
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.221.0",
+        "@opentelemetry/resources": "^2.10.0",
+        "@opentelemetry/sdk-trace-base": "^2.10.0",
+        "@opentelemetry/sdk-trace-node": "^2.10.0",
+        "commander": "^15.0.0"
+      },
+      "bin": {
+        "vally": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "@vscode/deviceid": "~0.1.5"
+      }
+    },
+    "node_modules/@microsoft/vally-server": {
+      "version": "0.14.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@microsoft/vally-server/-/vally-server-0.14.0.tgz",
+      "integrity": "sha1-fAB77Koyrmv/v+CdHkJ/GWEp9OM=",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^2.0.12",
+        "@microsoft/vally": "^0.14.0",
+        "better-sqlite3": "^13.0.2",
+        "hono": "^4.13.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha1-wbA0beM2ulWvLVp5cIggN7rt7AU=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.200.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/api-logs/-/api-logs-0.200.0.tgz",
+      "integrity": "sha1-+QFf2ESSDBOWhxWzzcz1pNT/kH4=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.10.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/context-async-hooks/-/context-async-hooks-2.10.0.tgz",
+      "integrity": "sha1-clms/Vk2rnE74/bTYkmt166Kylo=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha1-qnf3E450ulOZ1fO7DereDBaPALI=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.221.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.221.0.tgz",
+      "integrity": "sha1-tSimB24D3L4BiiscfleFM79N9/8=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.221.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.221.0.tgz",
+      "integrity": "sha1-BqsA2SdikoM4SOmsxc0iXyOGhGc=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/otlp-transformer": "0.221.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.221.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/otlp-transformer/-/otlp-transformer-0.221.0.tgz",
+      "integrity": "sha1-6/xaZZWh43zk8gTJcRXI7YaNv7s=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-logs": "0.221.0",
+        "@opentelemetry/sdk-metrics": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/api-logs": {
+      "version": "0.221.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha1-ZrhAWxIv8cdu50O5vSynOACi4t8=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.221.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/sdk-logs/-/sdk-logs-0.221.0.tgz",
+      "integrity": "sha1-nsDiy/tXKRe5SBAZg+CIaKaQkV4=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha1-znbBwbqvzkx3vCmJCWW6H1ZnGsw=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.200.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/sdk-logs/-/sdk-logs-0.200.0.tgz",
+      "integrity": "sha1-iT2GzvpvLAKnzQPVy0qVnu02U9E=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.200.0",
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/resources": "2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+      "version": "2.0.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/core/-/core-2.0.0.tgz",
+      "integrity": "sha1-N+nw6d3sRHmyZ6ym8y2IdXyUGzo=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.0.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/resources/-/resources-2.0.0.tgz",
+      "integrity": "sha1-FcBHlMMrfQs8dYkiXs5q6buiWYk=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.10.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/sdk-metrics/-/sdk-metrics-2.10.0.tgz",
+      "integrity": "sha1-Go841FFkuj77s1Bb62jK9KPs8tk=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha1-drAzEJJFKwGosvcESA4ldmQccBE=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.10.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha1-P5v4oUwduoeQYZ4oMm98V/i5528=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.10.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.10.0.tgz",
+      "integrity": "sha1-ay7F8Vy5nJqsdHZDCAHR3JM+zxk=",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.10.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/sdk-trace-base": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha1-8/Rn42wnMy8Oc17IbNzXjdbyeGU=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha1-ItHMnVQtNZPK6nZPl0MGqzYobuc=",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha1-fM9y7dLxqn3TQ34YDGQ3NYWATdY=",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha1-BSqmekjszEMJ1/AZG35BQ0uQu3g=",
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha1-rKqw+RnOaczmKcLU7S60rcG2wgw=",
+      "license": "MIT"
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.8",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.8.tgz",
+      "integrity": "sha1-tN7lpeeXGu3HCVO7fS2/V4P0LTg=",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@vscode/deviceid": {
+      "version": "0.1.5",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@vscode/deviceid/-/deviceid-0.1.5.tgz",
+      "integrity": "sha1-ven4iNvP0fzpoBcj+qJ1LUh58pw=",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fs-extra": "^11.2.0",
+        "uuid": "^14.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha1-48121MVI7oldPD/Y3B9sW5Ay56g=",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "13.0.3",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
+      "integrity": "sha1-tuoNx//34o0E2Qk+gQUdOPe+q+I=",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha1-LQnC5yzZUjB2zLIRV9/2atQ/zCI=",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "15.0.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha1-lvOWHxKtrBeZ7z+9i8YdQFctGxE=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha1-PkBgN2CHTC5YZ2kbWZ1zp9oltT8=",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha1-JkQhTxmX057Q7g7OcjNUkKesZ74=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha1-aJxdzcGQDvVYOky59te0c3QgdK0=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha1-TbfCyk3G4Og0wwvnDJS7yXbccBg=",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.4.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha1-+I7W0YCsnhS2GwjmeUaPCxtrRzA=",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha1-QYPk6L8Iu24Fu7L30uDI9xLKQOM=",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/hono": {
+      "version": "4.13.5",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/hono/-/hono-4.13.5.tgz",
+      "integrity": "sha1-PflGPEZooDIcOVFTCfWJHjiOlwk=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha1-mosfJGhmwChQlIZYX2K48sGMJw4=",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha1-2o3+rH2hMLBcK6S1nJts1mYRprk=",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha1-NoqZV1kaMKYpl90MTPMIZvAPgiE=",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha1-tuMXF/Isw3MwsIHOAFHtXeU68vY=",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/koffi": {
+      "version": "3.1.6",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/koffi/-/koffi-3.1.6.tgz",
+      "integrity": "sha1-l/qLxQwq9uGoc/3uNxPMEovyhv8=",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      },
+      "optionalDependencies": {
+        "@koromix/koffi-darwin-arm64": "3.1.6",
+        "@koromix/koffi-darwin-x64": "3.1.6",
+        "@koromix/koffi-freebsd-arm64": "3.1.6",
+        "@koromix/koffi-freebsd-ia32": "3.1.6",
+        "@koromix/koffi-freebsd-x64": "3.1.6",
+        "@koromix/koffi-linux-arm64": "3.1.6",
+        "@koromix/koffi-linux-ia32": "3.1.6",
+        "@koromix/koffi-linux-loong64": "3.1.6",
+        "@koromix/koffi-linux-riscv64": "3.1.6",
+        "@koromix/koffi-linux-x64": "3.1.6",
+        "@koromix/koffi-openbsd-ia32": "3.1.6",
+        "@koromix/koffi-openbsd-x64": "3.1.6",
+        "@koromix/koffi-win32-arm64": "3.1.6",
+        "@koromix/koffi-win32-ia32": "3.1.6",
+        "@koromix/koffi-win32-x64": "3.1.6"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha1-yVgiuRqrdfGKTL6LL1G4c+0s8Mc=",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha1-elEhR1VWoE5+3etnsmSq550xKBQ=",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha1-kTlaPhiEoZjmIRbjPJxWjjmTb9s=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha1-xpFjDkhQIaaM8o28Kyyifr9njNQ=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha1-j++OD3CB8EdPvdkt61DJkKAmRjk=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha1-UmfvqX8eUlTvx/ILRZo4yyEFi6E=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha1-NtAhLpYrKzEh+FJfx6PHwCnzNPw=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha1-I35KpdWKlYY/AQMtnumwkPHebpQ=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha1-BrJrKYPE0nv8xlezPiUTTUhosLE=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha1-L5h4MaQNTFEKwmHomFLE6XA8zaY=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha1-R/vNk0caP8yrhs/wOEf8NVLbEFE=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha1-05n6+cRcoUyLS+mLHqSBvO2Htik=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha1-Kg9JCrCL/1zC/V7sbdDKBPibMKk=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha1-/PFbZgl5OI5vEYzba/fXnXPSb+U=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha1-bLmVguXScehO/KjmGoB5lNcWHrI=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha1-DVHRwJVVHPqsNoMmljz1XxX1QLg=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha1-5AQDCWSBmGtBwQZif5j3LU0QuCU=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha1-ww13sugyrPZSb4vxqke8nJQ4wW0=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha1-4aLWLN0jcjCirhGDkCexk4HjHos=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha1-q4l4m4GKWHUrc9a1UjhiG3+qj9c=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha1-2K3lug8xl6HPaimZ+7/mNXoaGe4=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha1-5dpJTo6ysHGg0I+zT2zv7GwKGbg=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha1-8AIl9fWg68MlT5bDa2YFxLOTkI4=",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.9.2",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha1-23rJShP/2bVebLBFhL1e+OHXSxg=",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.7",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha1-YxM2ADTMs2s9xh7L3/eBIfkP4h8=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha1-YS7+TtI11Wfoq6Xypfq3AoCt6D8=",
+      "license": "0BSD"
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha1-RJxuIaiA4IVb9aq63rOnQDFKusI=",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha1-Fo78IYCWTmOG0GHglN9hr+I5sY0=",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.2",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/uuid/-/uuid-14.0.2.tgz",
+      "integrity": "sha1-1a4D5NsIgchycfiwub1zEtAseZo=",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha1-oyLMDx2X95T/2cTNKomKC94JfzQ=",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha1-eCdK/ZNZih391hMN9qVm3vy/mqQ=",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha1-toDxcohdGLvr8hqDTqJeVaG781Y=",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/eng/skill-evals/evaluation-tools/package.json
+++ b/eng/skill-evals/evaluation-tools/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "aspnetcore-skill-evaluation-tools",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Pinned command-line tools used by the skill evaluation workflow.",
+  "dependencies": {
+    "@github/copilot": "1.0.80",
+    "@microsoft/vally-cli": "0.14.0"
+  },
+  "overrides": {
+    "@github/copilot": "1.0.80"
+  }
+}

--- a/eng/skill-evals/run.ps1
+++ b/eng/skill-evals/run.ps1
@@ -17,7 +17,7 @@ param(
     [string[]]$VallyPrefix = @(
         '--yes',
         '--registry=https://packagefeedproxy.microsoft.io/npm/',
-        '@microsoft/vally-cli@0.13.0'
+        '@microsoft/vally-cli@0.14.0'
     ),
 
     [Parameter(ValueFromRemainingArguments = $true)]
@@ -26,6 +26,27 @@ param(
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 3
+
+if (-not $PSBoundParameters.ContainsKey('Vally')) {
+    $installedVally = if ($IsWindows) {
+        Join-Path $PSScriptRoot 'evaluation-tools/node_modules/.bin/vally.cmd'
+    } else {
+        Join-Path $PSScriptRoot 'evaluation-tools/node_modules/.bin/vally'
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:SKILL_EVAL_VALLY)) {
+        $Vally = $env:SKILL_EVAL_VALLY
+        if (-not $PSBoundParameters.ContainsKey('VallyPrefix')) {
+            $VallyPrefix = @()
+        }
+    } elseif (Test-Path $installedVally -PathType Leaf) {
+        $Vally = $installedVally
+        if (-not $PSBoundParameters.ContainsKey('VallyPrefix')) {
+            $VallyPrefix = @()
+        }
+    } elseif ($Action -eq 'Run') {
+        throw 'Run requires the pinned evaluation tools. Run npm ci --prefix eng/skill-evals/evaluation-tools first.'
+    }
+}
 
 $repoRoot = if ($Root) {
     (Resolve-Path $Root).Path

--- a/eng/skill-evals/test_run.ps1
+++ b/eng/skill-evals/test_run.ps1
@@ -14,6 +14,8 @@ $specialized = Join-Path $testRoot 'specialized.vally.yaml'
 $customExperiment = Join-Path $testRoot 'custom.experiment.yaml'
 $output = Join-Path $testRoot 'results'
 $relativeOutput = 'artifacts/skill-eval-runner-selftest'
+$previousVally = [Environment]::GetEnvironmentVariable('SKILL_EVAL_VALLY')
+$hadPreviousVally = Test-Path Env:SKILL_EVAL_VALLY
 
 function Assert-True {
     param([bool]$Condition, [string]$Message)
@@ -68,10 +70,11 @@ if ($env:SKILL_EVAL_FAKE_FAILURE) {
     Set-Content $specialized "name: specialized`n"
     Set-Content $customExperiment "name: custom`n"
     $env:SKILL_EVAL_RUNNER_RECORD = $record
+    $env:SKILL_EVAL_VALLY = $fakeVally
 
     Push-Location $testRoot
     try {
-        & $runner -Vally $fakeVally -VallyPrefix @()
+        & $runner
     } finally {
         Pop-Location
     }
@@ -172,5 +175,10 @@ if ($env:SKILL_EVAL_FAKE_FAILURE) {
 } finally {
     Remove-Item Env:SKILL_EVAL_RUNNER_RECORD -ErrorAction SilentlyContinue
     Remove-Item Env:SKILL_EVAL_FAKE_FAILURE -ErrorAction SilentlyContinue
+    if ($hadPreviousVally) {
+        $env:SKILL_EVAL_VALLY = $previousVally
+    } else {
+        Remove-Item Env:SKILL_EVAL_VALLY -ErrorAction SilentlyContinue
+    }
     Remove-Item -Recurse -Force $testRoot
 }

--- a/eng/skill-evals/test_workflow.ps1
+++ b/eng/skill-evals/test_workflow.ps1
@@ -62,6 +62,131 @@ if ($patPoolJobText -notmatch [regex]::Escape('echo "copilot_pat_number=$PAT_NUM
     throw 'The PAT-pool selector does not expose the selected numeric slot.'
 }
 
+$selectorScriptMatch = [regex]::Match(
+    $patPoolJobText,
+    '(?ms)^      - name: Select Copilot token from pool\r?\n.*?^        run: \|\r?\n(?<script>.*)\z'
+)
+if (-not $selectorScriptMatch.Success) {
+    throw 'The PAT-pool selector script could not be extracted for behavioral testing.'
+}
+
+$selectorScript = (
+    $selectorScriptMatch.Groups['script'].Value -split '\r?\n' |
+        ForEach-Object {
+            if ($_.StartsWith('          ')) {
+                $_.Substring(10)
+            } elseif ($_.Length -eq 0) {
+                ''
+            } else {
+                throw "Unexpected indentation in the PAT-pool selector script: '$_'"
+            }
+        }
+) -join "`n"
+
+$bash = Get-Command bash -ErrorAction Stop
+$selectorTestRoot = Join-Path ([IO.Path]::GetTempPath()) (
+    'aspnetcore-skill-eval-pat-pool-test-' + [guid]::NewGuid().ToString('N')
+)
+New-Item -ItemType Directory -Path $selectorTestRoot | Out-Null
+
+function Invoke-PatPoolSelector {
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable] $Pool
+    )
+
+    $caseRoot = Join-Path $selectorTestRoot ([guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Path $caseRoot | Out-Null
+    $scriptPath = Join-Path $caseRoot 'select-pat.sh'
+    $outputPath = Join-Path $caseRoot 'github-output.txt'
+    $summaryPath = Join-Path $caseRoot 'github-summary.md'
+    Set-Content $scriptPath $selectorScript -Encoding utf8NoBOM
+
+    $startInfo = [Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $bash.Source
+    $startInfo.ArgumentList.Add($scriptPath)
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $startInfo.Environment['GITHUB_OUTPUT'] = $outputPath
+    $startInfo.Environment['GITHUB_STEP_SUMMARY'] = $summaryPath
+    foreach ($patNumber in 0..9) {
+        $key = "COPILOT_PAT_$patNumber"
+        $startInfo.Environment[$key] = if ($Pool.ContainsKey($patNumber)) {
+            [string] $Pool[$patNumber]
+        } else {
+            ''
+        }
+    }
+
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    if (-not $process.Start()) {
+        throw 'The PAT-pool selector process did not start.'
+    }
+
+    $standardOutput = $process.StandardOutput.ReadToEnd()
+    $standardError = $process.StandardError.ReadToEnd()
+    $process.WaitForExit()
+    if ($process.ExitCode -ne 0) {
+        throw "The PAT-pool selector exited with code $($process.ExitCode): $standardError"
+    }
+
+    $githubOutput = if (Test-Path $outputPath) {
+        Get-Content $outputPath -Raw
+    } else {
+        ''
+    }
+    $summary = if (Test-Path $summaryPath) {
+        Get-Content $summaryPath -Raw
+    } else {
+        ''
+    }
+    $selectedPatMatch = [regex]::Match(
+        $githubOutput,
+        '(?m)^copilot_pat_number=(?<number>[0-9])\r?$'
+    )
+    $combinedOutput = "$standardOutput`n$standardError`n$githubOutput`n$summary"
+    foreach ($patValue in $Pool.Values) {
+        if ($combinedOutput.Contains([string] $patValue, [StringComparison]::Ordinal)) {
+            throw 'The PAT-pool selector exposed a credential value in its output.'
+        }
+    }
+
+    return [pscustomobject]@{
+        Number = if ($selectedPatMatch.Success) {
+            $selectedPatMatch.Groups['number'].Value
+        } else {
+            $null
+        }
+        StandardOutput = $standardOutput
+    }
+}
+
+try {
+    $emptyPool = Invoke-PatPoolSelector -Pool @{}
+    if ($null -ne $emptyPool.Number -or
+        $emptyPool.StandardOutput -notmatch 'None of the PAT pool entries had values') {
+        throw 'The PAT-pool selector did not preserve the empty-pool fallback path.'
+    }
+
+    $singlePat = Invoke-PatPoolSelector -Pool @{ 2 = 'single-slot-secret' }
+    if ($singlePat.Number -ne '2') {
+        throw "The PAT-pool selector did not select the only populated slot: '$($singlePat.Number)'."
+    }
+
+    $multiplePats = Invoke-PatPoolSelector -Pool @{
+        1 = 'first-multi-slot-secret'
+        4 = 'second-multi-slot-secret'
+        9 = 'third-multi-slot-secret'
+    }
+    if ($multiplePats.Number -notin @('1', '4', '9')) {
+        throw "The PAT-pool selector selected an empty slot: '$($multiplePats.Number)'."
+    }
+} finally {
+    Remove-Item -Recurse -Force $selectorTestRoot
+}
+
 $reportJob = [regex]::Match(
     $workflow,
     '(?ms)^  report:\r?\n(?<job>.*?)(?=^  \S|\z)'

--- a/eng/skill-evals/test_workflow.ps1
+++ b/eng/skill-evals/test_workflow.ps1
@@ -29,6 +29,17 @@ if ($expectedRefCount -ne 2) {
     throw "Expected two closed default-branch comparisons; found $expectedRefCount."
 }
 
+$copilotCredentialExpression = @'
+COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT_0 || secrets.COPILOT_PAT_1 || secrets.COPILOT_PAT_2 || secrets.COPILOT_PAT_3 || secrets.COPILOT_PAT_4 || secrets.COPILOT_PAT_5 || secrets.COPILOT_PAT_6 || secrets.COPILOT_PAT_7 || secrets.COPILOT_PAT_8 || secrets.COPILOT_PAT_9 || secrets.COPILOT_GITHUB_TOKEN }}
+'@.Trim()
+$copilotCredentialExpressionCount = ([regex]::Matches(
+    $workflow,
+    [regex]::Escape($copilotCredentialExpression)
+)).Count
+if ($copilotCredentialExpressionCount -ne 1) {
+    throw "Expected one ordered Copilot PAT-pool expression with the repository fallback; found $copilotCredentialExpressionCount."
+}
+
 $reportJob = [regex]::Match(
     $workflow,
     '(?ms)^  report:\r?\n(?<job>.*?)(?=^  \S|\z)'

--- a/eng/skill-evals/test_workflow.ps1
+++ b/eng/skill-evals/test_workflow.ps1
@@ -40,6 +40,75 @@ if ($copilotCredentialExpressionCount -ne 1) {
     throw "Expected one static Copilot PAT mapping with the repository fallback; found $copilotCredentialExpressionCount."
 }
 
+$installStepCount = ([regex]::Matches(
+    $workflow,
+    [regex]::Escape('- name: Install evaluation tools')
+)).Count
+if ($installStepCount -ne 2) {
+    throw "Expected tokenless pinned-tool installation in validation and execution jobs; found $installStepCount."
+}
+
+foreach ($expectedInstallFragment in @(
+    'npm ci \',
+    '--userconfig "$RUNNER_TEMP/evaluation.npmrc"',
+    '--registry https://packagefeedproxy.microsoft.io/npm/',
+    'node_modules/.bin/vally" --version',
+    'node_modules/.bin/copilot" --version',
+    'cd "$RUNNER_TEMP/evaluation-tools/node_modules/@github/copilot-sdk/dist"',
+    "import.meta.resolve('@github/copilot-linux-x64/sdk')",
+    'SKILL_EVAL_VALLY: ${{ runner.temp }}/evaluation-tools/node_modules/.bin/vally'
+)) {
+    $fragmentCount = ([regex]::Matches(
+        $workflow,
+        [regex]::Escape($expectedInstallFragment)
+    )).Count
+    if ($fragmentCount -ne 2) {
+        throw "Expected two pinned-tool workflow references to '$expectedInstallFragment'; found $fragmentCount."
+    }
+}
+
+if ($workflow -notmatch [regex]::Escape(
+    'cp _trusted-control-plane/eng/skill-evals/evaluation-tools/package.json \'
+)) {
+    throw 'The credentialed job does not install the trusted evaluation tool manifest.'
+}
+
+$evaluationToolsRoot = Join-Path $PSScriptRoot 'evaluation-tools'
+$evaluationToolsManifest = Get-Content (
+    Join-Path $evaluationToolsRoot 'package.json'
+) -Raw | ConvertFrom-Json
+if ($evaluationToolsManifest.dependencies.'@github/copilot' -ne '1.0.80') {
+    throw 'The evaluation tool manifest does not pin @github/copilot 1.0.80.'
+}
+if ($evaluationToolsManifest.overrides.'@github/copilot' -ne '1.0.80') {
+    throw 'The evaluation tool manifest does not constrain transitive Copilot packages to 1.0.80.'
+}
+if ($evaluationToolsManifest.dependencies.'@microsoft/vally-cli' -ne '0.14.0') {
+    throw 'The evaluation tool manifest does not pin @microsoft/vally-cli 0.14.0.'
+}
+
+$evaluationToolsLock = Get-Content (
+    Join-Path $evaluationToolsRoot 'package-lock.json'
+) -Raw | ConvertFrom-Json -AsHashtable
+$lockedRoot = $evaluationToolsLock.packages['']
+if ($lockedRoot.dependencies['@github/copilot'] -ne '1.0.80' -or
+    $lockedRoot.dependencies['@microsoft/vally-cli'] -ne '0.14.0') {
+    throw 'The evaluation tool lockfile root does not match the pinned manifest.'
+}
+foreach ($lockedPackage in @(
+    'node_modules/@github/copilot-linux-x64',
+    'node_modules/@microsoft/vally-cli'
+)) {
+    if (-not $evaluationToolsLock.packages.ContainsKey($lockedPackage)) {
+        throw "The evaluation tool lockfile does not contain '$lockedPackage'."
+    }
+}
+foreach ($lockedPackage in $evaluationToolsLock.packages.Keys) {
+    if ($lockedPackage -like 'node_modules/@github/copilot-sdk/node_modules/@github/copilot*') {
+        throw "The evaluation tool lockfile contains a conflicting nested Copilot package: '$lockedPackage'."
+    }
+}
+
 $patPoolJob = [regex]::Match(
     $workflow,
     '(?ms)^  pat_pool:\r?\n(?<job>.*?)(?=^  \S|\z)'

--- a/eng/skill-evals/test_workflow.ps1
+++ b/eng/skill-evals/test_workflow.ps1
@@ -17,27 +17,49 @@ $selectedRefCount = ([regex]::Matches(
     $workflow,
     [regex]::Escape('SELECTED_REF: ${{ github.ref }}')
 )).Count
-if ($selectedRefCount -ne 2) {
-    throw "Expected two full-ref default-branch guards; found $selectedRefCount."
+if ($selectedRefCount -ne 3) {
+    throw "Expected three full-ref default-branch guards; found $selectedRefCount."
 }
 
 $expectedRefCount = ([regex]::Matches(
     $workflow,
     [regex]::Escape('EXPECTED_REF="refs/heads/$DEFAULT_BRANCH"')
 )).Count
-if ($expectedRefCount -ne 2) {
-    throw "Expected two closed default-branch comparisons; found $expectedRefCount."
+if ($expectedRefCount -ne 3) {
+    throw "Expected three closed default-branch comparisons; found $expectedRefCount."
 }
 
 $copilotCredentialExpression = @'
-COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_PAT_0 || secrets.COPILOT_PAT_1 || secrets.COPILOT_PAT_2 || secrets.COPILOT_PAT_3 || secrets.COPILOT_PAT_4 || secrets.COPILOT_PAT_5 || secrets.COPILOT_PAT_6 || secrets.COPILOT_PAT_7 || secrets.COPILOT_PAT_8 || secrets.COPILOT_PAT_9 || secrets.COPILOT_GITHUB_TOKEN }}
+COPILOT_GITHUB_TOKEN: ${{ secrets[format('COPILOT_PAT_{0}', needs.pat_pool.outputs.pat_number)] || secrets.COPILOT_GITHUB_TOKEN }}
 '@.Trim()
 $copilotCredentialExpressionCount = ([regex]::Matches(
     $workflow,
     [regex]::Escape($copilotCredentialExpression)
 )).Count
 if ($copilotCredentialExpressionCount -ne 1) {
-    throw "Expected one ordered Copilot PAT-pool expression with the repository fallback; found $copilotCredentialExpressionCount."
+    throw "Expected one selected Copilot PAT expression with the repository fallback; found $copilotCredentialExpressionCount."
+}
+
+$patPoolJob = [regex]::Match(
+    $workflow,
+    '(?ms)^  pat_pool:\r?\n(?<job>.*?)(?=^  \S|\z)'
+)
+if (-not $patPoolJob.Success) {
+    throw 'The workflow does not contain the trusted PAT-pool selector job.'
+}
+
+$patPoolJobText = $patPoolJob.Groups['job'].Value
+foreach ($patNumber in 0..9) {
+    $secretReference = "COPILOT_PAT_${patNumber}: `${{ secrets.COPILOT_PAT_${patNumber} }}"
+    if ($patPoolJobText -notmatch [regex]::Escape($secretReference)) {
+        throw "The PAT-pool selector does not inspect COPILOT_PAT_$patNumber."
+    }
+}
+if ($patPoolJobText -notmatch [regex]::Escape('PAT_INDEX=$((RANDOM % ${#PAT_NUMBERS[@]}))')) {
+    throw 'The PAT-pool selector does not randomly balance across configured entries.'
+}
+if ($patPoolJobText -notmatch [regex]::Escape('echo "copilot_pat_number=$PAT_NUMBER" >> "$GITHUB_OUTPUT"')) {
+    throw 'The PAT-pool selector does not expose the selected numeric slot.'
 }
 
 $reportJob = [regex]::Match(

--- a/eng/skill-evals/test_workflow.ps1
+++ b/eng/skill-evals/test_workflow.ps1
@@ -30,14 +30,14 @@ if ($expectedRefCount -ne 3) {
 }
 
 $copilotCredentialExpression = @'
-COPILOT_GITHUB_TOKEN: ${{ secrets[format('COPILOT_PAT_{0}', needs.pat_pool.outputs.pat_number)] || secrets.COPILOT_GITHUB_TOKEN }}
+COPILOT_GITHUB_TOKEN: ${{ case(needs.pat_pool.outputs.pat_number == '0', secrets.COPILOT_PAT_0, needs.pat_pool.outputs.pat_number == '1', secrets.COPILOT_PAT_1, needs.pat_pool.outputs.pat_number == '2', secrets.COPILOT_PAT_2, needs.pat_pool.outputs.pat_number == '3', secrets.COPILOT_PAT_3, needs.pat_pool.outputs.pat_number == '4', secrets.COPILOT_PAT_4, needs.pat_pool.outputs.pat_number == '5', secrets.COPILOT_PAT_5, needs.pat_pool.outputs.pat_number == '6', secrets.COPILOT_PAT_6, needs.pat_pool.outputs.pat_number == '7', secrets.COPILOT_PAT_7, needs.pat_pool.outputs.pat_number == '8', secrets.COPILOT_PAT_8, needs.pat_pool.outputs.pat_number == '9', secrets.COPILOT_PAT_9, secrets.COPILOT_GITHUB_TOKEN) }}
 '@.Trim()
 $copilotCredentialExpressionCount = ([regex]::Matches(
     $workflow,
     [regex]::Escape($copilotCredentialExpression)
 )).Count
 if ($copilotCredentialExpressionCount -ne 1) {
-    throw "Expected one selected Copilot PAT expression with the repository fallback; found $copilotCredentialExpressionCount."
+    throw "Expected one static Copilot PAT mapping with the repository fallback; found $copilotCredentialExpressionCount."
 }
 
 $patPoolJob = [regex]::Match(


### PR DESCRIPTION
Fixes the authentication and runtime failures seen while evaluating #69028 in https://github.com/dotnet/aspnetcore/actions/runs/33777017172.

Two independent issues prevented the model evaluation from completing:

1. The workflow assumed `COPILOT_PAT_0` was populated even though the shared `copilot-pat-pool` environment can expose any populated slot.
2. The transient Vally/Copilot installation could resolve an incompatible Copilot platform package whose SDK entry point was unavailable.

This change follows the trusted PAT-pool and pinned-toolchain design used by the existing ASP.NET Core agentic workflows and `dotnet/skills`:

- A dedicated trusted job receives `COPILOT_PAT_0` through `COPILOT_PAT_9`, finds the populated slots, and randomly selects one.
- The selector emits only the selected numeric slot, never a secret value.
- The model step resolves that slot through the repository's canonical static `case(...)` secret mapping, with `COPILOT_GITHUB_TOKEN` as the empty-pool fallback.
- The selected credential remains scoped only to the trusted Vally execution step.
- Vally and Copilot are installed from a checked-in manifest and lockfile before credentials enter scope.
- The Copilot dependency graph is constrained to SDK-compatible version `1.0.80`, and the workflow verifies Linux platform SDK resolution from the consuming SDK package's module path before running a model.
- Workflow tests execute the real selector against empty, one-slot, and multi-slot synthetic pools and reject credential disclosure or conflicting nested Copilot packages.

The existing authorization, same-repository restriction, exact-commit binding, trusted default-branch workflow, and trusted-file staging boundaries are unchanged.

Validated locally with:

- `pwsh ./eng/skill-evals/run.ps1 Test`
- `pwsh ./eng/skill-evals/run.ps1 Validate`
- an isolated `npm ci` from the checked-in lockfile and SDK-relative platform-resolution probe
- `git diff --check`

End-to-end validation used `PureWeen/aspnetcore`, whose `copilot-pat-pool` environment contained only `COPILOT_PAT_2`: https://github.com/PureWeen/aspnetcore/actions/runs/33795737099

- The selector reported pool size 1 and selected slot 2.
- The model step received a non-empty masked credential.
- Vally `0.14.0`, Copilot CLI `1.0.80`, and the Linux x64 SDK platform entry point resolved successfully.
- All five baseline and five skilled executions completed successfully.
- The skilled variant scored `0.79` against the `0.6` threshold; baseline scored `0.555`.
- The uploaded artifact contained provenance, report, summaries, results, metadata, and event logs for both variants.

The temporary fork commits were restored with a normal revert after the run.