### PR TITLE
Fix focus indicator contrast in templates

### DIFF
--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Layout/NavMenu.razor.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Layout/NavMenu.razor.css
@@ -97,6 +97,12 @@ nav-menu {
         width: 100%;
     }
 
+.nav-item ::deep .nav-link:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: -2px;
+    box-shadow: none;
+}
+
 .nav-item ::deep a.active {
     background-color: rgba(255,255,255,0.37);
     color: white;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Layout/NavMenu.razor.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Layout/NavMenu.razor.css
@@ -55,6 +55,12 @@
         line-height: 3rem;
     }
 
+.nav-item ::deep .nav-link:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: -2px;
+    box-shadow: none;
+}
+
 .nav-item ::deep a.active {
     background-color: rgba(255,255,255,0.37);
     color: white;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/RazorPagesWeb-CSharp/wwwroot/css/site.css
@@ -12,6 +12,13 @@ html {
   box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb;
 }
 
+.navbar-light .navbar-brand:focus-visible, .navbar-light .navbar-nav .nav-link:focus-visible {
+  outline: 2px solid #212529;
+  outline-offset: 2px;
+  border-radius: 2px;
+  box-shadow: none;
+}
+
 html {
   position: relative;
   min-height: 100%;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-CSharp/wwwroot/css/site.css
@@ -12,6 +12,13 @@ html {
   box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb;
 }
 
+.navbar-light .navbar-brand:focus-visible, .navbar-light .navbar-nav .nav-link:focus-visible {
+  outline: 2px solid #212529;
+  outline-offset: 2px;
+  border-radius: 2px;
+  box-shadow: none;
+}
+
 html {
   position: relative;
   min-height: 100%;

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/wwwroot/css/site.css
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/StarterWeb-FSharp/wwwroot/css/site.css
@@ -48,6 +48,13 @@ button.accept-policy {
   line-height: inherit;
 }
 
+.navbar-light .navbar-brand:focus-visible, .navbar-light .navbar-nav .nav-link:focus-visible {
+  outline: 2px solid #212529;
+  outline-offset: 2px;
+  border-radius: 2px;
+  box-shadow: none;
+}
+
 html {
   position: relative;
   min-height: 100%;


### PR DESCRIPTION
# Fix focus indicator contrast in templates

This fixes the color contrast for focus indicator in Blazor, Mvc, and Razor Pages templates.

## Description

This is an accessibility issue where the color contrast of the keyboard focus indicator is low.

**Blazor template (before fix):**

<img width="368" height="379" alt="image" src="https://github.com/user-attachments/assets/4f8005df-372b-430a-ab42-2440368f5ac7" />

<img width="351" height="378" alt="image" src="https://github.com/user-attachments/assets/946f1c24-65da-43a1-b65a-b004986da5cb" />

**Blazor template (after fix - tested with `dotnet new blazor` and `dotnet new blazorwasm`):**

<img width="362" height="389" alt="image" src="https://github.com/user-attachments/assets/baf503a8-d057-43be-9936-e158d4a068a2" />

<img width="360" height="360" alt="image" src="https://github.com/user-attachments/assets/bebfe8bd-0ff6-4b38-871f-9df835c884ea" />

**Mvc and Razor Pages:**

<img width="215" height="79" alt="image" src="https://github.com/user-attachments/assets/8f58c9cd-7a39-4f08-8ad3-d53742e762dc" />

Linked issue (intentionally not closing per instructions in the issue) -> https://github.com/dotnet/aspnetcore/issues/68228

## Customer Impact

New applications created from templates are more compliant to accessibility rules.

## Regression?

No

## Risk

Low

Fix is manually tested, and it's only an update to templates, not a real product change. So existing applications updating to newer version are not impacted. This is only when creating a new application from template which reduces the risks.

## Verification

Manual

## Packaging changes reviewed?

N/A
