### PR TITLE
Honor two-factor authentication on external-login sign-in

### DIFF
--- a/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ExternalLogin.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V4/Account/ExternalLogin.cshtml.cs
@@ -138,7 +138,9 @@ internal sealed class ExternalLoginModel<TUser> : ExternalLoginModel where TUser
         }
 
         // Sign in the user with this external login provider if the user already has a login.
-        var result = await _signInManager.ExternalLoginSignInAsync(info.LoginProvider, info.ProviderKey, isPersistent: false, bypassTwoFactor: true);
+        // bypassTwoFactor is false so that accounts with two-factor authentication enabled are
+        // still challenged for a second factor, consistent with the password sign-in path.
+        var result = await _signInManager.ExternalLoginSignInAsync(info.LoginProvider, info.ProviderKey, isPersistent: false, bypassTwoFactor: false);
         if (result.Succeeded)
         {
             if (_logger.IsEnabled(LogLevel.Information))
@@ -146,6 +148,10 @@ internal sealed class ExternalLoginModel<TUser> : ExternalLoginModel where TUser
                 _logger.LogInformation(LoggerEventIds.UserLoggedInByExternalProvider, "User logged in with {LoginProvider} provider.", info.LoginProvider);
             }
             return LocalRedirect(returnUrl);
+        }
+        if (result.RequiresTwoFactor)
+        {
+            return RedirectToPage("./LoginWith2fa", new { ReturnUrl = returnUrl });
         }
         if (result.IsLockedOut)
         {

--- a/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ExternalLogin.cshtml.cs
+++ b/src/Identity/UI/src/Areas/Identity/Pages/V5/Account/ExternalLogin.cshtml.cs
@@ -138,7 +138,9 @@ internal sealed class ExternalLoginModel<TUser> : ExternalLoginModel where TUser
         }
 
         // Sign in the user with this external login provider if the user already has a login.
-        var result = await _signInManager.ExternalLoginSignInAsync(info.LoginProvider, info.ProviderKey, isPersistent: false, bypassTwoFactor: true);
+        // bypassTwoFactor is false so that accounts with two-factor authentication enabled are
+        // still challenged for a second factor, consistent with the password sign-in path.
+        var result = await _signInManager.ExternalLoginSignInAsync(info.LoginProvider, info.ProviderKey, isPersistent: false, bypassTwoFactor: false);
         if (result.Succeeded)
         {
             if (_logger.IsEnabled(LogLevel.Information))
@@ -146,6 +148,10 @@ internal sealed class ExternalLoginModel<TUser> : ExternalLoginModel where TUser
                 _logger.LogInformation(LoggerEventIds.UserLoggedInByExternalProvider, "User logged in with {LoginProvider} provider.", info.LoginProvider);
             }
             return LocalRedirect(returnUrl);
+        }
+        if (result.RequiresTwoFactor)
+        {
+            return RedirectToPage("./LoginWith2fa", new { ReturnUrl = returnUrl });
         }
         if (result.IsLockedOut)
         {

--- a/src/Identity/test/Identity.FunctionalTests/LoginTests.cs
+++ b/src/Identity/test/Identity.FunctionalTests/LoginTests.cs
@@ -282,6 +282,37 @@ public abstract class LoginTests<TStartup, TContext> : IClassFixture<ServerFacto
     }
 
     [Fact]
+    public async Task ExternalLoginIsChallengedForTwoFactorWhenAccountHasTwoFactorEnabled()
+    {
+        // Arrange
+        void ConfigureTestServices(IServiceCollection services) =>
+            services.SetupTestThirdPartyLogin();
+
+        var server = ServerFactory.WithWebHostBuilder(whb => whb.ConfigureServices(ConfigureTestServices));
+
+        var client = server.CreateClient();
+        var newClient = server.CreateClient();
+
+        var guid = Guid.NewGuid();
+        var userName = $"{guid}";
+        var email = $"{guid}@example.com";
+
+        var index = await UserStories.RegisterNewUserWithSocialLoginAsync(client, userName, email);
+        var manage = await index.ClickManageLinkWithExternalLoginAsync();
+        var twoFactor = await manage.ClickTwoFactorLinkAsync();
+        var enableAuthenticator = await twoFactor.ClickEnableAuthenticatorLinkAsync();
+        var showRecoveryCodes = await enableAuthenticator.SendValidCodeAsync();
+
+        var twoFactorKey = showRecoveryCodes.Context.AuthenticatorKey;
+
+        // Act & Assert
+        // Use a new client to simulate a new browser session. Signing in again via the same
+        // external provider must now be challenged for the second factor instead of completing
+        // immediately, matching the behavior of the password sign-in path.
+        await UserStories.LoginWithSocialLogin2FaAsync(newClient, userName, twoFactorKey);
+    }
+
+    [Fact]
     public async Task CanLoginWithASocialLoginProvider()
     {
         // Arrange

--- a/src/Identity/test/Identity.FunctionalTests/Pages/Contoso/Login.cs
+++ b/src/Identity/test/Identity.FunctionalTests/Pages/Contoso/Login.cs
@@ -31,6 +31,26 @@ public class Login : DefaultUIPage
         return new Index(Client, externalLogin, Context.WithAuthenticatedUser());
     }
 
