### PR TITLE
Avoid starting the response when navigating with exception

### DIFF
--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -101,6 +101,7 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
             waitForQuiescence: result.IsPost || isErrorHandlerOrReExecuted);
 
         Task quiesceTask;
+        var navigationExceptionHandledInPendingTasks = false;
         if (!result.IsPost || isReExecuted)
         {
             quiesceTask = htmlContent.QuiescenceTask;
@@ -116,7 +117,7 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
                     return;
                 }
 
-                await _renderer.WaitForNonStreamingPendingTasks();
+                navigationExceptionHandledInPendingTasks = await _renderer.WaitForNonStreamingPendingTasks();
             }
             catch (NavigationException ex)
             {
@@ -124,6 +125,12 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
                 quiesceTask = Task.CompletedTask;
             }
         }
+
+        // A handled non-streaming navigation leaves the full quiescence task faulted,
+        // but there are no navigation updates left to send through the streaming writer.
+        var navigationExceptionWasHandled = navigationExceptionHandledInPendingTasks
+            && quiesceTask is { IsFaulted: true, Exception: { } exception }
+            && ContainsOnlyNavigationExceptions(exception);
 
         if (_renderer.NotFoundEventArgs != null)
         {
@@ -160,7 +167,7 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
         // renderer sync context and cause a batch that would get missed.
         htmlContent.WriteTo(bufferWriter, HtmlEncoder.Default); // Don't use WriteToAsync, as per the comment above
 
-        if (!quiesceTask.IsCompletedSuccessfully)
+        if (!quiesceTask.IsCompletedSuccessfully && !navigationExceptionWasHandled)
         {
             await _renderer.SendStreamingUpdatesAsync(context, quiesceTask, bufferWriter);
             if (_renderer.NotFoundEventArgs != null)
@@ -271,6 +278,25 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
             }
         }
         return null;
+    }
+
+    private static bool ContainsOnlyNavigationExceptions(AggregateException aggregateException)
+    {
+        var flattened = aggregateException.Flatten();
+        if (flattened.InnerExceptions.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var innerException in flattened.InnerExceptions)
+        {
+            if (innerException is not NavigationException)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]

--- a/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
+++ b/src/Components/Endpoints/src/RazorComponentEndpointInvoker.cs
@@ -130,7 +130,7 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
         // but there are no navigation updates left to send through the streaming writer.
         var navigationExceptionWasHandled = navigationExceptionHandledInPendingTasks
             && quiesceTask is { IsFaulted: true, Exception: { } exception }
-            && ContainsOnlyNavigationExceptions(exception);
+            && EndpointHtmlRenderer.GetFirstNonNavigationException(exception) is null;
 
         if (_renderer.NotFoundEventArgs != null)
         {
@@ -278,25 +278,6 @@ internal partial class RazorComponentEndpointInvoker : IRazorComponentEndpointIn
             }
         }
         return null;
-    }
-
-    private static bool ContainsOnlyNavigationExceptions(AggregateException aggregateException)
-    {
-        var flattened = aggregateException.Flatten();
-        if (flattened.InnerExceptions.Count == 0)
-        {
-            return false;
-        }
-
-        foreach (var innerException in flattened.InnerExceptions)
-        {
-            if (innerException is not NavigationException)
-            {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.ExceptionServices;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.RenderTree;
@@ -192,12 +193,13 @@ internal partial class EndpointHtmlRenderer
         }
     }
 
-    public Task WaitForNonStreamingPendingTasks()
+    public Task<bool> WaitForNonStreamingPendingTasks()
     {
         return NonStreamingPendingTasksCompletion ??= Execute();
 
-        async Task Execute()
+        async Task<bool> Execute()
         {
+            var navigationExceptionHandled = false;
             while (_nonStreamingPendingTasks.Count > 0)
             {
                 // Create a Task that represents the remaining ongoing work for the rendering process
@@ -214,10 +216,36 @@ internal partial class EndpointHtmlRenderer
                 }
                 catch (NavigationException navigationException)
                 {
+                    if (GetFirstNonNavigationException(pendingWork.Exception) is { } nonNavigationException)
+                    {
+                        ExceptionDispatchInfo.Capture(nonNavigationException).Throw();
+                    }
+
+                    navigationExceptionHandled = true;
                     await HandleNavigationException(_httpContext, navigationException);
                 }
             }
+
+            return navigationExceptionHandled;
         }
+    }
+
+    private static Exception? GetFirstNonNavigationException(AggregateException? aggregateException)
+    {
+        if (aggregateException is null)
+        {
+            return null;
+        }
+
+        foreach (var innerException in aggregateException.Flatten().InnerExceptions)
+        {
+            if (innerException is not NavigationException)
+            {
+                return innerException;
+            }
+        }
+
+        return null;
     }
 
     public static ValueTask<PrerenderedComponentHtmlContent> HandleNavigationException(HttpContext httpContext, NavigationException navigationException)

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.Prerendering.cs
@@ -230,7 +230,7 @@ internal partial class EndpointHtmlRenderer
         }
     }
 
