### PR TITLE
Revert "[test-quarantine] Quarantine flaky RedirectionTest.RedirectEnhancedNonBlazorGetToExternal"

### DIFF
--- a/src/Components/test/E2ETest/ServerRenderingTests/RedirectionTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/RedirectionTest.cs
@@ -240,7 +240,6 @@ public class RedirectionTest :
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/#aw_redirext")]
     public void RedirectEnhancedNonBlazorGetToExternal(bool disableThrowNavigationException)
     {
         AppContext.SetSwitch("Microsoft.AspNetCore.Components.Endpoints.NavigationManager.DisableThrowNavigationException", disableThrowNavigationException);


### PR DESCRIPTION
Reverts dotnet/aspnetcore#68946. The failures should be fixed since https://github.com/dotnet/aspnetcore/pull/68782 and the 2 builds quoted in quarantine PR were from 13th August and even older (details got already deleted by now). Not sure if the `no-quarantine` label works on a merged PR, maybe we will have to re-label it once the bot reports it broken again.

I don't understand "has never carried a [QuarantinedTest] attribute before" in the bot's PR, when we can see that https://github.com/dotnet/aspnetcore/pull/68782/changes has
<img width="2192" height="576" alt="image" src="https://github.com/user-attachments/assets/707eede1-24bc-4f73-9b94-174319acf6f9" />

Do I read something wrong?

Also, https://github.com/dotnet/aspnetcore/pull/68849 carries the `no-quarantine` label and the bot got triggered anyway.