### PR TITLE
Prevent Static SSR Stack Overflow During Section Updates

### DIFF
--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -845,12 +845,12 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
         _renderQueueDeferralDepth++;
     }
 
-    internal void EndRenderQueueDeferral()
+    internal void EndRenderQueueDeferral(bool processPendingRender)
     {
         Dispatcher.AssertAccess();
         Debug.Assert(_renderQueueDeferralDepth > 0);
 
-        if (--_renderQueueDeferralDepth == 0 && !_isBatchInProgress)
+        if (--_renderQueueDeferralDepth == 0 && processPendingRender && !_isBatchInProgress)
         {
             ProcessPendingRender();
         }

--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -51,6 +51,7 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
 
     private int _nextComponentId;
     private bool _isBatchInProgress;
+    private int _renderQueueDeferralDepth;
     private ulong _lastEventHandlerId;
     private List<Task>? _pendingTasks;
     private Task? _disposeTask;
@@ -830,7 +831,29 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
             return;
         }
 
+        if (_renderQueueDeferralDepth > 0)
+        {
+            return;
+        }
+
         ProcessRenderQueue();
+    }
+
+    internal void BeginRenderQueueDeferral()
+    {
+        Dispatcher.AssertAccess();
+        _renderQueueDeferralDepth++;
+    }
+
+    internal void EndRenderQueueDeferral()
+    {
+        Dispatcher.AssertAccess();
+        Debug.Assert(_renderQueueDeferralDepth > 0);
+
+        if (--_renderQueueDeferralDepth == 0 && !_isBatchInProgress)
+        {
+            ProcessPendingRender();
+        }
     }
 
     private void ProcessRenderQueue()

--- a/src/Components/Components/src/RenderTree/Renderer.cs
+++ b/src/Components/Components/src/RenderTree/Renderer.cs
@@ -365,7 +365,7 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
             _rootComponentsLatestParameters?.Remove(componentId);
         }
 
-        ProcessRenderQueue();
+        ProcessRenderQueueIfNotDeferred();
     }
 
     /// <summary>
@@ -831,12 +831,15 @@ public abstract partial class Renderer : IDisposable, IAsyncDisposable
             return;
         }
 
-        if (_renderQueueDeferralDepth > 0)
-        {
-            return;
-        }
+        ProcessRenderQueueIfNotDeferred();
+    }
 
-        ProcessRenderQueue();
+    private void ProcessRenderQueueIfNotDeferred()
+    {
+        if (_renderQueueDeferralDepth == 0)
+        {
+            ProcessRenderQueue();
+        }
     }
 
     internal void BeginRenderQueueDeferral()

--- a/src/Components/Endpoints/test/EndpointHtmlRendererTest.cs
+++ b/src/Components/Endpoints/test/EndpointHtmlRendererTest.cs
@@ -73,6 +73,33 @@ public class EndpointHtmlRendererTest
     }
 
     [Fact]
