### PR TITLE
Properly validate segments and cap cache of pathDescriptors

### DIFF
--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/CallHandlers/CallHandlerDescriptorInfo.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/CallHandlers/CallHandlerDescriptorInfo.cs
@@ -10,6 +10,8 @@ namespace Microsoft.AspNetCore.Grpc.JsonTranscoding.Internal.CallHandlers;
 
 internal sealed class CallHandlerDescriptorInfo
 {
+    internal readonly int MaxPathDescriptorsCacheCount;
+
     public CallHandlerDescriptorInfo(
         FieldDescriptor? responseBodyDescriptor,
         MessageDescriptor? bodyDescriptor,
@@ -26,12 +28,12 @@ internal sealed class CallHandlerDescriptorInfo
         RouteAdapter = routeAdapter;
         PathDescriptorsCache = new ConcurrentDictionary<string, List<FieldDescriptor>>();
 
-        var jsonPaths = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var routeParameter in routeParameterDescriptors.Values)
+        MaxPathDescriptorsCacheCount = AppContext.GetData("Microsoft.AspNetCore.Grpc.JsonTranscoding.MaxPathDescriptorsCacheCount") switch
         {
-            jsonPaths.Add(routeParameter.JsonPath);
-        }
-        RouteParameterJsonPaths = jsonPaths;
+            int count when count > 0 => count,
+            string countStr when int.TryParse(countStr, out var parsed) && parsed > 0 => parsed,
+            _ => 1000,
+        };
     }
 
     public FieldDescriptor? ResponseBodyDescriptor { get; }
@@ -41,6 +43,15 @@ internal sealed class CallHandlerDescriptorInfo
     public FieldDescriptor? BodyFieldDescriptor { get; }
     public Dictionary<string, RouteParameter> RouteParameterDescriptors { get; }
     public JsonTranscodingRouteAdapter RouteAdapter { get; }
-    public HashSet<string> RouteParameterJsonPaths { get; }
     public ConcurrentDictionary<string, List<FieldDescriptor>> PathDescriptorsCache { get; }
+
+    public bool TryAddPathDescriptors(string path, List<FieldDescriptor> pathDescriptors)
+    {
+        if (PathDescriptorsCache.Count >= MaxPathDescriptorsCacheCount)
+        {
+            return false;
+        }
+
+        return PathDescriptorsCache.TryAdd(path, pathDescriptors);
+    }
 }

