### PR TITLE
[SignalR] [Java] Fix hang when reading an HTTP response body fails

### DIFF
--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/DefaultHttpClient.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/DefaultHttpClient.java
@@ -150,11 +150,20 @@ final class DefaultHttpClient extends HttpClient {
             }
 
             @Override
-            public void onResponse(Call call, Response response) throws IOException {
+            public void onResponse(Call call, Response response) {
+                HttpResponse httpResponse;
                 try (ResponseBody body = response.body()) {
-                    HttpResponse httpResponse = new HttpResponse(response.code(), response.message(), ByteBuffer.wrap(body.bytes()));
-                    responseSubject.onSuccess(httpResponse);
+                    httpResponse = new HttpResponse(response.code(), response.message(), ByteBuffer.wrap(body.bytes()));
+                } catch (Throwable ex) {
+                    // OkHttp marks the callback as signalled before invoking onResponse, so it never calls
+                    // onFailure for anything thrown from here. Reading the body can still fail, for example when
+                    // the connection drops mid-response, so terminate the Single ourselves. Otherwise callers
+                    // such as negotiate would wait on it forever.
+                    responseSubject.onError(ex);
+                    return;
                 }
+
+                responseSubject.onSuccess(httpResponse);
             }
         });
 

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/DefaultHttpClientTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/DefaultHttpClientTest.java
@@ -1,0 +1,140 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+package com.microsoft.signalr;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava3.observers.TestObserver;
+
+public class DefaultHttpClientTest {
+    private static final String NEGOTIATE_BODY = "{\"connectionId\":\"bVOiRPONXYEq3sPMCVqCuA\",\"connectionToken\":\"connection-token\","
+            + "\"negotiateVersion\":1,\"availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}";
+
+    @Test
+    public void requestCompletesWhenResponseIsWellFormed() throws Exception {
+        try (RawResponseServer server = RawResponseServer.start(ResponseMode.COMPLETE);
+             DefaultHttpClient client = new DefaultHttpClient(null)) {
+            TestObserver<HttpResponse> observer = client.get(server.getUrl()).test();
+
+            assertTrue(observer.await(30, TimeUnit.SECONDS), "The request never terminated.");
+            observer.assertNoErrors();
+            assertEquals(200, observer.values().get(0).getStatusCode());
+        }
+    }
+
+    // Reading the response body can fail after OkHttp has already handed us the response. OkHttp does not
+    // call onFailure in that case, so the client has to terminate the Single itself.
+    @Test
+    public void requestFailsWhenResponseBodyIsTruncated() throws Exception {
+        try (RawResponseServer server = RawResponseServer.start(ResponseMode.TRUNCATED_BODY);
+             DefaultHttpClient client = new DefaultHttpClient(null)) {
+            TestObserver<HttpResponse> observer = client.get(server.getUrl()).test();
+
+            assertTrue(observer.await(30, TimeUnit.SECONDS), "The request never terminated.");
+            observer.assertError(IOException.class);
+        }
+    }
+
+    // Regression test for a truncated negotiate response leaving HubConnection.start() pending forever,
+    // which also made stop() hang because it waits on the start task.
+    @Test
+    public void startFailsWhenNegotiateResponseIsTruncated() throws Exception {
+        try (RawResponseServer server = RawResponseServer.start(ResponseMode.TRUNCATED_BODY)) {
+            HubConnection hubConnection = HubConnectionBuilder.create(server.getUrl()).build();
+
+            // Await the start task directly rather than applying an Rx timeout to it, otherwise this would
+            // still pass while start() itself hangs.
+            TestObserver<Void> observer = hubConnection.start().test();
+
+            assertTrue(observer.await(30, TimeUnit.SECONDS), "start() never terminated.");
+            observer.assertError(IOException.class);
+            assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+
+            hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
+
+            // Release the underlying HttpClient. This is deliberately not a try-with-resources or a finally
+            // block: close() waits on the start task without a timeout, so closing after a failed assertion
+            // would hang the test run instead of reporting the failure. Getting here means stop() already
+            // completed, which leaves close() with no work to wait for.
+            hubConnection.close();
+        }
+    }
+
+    private enum ResponseMode {
+        COMPLETE,
+        TRUNCATED_BODY
+    }
+
+    /**
+     * A minimal HTTP server that writes a canned raw response so tests can control exactly what reaches the client.
+     */
+    private static final class RawResponseServer implements AutoCloseable {
+        private final ServerSocket serverSocket;
+        private final Thread acceptThread;
+
+        private RawResponseServer(ServerSocket serverSocket, ResponseMode mode) {
+            this.serverSocket = serverSocket;
+            this.acceptThread = new Thread(() -> {
+                while (!serverSocket.isClosed()) {
+                    try {
+                        Socket socket = serverSocket.accept();
+                        new Thread(() -> respond(socket, mode)).start();
+                    } catch (Exception ex) {
+                        return;
+                    }
+                }
+            });
+            this.acceptThread.setDaemon(true);
+        }
+
+        public static RawResponseServer start(ResponseMode mode) throws Exception {
+            RawResponseServer server = new RawResponseServer(new ServerSocket(0), mode);
+            server.acceptThread.start();
+            return server;
+        }
+
+        public String getUrl() {
+            return "http://localhost:" + serverSocket.getLocalPort() + "/hub";
+        }
+
+        private static void respond(Socket socket, ResponseMode mode) {
+            try (Socket toClose = socket) {
+                InputStream input = socket.getInputStream();
+                byte[] buffer = new byte[8192];
+                if (input.read(buffer) <= 0) {
+                    return;
+                }
+
+                byte[] body = NEGOTIATE_BODY.getBytes(StandardCharsets.UTF_8);
+                // Always advertise the full length, but only write part of the body when truncating so the
+                // client sees the connection end in the middle of the response.
+                int bytesToWrite = mode == ResponseMode.TRUNCATED_BODY ? body.length / 2 : body.length;
+                String headers = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: " + body.length + "\r\n\r\n";
+
+                OutputStream output = socket.getOutputStream();
+                output.write(headers.getBytes(StandardCharsets.UTF_8));
+                output.write(body, 0, bytesToWrite);
+                output.flush();
+            } catch (Exception ex) {
+                // The client closing first is expected for some of these tests.
+            }
+        }
+
+        @Override
+        public void close() throws Exception {
+            serverSocket.close();
+        }
+    }
+}


