### PR TITLE
Fix support for unions with null values as root component parameters

### DIFF
--- a/src/Components/WebAssembly/WebAssembly/src/Prerendering/WebAssemblyComponentParameterDeserializer.cs
+++ b/src/Components/WebAssembly/WebAssembly/src/Prerendering/WebAssemblyComponentParameterDeserializer.cs
@@ -12,14 +12,19 @@ namespace Microsoft.AspNetCore.Components;
 internal sealed class WebAssemblyComponentParameterDeserializer
 {
     private readonly ComponentParametersTypeCache _parametersCache;
+    private readonly JsonSerializerOptions _jsonSerializationOptions;
 
     public WebAssemblyComponentParameterDeserializer(
-        ComponentParametersTypeCache parametersCache)
+        ComponentParametersTypeCache parametersCache,
+        JsonSerializerOptions jsonSerializationOptions)
     {
         _parametersCache = parametersCache;
+        _jsonSerializationOptions = jsonSerializationOptions;
     }
 
-    public static WebAssemblyComponentParameterDeserializer Instance { get; } = new WebAssemblyComponentParameterDeserializer(new ComponentParametersTypeCache());
+    public static WebAssemblyComponentParameterDeserializer Instance { get; } = new WebAssemblyComponentParameterDeserializer(
+        new ComponentParametersTypeCache(),
+        WebAssemblyComponentSerializationSettings.JsonSerializationOptions);
 
     [DynamicDependency(JsonSerialized, typeof(SerializedRenderFragment))]
     [DynamicDependency(JsonSerialized, typeof(RenderTreeNode))]
@@ -59,8 +64,8 @@ internal sealed class WebAssemblyComponentParameterDeserializer
                     var value = (JsonElement)parameterValues[i];
                     var serialized = JsonSerializer.Deserialize<SerializedRenderFragment>(
                         value.GetRawText(),
-                        WebAssemblyComponentSerializationSettings.JsonSerializationOptions);
-                    parametersDictionary[definition.Name] = RenderFragmentSerializer.Deserialize(serialized!.Nodes, WebAssemblyComponentSerializationSettings.JsonSerializationOptions, _parametersCache);
+                        _jsonSerializationOptions);
+                    parametersDictionary[definition.Name] = RenderFragmentSerializer.Deserialize(serialized!.Nodes, _jsonSerializationOptions, _parametersCache);
                 }
                 catch (Exception e)
                 {
@@ -77,8 +82,7 @@ internal sealed class WebAssemblyComponentParameterDeserializer
                 try
                 {
                     object? parameterValue;
-                    if (parameterValues[i] is null &&
-                        WebAssemblyComponentSerializationSettings.JsonSerializationOptions.GetTypeInfo(parameterType).Kind == JsonTypeInfoKind.Union)
+                    if (parameterValues[i] is null && IsUnion(parameterType))
                     {
                         // A union whose active case serializes to JSON null (for example a Union(int?, string)
                         // holding a null int?) is still a non-null box, so the prerender protocol records its
@@ -89,7 +93,7 @@ internal sealed class WebAssemblyComponentParameterDeserializer
                         parameterValue = JsonSerializer.Deserialize(
                             "null",
                             parameterType,
-                            WebAssemblyComponentSerializationSettings.JsonSerializationOptions);
+                            _jsonSerializationOptions);
                     }
                     else
                     {
@@ -97,7 +101,7 @@ internal sealed class WebAssemblyComponentParameterDeserializer
                         parameterValue = JsonSerializer.Deserialize(
                             value.GetRawText(),
                             parameterType,
-                            WebAssemblyComponentSerializationSettings.JsonSerializationOptions);
+                            _jsonSerializationOptions);
                     }
 
                     parametersDictionary[definition.Name] = parameterValue;
@@ -110,6 +114,14 @@ internal sealed class WebAssemblyComponentParameterDeserializer
         }
 
         return ParameterView.FromDictionary(parametersDictionary);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "We expect application code is configured to preserve component parameter types.")]
+    private bool IsUnion(Type parameterType)
+    {
+        // GetTypeInfo can run before the first deserialization and does not populate the default resolver.
+        _jsonSerializationOptions.MakeReadOnly(populateMissingResolver: true);
+        return _jsonSerializationOptions.GetTypeInfo(parameterType).Kind == JsonTypeInfoKind.Union;
     }
 
     [DynamicDependency(JsonSerialized, typeof(ComponentParameter))]