+    public async Task ProcessesRenderQueuedWhileWritingStreamingUpdate()
+    {
+        var httpContext = GetHttpContext();
+        var writer = new StringWriter();
+        var streamingCompleted = new TaskCompletionSource();
+        var component = new StreamingUpdatingComponent();
+
+        await renderer.Dispatcher.InvokeAsync(async () =>
+        {
+            var result = renderer.BeginRenderingComponent(component, ParameterView.Empty);
+            await result.QuiescenceTask;
+            renderer.InitializeStreamingRenderingFraming(httpContext, isErrorHandler: false, isReExecuted: false);
+
+            var streamingTask = renderer.SendStreamingUpdatesAsync(httpContext, streamingCompleted.Task, writer);
+            renderer.BeforeWritingComponentHtml = component.RenderSecondUpdate;
+
+            component.RenderFirstUpdate();
+            streamingCompleted.SetResult();
+            await streamingTask;
+        });
+
+        var output = writer.ToString();
+        Assert.Matches("<template blazor-component-id=\"[0-9]+\">.*First update.*</template>", output);
+        Assert.Matches("<template blazor-component-id=\"[0-9]+\">.*Second update.*</template>", output);
+    }
+
+    [Fact]
     public async Task CanRender_ParameterlessComponent_ClientMode()
     {
         // Arrange
@@ -1983,6 +2010,16 @@ public class EndpointHtmlRendererTest
 
         public int RenderCount => _renderCount;
 
+        public Action BeforeWritingComponentHtml { get; set; }
+
+        protected override void RenderChildComponent(TextWriter output, ref RenderTreeFrame componentFrame)
+        {
+            var callback = BeforeWritingComponentHtml;
+            BeforeWritingComponentHtml = null;
+            callback?.Invoke();
+            base.RenderChildComponent(output, ref componentFrame);
+        }
+
         public new void SignalRendererToFinishRendering()
         {
             _rendererIsStopped = true;
@@ -1994,6 +2031,55 @@ public class EndpointHtmlRendererTest
             SetHttpContext(httpContext);
             await SetNotFoundWhenResponseHasStarted();
         }
+    }
+
+    [StreamRendering]
+    private sealed class StreamingUpdatingComponent : IComponent
+    {
+        private RenderHandle _renderHandle;
+        private string _content = "Initial";
+
+        public void Attach(RenderHandle renderHandle)
+        {
+            _renderHandle = renderHandle;
+        }
+
+        public Task SetParametersAsync(ParameterView parameters)
+        {
+            Render();
+            return Task.CompletedTask;
+        }
+
+        public void RenderFirstUpdate()
+        {
+            _content = "First update";
+            Render();
+        }
+
+        public void RenderSecondUpdate()
+        {
+            _content = "Second update";
+            Render();
+        }
+
+        private void Render()
+        {
+            _renderHandle.Render(builder =>
+            {
+                builder.OpenComponent<StreamingContent>(0);
+                builder.AddComponentParameter(1, nameof(StreamingContent.Content), _content);
+                builder.CloseComponent();
+            });
+        }
+    }
+
+    private sealed class StreamingContent : ComponentBase
+    {
+        [Parameter]
+        public string Content { get; set; }
+
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+            => builder.AddContent(0, Content);
     }
 
     private HttpContext GetHttpContext(HttpContext context = null)

--- a/src/Components/Endpoints/test/EndpointHtmlRendererTest.cs
+++ b/src/Components/Endpoints/test/EndpointHtmlRendererTest.cs
@@ -73,33 +73,6 @@ public class EndpointHtmlRendererTest
     }
 
     [Fact]
