### PR TITLE
[SignalR] Fix CTS disposal

### DIFF
--- a/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
+++ b/src/SignalR/server/Core/src/Internal/DefaultHubDispatcher.cs
@@ -609,6 +609,7 @@ internal sealed partial class DefaultHubDispatcher<[DynamicallyAccessedMembers(H
             {
                 Log.InvocationIdInUse(_logger, invocationId);
                 error = $"Invocation ID '{invocationId}' is already in use.";
+                streamCts.Dispose();
                 return;
             }
             ctsRegistered = true;


### PR DESCRIPTION
# [SignalR] Fix CTS disposal- #69158

## Description

When we added [cancellation support for non-streaming methods](https://github.com/dotnet/aspnetcore/pull/64098/), we didn't dispose the CTS in error cases.

## Customer Impact

Fixes a server reliability issue.

## Regression?

- [x] Yes
- [ ] No

Regressed in 11.0-p6

## Risk

- [ ] High
- [ ] Medium
- [x] Low

Simple change, just missed an error case

## Verification

- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [x] N/A