--- a/src/Components/WebAssembly/WebAssembly/test/WebAssemblyComponentParameterDeserializerUnionTest.cs
+++ b/src/Components/WebAssembly/WebAssembly/test/WebAssemblyComponentParameterDeserializerUnionTest.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using Microsoft.AspNetCore.Components.WebAssembly.Infrastructure;
 
 namespace Microsoft.AspNetCore.Components.WebAssembly.Prerendering;
 
@@ -39,23 +40,58 @@ public class WebAssemblyComponentParameterDeserializerUnionTest
         Assert.Equal(new UnionIntString("hi"), parameters["Value"]);
     }
 
+    [Fact]
+    public void NullParameter_RoundTripsThroughPrerenderParameters()
+    {
+        var parameters = RoundTrip<string?>(null);
+
+        Assert.Null(parameters["Value"]);
+    }
+
+    [Theory]
+    [InlineData(typeof(string))]
+    [InlineData(typeof(int?))]
+    public void DeserializeParameters_RejectsTypedNullForNonUnion(Type parameterType)
+    {
+        var definition = new ComponentParameter
+        {
+            Name = "Value",
+            TypeName = parameterType.FullName,
+            Assembly = parameterType.Assembly.GetName().Name,
+        };
+        var wireValues = WebAssemblyComponentParameterDeserializer.GetParameterValues("[null]");
+        var deserializer = new WebAssemblyComponentParameterDeserializer(
+            new ComponentParametersTypeCache(),
+            WebAssemblyComponentSerializationSettings.CreateOptions());
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            deserializer.DeserializeParameters([definition], wireValues));
+
+        Assert.Equal(
+            $"Could not parse the parameter value for parameter '{definition.Name}' of type '{definition.TypeName}' and assembly '{definition.Assembly}'.",
+            exception.Message);
+    }
+
     private static IReadOnlyDictionary<string, object?> RoundTrip<T>(T value)
     {
         var (definitions, values) = ComponentParameter.FromParameterView(
             ParameterView.FromDictionary(new Dictionary<string, object?> { ["Value"] = value }));
 
-        // Mirror the marker marshalling: parameter values are serialized to JSON and read back as an
-        // object list, so a union active case that serializes to JSON null becomes a CLR null here.
-        var json = JsonSerializer.Serialize(values, WebAssemblyComponentSerializationSettings.JsonSerializationOptions);
+        // Prerendering and WebAssembly run in separate runtimes. Keep both options fresh and separate
+        // so neither producer serialization nor another test can initialize the reader's options.
+        var producerOptions = WebAssemblyComponentSerializationSettings.CreateOptions();
+        var readerOptions = WebAssemblyComponentSerializationSettings.CreateOptions();
+        var deserializer = new WebAssemblyComponentParameterDeserializer(
+            new ComponentParametersTypeCache(),
+            readerOptions);
+        var json = JsonSerializer.Serialize(values, producerOptions);
         var wireValues = WebAssemblyComponentParameterDeserializer.GetParameterValues(json);
 
-        return WebAssemblyComponentParameterDeserializer.Instance
+        return deserializer
             .DeserializeParameters(definitions, wireValues)
             .ToDictionary();
     }
 }
-
-// --- Test union types (kept together, mirroring SharedTypes.Unions.cs) ---
 
 // Unambiguous primitive-paired union: int and string serialize to distinct JSON tokens.
 public union UnionIntString(int, string);

--- a/src/Components/test/E2ETest/ServerRenderingTests/InteractivityTest.cs
+++ b/src/Components/test/E2ETest/ServerRenderingTests/InteractivityTest.cs
@@ -152,6 +152,82 @@ public class InteractivityTest : ServerTestBase<BasicTestAppServerSiteFixture<Ra
         Browser.Equal("4", () => countWasmElem.Text);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void CanUseCallSiteRenderMode_WebAssembly_WithInitiallyNullUnionParameter(bool prerender)