-    public async Task ProcessesRenderQueuedWhileWritingStreamingUpdate()
-    {
-        var httpContext = GetHttpContext();
-        var writer = new StringWriter();
-        var streamingCompleted = new TaskCompletionSource();
-        var component = new StreamingUpdatingComponent();
-
-        await renderer.Dispatcher.InvokeAsync(async () =>
-        {
-            var result = renderer.BeginRenderingComponent(component, ParameterView.Empty);
-            await result.QuiescenceTask;
-            renderer.InitializeStreamingRenderingFraming(httpContext, isErrorHandler: false, isReExecuted: false);
-
-            var streamingTask = renderer.SendStreamingUpdatesAsync(httpContext, streamingCompleted.Task, writer);
-            renderer.BeforeWritingComponentHtml = component.RenderSecondUpdate;
-
-            component.RenderFirstUpdate();
-            streamingCompleted.SetResult();
-            await streamingTask;
-        });
-
-        var output = writer.ToString();
-        Assert.Matches("<template blazor-component-id=\"[0-9]+\">.*First update.*</template>", output);
-        Assert.Matches("<template blazor-component-id=\"[0-9]+\">.*Second update.*</template>", output);
-    }
-
-    [Fact]
     public async Task CanRender_ParameterlessComponent_ClientMode()
     {
         // Arrange
@@ -2010,16 +1983,6 @@ public class EndpointHtmlRendererTest
 
         public int RenderCount => _renderCount;
 
-        public Action BeforeWritingComponentHtml { get; set; }
-
-        protected override void RenderChildComponent(TextWriter output, ref RenderTreeFrame componentFrame)
-        {
-            var callback = BeforeWritingComponentHtml;
-            BeforeWritingComponentHtml = null;
-            callback?.Invoke();
-            base.RenderChildComponent(output, ref componentFrame);
-        }
-
         public new void SignalRendererToFinishRendering()
         {
             _rendererIsStopped = true;
@@ -2031,55 +1994,6 @@ public class EndpointHtmlRendererTest
             SetHttpContext(httpContext);
             await SetNotFoundWhenResponseHasStarted();
         }
-    }
-
-    [StreamRendering]
-    private sealed class StreamingUpdatingComponent : IComponent
-    {
-        private RenderHandle _renderHandle;
-        private string _content = "Initial";
-
-        public void Attach(RenderHandle renderHandle)
-        {
-            _renderHandle = renderHandle;
-        }
-
-        public Task SetParametersAsync(ParameterView parameters)
-        {
-            Render();
-            return Task.CompletedTask;
-        }
-
-        public void RenderFirstUpdate()
-        {
-            _content = "First update";
-            Render();
-        }
-
-        public void RenderSecondUpdate()
-        {
-            _content = "Second update";
-            Render();
-        }
-
-        private void Render()
-        {
-            _renderHandle.Render(builder =>
-            {
-                builder.OpenComponent<StreamingContent>(0);
-                builder.AddComponentParameter(1, nameof(StreamingContent.Content), _content);
-                builder.CloseComponent();
-            });
-        }
-    }
-
-    private sealed class StreamingContent : ComponentBase
-    {
-        [Parameter]
-        public string Content { get; set; }
-
-        protected override void BuildRenderTree(RenderTreeBuilder builder)
-            => builder.AddContent(0, Content);
     }
 
     private HttpContext GetHttpContext(HttpContext context = null)

--- a/src/Components/Web/src/HtmlRendering/StaticHtmlRenderer.HtmlWriting.cs
+++ b/src/Components/Web/src/HtmlRendering/StaticHtmlRenderer.HtmlWriting.cs
@@ -37,14 +37,16 @@ public partial class StaticHtmlRenderer
         Dispatcher.AssertAccess();
 
         BeginRenderQueueDeferral();
+        var writeCompletedSuccessfully = false;
         try
         {
             var frames = GetCurrentRenderTreeFrames(componentId);
             RenderFrames(componentId, output, frames, 0, frames.Count);
+            writeCompletedSuccessfully = true;
         }
         finally
         {
-            EndRenderQueueDeferral();
+            EndRenderQueueDeferral(writeCompletedSuccessfully);
         }
     }
 

--- a/src/Components/Web/src/HtmlRendering/StaticHtmlRenderer.HtmlWriting.cs
+++ b/src/Components/Web/src/HtmlRendering/StaticHtmlRenderer.HtmlWriting.cs
@@ -34,6 +34,7 @@ public partial class StaticHtmlRenderer
     {
         // The frame buffers must remain stable for the whole synchronous walk. Dispatcher access prevents
         // concurrent execution, and render queue deferral prevents reentrant rendering from mutating them.
+        // Updates queued during the walk are reflected the next time the component is written.
         Dispatcher.AssertAccess();
 
         BeginRenderQueueDeferral();
@@ -46,6 +47,7 @@ public partial class StaticHtmlRenderer
         }
         finally
         {
+            // If writing failed, leave queued work unprocessed so its failure cannot mask the writer exception.
             EndRenderQueueDeferral(writeCompletedSuccessfully);
         }
     }