--- a/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonRequestHelpers.cs
+++ b/src/Grpc/JsonTranscoding/src/Microsoft.AspNetCore.Grpc.JsonTranscoding/Internal/JsonRequestHelpers.cs
@@ -291,8 +291,7 @@ internal static class JsonRequestHelpers
                 if (CanBindQueryStringVariable(serverCallContext, item.Key))
                 {
                     var pathDescriptors = GetPathDescriptors(serverCallContext, requestMessage, item.Key);
-
-                    if (pathDescriptors != null)
+                    if (pathDescriptors != null && !ConflictsWithRouteParameter(serverCallContext, pathDescriptors))
                     {
                         var value = item.Value.Count == 1 ? (object?)item.Value[0] : item.Value;
                         ServiceDescriptorHelpers.RecursiveSetValue(requestMessage, pathDescriptors, value);
@@ -362,14 +361,14 @@ internal static class JsonRequestHelpers
     private static List<FieldDescriptor>? GetPathDescriptors(JsonTranscodingServerCallContext serverCallContext, IMessage requestMessage, string path)
     {
         // Must not add null values for paths that don't resolve to a descriptor
-        var cache = serverCallContext.DescriptorInfo.PathDescriptorsCache;
-        if (cache.TryGetValue(path, out var pathDescriptors))
+        var descriptorInfo = serverCallContext.DescriptorInfo;
+        if (descriptorInfo.PathDescriptorsCache.TryGetValue(path, out var pathDescriptors))
         {
             return pathDescriptors;
         }
         if (ServiceDescriptorHelpers.TryResolveDescriptors(requestMessage.Descriptor, path.Split('.'), allowJsonName: true, out pathDescriptors))
         {
-            cache.TryAdd(path, pathDescriptors);
+            descriptorInfo.TryAddPathDescriptors(path, pathDescriptors);
             return pathDescriptors;
         }
         return null;
@@ -444,11 +443,37 @@ internal static class JsonRequestHelpers
             return false;
         }
 
-        // Also check JSON name aliases. Route parameter keys use proto names (e.g. "user_id"),
-        // but query parameters can use JSON names (e.g. "userId") which resolve to the same field.
-        if (serverCallContext.DescriptorInfo.RouteParameterJsonPaths.Contains(variable))
+        return true;
+    }
+
+    // A query string variable must not overwrite a value already bound from a route parameter.
+    // The variable is compared against route parameters by resolved field identity so that
+    // proto-name, JSON-name, and mixed-name spellings (e.g. "tenantScope.tenant_id") as well as
+    // ancestor paths (e.g. "timestamp_value" overwriting a route-bound "timestamp_value.seconds")
+    // are all detected.
+    private static bool ConflictsWithRouteParameter(JsonTranscodingServerCallContext serverCallContext, List<FieldDescriptor> pathDescriptors)
+    {
+        foreach (var routeParameter in serverCallContext.DescriptorInfo.RouteParameterDescriptors.Values)
         {
-            return false;
+            if (PathsOverlap(pathDescriptors, routeParameter.DescriptorsPath))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Two field paths overlap when one is equal to, or an ancestor of, the other.
+    private static bool PathsOverlap(List<FieldDescriptor> first, List<FieldDescriptor> second)
+    {
+        var count = Math.Min(first.Count, second.Count);
+        for (var i = 0; i < count; i++)
+        {
+            if (first[i] != second[i])
+            {
+                return false;
+            }
         }
 
         return true;

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/transcoding.proto
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/Proto/transcoding.proto
@@ -149,6 +149,7 @@ message HelloRequest {
   message SubMessage {
     string subfield = 1;
     repeated string subfields = 2;
+    string sub_field_name = 3 [json_name="subFieldNameJson"];
   }
   message DataTypes {
     enum NestedEnum {
@@ -190,6 +191,10 @@ message HelloRequest {
     google.protobuf.UInt64Value uint64_value = 8;
     google.protobuf.BytesValue bytes_value = 9;
   }
+  message RecursiveMessage {
+    string value = 1;
+    RecursiveMessage child = 2;
+  }
   string name = 1;
   SubMessage sub = 2;
   DataTypes data = 3;
@@ -219,6 +224,7 @@ message HelloRequest {
   repeated SubMessage repeated_messages = 25;
   map<int32, int32> map_keyint_valueint = 26;
   SubMessage sub_data = 27;
+  RecursiveMessage recursive = 28;
 }
 
 message HelloReply {

--- a/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/UnaryServerCallHandlerTests.cs
+++ b/src/Grpc/JsonTranscoding/test/Microsoft.AspNetCore.Grpc.JsonTranscoding.Tests/UnaryServerCallHandlerTests.cs
@@ -1549,6 +1549,78 @@ public class UnaryServerCallHandlerTests : LoggedTest
     }
 
     [Fact]
+    public async Task HandleCallAsync_ManyDistinctQueryStringPaths_CacheSizeIsBounded()
+    {
+        // Arrange
+        HelloRequest? request = null;
+        UnaryServerMethod<JsonTranscodingGreeterService, HelloRequest, HelloReply> invoker = (s, r, c) =>
+        {
+            request = r;
+            return Task.FromResult(new HelloReply());
+        };
+        var descriptorInfo = TestHelpers.CreateDescriptorInfo();
+        var unaryServerCallHandler = CreateCallHandler(invoker, descriptorInfo);
+        var httpContext = TestHelpers.CreateHttpContext();
+
+        var query = new Dictionary<string, StringValues>();
+        var pathBuilder = new StringBuilder("recursive");
+        for (var i = 0; i < descriptorInfo.MaxPathDescriptorsCacheCount + 100; i++)
+        {
+            query[pathBuilder.ToString() + ".value"] = "value";
+            pathBuilder.Append(".child");
+        }
+        httpContext.Request.Query = new QueryCollection(query);
+
+        // Act
+        await unaryServerCallHandler.HandleCallAsync(httpContext);
+
+        // Assert
+        Assert.NotNull(request);
+        Assert.Equal(descriptorInfo.MaxPathDescriptorsCacheCount, descriptorInfo.PathDescriptorsCache.Count);
+    }
+
+    [Fact]
+    public async Task HandleCallAsync_CacheAtCapacity_StillBindsUncachedQueryStringValues()
+    {
+        // Arrange
+        HelloRequest? request = null;
+        UnaryServerMethod<JsonTranscodingGreeterService, HelloRequest, HelloReply> invoker = (s, r, c) =>
+        {
+            request = r;
+            return Task.FromResult(new HelloReply());
+        };
+        var descriptorInfo = TestHelpers.CreateDescriptorInfo();
+        var unaryServerCallHandler = CreateCallHandler(invoker, descriptorInfo);
+
+        var fillQuery = new Dictionary<string, StringValues>();
+        var pathBuilder = new StringBuilder("recursive");
+        for (var i = 0; i < descriptorInfo.MaxPathDescriptorsCacheCount + 10; i++)
+        {
+            fillQuery[pathBuilder.ToString() + ".value"] = "value";
+            pathBuilder.Append(".child");
+        }
+        var fillContext = TestHelpers.CreateHttpContext();
+        fillContext.Request.Query = new QueryCollection(fillQuery);
+        await unaryServerCallHandler.HandleCallAsync(fillContext);
+        Assert.Equal(descriptorInfo.MaxPathDescriptorsCacheCount, descriptorInfo.PathDescriptorsCache.Count);
+
+        var httpContext = TestHelpers.CreateHttpContext();
+        httpContext.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+        {
+            ["name"] = "QueryName"
+        });
+
+        // Act
+        await unaryServerCallHandler.HandleCallAsync(httpContext);
+
+        // Assert
+        Assert.NotNull(request);
+        Assert.Equal("QueryName", request!.Name);
+        Assert.False(descriptorInfo.PathDescriptorsCache.ContainsKey("name"));
+        Assert.Equal(descriptorInfo.MaxPathDescriptorsCacheCount, descriptorInfo.PathDescriptorsCache.Count);
+    }
+
+    [Fact]
     public async Task HandleCallAsync_DataTypes_SetOnRequestMessage()
     {
         // Arrange
@@ -2025,6 +2097,128 @@ public class UnaryServerCallHandlerTests : LoggedTest
         // Assert
         Assert.NotNull(request);
         Assert.Equal("body_value", request!.SubData.Subfield);
+    }
+
+    [Fact]
+    public async Task HandleCallAsync_QueryStringMixedNameNestedRoute_DoesNotOverwriteRouteValue()
+    {
+        // Route binds the nested field "sub_data.sub_field_name".
+        //   proto path: sub_data.sub_field_name
+        //   JSON path:  subData.subFieldNameJson
+        // A query parameter using a mixed spelling ("subData.sub_field_name") resolves to the
+        // same field and must not overwrite the route-bound value.
+
+        // Arrange
+        HelloRequest? request = null;
+        UnaryServerMethod<JsonTranscodingGreeterService, HelloRequest, HelloReply> invoker = (s, r, c) =>
+        {
+            request = r;
+            return Task.FromResult(new HelloReply());
+        };
+
+        var routeParameterDescriptors = new Dictionary<string, RouteParameter>
+        {
+            ["sub_data.sub_field_name"] = CreateRouteParameter(new List<FieldDescriptor>(new[]
+            {
+                HelloRequest.Descriptor.FindFieldByName("sub_data"),
+                HelloRequest.Types.SubMessage.Descriptor.FindFieldByName("sub_field_name")
+            }))
+        };
+        var descriptorInfo = TestHelpers.CreateDescriptorInfo(routeParameterDescriptors: routeParameterDescriptors);
+        var unaryServerCallHandler = CreateCallHandler(invoker, descriptorInfo: descriptorInfo);
+        var httpContext = TestHelpers.CreateHttpContext();
+        httpContext.Request.RouteValues["sub_data.sub_field_name"] = "route_value";
+        httpContext.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+        {
+            ["subData.sub_field_name"] = "different_value"
+        });
+
+        // Act
+        await unaryServerCallHandler.HandleCallAsync(httpContext);
+
+        // Assert
+        Assert.NotNull(request);
+        Assert.Equal("route_value", request!.SubData.SubFieldName);
+    }
+
+    [Fact]
+    public async Task HandleCallAsync_QueryStringAncestorOfRoute_DoesNotOverwriteRouteValue()
+    {
+        // Route binds the nested field "timestamp_value.seconds". A query parameter targeting the
+        // ancestor "timestamp_value" would replace the whole Timestamp (well-known types serialize
+        // as a single scalar) and discard the route-bound child. It must be blocked.
+
+        // Arrange
+        HelloRequest? request = null;
+        UnaryServerMethod<JsonTranscodingGreeterService, HelloRequest, HelloReply> invoker = (s, r, c) =>
+        {
+            request = r;
+            return Task.FromResult(new HelloReply());
+        };
+
+        var routeParameterDescriptors = new Dictionary<string, RouteParameter>
+        {
+            ["timestamp_value.seconds"] = CreateRouteParameter(new List<FieldDescriptor>(new[]
+            {
+                HelloRequest.Descriptor.FindFieldByName("timestamp_value"),
+                Timestamp.Descriptor.FindFieldByName("seconds")
+            }))
+        };
+        var descriptorInfo = TestHelpers.CreateDescriptorInfo(routeParameterDescriptors: routeParameterDescriptors);
+        var unaryServerCallHandler = CreateCallHandler(invoker, descriptorInfo: descriptorInfo);
+        var httpContext = TestHelpers.CreateHttpContext();
+        httpContext.Request.RouteValues["timestamp_value.seconds"] = "5";
+        httpContext.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+        {
+            ["timestamp_value"] = "2020-01-01T00:00:00Z"
+        });
+
+        // Act
+        await unaryServerCallHandler.HandleCallAsync(httpContext);
+
+        // Assert
+        Assert.NotNull(request);
+        Assert.Equal(5, request!.TimestampValue.Seconds);
+    }
+
+    [Fact]
+    public async Task HandleCallAsync_QueryStringSiblingOfNestedRoute_StillBinds()
+    {
+        // Route binds "timestamp_value.seconds". A query parameter for the sibling field
+        // "timestamp_value.nanos" targets a different field and must still bind.
+
+        // Arrange
+        HelloRequest? request = null;
+        UnaryServerMethod<JsonTranscodingGreeterService, HelloRequest, HelloReply> invoker = (s, r, c) =>
+        {
+            request = r;
+            return Task.FromResult(new HelloReply());
+        };
+
+        var routeParameterDescriptors = new Dictionary<string, RouteParameter>
+        {
+            ["timestamp_value.seconds"] = CreateRouteParameter(new List<FieldDescriptor>(new[]
+            {
+                HelloRequest.Descriptor.FindFieldByName("timestamp_value"),
+                Timestamp.Descriptor.FindFieldByName("seconds")
+            }))
+        };
+        var descriptorInfo = TestHelpers.CreateDescriptorInfo(routeParameterDescriptors: routeParameterDescriptors);
+        var unaryServerCallHandler = CreateCallHandler(invoker, descriptorInfo: descriptorInfo);
+        var httpContext = TestHelpers.CreateHttpContext();
+        httpContext.Request.RouteValues["timestamp_value.seconds"] = "5";
+        httpContext.Request.Query = new QueryCollection(new Dictionary<string, StringValues>
+        {
+            ["timestamp_value.nanos"] = "10"
+        });
+
+        // Act
+        await unaryServerCallHandler.HandleCallAsync(httpContext);
+
+        // Assert
+        Assert.NotNull(request);
+        Assert.Equal(5, request!.TimestampValue.Seconds);
+        Assert.Equal(10, request!.TimestampValue.Nanos);
     }
 
     private UnaryServerCallHandler<JsonTranscodingGreeterService, HelloRequest, HelloReply> CreateCallHandler(


### PR DESCRIPTION
Fixing 2 problems:

1) A query-string parameter written with a mixed or shortened field-name spelling (e.g. `?tenantScope.tenant_id=…` or a parent like `?timestamp_value=…`) could bypass the existing name check and overwrite a value already bound from the URL path. This change compares the resolved field identities instead of raw name strings, so query parameters can no longer clobber route-bound fields regardless of how they're spelled.

2) A transcoded method whose request has a self-referential message field allows an unbounded set of valid dotted paths, so the per-endpoint path descriptor cache could grow without limit from repeated requests. Cap the cache size (default 1000, overridable via AppContext) to prevent it.