+    {
+        // Keep the union as the first and only typed parameter in a fresh WebAssembly runtime.
+        // Deserializing another parameter first can initialize the shared JSON options.
+        Navigate($"{InteractiveCallsiteUrl(prerender)}&union=true");
+        Browser.Equal("Call-site interactive components", () => Browser.FindElement(By.TagName("h1")).Text);
+
+        if (prerender)
+        {
+            Browser.Equal("active null", () => Browser.FindElement(By.Id("value-union")).Text);
+            Browser.Equal("Static", () => Browser.FindElement(By.Id("render-mode-union")).Text);
+            Browser.Equal("False", () => Browser.FindElement(By.Id("is-interactive-union")).Text);
+            Browser.Equal("0", () => Browser.FindElement(By.Id("count-union")).Text);
+        }
+        else
+        {
+            Browser.DoesNotExist(By.Id("value-union"));
+            Browser.DoesNotExist(By.Id("count-union"));
+        }
+
+        Browser.Exists(By.Id("call-blazor-start")).Click();
+        Browser.Equal("WebAssembly", () => Browser.FindElement(By.Id("render-mode-union")).Text);
+        Browser.Equal("True", () => Browser.FindElement(By.Id("is-interactive-union")).Text);
+        Browser.Equal("active null", () => Browser.FindElement(By.Id("value-union")).Text);
+        Browser.Equal("0", () => Browser.FindElement(By.Id("count-union")).Text);
+
+        Browser.Click(By.Id("increment-union"));
+        Browser.Equal("1", () => Browser.FindElement(By.Id("count-union")).Text);
+
+        Browser.Click(By.Id("set-union-value"));
+        Browser.Equal("int:42", () => Browser.FindElement(By.Id("value-union")).Text);
+        Browser.Equal("1", () => Browser.FindElement(By.Id("count-union")).Text);
+
+        Browser.Click(By.Id("increment-union"));
+        Browser.Equal("2", () => Browser.FindElement(By.Id("count-union")).Text);
+
+        Browser.Click(By.Id("clear-union-value"));
+        Browser.Equal("active null", () => Browser.FindElement(By.Id("value-union")).Text);
+        Browser.Equal("2", () => Browser.FindElement(By.Id("count-union")).Text);
+
+        Browser.Click(By.Id("increment-union"));
+        Browser.Equal("3", () => Browser.FindElement(By.Id("count-union")).Text);
+
+        AssertBrowserLogDoesNotContainErrors();
+    }
+
+    [Theory]
+    [InlineData("server", "", "active null")]
+    [InlineData("server", "&unionValue=42", "int:42")]
+    [InlineData("server", "&unionText=hello", "string:hello")]
+    [InlineData("wasm", "", "active null")]
+    [InlineData("wasm", "&unionValue=42", "int:42")]
+    [InlineData("wasm", "&unionText=hello", "string:hello")]
+    public void CanUseCallSiteRenderMode_WithUnionParameter(string mode, string valueQuery, string expectedValue)
+    {
+        Navigate($"{InteractiveCallsiteUrl(prerender: true)}&union=true&unionMode={mode}{valueQuery}");
+
+        Browser.Equal("Static", () => Browser.FindElement(By.Id("render-mode-union")).Text);
+        Browser.Equal("False", () => Browser.FindElement(By.Id("is-interactive-union")).Text);
+        Browser.Equal(expectedValue, () => Browser.FindElement(By.Id("value-union")).Text);
+
+        Browser.Exists(By.Id("call-blazor-start")).Click();
+        Browser.Equal(mode == "server" ? "Server" : "WebAssembly", () => Browser.FindElement(By.Id("render-mode-union")).Text);
+        Browser.Equal("True", () => Browser.FindElement(By.Id("is-interactive-union")).Text);
+        Browser.Equal(expectedValue, () => Browser.FindElement(By.Id("value-union")).Text);
+        Browser.Equal("0", () => Browser.FindElement(By.Id("count-union")).Text);
+
+        Browser.Click(By.Id("increment-union"));
+        Browser.Equal("1", () => Browser.FindElement(By.Id("count-union")).Text);
+
+        AssertBrowserLogDoesNotContainErrors();
+    }
+
     [Fact]
     public void SurfacesExceptionThrownDuringWebAssemblyRootComponentActivation()
     {

--- a/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/CallSiteInteractiveComponents.razor
+++ b/src/Components/test/testassets/Components.TestServer/RazorComponents/Pages/CallSiteInteractiveComponents.razor
@@ -15,6 +15,13 @@
     <hr />
 }
 