--- a/src/Components/Web/src/HtmlRendering/StaticHtmlRenderer.HtmlWriting.cs
+++ b/src/Components/Web/src/HtmlRendering/StaticHtmlRenderer.HtmlWriting.cs
@@ -32,12 +32,20 @@ public partial class StaticHtmlRenderer
     /// <param name="output">The output destination.</param>
     protected internal virtual void WriteComponentHtml(int componentId, TextWriter output)
     {
-        // We're about to walk over some buffers inside the renderer that can be mutated during rendering.
-        // So, we require exclusive access to the renderer during this synchronous process.
+        // The frame buffers must remain stable for the whole synchronous walk. Dispatcher access prevents
+        // concurrent execution, and render queue deferral prevents reentrant rendering from mutating them.
         Dispatcher.AssertAccess();
 
-        var frames = GetCurrentRenderTreeFrames(componentId);
-        RenderFrames(componentId, output, frames, 0, frames.Count);
+        BeginRenderQueueDeferral();
+        try
+        {
+            var frames = GetCurrentRenderTreeFrames(componentId);
+            RenderFrames(componentId, output, frames, 0, frames.Count);
+        }
+        finally
+        {
+            EndRenderQueueDeferral();
+        }
     }
 
     /// <summary>

--- a/src/Components/Web/test/HtmlRendering/HtmlRendererTest.cs
+++ b/src/Components/Web/test/HtmlRendering/HtmlRendererTest.cs
@@ -862,6 +862,37 @@ public class HtmlRendererTest
     }
 
     [Fact]
+    public async Task WriteHtmlTo_PreservesWritingExceptionAndRetainsDeferredRender()
+    {
+        var services = GetServiceProvider();
+        await using var htmlRenderer = new SectionUpdatingStaticHtmlRenderer(services, NullLoggerFactory.Instance);
+
+        await htmlRenderer.Dispatcher.InvokeAsync(async () =>
+        {
+            var outlet = htmlRenderer.BeginRenderingComponent(
+                new SectionOutlet(),
+                ParameterView.FromDictionary(new Dictionary<string, object>
+                {
+                    { nameof(SectionOutlet.SectionId), "testsection" }
+                }));
+            await outlet.QuiescenceTask;
+
+            var content = new UpdatingSectionContent();
+            var contentRoot = htmlRenderer.BeginRenderingComponent(content, ParameterView.Empty);
+            await contentRoot.QuiescenceTask;
+
+            htmlRenderer.BeforeRenderingSectionContent = content.UpdateWithException;
+            using var writer = new ThrowingTextWriter();
+
+            var exception = Assert.Throws<IOException>(() => outlet.WriteHtmlTo(writer));
+            Assert.Equal("Writing failed.", exception.Message);
+
+            var renderException = Assert.Throws<InvalidOperationException>(() => outlet.ToHtmlString());
+            Assert.Equal("Rendering failed.", renderException.Message);
+        });
+    }
+
+    [Fact]
     public async Task RenderComponentAsync_CanOutputToTextWriter()
     {
         // Arrange
@@ -1381,6 +1412,12 @@ And now with HTML encoding: Person with special chars like &#x27; &quot; &lt;/sc
             Render();
         }
 
+        public void UpdateWithException()
+        {
+            _content = _ => throw new InvalidOperationException("Rendering failed.");
+            Render();
+        }
+
         private void Render()
         {
             _renderHandle.Render(builder =>
@@ -1391,6 +1428,18 @@ And now with HTML encoding: Person with special chars like &#x27; &quot; &lt;/sc
                 builder.CloseComponent();
             });
         }
+    }
+
+    private sealed class ThrowingTextWriter : StringWriter
+    {
+        public override void Write(char value)
+            => throw new IOException("Writing failed.");
+
+        public override void Write(string value)
+            => throw new IOException("Writing failed.");
+
+        public override void Write(ReadOnlySpan<char> buffer)
+            => throw new IOException("Writing failed.");
     }
 
     private class AsyncLoadingComponent : ComponentBase

--- a/src/Components/Web/test/HtmlRendering/HtmlRendererTest.cs
+++ b/src/Components/Web/test/HtmlRendering/HtmlRendererTest.cs
@@ -6,11 +6,14 @@ using System.Text;
 using System.Web;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Forms.Mapping;
+using Microsoft.AspNetCore.Components.HtmlRendering.Infrastructure;
 using Microsoft.AspNetCore.Components.Rendering;
