### PR TITLE
Move BasePath into Components.Web

### DIFF
--- a/src/Components/Endpoints/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Endpoints/src/PublicAPI.Unshipped.txt
@@ -1,6 +1,4 @@
 #nullable enable
-Microsoft.AspNetCore.Components.Endpoints.BasePath
-Microsoft.AspNetCore.Components.Endpoints.BasePath.BasePath() -> void
 Microsoft.AspNetCore.Components.Endpoints.RazorComponentsServiceOptions.CacheViewSizeLimit.get -> long
 Microsoft.AspNetCore.Components.Endpoints.RazorComponentsServiceOptions.CacheViewSizeLimit.set -> void
 Microsoft.AspNetCore.Components.Endpoints.RazorComponentsServiceOptions.DisableClientValidation.get -> bool

--- a/src/Components/Endpoints/test/Routing/BasePathTest.cs
+++ b/src/Components/Endpoints/test/Routing/BasePathTest.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Components.Test.Helpers;
 
 #nullable enable
 
-namespace Microsoft.AspNetCore.Components.Endpoints;
+namespace Microsoft.AspNetCore.Components.Web;
 
 public class BasePathTest
 {

--- a/src/Components/Samples/BlazorWebAppGlobal/Components/_Imports.razor
+++ b/src/Components/Samples/BlazorWebAppGlobal/Components/_Imports.razor
@@ -1,6 +1,5 @@
 ﻿@using System.Net.Http
 @using System.Net.Http.Json
-@using Microsoft.AspNetCore.Components.Endpoints
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web

--- a/src/Components/Samples/BlazorWebAppPerPage/Components/_Imports.razor
+++ b/src/Components/Samples/BlazorWebAppPerPage/Components/_Imports.razor
@@ -1,6 +1,5 @@
 ﻿@using System.Net.Http
 @using System.Net.Http.Json
-@using Microsoft.AspNetCore.Components.Endpoints
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web

--- a/src/Components/Web/src/BasePath.cs
+++ b/src/Components/Web/src/BasePath.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.AspNetCore.Components.Rendering;
 
-namespace Microsoft.AspNetCore.Components.Endpoints;
+namespace Microsoft.AspNetCore.Components.Web;
 
 /// <summary>
 /// Renders a &lt;base&gt; element whose <c>href</c> value matches the current request path base.

--- a/src/Components/Web/src/PublicAPI.Unshipped.txt
+++ b/src/Components/Web/src/PublicAPI.Unshipped.txt
@@ -43,6 +43,8 @@ Microsoft.AspNetCore.Components.Routing.NavLink.RelativeToCurrentUri.set -> void
 *REMOVED*static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Func<Microsoft.AspNetCore.Components.Web.ProgressEventArgs!, System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.ProgressEventArgs!>
 *REMOVED*static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Func<Microsoft.AspNetCore.Components.Web.TouchEventArgs!, System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.TouchEventArgs!>
 *REMOVED*static Microsoft.AspNetCore.Components.Web.WebEventCallbackFactoryEventArgsExtensions.Create(this Microsoft.AspNetCore.Components.EventCallbackFactory! factory, object! receiver, System.Func<Microsoft.AspNetCore.Components.Web.WheelEventArgs!, System.Threading.Tasks.Task!>! callback) -> Microsoft.AspNetCore.Components.EventCallback<Microsoft.AspNetCore.Components.Web.WheelEventArgs!>
+Microsoft.AspNetCore.Components.Web.BasePath
+Microsoft.AspNetCore.Components.Web.BasePath.BasePath() -> void
 Microsoft.AspNetCore.Components.Web.SupplyParameterFromSessionAttribute
 Microsoft.AspNetCore.Components.Web.SupplyParameterFromSessionAttribute.Name.get -> string?
 Microsoft.AspNetCore.Components.Web.SupplyParameterFromSessionAttribute.Name.set -> void

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/App.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/App.razor
@@ -4,7 +4,6 @@
 @using TestContentPackage.NotFound
 @using Components.TestServer.RazorComponents
 @using Microsoft.AspNetCore.Components
-@using Microsoft.AspNetCore.Components.Endpoints
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
 @using System.Threading.Tasks

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/NamedFormContextNoFormContextApp.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/NamedFormContextNoFormContextApp.razor
@@ -1,5 +1,4 @@
 ﻿@using Components.TestServer.RazorComponents.Pages.Forms
-@using Microsoft.AspNetCore.Components.Endpoints
 
 <!DOCTYPE html>
 <html lang="en">

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/ResourceCollection/Index.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/ResourceCollection/Index.razor
@@ -1,6 +1,5 @@
 ﻿@page "/resource-collection"
 @using Microsoft.AspNetCore.Components.Web;
-@using Microsoft.AspNetCore.Components.Endpoints;
 
 <PageTitle>Resource Collection</PageTitle>
 

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/RemoteAuthenticationApp.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/RemoteAuthenticationApp.razor
@@ -1,5 +1,4 @@
-﻿@using Microsoft.AspNetCore.Components.Endpoints
-
+﻿
 <!DOCTYPE html>
 <html lang="en">
 

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Root.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Root.razor
@@ -1,5 +1,4 @@
 @using Components.TestServer.RazorComponents.Pages.Forms
-@using Microsoft.AspNetCore.Components.Endpoints
 @using Microsoft.AspNetCore.Components.Web
 
 <!DOCTYPE html>

--- a/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/_Imports.razor
+++ b/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/_Imports.razor
@@ -1,6 +1,5 @@
 ﻿@using System.Net.Http
 @using System.Net.Http.Json
-@using Microsoft.AspNetCore.Components.Endpoints
 @*#if (IndividualLocalAuth)
 @using Microsoft.AspNetCore.Components.Authorization
 ##endif*@


### PR DESCRIPTION
# Move BasePath into Components.Web

`BasePath` is a new component (public API) introduced in .NET 11 Preview 1. It was put in the wrong namespace (and wrong assembly).

## Description

We added BasePath in https://github.com/dotnet/aspnetcore/pull/64590, but it requires users to pay attention to the namespaces they imported and add an additional `@using`.

Fixes #69115

## Customer Impact

The change makes it for a more friendly usage of a new component that we added in .NET 11.

## Regression?

No

## Risk

Low.

BasePath is a new component in .NET 11 and the change here is just the namespace.

## Verification

No verification needed. This is a public API change.

## Packaging changes reviewed?

N/A