### PR TITLE
Add MVC1007 analyzer to detect ActionResult<T> type mismatches in 2xx results

### DIFF
--- a/src/Mvc/Mvc.Analyzers/src/ActionResultOfTReturnTypeAnalyzer.cs
+++ b/src/Mvc/Mvc.Analyzers/src/ActionResultOfTReturnTypeAnalyzer.cs
@@ -1,0 +1,297 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ActionResultOfTReturnTypeAnalyzer : DiagnosticAnalyzer
+{
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
+        DiagnosticDescriptors.MVC1007_ActionResultOfTTypeMismatch);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            if (!SymbolCache.TryCreate(compilationContext.Compilation, out var symbolCache))
+            {
+                return;
+            }
+
+            compilationContext.RegisterOperationAction(
+                operationContext => AnalyzeReturnOperation(operationContext, symbolCache),
+                OperationKind.Return);
+        });
+    }
+
+    private static void AnalyzeReturnOperation(OperationAnalysisContext context, SymbolCache symbolCache)
+    {
+        var returnOperation = (IReturnOperation)context.Operation;
+        if (returnOperation.ReturnedValue is null)
+        {
+            return;
+        }
+
+        var containingMethod = GetContainingMethod(returnOperation);
+        if (containingMethod is null)
+        {
+            return;
+        }
+
+        var declaredTypeArgument = GetActionResultTypeArgument(containingMethod, symbolCache);
+        if (declaredTypeArgument is null)
+        {
+            return;
+        }
+
+        var returnedValue = returnOperation.ReturnedValue;
+
+        // Unwrap implicit conversions (e.g. ActionResult<T> implicit operator)
+        while (returnedValue is IConversionOperation conversion && conversion.IsImplicit)
+        {
+            returnedValue = conversion.Operand;
+        }
+
+        var returnedType = returnedValue.Type;
+        if (returnedType is null)
+        {
+            return;
+        }
+
+        // Check if the returned value is a 2xx result type with an object value argument
+        if (!TryGetObjectValueType(returnedValue, symbolCache, out var objectValueType))
+        {
+            return;
+        }
+
+        if (objectValueType is null)
+        {
+            // null literal — valid for any reference type
+            return;
+        }
+
+        if (!IsAssignableTo(objectValueType, declaredTypeArgument, context.Compilation))
+        {
+            // Unwrap the returned value back to the invocation to get the right location
+            var returnedValueForLocation = returnOperation.ReturnedValue;
+            while (returnedValueForLocation is IConversionOperation conv && conv.IsImplicit)
+            {
+                returnedValueForLocation = conv.Operand;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(
+                DiagnosticDescriptors.MVC1007_ActionResultOfTTypeMismatch,
+                returnedValueForLocation.Syntax.GetLocation(),
+                objectValueType.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat),
+                declaredTypeArgument.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat)));
+        }
+    }
+
+    private static IMethodSymbol? GetContainingMethod(IOperation operation)
+    {
+        for (var current = operation; current is not null; current = current.Parent)
+        {
+            if (current is IAnonymousFunctionOperation or ILocalFunctionOperation)
+            {
+                return null;
+            }
+        }
+
+        return operation.SemanticModel?.GetEnclosingSymbol(operation.Syntax.SpanStart) as IMethodSymbol;
+    }
+
+    internal static ITypeSymbol? GetActionResultTypeArgument(IMethodSymbol method, SymbolCache symbolCache)
+    {
+        var returnType = method.ReturnType;
+
+        // Handle Task<ActionResult<T>> and ValueTask<ActionResult<T>>
+        if (returnType is INamedTypeSymbol namedReturn && namedReturn.IsGenericType)
+        {
+            var definition = namedReturn.OriginalDefinition;
+            if (SymbolEqualityComparer.Default.Equals(definition, symbolCache.TaskOfT) ||
+                SymbolEqualityComparer.Default.Equals(definition, symbolCache.ValueTaskOfT))
+            {
+                returnType = namedReturn.TypeArguments[0];
+            }
+        }
+
+        if (returnType is INamedTypeSymbol actionResultType &&
+            actionResultType.IsGenericType &&
+            SymbolEqualityComparer.Default.Equals(actionResultType.OriginalDefinition, symbolCache.ActionResultOfT))
+        {
+            return actionResultType.TypeArguments[0];
+        }
+
+        return null;
+    }
+
+    private static bool TryGetObjectValueType(
+        IOperation returnedValue,
+        SymbolCache symbolCache,
+        out ITypeSymbol? objectValueType)
+    {
+        objectValueType = null;
+
+        if (returnedValue is not IInvocationOperation invocation)
+        {
+            return false;
+        }
+
+        var method = invocation.TargetMethod;
+        var returnType = method.ReturnType;
+
+        // Check if the return type has a [DefaultStatusCode] that is 2xx
+        if (!Is2xxResultType(returnType, symbolCache))
+        {
+            return false;
+        }
+
+        // Find the parameter annotated with [ActionResultObjectValue]
+        for (var i = 0; i < method.Parameters.Length; i++)
+        {
+            var parameter = method.Parameters[i];
+            if (HasActionResultObjectValueAttribute(parameter))
+            {
+                var argument = GetArgumentForParameter(invocation, parameter);
+                if (argument is null)
+                {
+                    return false;
+                }
+
+                var argumentValue = argument.Value;
+                // Unwrap implicit conversions (e.g. boxing int to object)
+                while (argumentValue is IConversionOperation conv && conv.IsImplicit)
+                {
+                    argumentValue = conv.Operand;
+                }
+
+                objectValueType = argumentValue.Type;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IArgumentOperation? GetArgumentForParameter(IInvocationOperation invocation, IParameterSymbol parameter)
+    {
+        foreach (var argument in invocation.Arguments)
+        {
+            if (SymbolEqualityComparer.Default.Equals(argument.Parameter, parameter))
+            {
+                if (argument.ArgumentKind == ArgumentKind.DefaultValue)
+                {
+                    return null;
+                }
+                return argument;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool Is2xxResultType(ITypeSymbol type, SymbolCache symbolCache)
+    {
+        foreach (var attribute in type.GetAttributes())
+        {
+            if (!SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, symbolCache.DefaultStatusCodeAttribute))
+            {
+                continue;
+            }
+
+            if (attribute.ConstructorArguments.Length == 1 &&
+                attribute.ConstructorArguments[0].Value is int statusCode &&
+                statusCode >= 200 && statusCode < 300)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasActionResultObjectValueAttribute(IParameterSymbol parameter)
+    {
+        foreach (var attribute in parameter.GetAttributes())
+        {
+            if (attribute.AttributeClass?.Name == "ActionResultObjectValueAttribute")
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsAssignableTo(ITypeSymbol source, ITypeSymbol destination, Compilation compilation)
+    {
+        if (compilation is not CSharpCompilation csharpCompilation)
+        {
+            return true;
+        }
+
+        var conversion = csharpCompilation.ClassifyConversion(source, destination);
+        return conversion.IsIdentity || conversion.IsImplicit;
+    }
+
+    internal readonly struct SymbolCache
+    {
+        public SymbolCache(
+            INamedTypeSymbol actionResultOfT,
+            INamedTypeSymbol defaultStatusCodeAttribute,
+            INamedTypeSymbol taskOfT,
+            INamedTypeSymbol valueTaskOfT)
+        {
+            ActionResultOfT = actionResultOfT;
+            DefaultStatusCodeAttribute = defaultStatusCodeAttribute;
+            TaskOfT = taskOfT;
+            ValueTaskOfT = valueTaskOfT;
+        }
+
+        public static bool TryCreate(Compilation compilation, out SymbolCache symbolCache)
+        {
+            symbolCache = default;
+
+            var actionResultOfT = compilation.GetTypeByMetadataName(SymbolNames.ActionResultOfT);
+            if (actionResultOfT is null)
+            {
+                return false;
+            }
+
+            var defaultStatusCodeAttribute = compilation.GetTypeByMetadataName("Microsoft.AspNetCore.Mvc.Infrastructure.DefaultStatusCodeAttribute");
+            if (defaultStatusCodeAttribute is null)
+            {
+                return false;
+            }
+
+            var taskOfT = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
+            if (taskOfT is null)
+            {
+                return false;
+            }
+
+            var valueTaskOfT = compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask`1");
+            if (valueTaskOfT is null)
+            {
+                return false;
+            }
+
+            symbolCache = new SymbolCache(actionResultOfT, defaultStatusCodeAttribute, taskOfT, valueTaskOfT);
+            return true;
+        }
+
+        public INamedTypeSymbol ActionResultOfT { get; }
+        public INamedTypeSymbol DefaultStatusCodeAttribute { get; }
+        public INamedTypeSymbol TaskOfT { get; }
+        public INamedTypeSymbol ValueTaskOfT { get; }
+    }
+}

--- a/src/Mvc/Mvc.Analyzers/src/DiagnosticDescriptors.cs
+++ b/src/Mvc/Mvc.Analyzers/src/DiagnosticDescriptors.cs
@@ -68,4 +68,13 @@ public static class DiagnosticDescriptors
             Usage,
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
+
+    public static readonly DiagnosticDescriptor MVC1007_ActionResultOfTTypeMismatch =
+        new DiagnosticDescriptor(
+            "MVC1007",
+            "The action result object type does not match the declared ActionResult type parameter",
+            "The type '{0}' is not assignable to the ActionResult type parameter '{1}'.",
+            Usage,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
 }

--- a/src/Mvc/Mvc.Analyzers/test/ActionResultOfTReturnTypeAnalyzerTest.cs
+++ b/src/Mvc/Mvc.Analyzers/test/ActionResultOfTReturnTypeAnalyzerTest.cs
@@ -1,0 +1,351 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Microsoft.AspNetCore.Analyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Microsoft.AspNetCore.Mvc.Analyzers;
+
+public class ActionResultOfTReturnTypeAnalyzerTest
+{
+    private static readonly DiagnosticResult Diagnostic = new(DiagnosticDescriptors.MVC1007_ActionResultOfTTypeMismatch);
+
+    private const string Usings = @"using Microsoft.AspNetCore.Mvc;
+";
+
+    [Fact]
+    public Task DiagnosticIsReturned_WhenOkReturnsWrongType()
+    {
+        var source = Usings + @"
+namespace TestApp
+{
+    public class Customer
+    {
+        public string Name { get; set; }
+    }
+
+    public class TestController : Controller
+    {
+        [HttpGet]
+        public ActionResult<Customer> GetCustomer()
+        {
+            return {|#0:Ok(42)|};
+        }
+    }
+}";
+        var expected = Diagnostic.WithLocation(0)
+            .WithArguments("int", "Customer");
+
+        return VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public Task DiagnosticIsReturned_WhenOkReturnsWrongReferenceType()
+    {
+        var source = Usings + @"
+namespace TestApp
+{
+    public class Customer
+    {
+        public string Name { get; set; }
+    }
+
+    public class Order
+    {
+        public int Id { get; set; }
+    }
+
+    public class TestController : Controller
+    {
+        [HttpGet]
+        public ActionResult<Customer> GetCustomer()
+        {
+            return {|#0:Ok(new Order())|};
+        }
+    }
+}";
+        var expected = Diagnostic.WithLocation(0)
+            .WithArguments("Order", "Customer");
+
+        return VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public Task DiagnosticIsReturned_WhenCreatedReturnsWrongType()
+    {
+        var source = Usings + @"
+namespace TestApp
+{
+    public class Customer
+    {
+        public string Name { get; set; }
+    }
+
+    public class TestController : Controller
+    {
+        [HttpPost]
+        public ActionResult<Customer> Create()
+        {
+            return {|#0:Created(""https://example.com"", 42)|};
+        }
+    }
+}";
+        var expected = Diagnostic.WithLocation(0)
+            .WithArguments("int", "Customer");
+
+        return VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public Task DiagnosticIsReturned_WhenAcceptedReturnsWrongType()
+    {
+        var source = Usings + @"
+namespace TestApp
+{
+    public class Customer
+    {
+        public string Name { get; set; }
+    }
+
+    public class TestController : Controller
+    {
+        [HttpPost]
+        public ActionResult<Customer> Create()
+        {
+            return {|#0:Accepted(new object())|};
+        }
+    }
+}";
+        var expected = Diagnostic.WithLocation(0)
+            .WithArguments("object", "Customer");
+
+        return VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public Task NoDiagnostic_WhenOkReturnsCorrectType()
+    {
+        var source = Usings + @"
+namespace TestApp
+{
+    public class Customer
+    {
+        public string Name { get; set; }
+    }
+
+    public class TestController : Controller
+    {
+        [HttpGet]
+        public ActionResult<Customer> GetCustomer()
+        {
+            return Ok(new Customer());
+        }
+    }
+}";
+        return VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public Task NoDiagnostic_WhenOkReturnsDerivedType()
+    {
+        var source = Usings + @"
+namespace TestApp
+{
+    public class Animal { }
+    public class Dog : Animal { }
+
+    public class TestController : Controller
+    {
+        [HttpGet]
+        public ActionResult<Animal> GetAnimal()
+        {
+            return Ok(new Dog());
+        }
+    }
+}";
+        return VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public Task NoDiagnostic_WhenReturningNon2xxResult()
+    {
+        var source = Usings + @"
+namespace TestApp
+{
+    public class Customer
+    {
+        public string Name { get; set; }
+    }
+
+    public class TestController : Controller
+    {
+        [HttpGet]
+        public ActionResult<Customer> GetCustomer()
+        {
+            return NotFound();
+        }
+    }
+}";
+        return VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public Task NoDiagnostic_WhenReturningBadRequest()
+    {
+        var source = Usings + @"
+namespace TestApp
+{
+    public class Customer
+    {
+        public string Name { get; set; }
+    }
+
+    public class TestController : Controller
+    {
+        [HttpGet]
+        public ActionResult<Customer> GetCustomer()
+        {
+            return BadRequest(""error"");
+        }
+    }
+}";
+        return VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public Task NoDiagnostic_WhenMethodReturnsIActionResult()
+    {
+        var source = Usings + @"
+namespace TestApp
+{
+    public class TestController : Controller
+    {
+        [HttpGet]
+        public IActionResult GetCustomer()
+        {
+            return Ok(42);
+        }
+    }
+}";
+        return VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public Task NoDiagnostic_WhenOkReturnsNull()
+    {
+        var source = Usings + @"
+namespace TestApp
+{
+    public class Customer
+    {
+        public string Name { get; set; }
+    }
+
+    public class TestController : Controller
+    {
+        [HttpGet]
+        public ActionResult<Customer> GetCustomer()
+        {
+            return Ok(null);
+        }
+    }
+}";
+        return VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public Task NoDiagnostic_WhenOkCalledWithNoArgument()
+    {
+        var source = Usings + @"
+namespace TestApp
+{
+    public class Customer
+    {
+        public string Name { get; set; }
+    }
+
+    public class TestController : Controller
+    {
+        [HttpGet]
+        public ActionResult<Customer> GetCustomer()
+        {
+            return Ok();
+        }
+    }
+}";
+        return VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public Task DiagnosticIsReturned_ForAsyncMethod()
+    {
+        var source = @"using System.Threading.Tasks;
+" + Usings + @"
+namespace TestApp
+{
+    public class Customer
+    {
+        public string Name { get; set; }
+    }
+
+    public class TestController : Controller
+    {
+        [HttpGet]
+        public async Task<ActionResult<Customer>> GetCustomer()
+        {
+            await Task.CompletedTask;
+            return {|#0:Ok(42)|};
+        }
+    }
+}";
+        var expected = Diagnostic.WithLocation(0)
+            .WithArguments("int", "Customer");
+
+        return VerifyAnalyzerAsync(source, expected);
+    }
+
+    [Fact]
+    public Task NoDiagnostic_WhenOkReturnsImplementedInterface()
+    {
+        var source = @"using System.Collections.Generic;
+" + Usings + @"
+namespace TestApp
+{
+    public class TestController : Controller
+    {
+        [HttpGet]
+        public ActionResult<IEnumerable<string>> GetItems()
+        {
+            return Ok(new List<string>());
+        }
+    }
+}";
+        return VerifyAnalyzerAsync(source);
+    }
+
+    private static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+    {
+        var test = new ActionResultOfTCSharpAnalyzerTest(TestReferences.MetadataReferences)
+        {
+            TestCode = source,
+            ReferenceAssemblies = TestReferences.EmptyReferenceAssemblies,
+        };
+
+        test.ExpectedDiagnostics.AddRange(expected);
+        return test.RunAsync();
+    }
+
+    internal sealed class ActionResultOfTCSharpAnalyzerTest : CSharpAnalyzerTest<ActionResultOfTReturnTypeAnalyzer, DefaultVerifier>
+    {
+        public ActionResultOfTCSharpAnalyzerTest(ImmutableArray<MetadataReference> metadataReferences)
+        {
+            TestState.AdditionalReferences.AddRange(metadataReferences);
+        }
+
+        protected override IEnumerable<DiagnosticAnalyzer> GetDiagnosticAnalyzers() => new[] { new ActionResultOfTReturnTypeAnalyzer() };
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #28600

When a controller action returns `ActionResult<T>`, the generic parameter `T` indicates the expected success response type. However, nothing enforces that 2xx helper methods (`Ok()`, `Created()`, `Accepted()`, etc.) actually return an object assignable to `T`. For example:

```csharp
public ActionResult<Customer> GetCustomer(int id)
{
    return Ok(42); // No compile error, but int != Customer
}
```

This PR adds a new Roslyn analyzer (**MVC1007**) that reports a warning when the object value passed to a 2xx result helper does not match the declared `ActionResult<T>` type parameter.

### How it works

- Registers on `OperationKind.Return` to inspect return statements
- Extracts `T` from the method's `ActionResult<T>` return type (handles `Task<ActionResult<T>>` for async methods)
- Identifies 2xx result types via the existing `[DefaultStatusCode]` attribute (status codes 200–299)
- Finds the value argument via the existing `[ActionResultObjectValue]` attribute on the helper method's parameter
- Uses `CSharpCompilation.ClassifyConversion` to check assignability
- Reports MVC1007 when the types don't match

### What it catches vs. ignores

| Scenario | Result |
|----------|--------|
| `ActionResult<Customer>` + `Ok(42)` | Warning |
| `ActionResult<Customer>` + `Ok(new Order())` | Warning |
| `ActionResult<Customer>` + `Created(uri, 42)` | Warning |
| `ActionResult<Customer>` + `Ok(new Customer())` | No warning |
| `ActionResult<Animal>` + `Ok(new Dog())` | No warning (derived type) |
| `ActionResult<IEnumerable<string>>` + `Ok(new List<string>())` | No warning (interface impl) |
| `ActionResult<Customer>` + `NotFound()` | No warning (not 2xx) |
| `ActionResult<Customer>` + `BadRequest("err")` | No warning (not 2xx) |
| `ActionResult<Customer>` + `Ok(null)` | No warning |
| `IActionResult` return type | No warning (not our concern) |

## Test plan

- [x] 13 new unit tests in `ActionResultOfTReturnTypeAnalyzerTest` covering all scenarios above
- [x] All 100 existing analyzer tests still pass (zero regressions)
- [x] Build succeeds with zero warnings