-    private static Exception? GetFirstNonNavigationException(AggregateException? aggregateException)
+    internal static Exception? GetFirstNonNavigationException(AggregateException? aggregateException)
     {
         if (aggregateException is null)
         {

--- a/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
+++ b/src/Components/Endpoints/src/Rendering/EndpointHtmlRenderer.cs
@@ -211,7 +211,7 @@ internal partial class EndpointHtmlRenderer : StaticHtmlRenderer, IComponentPrer
     }
 
     // For tests only
-    internal Task? NonStreamingPendingTasksCompletion;
+    internal Task<bool>? NonStreamingPendingTasksCompletion;
 
     protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)
     {

--- a/src/Components/Endpoints/test/EndpointHtmlRendererTest.cs
+++ b/src/Components/Endpoints/test/EndpointHtmlRendererTest.cs
@@ -31,6 +31,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.JSInterop;
+using Microsoft.Net.Http.Headers;
 using Moq;
 
 namespace Microsoft.AspNetCore.Components.Endpoints;
@@ -982,6 +983,38 @@ public class EndpointHtmlRendererTest
             + "has not yet loaded in the browser. Statically-rendered components must wrap any JavaScript interop calls "
             + "in conditional logic to ensure those interop calls are not attempted during static rendering.",
             exception.Message);
+    }
+
+    [Fact]
+    public async Task WaitForNonStreamingPendingTasks_ReportsHandledNavigationException()
+    {
+        var httpContext = GetHttpContext();
+        var renderer = GetEndpointHtmlRenderer();
+        renderer.SetHttpContext(httpContext);
+        renderer.AddNonStreamingPendingTask(Task.FromException(new NavigationException("http://localhost/redirect")));
+
+        var navigationExceptionHandled = await renderer.WaitForNonStreamingPendingTasks();
+
+        Assert.True(navigationExceptionHandled);
+        Assert.Equal(StatusCodes.Status302Found, httpContext.Response.StatusCode);
+        Assert.Equal("http://localhost/redirect", httpContext.Response.Headers.Location);
+    }
+
+    [Fact]
+    public async Task WaitForNonStreamingPendingTasks_DoesNotHandleMixedNavigationAndNonNavigationExceptions()
+    {
+        var httpContext = GetHttpContext();
+        var renderer = GetEndpointHtmlRenderer();
+        renderer.SetHttpContext(httpContext);
+        renderer.AddNonStreamingPendingTask(Task.FromException(new NavigationException("http://localhost/redirect")));
+        renderer.AddNonStreamingPendingTask(Task.FromException(new InvalidOperationException("Test exception")));
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            renderer.WaitForNonStreamingPendingTasks);
+
+        Assert.Equal("Test exception", exception.Message);
+        Assert.Equal(StatusCodes.Status200OK, httpContext.Response.StatusCode);
+        Assert.False(httpContext.Response.Headers.ContainsKey(HeaderNames.Location));
     }
 
     [ConditionalTheory]
@@ -1993,6 +2026,11 @@ public class EndpointHtmlRendererTest
         {
             SetHttpContext(httpContext);
             await SetNotFoundWhenResponseHasStarted();
+        }
+
+        public void AddNonStreamingPendingTask(Task task)
+        {
+            AddPendingTask(null, task);
         }
     }
 

--- a/src/Components/test/E2ETest/Tests/TempDataCookieTest.cs
+++ b/src/Components/test/E2ETest/Tests/TempDataCookieTest.cs
@@ -158,6 +158,17 @@ public class TempDataCookieTest : ServerTestBase<BasicTestAppServerSiteFixture<R
     }
 
     [Fact]
