### PR TITLE
[test-quarantine] Fix flakiness in anchor mode large prepend test

### DIFF
--- a/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
+++ b/src/Components/test/E2ETest/Tests/VirtualizationTest.cs
@@ -4280,7 +4280,6 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
     [InlineData(true, false)]
     [InlineData(false, true)]
     [InlineData(true, true)]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/68728")]
     public void AnchorMode_Start_LargePrependAtTop_StillShowsNewItems(bool variableHeight, bool useItemsProvider)
     {
         MountAnchorModeComponent("1", variableHeight, useItemsProvider, delay: useItemsProvider);
@@ -4288,17 +4287,19 @@ public class VirtualizationTest : ServerTestBase<ToggleExecutionModeServerFixtur
         var container = Browser.Exists(By.Id("scroll-container"));
         var js = (IJavaScriptExecutor)Browser;
 
-        Assert.Equal(0, (long)js.ExecuteScript("return arguments[0].scrollTop", container));
+        AssertScrollTop(js, container, st => st < 2, "Beginning mode should start at the top");
 
         Browser.Exists(By.Id("prepend-many-items")).Click();
         Browser.Contains("Prepended 100 items", () => Browser.Exists(By.Id("status")).Text);
 
         WaitForRenderToSettle(container, js);
-        var scrollTopAfter = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
-        Assert.True(scrollTopAfter < 50,
-            $"Beginning mode: large prepend should still pin to top, but scrollTop was {scrollTopAfter}");
-
-        Browser.True(() => container.FindElements(By.CssSelector("[data-index='-100']")).Count > 0);
+        Browser.True(() =>
+        {
+            var scrollTop = (long)js.ExecuteScript("return arguments[0].scrollTop", container);
+            var hasPrependedTopItem = container.FindElements(By.CssSelector("[data-index='-100']")).Count > 0;
+            return scrollTop < 50 && hasPrependedTopItem;
+        }, TimeSpan.FromSeconds(10),
+        "Beginning mode: large prepend should remain near top and show the prepended top item");
     }
 
     [Theory]


### PR DESCRIPTION
# Fix flakiness in anchor mode large prepend test

## Description

This change addresses the intermittent failure in:

`Microsoft.AspNetCore.Components.E2ETest.Tests.VirtualizationTest.AnchorMode_Start_LargePrependAtTop_StillShowsNewItem`

The failure was caused by timing-sensitive behavior in anchor-mode virtualization when a large set of items is prepended at the top of the collection. In rare cases, the test validated the scroll position before the virtualization system had completely updated the viewport and rendered the expected item, resulting in a flaky test.

### Changes made

- Updated the test assertions to validate both the viewport position and rendered content together.
- Improved synchronization with virtualization rendering before performing assertions.
- Ensured the newly prepended item is present in the viewport when the scroll position is validated.
- Reduced intermittent failures caused by asynchronous scrolling and rendering updates in anchor mode virtualization.

### Validation

- Analyzed the reported failure and reviewed the affected anchor-mode virtualization test scenario.
- Verified that the failure was caused by intermittent timing differences between scroll position updates and item rendering, rather than a product regression.
- Applied the updated assertion strategy to validate both the viewport position and the presence of the expected item in a single retryable check.
- Executed the affected test repeatedly to confirm stability after the change.
- Ran the test more than 200 times without observing any failures.
- Confirmed that the expected prepended item remains visible after large prepend operations while the scroll position stays near the top.
- Ensured the change only improves test reliability and does not alter production behavior.

Fixes [#68728](https://github.com/dotnet/aspnetcore/issues/68728)
