### PR TITLE
Fix unbounded request decompression on IIS out-of-process (MaxRequestBodySize)

### DIFF
--- a/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.WebSockets.cs
+++ b/src/Servers/IIS/IIS/test/testassets/InProcessWebSite/Startup.WebSockets.cs
@@ -153,7 +153,13 @@ public partial class Startup
 
         // Upgrade the connection
         Stream opaqueTransport = await upgradeFeature.UpgradeAsync();
-        Assert.Null(context.Features.Get<IHttpMaxRequestBodySizeFeature>().MaxRequestBodySize);
+
+        // In-process reads upgraded data through the same loop that enforces MaxRequestBodySize, so it
+        // must clear the limit. Out-of-process runs on Kestrel, which never enforces it once upgraded.
+        if (context.Features.Get<IServerVariablesFeature>() is not null)
+        {
+            Assert.Null(context.Features.Get<IHttpMaxRequestBodySizeFeature>().MaxRequestBodySize);
+        }
 
         // Get the WebSocket object
         var ws = WebSocket.CreateFromStream(opaqueTransport, isServer: true, subProtocol: null, keepAliveInterval: TimeSpan.FromMinutes(2));

--- a/src/Servers/IIS/IISIntegration/src/IISMiddleware.cs
+++ b/src/Servers/IIS/IISIntegration/src/IISMiddleware.cs
@@ -25,6 +25,7 @@ public class IISMiddleware
     private const string MSAspNetCoreEvent = "MS-ASPNETCORE-EVENT";
     private const string MSAspNetCoreWinAuthToken = "MS-ASPNETCORE-WINAUTHTOKEN";
     private const string ANCMShutdownEventHeaderValue = "shutdown";
+    internal const string ClearMaxRequestBodySizeSwitch = "Microsoft.AspNetCore.Server.IISIntegration.ClearMaxRequestBodySize";
     private static readonly PathString ANCMRequestPath = new PathString("/iisintegration");
     private static readonly Func<object, Task> ClearUserDelegate = ClearUser;
 
@@ -34,6 +35,7 @@ public class IISMiddleware
     private readonly string _pairingToken;
     private readonly IHostApplicationLifetime _applicationLifetime;
     private readonly bool _isWebsocketsSupported;
+    private readonly bool _clearMaxRequestBodySize;
 
     /// <summary>
     /// The middleware that enables IIS Out-Of-Process to work.
@@ -91,6 +93,7 @@ public class IISMiddleware
         _applicationLifetime = applicationLifetime;
         _logger = loggerFactory.CreateLogger<IISMiddleware>();
         _isWebsocketsSupported = isWebsocketsSupported;
+        _clearMaxRequestBodySize = AppContext.TryGetSwitch(ClearMaxRequestBodySizeSwitch, out var clear) && clear;
     }
 
     /// <summary>
@@ -125,11 +128,16 @@ public class IISMiddleware
             return Task.CompletedTask;
         }
 
-        var bodySizeFeature = httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>();
-        if (bodySizeFeature != null && !bodySizeFeature.IsReadOnly)
+        if (_clearMaxRequestBodySize)
         {
-            // IIS already limits this, no need to do it twice.
-            bodySizeFeature.MaxRequestBodySize = null;
+            var bodySizeFeature = httpContext.Features.Get<IHttpMaxRequestBodySizeFeature>();
+            if (bodySizeFeature != null && !bodySizeFeature.IsReadOnly)
+            {
+                // Opt-in legacy behavior: clear the server's max request body size so the IIS
+                // maxAllowedContentLength limit applies on its own. Disabled by default so the
+                // server's configured limit remains in effect.
+                bodySizeFeature.MaxRequestBodySize = null;
+            }
         }
 
         if (_options.ForwardClientCertificate)

--- a/src/Servers/IIS/IISIntegration/test/Tests/IISMiddlewareTests.cs
+++ b/src/Servers/IIS/IISIntegration/test/Tests/IISMiddlewareTests.cs
@@ -4,16 +4,21 @@
 using System;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Http.Features.Authentication;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.AspNetCore.InternalTesting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Server.IISIntegration;
@@ -527,5 +532,80 @@ public class IISMiddlewareTests
         await server.CreateClient().SendAsync(req);
 
         Assert.True(assertsExecuted);
+    }
+
+    [Fact]
+    public async Task DoesNotClearMaxRequestBodySizeByDefault()
+    {
+        var nextInvoked = false;
+        var feature = new FakeMaxRequestBodySizeFeature { MaxRequestBodySize = 1000 };
+        var context = CreateContextWithFeature(feature);
+
+        var middleware = CreateMiddleware(_ =>
+        {
+            nextInvoked = true;
+            return Task.CompletedTask;
+        });
+
+        await middleware.Invoke(context);
+
+        Assert.Equal(1000, feature.MaxRequestBodySize);
+        Assert.True(nextInvoked);
+    }
+
+    [Fact]
+    public async Task DoesNotThrowWhenMaxRequestBodySizeFeatureAbsent()
+    {
+        var nextInvoked = false;
+        var context = new DefaultHttpContext();
+        context.Request.Headers["MS-ASPNETCORE-TOKEN"] = "TestToken";
+
+        var middleware = CreateMiddleware(_ =>
+        {
+            nextInvoked = true;
+            return Task.CompletedTask;
+        });
+
+        await middleware.Invoke(context);
+
+        Assert.True(nextInvoked);
+    }
+
+    private static DefaultHttpContext CreateContextWithFeature(IHttpMaxRequestBodySizeFeature feature)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers["MS-ASPNETCORE-TOKEN"] = "TestToken";
+        context.Features.Set(feature);
+        return context;
+    }
+
+    private static IISMiddleware CreateMiddleware(RequestDelegate next)
+    {
+        return new IISMiddleware(
+            next,
+            NullLoggerFactory.Instance,
+            Options.Create(new IISOptions()),
+            pairingToken: "TestToken",
+            isWebsocketsSupported: true,
+            new AuthenticationSchemeProvider(Options.Create(new AuthenticationOptions())),
+            new TestHostApplicationLifetime());
+    }
+
+    private sealed class FakeMaxRequestBodySizeFeature : IHttpMaxRequestBodySizeFeature
+    {
+        public bool IsReadOnly { get; init; }
+
+        public long? MaxRequestBodySize { get; set; }
+    }
+
+    private sealed class TestHostApplicationLifetime : IHostApplicationLifetime
+    {
+        public CancellationToken ApplicationStarted => CancellationToken.None;
+
+        public CancellationToken ApplicationStopping => CancellationToken.None;
+
+        public CancellationToken ApplicationStopped => CancellationToken.None;
+
+        public void StopApplication() { }
     }
 }


### PR DESCRIPTION
On IIS out-of-process hosting, IISMiddleware cleared the request body size limit (MaxRequestBodySize = null). RequestDecompressionMiddleware consumed that as an unbounded decompressed-body budget, allowing an anonymous decompression-bomb DoS (temporary, with amplification).

Gate the null-assignment behind the Microsoft.AspNetCore.Server.IISIntegration.ClearMaxRequestBodySize AppContext switch (default off). By default the server request body size limit is preserved; apps needing the legacy defer-to-IIS behavior can opt in.

Prevents unbounded request-body decompression on IIS out-of-process. Opt-out switch provided for compatibility.