### PR TITLE
Fix rendering of messages after tool call

### DIFF
--- a/src/Components/AI/src/Components/ConversationTurnRenderer.cs
+++ b/src/Components/AI/src/Components/ConversationTurnRenderer.cs
@@ -18,17 +18,20 @@ internal class ConversationTurnRenderer : IDisposable
         AgentContext agentContext,
         ConversationTurn turn,
         MessageListContext listContext,
-        Action requestRender)
+        Action render,
+        Action<Action> dispatchToRenderer)
     {
         _turn = turn;
         _listContext = listContext;
-        _requestRender = requestRender;
+        _requestRender = () => dispatchToRenderer(render);
 
         _blockAddedSub = agentContext.RegisterOnBlockAdded((t, block) =>
         {
             if (ReferenceEquals(t, _turn))
             {
-                OnBlockAdded(block);
+                // Marshalled as a whole so the container list is only mutated on the dispatcher,
+                // where the render loop reads it.
+                dispatchToRenderer(() => OnBlockAdded(block));
             }
         });
 

--- a/src/Components/AI/src/Components/MessageInput.cs
+++ b/src/Components/AI/src/Components/MessageInput.cs
@@ -64,13 +64,29 @@ public class MessageInput : IComponent, IDisposable
         // so re-registering on every parameter set would accumulate handlers and retain the
         // component on each parent re-render.
         _statusSub ??= _agentContext.RegisterOnStatusChanged(status =>
-        {
-            _isDisabled = status is ConversationStatus.Streaming or ConversationStatus.AwaitingInput;
-            Render();
-        });
+            DispatchToRenderer(() =>
+            {
+                _isDisabled = status is ConversationStatus.Streaming or ConversationStatus.AwaitingInput;
+                Render();
+            }));
 
         Render();
         return Task.CompletedTask;
+    }
+
+    // Status changes are raised from the agent pipeline, which does not run on the renderer's
+    // synchronization context once a UI action has resumed it on the thread pool.
+    private void DispatchToRenderer(Action action)
+    {
+        var dispatcher = _renderHandle.Dispatcher;
+        if (dispatcher.CheckAccess())
+        {
+            action();
+        }
+        else
+        {
+            _ = dispatcher.InvokeAsync(action);
+        }
     }
 
     private void Render()

--- a/src/Components/AI/src/Components/MessageList.cs
+++ b/src/Components/AI/src/Components/MessageList.cs
@@ -65,13 +65,15 @@ public class MessageList : IComponent, IDisposable
             _agentContext = newAgentContext;
             _listContext.OnRegistrationsChanged = Render;
 
-            _turnAddedSub = _agentContext.RegisterOnTurnAdded(OnTurnAdded);
-            _statusChangedSub = _agentContext.RegisterOnStatusChanged(_ => Render());
+            _turnAddedSub = _agentContext.RegisterOnTurnAdded(
+                turn => DispatchToRenderer(() => OnTurnAdded(turn)));
+            _statusChangedSub = _agentContext.RegisterOnStatusChanged(
+                _ => DispatchToRenderer(Render));
 
             foreach (var turn in _agentContext.Turns)
             {
                 var renderer = new ConversationTurnRenderer(
-                    _agentContext, turn, _listContext, Render);
+                    _agentContext, turn, _listContext, Render, DispatchToRenderer);
                 _turnRenderers.Add(renderer);
             }
         }
@@ -86,9 +88,29 @@ public class MessageList : IComponent, IDisposable
     private void OnTurnAdded(ConversationTurn turn)
     {
         var renderer = new ConversationTurnRenderer(
-            _agentContext, turn, _listContext, Render);
+            _agentContext, turn, _listContext, Render, DispatchToRenderer);
         _turnRenderers.Add(renderer);
         Render();