+@if (ShowUnion)
+{
+    <TestContentPackage.UnionParameterCounter @key="@("union")" @rendermode="UnionRenderMode" Value="@SelectedUnionValue" />
+    <a id="set-union-value" href="@($"interactive-callsite?suppress-autostart&prerender={Prerender}&union=true&unionMode={UnionMode ?? "wasm"}&unionValue=42")">Set union value to 42</a>
+    <a id="clear-union-value" href="@($"interactive-callsite?suppress-autostart&prerender={Prerender}&union=true&unionMode={UnionMode ?? "wasm"}")">Set union value to null</a>
+}
+
 @code {
     [Parameter, SupplyParameterFromQuery(Name = "server")]
     public int? ServerIncrementAmount { get; set; }
@@ -22,6 +29,28 @@
     [Parameter, SupplyParameterFromQuery(Name = "wasm")]
     public int? WebAssemblyIncrementAmount { get; set; }
 
+    [Parameter, SupplyParameterFromQuery(Name = "union")]
+    public bool ShowUnion { get; set; }
+
+    [Parameter, SupplyParameterFromQuery(Name = "unionValue")]
+    public int? UnionValue { get; set; }
+
+    [Parameter, SupplyParameterFromQuery(Name = "unionText")]
+    public string? UnionText { get; set; }
+
+    [Parameter, SupplyParameterFromQuery(Name = "unionMode")]
+    public string? UnionMode { get; set; }
+
     [Parameter, SupplyParameterFromQuery(Name = "prerender")]
     public bool Prerender { get; set; }
+
+    private TestContentPackage.UnionParameterCounter.NullableIntOrString SelectedUnionValue
+        => UnionText is not null ? UnionText : UnionValue;
+
+    private IComponentRenderMode UnionRenderMode => UnionMode switch
+    {
+        "server" => new InteractiveServerRenderMode(Prerender),
+        null or "wasm" => new InteractiveWebAssemblyRenderMode(Prerender),
+        _ => throw new InvalidOperationException($"Unknown union render mode '{UnionMode}'."),
+    };
 }

--- a/src/Components/test/testassets/TestContentPackage/UnionParameterCounter.razor
+++ b/src/Components/test/testassets/TestContentPackage/UnionParameterCounter.razor
@@ -1,0 +1,22 @@
+<p>Value: <span id="value-union">@DescribeValue()</span></p>
+<p>Interactive: <span id="is-interactive-union">@RendererInfo.IsInteractive</span></p>
+<p>Render mode: <span id="render-mode-union">@RendererInfo.Name</span></p>
+<p>Current count: <span id="count-union">@_currentCount</span></p>
+
+<button id="increment-union" @onclick="() => _currentCount++">Click me</button>
+
+@code {
+    private int _currentCount;
+
+    [Parameter]
+    public NullableIntOrString Value { get; set; }
+
+    private string DescribeValue() => Value switch
+    {
+        int number => $"int:{number}",
+        string text => $"string:{text}",
+        null => "active null",
+    };
+
+    public union NullableIntOrString(int?, string);
+}

--- a/src/Shared/Components/WebAssemblyComponentSerializationSettings.cs
+++ b/src/Shared/Components/WebAssemblyComponentSerializationSettings.cs
@@ -8,7 +8,9 @@ namespace Microsoft.AspNetCore.Components;
 
 internal static class WebAssemblyComponentSerializationSettings
 {
-    public static readonly JsonSerializerOptions JsonSerializationOptions =
+    public static readonly JsonSerializerOptions JsonSerializationOptions = CreateOptions();
+
+    public static JsonSerializerOptions CreateOptions() =>
         new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,


### PR DESCRIPTION
Fixes #68798

An interactive-root component parameter whose union active case is null could fail to restore in a fresh WebAssembly runtime. The null-value path called `GetTypeInfo` before the serializer options had a configured resolver, preventing the component from becoming interactive.

Initialize the options with `MakeReadOnly(populateMissingResolver: true)` before inspecting union metadata. This follows the normal System.Text.Json initialization behavior while preserving existing null handling and invalid-parameter rejection.