+using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.AspNetCore.Components.Sections;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.Web.HtmlRendering;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.AspNetCore.Components.HtmlRendering;
@@ -832,6 +835,33 @@ public class HtmlRendererTest
     }
 
     [Fact]
+    public async Task WriteHtmlTo_CanReplaceSectionContentWhileRenderingOutlet()
+    {
+        var services = GetServiceProvider();
+        await using var htmlRenderer = new SectionUpdatingStaticHtmlRenderer(services, NullLoggerFactory.Instance);
+
+        await htmlRenderer.Dispatcher.InvokeAsync(async () =>
+        {
+            var outlet = htmlRenderer.BeginRenderingComponent(
+                new SectionOutlet(),
+                ParameterView.FromDictionary(new Dictionary<string, object>
+                {
+                    { nameof(SectionOutlet.SectionId), "testsection" }
+                }));
+            await outlet.QuiescenceTask;
+
+            var content = new UpdatingSectionContent();
+            var contentRoot = htmlRenderer.BeginRenderingComponent(content, ParameterView.Empty);
+            await contentRoot.QuiescenceTask;
+
+            htmlRenderer.BeforeRenderingSectionContent = content.Update;
+
+            Assert.Equal("initial", outlet.ToHtmlString());
+            Assert.Equal("updated", outlet.ToHtmlString());
+        });
+    }
+
+    [Fact]
     public async Task RenderComponentAsync_CanOutputToTextWriter()
     {
         // Arrange
@@ -1308,6 +1338,58 @@ And now with HTML encoding: Person with special chars like &#x27; &quot; &lt;/sc
         {
             _renderHandle.Render(Fragment);
             return Task.CompletedTask;
+        }
+    }
+
+    private sealed class SectionUpdatingStaticHtmlRenderer(IServiceProvider services, ILoggerFactory loggerFactory)
+        : StaticHtmlRenderer(services, loggerFactory)
+    {
+        public Action BeforeRenderingSectionContent { get; set; }
+
+        protected override void RenderChildComponent(TextWriter output, ref RenderTreeFrame componentFrame)
+        {
+            if (componentFrame.Component is SectionOutlet.SectionOutletContentRenderer)
+            {
+                var callback = BeforeRenderingSectionContent;
+                BeforeRenderingSectionContent = null;
+                callback?.Invoke();
+            }
+
+            base.RenderChildComponent(output, ref componentFrame);
+        }
+    }
+
+    private sealed class UpdatingSectionContent : IComponent
+    {
+        private RenderHandle _renderHandle;
+        private RenderFragment _content = builder => builder.AddContent(0, "initial");
+
+        public void Attach(RenderHandle renderHandle)
+        {
+            _renderHandle = renderHandle;
+        }
+
+        public Task SetParametersAsync(ParameterView parameters)
+        {
+            Render();
+            return Task.CompletedTask;
+        }
+
+        public void Update()
+        {
+            _content = builder => builder.AddContent(0, "updated");
+            Render();
+        }
+
+        private void Render()
+        {
+            _renderHandle.Render(builder =>
+            {
+                builder.OpenComponent<SectionContent>(0);
+                builder.AddComponentParameter(1, nameof(SectionContent.SectionId), "testsection");
+                builder.AddComponentParameter(2, nameof(SectionContent.ChildContent), _content);
+                builder.CloseComponent();
+            });
         }
     }
 

--- a/src/Components/Web/test/HtmlRendering/HtmlRendererTest.cs
+++ b/src/Components/Web/test/HtmlRendering/HtmlRendererTest.cs
@@ -862,6 +862,33 @@ public class HtmlRendererTest
     }
 
     [Fact]