+    }
+
+    // Conversation callbacks arrive on whichever thread the agent pipeline is running on: a UI
+    // action completes its result with RunContinuationsAsynchronously, so the streaming loop
+    // resumes off the renderer's synchronization context. Both the renderer-state mutation and
+    // the render itself have to run on the dispatcher, so the whole callback is marshalled
+    // rather than only the Render call.
+    private void DispatchToRenderer(Action action)
+    {
+        var dispatcher = _renderHandle.Dispatcher;
+        if (dispatcher.CheckAccess())
+        {
+            action();
+        }
+        else
+        {
+            // Discarding the task is safe: it only represents the dispatch, and exceptions inside
+            // the work item are reported through the renderer.
+            _ = dispatcher.InvokeAsync(action);
+        }
     }
 
     private void Render()


### PR DESCRIPTION
# Fix rendering of messages after tool call

## Summary

`MessageList`, `MessageInput` and `ConversationTurnRenderer` render directly from the conversation callbacks raised by the agent pipeline. Those callbacks do not always arrive on the renderer's synchronization context, and `RenderHandle.Render` asserts dispatcher access, so the render threw `InvalidOperationException: The current thread is not associated with the Dispatcher`. `AgentContext` catches that exception and converts it into `ConversationStatus.Error`, so the failure surfaced in the UI as "Something went wrong. Please try again." with nothing written to the log.

## Why it happens

`Dispatcher.CheckAccess()` compares `SynchronizationContext.Current` against the renderer's context, so access is context affinity rather than thread affinity. `UIAgent.SendMessagesAsync` enumerates the chat client with `ConfigureAwait(false)`, so the pipeline continues on whatever context completed the read. A UI action makes this deterministic: `UIActionBlock` completes its result through a `TaskCompletionSource` created with `TaskCreationOptions.RunContinuationsAsynchronously`, which forces the awaiting continuation onto the thread pool without the renderer's context. Any chat client whose streaming read genuinely awaits and resumes without that context reaches the same state, which is why this reproduces with a plain `IChatClient` talking to a real model but not with the AG-UI transport the dojo apps use.

## Changes

- `MessageList` and `MessageInput` each gain a private `DispatchToRenderer(Action)` helper that runs the work inline when `Dispatcher.CheckAccess()` is true and marshals it through `Dispatcher.InvokeAsync` otherwise.
- `MessageList` routes its `RegisterOnTurnAdded` and `RegisterOnStatusChanged` subscriptions through the helper, and passes the helper to every `ConversationTurnRenderer` it creates.
- `MessageInput` routes its `RegisterOnStatusChanged` subscription through the helper.
- `ConversationTurnRenderer` now takes the render delegate and the dispatch delegate separately. It marshals its `RegisterOnBlockAdded` handler and builds a dispatching `_requestRender`, which is what `BlockContainer` passes to `ContentBlock.OnChanged`.

## Details

The whole callback is marshalled rather than only the `Render()` call. `OnTurnAdded` and `OnBlockAdded` mutate `_turnRenderers` and `_blockContainers`, and the render loop enumerates those same lists, so dispatching only the render would still leave a data race on collections the renderer reads. This follows the existing pattern in `CascadingAuthenticationState`, which assigns its state inside the dispatched block, and `CascadingValueSource`, which copies its subscriber list before notifying for the same reason.

The `CheckAccess()` short circuit keeps the common on-dispatcher path free of extra allocation or queueing. Discarding the task returned by `InvokeAsync` matches the precedent in `CascadingAuthenticationStateServiceCollectionExtensions`: the task represents only the dispatch, and exceptions raised inside the work item are reported through the renderer.

## Breaking changes

None. `ConversationTurnRenderer` is internal, and the public API surface is unchanged.

## Testing

This bug only reproduces when a chat component is wired directly to an `IChatClient` whose streaming read genuinely awaits and resumes without the renderer's synchronization context, which is what the OpenAI client does when it reads a real server-sent event stream. The existing E2E suites cannot catch it: `DojoClient` reaches its model through the AG-UI transport, which preserves the synchronization context across the read, so the pipeline stays on the dispatcher and the render never fails. An E2E test added to `DojoClient.E2E.Tests` for the tool call followed by another message passes both with and without this fix, so it would give false confidence as a regression guard.

Fixes #69057