+    // Used when the existing external-login account has two-factor authentication enabled:
+    // the external sign-in must be challenged for a second factor instead of completing immediately.
+    public async Task<Account.LoginWith2fa> SendExistingUserNameWith2FaAsync(string userName)
+    {
+        var contosoResponse = await Client.SendAsync(_loginForm, new Dictionary<string, string>
+        {
+            ["Input_Login"] = userName
+        });
+
+        var goToExternalLogin = ResponseAssert.IsRedirect(contosoResponse);
+        var externalLogInResponse = await Client.GetAsync(goToExternalLogin);
+
+        var goToLoginWith2fa = ResponseAssert.IsRedirect(externalLogInResponse);
+        Assert.StartsWith(Account.LoginWith2fa.Path, goToLoginWith2fa.ToString());
+        var loginWith2faResponse = await Client.GetAsync(goToLoginWith2fa);
+        var loginWith2fa = await ResponseAssert.IsHtmlDocumentAsync(loginWith2faResponse);
+
+        return new Account.LoginWith2fa(Client, loginWith2fa, Context);
+    }
+
     private async Task<IHtmlDocument> SendLoginForm(string userName)
     {
         var contosoResponse = await Client.SendAsync(_loginForm, new Dictionary<string, string>

--- a/src/Identity/test/Identity.FunctionalTests/UserStories.cs
+++ b/src/Identity/test/Identity.FunctionalTests/UserStories.cs
@@ -131,6 +131,25 @@ public class UserStories
         return await contosoLogin.SendExistingUserNameAsync(userName);
     }
 
+    // Covers the case where an existing external-login account has two-factor authentication
+    // enabled: the sign-in must route through the two-factor page before completing.
+    internal static async Task<Index> LoginWithSocialLogin2FaAsync(HttpClient client, string userName, string twoFactorKey)
+    {
+        var index = await Index.CreateAsync(
+            client,
+            new DefaultUIContext()
+                .WithSocialLoginEnabled()
+                .WithExistingUser());
+
+        var login = await index.ClickLoginLinkAsync();
+
+        var contosoLogin = await login.ClickLoginWithContosoLinkAsync();
+
+        var login2Fa = await contosoLogin.SendExistingUserNameWith2FaAsync(userName);
+
+        return await login2Fa.Send2FACodeAsync(twoFactorKey);
+    }
+
     internal static async Task<Index> LoginExistingUser2FaAsync(HttpClient client, string userName, string password, string twoFactorKey)
     {
         var index = await Index.CreateAsync(client);


### PR DESCRIPTION
# Honor two-factor authentication on external-login sign-in

- [x] You've read the [Contributor Guide](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/dotnet/aspnetcore/blob/main/CODE-OF-CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

The default scaffolded Identity UI completed an external-provider (OAuth/OIDC) sign-in with two-factor authentication bypassed unconditionally, even for accounts that had 2FA enabled. This diverged from the password sign-in path, which already honors 2FA.

In `ExternalLogin.cshtml.cs` (both V4 and V5), `ExternalLoginSignInAsync` is now called with `bypassTwoFactor: false` instead of `true`, and a `result.RequiresTwoFactor` branch was added that redirects to `./LoginWith2fa`, mirroring the existing pattern in `Login.cshtml.cs`. No changes were needed in `SignInManager`: `ExternalLoginSignInAsync` already resolves the user internally and forwards the external `loginProvider` through the two-factor round-trip, so the completed sign-in after the second factor still preserves the external login and the external sign-in cookie is cleaned up as part of the existing two-factor completion flow.

Scope notes:
- The `RedirectToPage("./LoginWith2fa", ...)` call in the external-login callback intentionally omits `RememberMe`, since external sign-in has no "remember me" concept on the login form; it defaults to `false`.
- This is a UI-only change to the scaffolded Identity pages. Apps that have already scaffolded or overridden `ExternalLogin.cshtml.cs` will not pick up this change automatically.
- A new test, `ExternalLoginIsChallengedForTwoFactorWhenAccountHasTwoFactorEnabled`, locks down that an external-login account with 2FA enabled is routed through `LoginWith2fa` before sign-in completes, and that an account without 2FA continues to sign in unchanged (covered by the existing `CanLoginWithASocialLoginProvider` test).

Fixes #68497