### PR TITLE
[test-quarantine] Stabilize the QuickGrid paginator E2E test

### DIFF
--- a/src/Components/test/E2ETest/Tests/QuickGridInteractiveCompatTest.cs
+++ b/src/Components/test/E2ETest/Tests/QuickGridInteractiveCompatTest.cs
@@ -5,6 +5,7 @@ using Components.TestServer.RazorComponents;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
+using Microsoft.AspNetCore.InternalTesting;
 using OpenQA.Selenium;
 using TestServer;
 using Xunit.Abstractions;
@@ -108,6 +109,7 @@ public class QuickGridInteractiveCompatTest : ServerTestBase<BasicTestAppServerS
     }
 
     [Fact]
+    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/68680")]
     public void PaginatorCorrectItemsPerPage()
     {
         Navigate($"{ServerPathBase}/quickgrid-interactive");

--- a/src/Components/test/E2ETest/Tests/QuickGridInteractiveCompatTest.cs
+++ b/src/Components/test/E2ETest/Tests/QuickGridInteractiveCompatTest.cs
@@ -5,7 +5,6 @@ using Components.TestServer.RazorComponents;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure;
 using Microsoft.AspNetCore.Components.E2ETest.Infrastructure.ServerFixtures;
 using Microsoft.AspNetCore.E2ETesting;
-using Microsoft.AspNetCore.InternalTesting;
 using OpenQA.Selenium;
 using TestServer;
 using Xunit.Abstractions;
@@ -109,20 +108,17 @@ public class QuickGridInteractiveCompatTest : ServerTestBase<BasicTestAppServerS
     }
 
     [Fact]
-    [QuarantinedTest("https://github.com/dotnet/aspnetcore/issues/68680")]
     public void PaginatorCorrectItemsPerPage()
     {
         Navigate($"{ServerPathBase}/quickgrid-interactive");
         Browser.Exists(By.CssSelector("#grid > table"));
 
-        var grid = Browser.FindElement(By.ClassName("quickgrid"));
-        var rowCount = grid.FindElements(By.CssSelector("tbody > tr")).Count;
-        Assert.Equal(10, rowCount);
+        Browser.Equal(10, () => Browser.FindElements(By.CssSelector("#grid .quickgrid tbody tr")).Count);
 
         Browser.Click(By.CssSelector(".first-paginator .go-next"));
 
         Browser.Equal("2", () => Browser.FindElement(By.CssSelector(".first-paginator .paginator nav > div > strong:nth-child(1)")).Text);
-        Browser.Equal(10, () => Browser.FindElement(By.CssSelector("#grid .quickgrid")).FindElements(By.CssSelector("tbody > tr")).Count);
+        Browser.Equal(10, () => Browser.FindElements(By.CssSelector("#grid .quickgrid tbody tr")).Count);
 
         // URL updates in both modes
         Assert.Contains("page=2", Browser.Url);


### PR DESCRIPTION


# Stabilize the QuickGrid paginator E2E test

## Description

The `QuickGridInteractiveCompatTest.PaginatorCorrectItemsPerPage` test could fail intermittently with a `StaleElementReferenceException`.

Clicking the next-page button causes QuickGrid to rerender and replace its DOM elements. The test could then use an old grid element while checking the row count.

The test now queries the rows directly from the browser inside `Browser.Equal(...)`. This ensures every retry uses the latest DOM elements and waits for the grid rerender to complete.

### Validation / Investigation

- Confirmed the failure occurs while querying grid rows after paginator interaction.
- Verified that the updated assertions query fresh DOM elements on every retry.

### Changes

- Removes the cached QuickGrid element.
- Re-queries grid rows inside `Browser.Equal(...)`.
- Uses the existing polling mechanism to wait for rerender completion. 

### Screenshot:
<img width="965" height="367" alt="image" src="https://github.com/user-attachments/assets/ad1d122c-cf0d-471d-9183-41d7ef221207" />


Fixes #68680