### PR TITLE
Server.IntegrationTesting: ApplicationPublisher: avoid recompiling framework project with different properties than the main build.

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -171,6 +171,14 @@
     <Features>$(Features);runtime-async=on</Features>
   </PropertyGroup>
 
+  <!-- Make build properties available to test processes via runtimeconfig.json,
+       so that subprocess dotnet invocations can forward them and avoid recompiling
+       framework projects with different properties. -->
+  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+    <RuntimeHostConfigurationOption Include="DotNetBuildUseMonoRuntime" Value="$(DotNetBuildUseMonoRuntime)" Condition="'$(DotNetBuildUseMonoRuntime)' != ''" />
+    <RuntimeHostConfigurationOption Include="ContinuousIntegrationBuild" Value="$(ContinuousIntegrationBuild)" Condition="'$(ContinuousIntegrationBuild)' != ''" />
+  </ItemGroup>
+
   <!-- Properties for Package Validation -->
   <PropertyGroup Condition="'$(ExcludeFromSourceOnlyBuild)' != 'true'">
     <EnablePackageValidation Condition="'$(EnablePackageValidation)' == ''">true</EnablePackageValidation>

--- a/src/Hosting/Server.IntegrationTesting/src/ApplicationPublisher.cs
+++ b/src/Hosting/Server.IntegrationTesting/src/ApplicationPublisher.cs
@@ -46,6 +46,16 @@ public class ApplicationPublisher
                 parameters += " -p:UseAppHost=false";
             }
 
+            // Forward build-mode properties from the outer build (via runtimeconfig.json)
+            // so subprocess compilations use the same settings.
+            foreach (var prop in new[] { "DotNetBuildUseMonoRuntime", "ContinuousIntegrationBuild" })
+            {
+                if (AppContext.GetData(prop) is string value && !string.IsNullOrEmpty(value))
+                {
+                    parameters += $" /p:{prop}={value}";
+                }
+            }
+
             parameters += $" {deploymentParameters.AdditionalPublishParameters}";
 
             var startInfo = new ProcessStartInfo


### PR DESCRIPTION
Without this a build that sets DotNetBuildUseMonoRuntime to disable runtime-async ends up with runtime-async DLLs intermediately when the ApplicationPublisher causes the framework assemblies to be recompiled without DotNetBuildUseMonoRuntime set.

ContinuousIntegrationBuild is passed to as it affects the version string that is used in the assemblies (e.g. dev vs ci).

@wtgodbe @dotnet/aspnet-build ptal.

cc @shrinivas-sidral