+    public void SupplyParameterFromTempDataReadsAndSavesValuesFromEditForm()
+    {
+        Navigate($"{ServerPathBase}/tempdata");
+        Browser.Equal("", () => Browser.FindElement(By.Id("supply-parameter-from-tempdata")).Text);
+        Browser.Equal("False", () => Browser.FindElement(By.Id("navigation-manager-returned")).Text);
+        Browser.FindElement(By.Id("set-supply-from-tempdata-edit-form")).Click();
+        Browser.Equal("Supplied from TempData", () => Browser.FindElement(By.Id("supply-parameter-from-tempdata")).Text);
+        Browser.Equal("False", () => Browser.FindElement(By.Id("navigation-manager-returned")).Text);
+    }
+
+    [Fact]
     public void StreamingSSR_CookieTempData_DoesNotPersistValuesWrittenAfterFirstFlush()
     {
         Navigate($"{ServerPathBase}/streaming-cookie-tempdata-persistence");

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/TempData/TempDataComponent.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/TempData/TempDataComponent.razor
@@ -19,6 +19,10 @@
     <button type="submit" id="set-supply-from-tempdata">Set TempData Values via SupplyParameterFromTempData</button>
 </form>
 
+<EditForm method="post" FormName="SetSupplyFromTempDataEditForm" Model="this" OnValidSubmit="SetValuesSupplyFromTempDataFromEditForm">
+    <button type="submit" id="set-supply-from-tempdata-edit-form">Set TempData Values via SupplyParameterFromTempData from EditForm</button>
+</EditForm>
+
 <form method="post" @formname="JustRedirect" @onsubmit="() => NavigateToSamePage()">
     <AntiforgeryToken />
     <button type="submit" id="redirect-button">Navigate to the Same Page</button>
@@ -46,6 +50,7 @@
 <p id="contains-message">@_containsMessageKey</p>
 <p id="contains-peeked-value">@_containsPeekedValueKey</p>
 <p id="supply-parameter-from-tempdata">@SupplyParameterFromTempDataValue</p>
+<p id="navigation-manager-returned">@_navigationManagerReturned</p>
 
 @code {
     [SupplyParameterFromForm(Name = "_handler")]
@@ -71,6 +76,7 @@
 
     private bool _containsMessageKey;
     private bool _containsPeekedValueKey;
+    private bool _navigationManagerReturned;
 
     protected override void OnInitialized()
     {
@@ -86,6 +92,7 @@
 
         _containsMessageKey = TempData?.ContainsKey("Message") ?? false;
         _containsPeekedValueKey = TempData?.ContainsKey("PeekedValue") ?? false;
+        _navigationManagerReturned = TempData!.Get("NavigationManagerReturned") as bool? ?? false;
 
         if (ValueToKeep == "all")
         {
@@ -127,6 +134,13 @@
     {
         SupplyParameterFromTempDataValue = "Supplied from TempData";
         NavigateToSamePage();
+    }
+
+    private void SetValuesSupplyFromTempDataFromEditForm()
+    {
+        SupplyParameterFromTempDataValue = "Supplied from TempData";
+        NavigateToSamePage();
+        TempData!["NavigationManagerReturned"] = true;
     }
 
     private void NavigateToSamePage() => NavigationManager.NavigateTo("/subdir/tempdata", forceLoad: true);


### PR DESCRIPTION
## Avoid starting the response when task didn't finish successfully due to the by-design navigation exception.

## Description

Cookie-backed `[SupplyParameterFromTempData]` values were lost when a non-streaming static SSR `EditForm` handler redirected using exception-driven navigation.

The redirect succeeded, but the response was accidentally routed through the streaming response path before TempData persistence. This started the response and prevented the TempData provider from adding its cookie.

## Background

During static SSR, `NavigationManager.NavigateTo` supports two control-flow modes:

- Old exception-driven navigation: `NavigateTo` throws `NavigationException`, which the renderer catches and converts into a redirect.
- New, non-throwing navigation: `NavigateTo` directly invokes the endpoint navigation callback.

Exception-driven navigation remains the runtime compatibility default when `BlazorDisableThrowNavigationException` is absent or `false`. This means newly created applications normally use non-throwing navigation, while existing applications upgraded to .NET 11 can continue using exception-driven navigation.

When `NavigateTo` throws inside `HandleSubmitAsync`, the exception becomes the failure of the task returned by `HandleSubmitAsync`. The renderer tracks that task as non-streaming pending work.

## Root cause

`WaitForNonStreamingPendingTasks` correctly caught the task's `NavigationException` and established the redirect before the response started. However, the separate full-quiescence task retained by `RazorComponentEndpointInvoker` remained non-successful:

```
IsCompleted             = true
IsFaulted               = true
IsCompletedSuccessfully = false
```

The invoker used `!quiesceTask.IsCompletedSuccessfully` to decide whether to call `SendStreamingUpdatesAsync`. As a result, the already-handled navigation fault was mistaken for streaming work.

`SendStreamingUpdatesAsync` flushed the response before awaiting the faulted task and then emitted a streaming redirection template. By the time `TempDataService.Persist` ran, `Response.HasStarted` was `true`, so the cookie provider could no longer add the TempData cookie.

This was what was meant by
>  "false streaming" mode in some cases,

in https://github.com/dotnet/aspnetcore/issues/68796#issuecomment-5440489958.

## Fix

`WaitForNonStreamingPendingTasks` reports whether it handled a `NavigationException` to avoid starting streaming in navigation-by-exception flows.

Before reporting navigation as handled, it inspects the original `Task.WhenAll` exception collection. If the batch contains any non-navigation exception, that exception is propagated instead of being treated as successful navigation.

The invoker excludes the quiescence task from the streaming path only when:

1. The non-streaming waiter handled navigation.
2. The full quiescence task is faulted.
3. All exceptions in that task are `NavigationException`.

Fixes #68796