+    public async Task WriteHtmlTo_CanRemoveSectionContentWhileRenderingOutlet()
+    {
+        var services = GetServiceProvider();
+        await using var htmlRenderer = new SectionUpdatingStaticHtmlRenderer(services, NullLoggerFactory.Instance);
+
+        await htmlRenderer.Dispatcher.InvokeAsync(async () =>
+        {
+            var outlet = htmlRenderer.BeginRenderingComponent(
+                new SectionOutlet(),
+                ParameterView.FromDictionary(new Dictionary<string, object>
+                {
+                    { nameof(SectionOutlet.SectionId), "testsection" }
+                }));
+            await outlet.QuiescenceTask;
+
+            var content = new UpdatingSectionContent();
+            var contentRoot = htmlRenderer.BeginRenderingComponent(content, ParameterView.Empty);
+            await contentRoot.QuiescenceTask;
+
+            htmlRenderer.BeforeRenderingSectionContent = () => htmlRenderer.RemoveRootComponent(content);
+
+            Assert.Equal("initial", outlet.ToHtmlString());
+            Assert.Empty(outlet.ToHtmlString());
+        });
+    }
+
+    [Fact]
     public async Task WriteHtmlTo_PreservesWritingExceptionAndRetainsDeferredRender()
     {
         var services = GetServiceProvider();
@@ -1376,6 +1403,9 @@ And now with HTML encoding: Person with special chars like &#x27; &quot; &lt;/sc
         : StaticHtmlRenderer(services, loggerFactory)
     {
         public Action BeforeRenderingSectionContent { get; set; }
+
+        public void RemoveRootComponent(IComponent component)
+            => RemoveRootComponent(GetComponentState(component).ComponentId);
 
         protected override void RenderChildComponent(TextWriter output, ref RenderTreeFrame componentFrame)
         {


### PR DESCRIPTION
### Bug Description
This PR fixes an issue where Blazor static SSR can encounter a process-terminating stack overflow when section content, such as PageTitle, changes while StaticHtmlRenderer is writing HTML.

Fixes [#69035](https://github.com/dotnet/aspnetcore/issues/69035)

### Problem
While StaticHtmlRenderer synchronously walks render-tree frames, a reentrant section update can replace and dispose the current SectionOutletContentRenderer.

The active HTML walk can then continue through stale render-tree frames, potentially creating a recursive component cycle and terminating the process with a StackOverflowException.

### Root Cause
Dispatcher access prevents concurrent rendering, but it does not prevent synchronous reentrant rendering.
A section update during HTML serialization can call:
AddToRenderQueue → ProcessPendingRender → ProcessRenderQueue
This mutates or recycles render-tree frame buffers while the renderer is still traversing them.

### Solution Description
Added nested render-queue deferral while StaticHtmlRenderer writes component HTML.
The fix:

- Keeps render-tree frame buffers stable throughout the synchronous HTML walk
- Supports recursive child-component HTML writes through a deferral-depth counter
- Processes queued work after the outermost successful write
- Defers root-component removal during the walk
- Avoids starting a nested batch when one is already active
- Preserves the original writer exception when HTML output fails

Updates queued during an HTML walk are applied to the next HTML write.

### Testing
Added three unit tests covering:

- Replacing section content while its outlet is being rendered
- Removing section content while its outlet is being rendered
- Preserving writer exceptions while retaining deferred rendering work

The root-removal regression failed before the fix with:
The renderer does not have a component with ID 4.
Validation results:

- Components: 1,299 passed, 8 skipped
- Components.Web: 316 passed
- Components.Endpoints: 876 passed

The exact intermittent Linux CI stack overflow could not be reproduced locally on Windows. However, the underlying reentrant render-tree mutation and disposed-component failure were reproduced deterministically in unit tests, including red/green verification.

With Fix:
<img width="1472" height="540" alt="image" src="https://github.com/user-attachments/assets/3583d4f8-7839-4824-9573-6cfa75453d14" />
Without Fix:
<img width="1481" height="877" alt="image" src="https://github.com/user-attachments/assets/d70f1ece-7ee8-47cf-af9b-d94631f96747" />

### Impact

- Prevents reentrant rendering from invalidating static SSR frame traversal
- Prevents stale section frames from producing recursive component cycles
- Preserves existing renderer-specific queue behavior
- Introduces no public API changes
- Changes reentrant updates to appear on the next HTML write instead of the active write