### PR DESCRIPTION
Fixes a hang where `HubConnection.start()` never completes and the connection cannot be recovered or disposed.

## Description

`DefaultHttpClient.send` read the response body inside OkHttp's `onResponse` callback:

```java
public void onResponse(Call call, Response response) throws IOException {
    try (ResponseBody body = response.body()) {
        HttpResponse httpResponse = new HttpResponse(response.code(), response.message(), ByteBuffer.wrap(body.bytes()));
        responseSubject.onSuccess(httpResponse);
    }   // body.bytes() throws -> nothing terminates responseSubject
}
```

OkHttp sets `signalledCallback = true` *before* invoking `onResponse`, so anything thrown from there is only logged (`Callback failure for call to ...`) and **`onFailure` is never called**. The `SingleSubject` is left unterminated.

Nothing bounds that wait. Only the handshake has a SignalR-level timeout (15s), and it is armed *after* `transport.send()` returns; negotiate and transport startup rely solely on OkHttp's per-operation timeouts. So a negotiate response that fails mid-body leaves `start()` pending forever:

- The `Completable` returned by `start()` never terminates, and subsequent `start()` calls return that same incomplete task.
- `stop()` hangs, because it waits on `connectionState.startTask`.
- `close()` hangs for the same reason, so its `finally` never reaches `httpClient.close()` and the OkHttp dispatcher threads are never shut down.

The trigger needs no misconfiguration — response headers arrive, then the body read fails (connection reset, proxy/load balancer dropping the connection, truncated body). Setting `callTimeout` makes it *more* likely rather than less: when the deadline lands during the body read, the resulting `InterruptedIOException` is exactly what gets swallowed, turning a transient stall into a permanent wedge.

This has been present since the code was introduced (#25253, 2020), so it affects all shipped versions.

### The fix

Terminate the `Single` when reading the body fails. `onSuccess` also moves out of the `try` block so that a throwing downstream observer can no longer double-terminate the subject.

`DefaultHttpClient` is package-private, so there is no public API change.

## Verification

New `DefaultHttpClientTest` uses a plain `ServerSocket` to serve a truncated response, so no new test dependencies are needed.

| Test | Before | After |
| --- | --- | --- |
| `requestCompletesWhenResponseIsWellFormed` | passed | passed |
| `requestFailsWhenResponseBodyIsTruncated` | **failed** — "The request never terminated" | passed |
| `startFailsWhenNegotiateResponseIsTruncated` | **failed** — `expected: <DISCONNECTED> but was: <CONNECTING>` | passed |

Both regression tests were confirmed to fail without the fix for the bug's actual reason, and the happy-path test stays green, so they are not passing incidentally. The end-to-end test awaits the start task directly instead of wrapping it in `.timeout(...)`, which would otherwise report success while `start()` was still hung.

Full Java client suite: 295 tests, 0 failures.

<!-- Not filing a separate issue; the analysis is captured above. -->