### PR TITLE
Add review candidate groups to PR attention queue

### DIFF
--- a/.github/skills/pr-attention-queue/SKILL.md
+++ b/.github/skills/pr-attention-queue/SKILL.md
@@ -7,7 +7,8 @@ description: >-
   review", "PR attention queue", "what should I review today", "stale community PRs", "who is the
   next actor", "show the Blazor queue", or requests to filter the queue by ASP.NET Core labels or
   changed paths. Returns a capped Review now list, Needs rescue list, ready-to-merge items, resolved
-  scope, next actor, and evidence-backed reason codes. DO NOT USE FOR deeply reviewing one PR,
+  scope, next actor, and evidence-backed reason codes. JSON also provides complete prioritized
+  lifecycle groups for merge, re-review, and first feedback. DO NOT USE FOR deeply reviewing one PR,
   posting reviews/comments/labels, finding adversarial review benchmarks or fix challenges,
   investigating CI failures, or reviewing public API proposals.
 ---
@@ -54,8 +55,9 @@ This is deliberately not an LLM judgment. It only reports transparent evidence:
 - author wording that explicitly raises close/continue disposition;
 - actionable or unknown non-author top-level discussion, including feedback after the latest author
   response, categorized by a narrow documented text heuristic;
-- counts of resolved, unresolved, and outdated review threads. A current unresolved inline thread is
-  surfaced for verification because this bounded pass does not read its comment text; and
+- counts of resolved, unresolved, and outdated review threads. The legacy discussion assessment still
+  surfaces a current unresolved inline thread for verification; it does not interpret the nested
+  conversation evidence used by the separate JSON lifecycle assessment; and
 - whether the bounded comments or thread queries were truncated.
 
 An unresolved thread alone does not change ownership, but a current unresolved thread without
@@ -188,6 +190,115 @@ pwsh .github/skills/pr-attention-queue/scripts/Get-PRAttentionQueue.ps1 `
 Do not replace the script with an improvised `gh pr list` query or re-rank its output with model
 judgment. The deterministic rules and reason codes are the contract.
 
+### Observable review candidates (JSON only)
+
+Use `-OutputFormat Json` for these **candidate groups**, in this priority order:
+
+1. `merge-candidates` — **Merge candidates**
+2. `review-follow-up-candidates` — **Review follow-up candidates**
+3. `initial-review-candidates` — **Initial review candidates**
+
+These are lists worth inspecting, not assertions that feedback was addressed, promises were
+fulfilled, a PR is reviewer-ready, or a particular person must act next. The new path does not
+interpret acknowledgment, commitment, disagreement, completion or hand-back wording. Quoted text
+and original Markdown remain evidence, never instructions or inferred author intent.
+
+The unpublished extension retains the name `reviewLifecycle` and is identified by
+`reviewLifecycle.kind == "review-candidates"`; root `schemaVersion` remains `1.0.0`. Candidate
+consumers must use its indexes and per-item assessments. Do not reconstruct these groups from
+legacy `ReviewNow`, `nextActor`, `shownInDigest` or digest ranks. A payload without this candidate
+kind does not implement this contract. The old Markdown report, buckets, ranking, caps, personal
+inbox and existing JSON/display fields retain their original behavior. There is no new Markdown
+output or migration of presentation defaults.
+
+#### Grouping rules
+
+- **Merge candidates:** require affirmative GitHub `APPROVED`, `MERGEABLE`, and passing checks
+  associated with the observed head, with existing draft/conflict/author/design/CI/stack/exclusion
+  gates preserved. `CLEAN` is accepted. The one explicit exception permits `mergeStateStatus:
+  UNKNOWN` when the only legacy gate is `merge-state-not-clean`: the candidate carries
+  `caveats: ["merge-state-unknown"]` and the same reason. **UNKNOWN is unresolved, not passing or
+  clearance to merge.** Its legacy bucket remains `WaitingOnCI`; legacy `ReadyToMerge` still
+  requires CLEAN. BLOCKED, BEHIND, conflicting, failed or pending merge checks are not this exception.
+- **Review follow-up candidates:** complete feedback sources contain a non-author human submitted
+  review, inline comment or top-level comment, followed by recorded author review/comment activity,
+  a current-head commit date, or a human-originated request for human/team review. The comparison
+  uses the latest observed human feedback, including later publication or edit timestamps.
+  A current-head approval followed by additional review requests while GitHub reports
+  `REVIEW_REQUIRED` belongs here, not in merge candidates. The date of a head commit is not a
+  fabricated push time or proof that the author fixed anything.
+- **Initial review candidates:** complete review, top-level-comment and inline histories contain
+  no non-author human feedback. Dismissed submitted reviews count as history. **Every observed
+  non-author human comment counts**, including greetings, acknowledgments, quoted comments and
+  administrative remarks; there is no “substantive comment” text parser. Bot and author-only
+  activity do not constitute human reviewer feedback. Zero submitted reviews alone is insufficient.
+
+Existing hard gates remain effective rather than being reinterpreted through discussion text.
+Pending CI can coexist with ordinary review under legacy rules, but is surfaced as `checks-pending`,
+not green. Missing check evidence is not passing. Existing feedback without later observed activity
+is `not-grouped`, not an automatic author obligation. Missing publication, identity, typed actors
+or required histories is `verification-needed`, never a fabricated initial-review candidate.
+The author's wording “I'll add that tomorrow” followed by “Thanks!” neither creates nor discharges
+an inferred obligation: neither such inference exists in candidate grouping.
+
+#### Candidate JSON contract
+
+Each `items[].reviewLifecycle` has:
+
+- `group` (one of the three identifiers, or null), `status`, and nullable within-group `rank`;
+- factual `reasons`, explicit `caveats`, and `primaryUncertaintyReason` when verification is needed;
+- `coverage` per source: `complete`, `partial` or `not-collected`, with observed connection metadata;
+- `evidence` containing head/draft/author identities, GitHub approval/merge/check facts, `headCommit`,
+  published `events`, `reviewRequestEvents`, `currentReviewRequests`, `laterReviewRequests`,
+  `humanFeedbackCount`, `latestHumanFeedbackAt`, `latestAuthorActivityAt`, and original source errors.
+  Feedback count counts published records, not people or inferred review rounds. Event records
+  preserve kind, actor, dates, state, original body, review/thread/reply identity and resolved flags.
+  A missing body does not imply an empty body or prevent grouping based on publication metadata.
+
+There is **no lifecycle `nextActor` field**, conversation-resolution verdict or confident-routing
+metric. Legacy `items[].nextActor` is unchanged. Nullable facts remain null rather than invented
+timestamps, SHAs or links.
+
+At the root:
+
+- `groupOrder` provides the priority above. `groups` contains `{ id, count, numbers }` references
+  into the sole PR records in `items`. No digest/per-author cap truncates these inventories.
+  Each PR has at most one group, with contiguous ranks using the existing within-group ordering.
+- `statusCounts` reconciles all scoped items across `grouped`, `not-grouped`, `blocked` and
+  `verification-needed`.
+- `coverage.inventory` covers every scoped item. `coverage.reviewWork` freezes the legacy
+  otherwise-reviewable cohort after explicit author/stack exclusions, before discussion and digest
+  limits; it includes `insideDiscussionBudget` and `outsideDiscussionBudget` breakdowns.
+  `coverage.mergeWork` separately covers eligible legacy merge items and the UNKNOWN exception.
+- Each summary reports `denominator`, `grouped`, `notGrouped`, `blocked`, `verificationNeeded`,
+  `groupedFraction`, `groupCounts`, `primaryUncertaintyReasons`, and per-source `sources` counts.
+  These measure **group membership and evidence availability**, not certification, accuracy,
+  established actors or successful routing. Fractions are null for zero denominators. One primary
+  uncertainty reason per PR makes cause totals reconcile; all reasons remain on the item.
+- `display.reviewLifecycle` supplies candidate-specific labels and descriptions without altering
+  existing display entries.
+
+#### Bounded collection and failure behavior
+
+The existing all-candidate detail query retains typed actors, authoritative counts/page metadata,
+head identity, published activity and review-request events. The leading **20** legacy review
+candidates receive the existing richer discussion collection: last 50 top-level comments and
+threads, with last 20 comments per thread. Batches remain at most five PRs. No crawler, expanded
+budget, personal-inbox dependency or model scoring is introduced. Assessment uses all collected
+events, not the legacy ten-comment excerpt. Filtered request timelines use `filteredCount`.
+
+Complete zero histories can establish initial candidates outside the richer budget. Incomplete
+feedback histories or unknown/deleted actors cannot. Pending private reviews/comments are ignored.
+The existing configured automation policy is preserved; User-typed service-looking identities
+without established policy remain uncertain and visible, not silently excluded.
+
+Shared detail GraphQL transport failures, returned errors, missing PRs or missing shared fields
+**abort the public query before emitting JSON**. Inventory-only records must never become a
+success-shaped legacy review digest. Lifecycle-only discussion failures can remain explicit
+uncertainty when the shared legacy detail data is intact. Repository incompleteness remains an
+error. Head/draft/author or review-identity disagreement between collection stages also prevents
+candidate grouping.
+
 JSON consumers must validate `schemaVersion`. Additive fields may be introduced within a supported
 schema version, and consumers must ignore fields they do not recognize. Removing, renaming,
 retyping, or changing the meaning of a required field requires a new schema version. The `display`
@@ -200,7 +311,8 @@ where `query.complete` is not `true`.
 The root `discussion` summary and each assessed item's `discussionAssessment` are additive contract
 fields. `discussionAssessment.state == verification-needed` is not a new bucket or an inference
 that the author is next. It means the item must be opened and its surfaced evidence interpreted
-before starting an ordinary review. Renderers must not present a `Review` action for those items.
+before starting an ordinary review in the legacy digest. Legacy discussion consumers must not present
+a `Review` action for those items; lifecycle consumers use the independent authoritative contract above.
 
 ### 3. Preserve the classifications
 

--- a/.github/skills/pr-attention-queue/scripts/PRAttentionQueue.psm1
+++ b/.github/skills/pr-attention-queue/scripts/PRAttentionQueue.psm1
@@ -1728,44 +1728,75 @@ function Add-PullRequestDetails {
         throw "Repository must use the owner/name format."
     }
 
-    for ($offset = 0; $offset -lt $Candidates.Count; $offset += 20) {
-        $chunk = @($Candidates | Select-Object -Skip $offset -First 20)
+    for ($offset = 0; $offset -lt $Candidates.Count; $offset += 5) {
+        $chunk = @($Candidates | Select-Object -Skip $offset -First 5)
         $aliases = @(
             foreach ($candidate in $chunk) {
                 $number = [int]$candidate.PullRequest.number
                 @"
 pr$number`: pullRequest(number: $number) {
   number
+  headRefOid
+  isDraft
+  author { __typename login }
   mergeable
   mergeStateStatus
   reviewDecision
   reviews(last: 50) {
+    totalCount
+    pageInfo { hasPreviousPage }
     nodes {
-      author { login }
+      id
+      url
+      body
+      author { __typename login }
       state
       submittedAt
+      updatedAt
       commit { oid }
     }
   }
   reviewRequests(first: 20) {
+    totalCount
+    pageInfo { hasNextPage }
     nodes {
       requestedReviewer {
+        __typename
         ... on User { login }
         ... on Team { name }
       }
     }
   }
   comments(last: 50) {
+    totalCount
+    pageInfo { hasPreviousPage }
     nodes {
-      author { login }
+      id
+      url
+      body
+      author { __typename login }
+      authorAssociation
       createdAt
+      updatedAt
     }
   }
+  reviewThreads(last: 1) {
+    totalCount
+    pageInfo { hasPreviousPage }
+    nodes { id }
+  }
   timelineItems(itemTypes: [REVIEW_REQUESTED_EVENT], last: 50) {
+    totalCount
+    filteredCount
+    pageInfo { hasPreviousPage }
     nodes {
+      __typename
       ... on ReviewRequestedEvent {
+        id
+        actor { __typename login }
         createdAt
         requestedReviewer {
+          __typename
           ... on User { login }
           ... on Team { name }
         }
@@ -1775,6 +1806,11 @@ pr$number`: pullRequest(number: $number) {
   commits(last: 1) {
     nodes {
       commit {
+        oid
+        url
+        committedDate
+        author { user { __typename login } }
+        committer { user { __typename login } }
         statusCheckRollup { state }
       }
     }
@@ -1797,14 +1833,33 @@ pr$number`: pullRequest(number: $number) {
             "-F",
             "name=$($repositoryParts[1])"
         )
+        $errors = @(ConvertTo-Array (Get-PropertyValue $result "errors"))
+        if ($errors.Count -gt 0) {
+            throw "GitHub shared detail query failed: $(($errors | ForEach-Object { Get-PropertyValue $_ 'message' }) -join '; ')"
+        }
 
         foreach ($candidate in $chunk) {
             $pullRequest = $candidate.PullRequest
             $number = [int]$pullRequest.number
-            $detail = Get-PropertyValue -Object $result.data.repository -Name "pr$number"
+            $repositoryData = Get-PropertyValue (Get-PropertyValue $result "data") "repository"
+            $detail = Get-PropertyValue -Object $repositoryData -Name "pr$number"
             if ($null -eq $detail) {
-                throw "GitHub did not return details for pull request #$number."
+                throw "GitHub did not return shared details for pull request #$number."
             }
+            foreach ($name in @("reviews", "comments", "reviewRequests", "timelineItems", "commits")) {
+                $connection = Get-PropertyValue $detail $name
+                $nodesProperty = if ($connection) { $connection.PSObject.Properties["nodes"] } else { $null }
+                if ($null -eq $nodesProperty -or $null -eq $nodesProperty.Value) {
+                    throw "GitHub shared details for pull request #$number are missing $name nodes."
+                }
+            }
+            foreach ($name in @("mergeable", "mergeStateStatus", "reviewDecision")) {
+                if ($null -eq $detail.PSObject.Properties[$name] -or
+                    ($name -ne "reviewDecision" -and $null -eq $detail.PSObject.Properties[$name].Value)) {
+                    throw "GitHub shared details for pull request #$number are missing $name."
+                }
+            }
+            $pullRequest | Add-Member -NotePropertyName "lifecycleDetails" -NotePropertyValue $detail -Force
 
             $reviews = @(
                 ConvertTo-Array (Get-PropertyValue `
@@ -1910,20 +1965,30 @@ function Add-DiscussionEvidenceDetails {
         throw "Repository must use the owner/name format."
     }
 
-    for ($offset = 0; $offset -lt $Candidates.Count; $offset += 20) {
-        $chunk = @($Candidates | Select-Object -Skip $offset -First 20)
+    for ($offset = 0; $offset -lt $Candidates.Count; $offset += 5) {
+        $chunk = @($Candidates | Select-Object -Skip $offset -First 5)
         $aliases = @(
             foreach ($candidate in $chunk) {
                 $number = [int]$candidate.PullRequest.number
                 @"
 pr$number`: pullRequest(number: $number) {
+  number
+  headRefOid
+  isDraft
+  author { __typename login }
+  reviewDecision
+  reviews { totalCount }
   comments(last: 50) {
     totalCount
     pageInfo { hasPreviousPage }
     nodes {
-      author { login }
+      id
+      url
+      author { __typename login }
       authorAssociation
       createdAt
+      updatedAt
+      body
       bodyText
     }
   }
@@ -1931,8 +1996,28 @@ pr$number`: pullRequest(number: $number) {
     totalCount
     pageInfo { hasPreviousPage }
     nodes {
+      id
       isResolved
       isOutdated
+      path
+      comments(last: 20) {
+        totalCount
+        pageInfo { hasPreviousPage }
+        nodes {
+          id
+          url
+          state
+          author { __typename login }
+          authorAssociation
+          createdAt
+          updatedAt
+          body
+          replyTo { id }
+          commit { oid }
+          originalCommit { oid }
+          pullRequestReview { id state submittedAt url }
+        }
+      }
     }
   }
 }
@@ -1943,7 +2028,10 @@ pr$number`: pullRequest(number: $number) {
         $query = 'query($owner:String!,$name:String!){repository(owner:$owner,name:$name){' +
             ($aliases -join [Environment]::NewLine) +
             '}}'
-        $result = Invoke-GhJson -Arguments @(
+        $result = $null
+        $discussionError = $null
+        try {
+            $result = Invoke-GhJson -Arguments @(
             "api",
             "graphql",
             "-f",
@@ -1952,14 +2040,27 @@ pr$number`: pullRequest(number: $number) {
             "owner=$($repositoryParts[0])",
             "-F",
             "name=$($repositoryParts[1])"
-        )
+            )
+        }
+        catch {
+            $discussionError = $_.Exception.Message
+        }
 
         foreach ($candidate in $chunk) {
             $pullRequest = $candidate.PullRequest
             $number = [int]$pullRequest.number
-            $detail = Get-PropertyValue -Object $result.data.repository -Name "pr$number"
-            if ($null -eq $detail) {
-                throw "GitHub did not return discussion evidence for pull request #$number."
+            $repositoryData = Get-PropertyValue (Get-PropertyValue $result "data") "repository"
+            $detail = Get-PropertyValue -Object $repositoryData -Name "pr$number"
+            $pullRequest | Add-Member -NotePropertyName "lifecycleDiscussion" -NotePropertyValue $detail -Force
+            $errors = @(ConvertTo-Array (Get-PropertyValue $result "errors") | Where-Object {
+                $path = @(Get-PropertyValue $_ "path")
+                $null -eq (Get-PropertyValue $_ "path") -or $path.Count -eq 0 -or $path -contains "pr$number"
+            })
+            if ($discussionError -or $errors.Count -gt 0 -or $null -eq $detail) {
+                $pullRequest | Add-Member -NotePropertyName "lifecycleDiscussionError" -NotePropertyValue $(
+                    if ($discussionError) { $discussionError }
+                    elseif ($errors.Count -gt 0) { ($errors | ForEach-Object { Get-PropertyValue $_ "message" }) -join "; " }
+                    else { "GitHub did not return discussion evidence for pull request #$number." }) -Force
             }
 
             $commentsConnection = Get-PropertyValue -Object $detail -Name "comments"
@@ -2047,7 +2148,7 @@ function Resolve-UnknownMergeable {
 
         Start-Sleep -Milliseconds $DelayMilliseconds
 
-        # Add-PullRequestDetails chunks at 20 because its query is heavy. This query
+        # Add-PullRequestDetails uses small batches because its query is heavy. This query
         # is small, but an UNKNOWN mergeable is the expensive case server-side, so
         # this stays well below that to avoid provoking a GraphQL timeout.
         for ($offset = 0; $offset -lt $pending.Count; $offset += 25) {
@@ -2055,7 +2156,7 @@ function Resolve-UnknownMergeable {
             $aliases = @(
                 foreach ($candidate in $chunk) {
                     $number = [int]$candidate.PullRequest.number
-                    "pr$number`: pullRequest(number: $number) { number mergeable }"
+                    "pr$number`: pullRequest(number: $number) { number headRefOid isDraft mergeable }"
                 }
             )
             $query = 'query($owner:String!,$name:String!){repository(owner:$owner,name:$name){' +
@@ -2078,6 +2179,10 @@ function Resolve-UnknownMergeable {
             catch {
                 # This pass only refines an already-complete queue, so a failed chunk
                 # must not discard the chunks that already resolved.
+                foreach ($candidate in $chunk) {
+                    $candidate.PullRequest | Add-Member -NotePropertyName "lifecycleMergeError" `
+                        -NotePropertyValue $_.Exception.Message -Force
+                }
                 $result = $null
             }
 
@@ -2092,6 +2197,16 @@ function Resolve-UnknownMergeable {
                     continue
                 }
 
+                if ((Get-PropertyValue $detail "headRefOid") -and
+                    ((Get-PropertyValue $detail "headRefOid") -ne $candidate.PullRequest.headRefOid -or
+                    (Get-PropertyValue $detail "isDraft") -ne $candidate.PullRequest.isDraft)) {
+                    $candidate.PullRequest | Add-Member -NotePropertyName "lifecycleIdentityMismatch" -NotePropertyValue $true -Force
+                }
+                $candidate.PullRequest.PSObject.Properties.Remove("lifecycleMergeError")
+                $candidate.PullRequest | Add-Member `
+                    -NotePropertyName "lifecycleMergeIdentity" `
+                    -NotePropertyValue $detail `
+                    -Force
                 $candidate.PullRequest | Add-Member `
                     -NotePropertyName "mergeable" `
                     -NotePropertyValue (Get-PropertyValue -Object $detail -Name "mergeable" -DefaultValue "UNKNOWN") `
@@ -2442,8 +2557,406 @@ function Get-Classification {
     }
 }
 
+function Get-LifecycleConnectionCoverage {
+    param([object]$Connection, [string]$PageFlag = "hasPreviousPage", [string]$CountField = "totalCount")
+
+    $nodes = @(ConvertTo-Array (Get-PropertyValue $Connection "nodes"))
+    $count = Get-PropertyValue $Connection $CountField
+    $hasMore = Get-PropertyValue (Get-PropertyValue $Connection "pageInfo") $PageFlag
+    $nodesProperty = if ($Connection) { $Connection.PSObject.Properties["nodes"] } else { $null }
+    $state = if ($null -eq $Connection) { "not-collected" }
+    elseif ($null -ne $count -and $null -ne $hasMore -and -not $hasMore -and
+        $null -ne $nodesProperty -and $null -ne $nodesProperty.Value -and $count -eq $nodes.Count) { "complete" }
+    else { "partial" }
+    return [pscustomobject]@{
+        state = $state
+        totalCount = $count
+        returnedCount = if ($null -ne $Connection) { $nodes.Count } else { $null }
+        hasMore = $hasMore
+    }
+}
+
+function Get-LifecycleActor {
+    param([object]$Actor, [string]$AuthorLogin, [string[]]$KnownBotPatterns)
+
+    $login = [string](Get-PropertyValue $Actor "login")
+    $type = Get-PropertyValue $Actor "__typename"
+    if (-not $login -or $type -notin @("User", "Bot")) { return "unknown" }
+    if ($type -eq "Bot" -or (Test-IsBotLogin $login $false $KnownBotPatterns)) { return "automation" }
+    # A User-typed service-looking identity is not a new exclusion or an ownership policy.
+    if ($login -like "*-bot") { return "unestablished-service" }
+    if ($login -eq $AuthorLogin) { return "author" }
+    return "human"
+}
+
+function Get-LifecycleEvent {
+    param([object]$Event, [string]$Kind, [object]$Thread, [string]$AuthorLogin, [string[]]$KnownBotPatterns)
+
+    $publication = if ($Kind -eq "review") { $Event } else { Get-PropertyValue $Event "pullRequestReview" }
+    $state = Get-PropertyValue $publication "state"
+    if ($state -eq "PENDING" -or (Get-PropertyValue $Event "state") -eq "PENDING") { return }
+    $createdAt = ConvertTo-UtcDateTime (Get-PropertyValue $Event "createdAt")
+    $submittedAt = ConvertTo-UtcDateTime (Get-PropertyValue $publication "submittedAt")
+    $updatedAt = ConvertTo-UtcDateTime (Get-PropertyValue $Event "updatedAt")
+    $actor = Get-LifecycleActor (Get-PropertyValue $Event "author") $AuthorLogin $KnownBotPatterns
+    $published = if ($Kind -eq "top-level-comment") { $null -ne $createdAt }
+        else { $submittedAt -and $state -in @("APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED") }
+    if ($Kind -eq "inline-comment") {
+        $published = $published -and $createdAt -and (Get-PropertyValue $Event "state") -eq "SUBMITTED"
+    }
+    $publishedAt = @($createdAt, $submittedAt | Where-Object { $null -ne $_ } | Sort-Object -Descending | Select-Object -First 1)
+    $publishedAt = if ($publishedAt.Count -gt 0) { $publishedAt[0] } else { $null }
+    $observedAt = if ($publishedAt -and $updatedAt -gt $publishedAt) { $updatedAt } else { $publishedAt }
+    return [pscustomobject]@{
+        kind = $Kind; id = Get-PropertyValue $Event "id"; url = Get-PropertyValue $Event "url"
+        actor = $actor; author = Get-PropertyValue (Get-PropertyValue $Event "author") "login"
+        published = [bool]$published; publishedAt = $publishedAt; updatedAt = $updatedAt; observedAt = $observedAt
+        state = Get-PropertyValue $Event "state"; reviewState = $state
+        reviewId = Get-PropertyValue $publication "id"; commitSha = Get-PropertyValue (Get-PropertyValue $Event "commit") "oid"
+        threadId = Get-PropertyValue $Thread "id"; isResolved = Get-PropertyValue $Thread "isResolved"
+        isOutdated = Get-PropertyValue $Thread "isOutdated"; replyTo = Get-PropertyValue (Get-PropertyValue $Event "replyTo") "id"
+        body = Get-PropertyValue $Event "body"
+    }
+}
+
+function Get-ReviewLifecycleAssessment {
+    param([object]$PullRequest, [object]$Item, [object]$Settings)
+
+    $detail = Get-PropertyValue $PullRequest "lifecycleDetails"
+    $discussion = Get-PropertyValue $PullRequest "lifecycleDiscussion"
+    $patterns = @($Settings.knownBotPatterns)
+    $author = [string](Get-PropertyValue (Get-PropertyValue $PullRequest "author") "login")
+    $head = Get-PropertyValue $PullRequest "headRefOid"
+    $draft = Get-PropertyValue $PullRequest "isDraft"
+    $reviewsConnection = Get-PropertyValue $detail "reviews"
+    $commentsConnection = Get-PropertyValue $(if ($discussion) { $discussion } else { $detail }) "comments"
+    $threadsConnection = Get-PropertyValue $(if ($discussion) { $discussion } else { $detail }) "reviewThreads"
+    $coverage = [ordered]@{
+        identity = [pscustomobject]@{ state = "not-collected" }
+        reviews = Get-LifecycleConnectionCoverage $reviewsConnection
+        comments = Get-LifecycleConnectionCoverage $commentsConnection
+        threads = Get-LifecycleConnectionCoverage $threadsConnection
+        threadComments = [pscustomobject]@{ state = "not-collected"; totalCount = $null; returnedCount = $null }
+        reviewRequests = Get-LifecycleConnectionCoverage (Get-PropertyValue $detail "reviewRequests") "hasNextPage"
+        timeline = Get-LifecycleConnectionCoverage (Get-PropertyValue $detail "timelineItems") -CountField "filteredCount"
+        commit = [pscustomobject]@{ state = "not-collected" }
+        merge = [pscustomobject]@{ state = "not-collected" }
+    }
+    $threads = @(ConvertTo-Array (Get-PropertyValue $threadsConnection "nodes"))
+    $nestedCount = 0; $nestedReturned = 0; $nestedCollected = 0
+    $nestedComplete = $coverage.threads.state -eq "complete"
+    foreach ($thread in $threads) {
+        $nested = Get-LifecycleConnectionCoverage (Get-PropertyValue $thread "comments")
+        if ($nested.state -ne "not-collected") { $nestedCollected++ }
+        if ($nested.state -ne "complete") { $nestedComplete = $false }
+        if ($null -ne $nested.totalCount) { $nestedCount += $nested.totalCount }
+        if ($null -ne $nested.returnedCount) { $nestedReturned += $nested.returnedCount }
+    }
+    $coverage.threadComments.state = if ($nestedComplete) { "complete" }
+        elseif ($nestedCollected -eq 0) { "not-collected" } else { "partial" }
+    $coverage.threadComments.totalCount = if ($nestedComplete) { $nestedCount } else { $null }
+    $coverage.threadComments.returnedCount = if ($nestedComplete -or $nestedCollected -gt 0) { $nestedReturned } else { $null }
+    $reasons = [System.Collections.Generic.List[string]]::new()
+    $events = @(
+        foreach ($review in @(ConvertTo-Array (Get-PropertyValue $reviewsConnection "nodes"))) {
+            Get-LifecycleEvent $review "review" $null $author $patterns
+        }
+        foreach ($comment in @(ConvertTo-Array (Get-PropertyValue $commentsConnection "nodes"))) {
+            Get-LifecycleEvent $comment "top-level-comment" $null $author $patterns
+        }
+        foreach ($thread in $threads) {
+            foreach ($comment in @(ConvertTo-Array (Get-PropertyValue (Get-PropertyValue $thread "comments") "nodes"))) {
+                Get-LifecycleEvent $comment "inline-comment" $thread $author $patterns
+            }
+        }
+    )
+    $decision = Get-PropertyValue $detail "reviewDecision"
+    $commitNodes = @(ConvertTo-Array (Get-PropertyValue (Get-PropertyValue $detail "commits") "nodes"))
+    $commit = if ($commitNodes.Count -eq 1) { Get-PropertyValue $commitNodes[0] "commit" } else { $null }
+    $commitAt = ConvertTo-UtcDateTime (Get-PropertyValue $commit "committedDate")
+    $commitOid = Get-PropertyValue $commit "oid"
+    $coverage.commit.state = if ($null -eq $commit) { "not-collected" }
+        elseif ($commitOid -eq $head -and $commitAt) { "complete" } else { "partial" }
+    $assessment = [pscustomobject]@{
+        group = $null; status = "verification-needed"; rank = $null
+        reasons = @(); caveats = @(); primaryUncertaintyReason = $null; coverage = [pscustomobject]$coverage
+        evidence = [pscustomobject]@{
+            headSha = $head; detailHeadSha = Get-PropertyValue $detail "headRefOid"
+            discussionHeadSha = Get-PropertyValue $discussion "headRefOid"
+            isDraft = $draft; reviewDecision = $decision
+            mergeable = Get-PropertyValue $detail "mergeable"
+            mergeStateStatus = Get-PropertyValue $detail "mergeStateStatus"
+            checkState = $Item.checkState
+            headCommit = [pscustomobject]@{
+                sha = $commitOid; committedAt = $commitAt; author = Get-PropertyValue (Get-PropertyValue (Get-PropertyValue $commit "author") "user") "login"
+                url = Get-PropertyValue $commit "url"
+            }
+            author = [pscustomobject]@{ login = $author; type = Get-PropertyValue (Get-PropertyValue $detail "author") "__typename" }
+            events = $events
+            reviewRequestEvents = @(ConvertTo-Array (Get-PropertyValue (Get-PropertyValue $detail "timelineItems") "nodes"))
+            currentReviewRequests = @(ConvertTo-Array (Get-PropertyValue (Get-PropertyValue $detail "reviewRequests") "nodes"))
+            humanFeedbackCount = $null; latestHumanFeedbackAt = $null
+            latestAuthorActivityAt = $null; laterReviewRequests = @()
+            sourceErrors = @(
+                foreach ($name in @("lifecycleDetailsError", "lifecycleDiscussionError", "lifecycleMergeError")) {
+                    $errorValue = Get-PropertyValue $PullRequest $name
+                    if ($errorValue) { [pscustomobject]@{ source = $name; message = $errorValue } }
+                }
+            )
+        }
+    }
+    $finish = {
+        param($status, $group, $reason)
+        if ($reason) { $reasons.Add($reason) }
+        $assessment.status = $status; $assessment.group = $group
+        $assessment.reasons = @($reasons | Select-Object -Unique)
+        $assessment.primaryUncertaintyReason = if ($status -eq "verification-needed") {
+            if ($reason) { $reason } else { $assessment.reasons[0] }
+        } else { $null }
+        return $assessment
+    }
+
+    $identityMissing = -not $head -or $null -eq $draft -or -not $detail
+    $identityMismatch = [bool](Get-PropertyValue $PullRequest "lifecycleIdentityMismatch" $false)
+    if ($commitOid -and $head -and $commitOid -ne $head) { $identityMismatch = $true }
+    foreach ($source in @($detail, $discussion, (Get-PropertyValue $PullRequest "lifecycleMergeIdentity"))) {
+        if ($null -eq $source) { continue }
+        if (-not (Get-PropertyValue $source "headRefOid") -or $null -eq (Get-PropertyValue $source "isDraft")) {
+            $identityMissing = $true
+        }
+        elseif ($head -ne $source.headRefOid -or $draft -ne $source.isDraft) { $identityMismatch = $true }
+        $sourceAuthor = Get-PropertyValue (Get-PropertyValue $source "author") "login"
+        if ($sourceAuthor -and $sourceAuthor -ne $author) { $identityMismatch = $true }
+    }
+    if ($discussion -and $detail -and
+        ((Get-PropertyValue $discussion "reviewDecision") -ne $decision -or
+        (Get-PropertyValue (Get-PropertyValue $discussion "reviews") "totalCount") -ne $coverage.reviews.totalCount)) {
+        $identityMismatch = $true
+    }
+    $mergeIdentity = Get-PropertyValue $PullRequest "lifecycleMergeIdentity"
+    $mergeable = if ($mergeIdentity -and -not $identityMismatch) { Get-PropertyValue $mergeIdentity "mergeable" }
+        else { Get-PropertyValue $detail "mergeable" }
+    $assessment.evidence.mergeable = $mergeable
+    $coverage.identity.state = if (-not $detail) { "not-collected" }
+        elseif ($identityMissing -or $identityMismatch) { "partial" } else { "complete" }
+    $coverage.merge.state = if (-not $detail) { "not-collected" }
+        elseif ($coverage.identity.state -eq "complete" -and $null -ne $decision -and $mergeable -and
+        (Get-PropertyValue $detail "mergeStateStatus") -and $commitOid -eq $head) { "complete" } else { "partial" }
+    if ($identityMismatch) { return & $finish "verification-needed" $null "source-identity-mismatch" }
+
+    $explicitExclusions = @($Item.digestExclusionReasons | Where-Object { $_ -in @("excluded-author", "stacked-on-unhealthy-pr") })
+    if ($explicitExclusions.Count -gt 0) {
+        foreach ($reason in $explicitExclusions) { $reasons.Add($reason) }
+        return & $finish "blocked" $null "explicit-queue-exclusion"
+    }
+    $unknownMergeGate = $Item.bucket -eq "WaitingOnCI" -and $decision -eq "APPROVED" -and
+        $Item.checkState -eq "Passing" -and $mergeable -eq "MERGEABLE" -and
+        (Get-PropertyValue $detail "mergeStateStatus") -eq "UNKNOWN" -and
+        $Item.reasonCodes -contains "merge-state-not-clean" -and
+        @($Item.reasonCodes | Where-Object { $_ -notin @("merge-state-not-clean", "community-contribution") }).Count -eq 0
+    if ($Item.bucket -notin @("ReviewNow", "ReadyToMerge") -and -not $unknownMergeGate) {
+        foreach ($reason in $Item.reasonCodes) { $reasons.Add($reason) }
+        return & $finish "blocked" $null "existing-actionability-gate"
+    }
+    if ($assessment.evidence.sourceErrors.Count -gt 0) { $reasons.Add("source-error") }
+    if ($identityMissing) { $reasons.Add("identity-not-collected") }
+    $ownerKind = Get-LifecycleActor (Get-PropertyValue $detail "author") $author $patterns
+    if ($ownerKind -eq "unknown") { $reasons.Add("author-metadata-incomplete") }
+    elseif ($ownerKind -ne "author") { $reasons.Add("author-policy-unestablished") }
+    if ($Item.bucket -eq "ReadyToMerge" -or $unknownMergeGate) {
+        $checkRollup = Get-PropertyValue $commit "statusCheckRollup"
+        if ($reasons.Count -eq 0 -and $coverage.merge.state -eq "complete" -and
+            $decision -eq "APPROVED" -and -not $draft -and $mergeable -eq "MERGEABLE" -and
+            $Item.checkState -eq "Passing" -and (Get-PropertyValue $checkRollup "state") -eq "SUCCESS" -and
+            (Get-PropertyValue $detail "mergeStateStatus") -in @("CLEAN", "UNKNOWN")) {
+            if ($unknownMergeGate) {
+                $assessment.caveats = @("merge-state-unknown")
+                $reasons.Add("merge-state-unknown")
+            }
+            return & $finish "grouped" "merge-candidates" "approval-and-passing-checks-observed"
+        }
+        return & $finish "verification-needed" $null "merge-evidence-incomplete"
+    }
+
+    foreach ($name in @("reviews", "comments", "threads")) {
+        if ($coverage[$name].state -ne "complete") { $reasons.Add("$name-incomplete") }
+    }
+    if (-not $nestedComplete) { $reasons.Add("thread-comments-incomplete") }
+    foreach ($event in $events) {
+        if (-not $event.published -or $event.actor -in @("unknown", "unestablished-service")) {
+            $reasons.Add("event-publication-or-actor-unknown")
+        }
+    }
+    if ($Item.checkState -eq "Unknown") { $reasons.Add("checks-not-collected") }
+    if ($reasons.Count -gt 0) { return & $finish "verification-needed" $null $null }
+
+    $feedback = @($events | Where-Object { $_.actor -eq "human" } | Sort-Object observedAt -Descending)
+    $authorActivity = @($events | Where-Object { $_.actor -eq "author" } | Sort-Object observedAt -Descending)
+    $assessment.evidence.humanFeedbackCount = $feedback.Count
+    $assessment.evidence.latestAuthorActivityAt = if ($authorActivity.Count -gt 0) { $authorActivity[0].observedAt } else { $null }
+    if ($Item.checkState -eq "Pending") { $assessment.caveats = @("checks-pending") }
+    if ($feedback.Count -eq 0) {
+        return & $finish "grouped" "initial-review-candidates" "no-human-feedback-observed"
+    }
+    $latestFeedbackAt = $feedback[0].observedAt
+    $assessment.evidence.latestHumanFeedbackAt = $latestFeedbackAt
+    $reasons.Add("human-feedback-observed")
+    if ($authorActivity.Count -gt 0 -and $authorActivity[0].observedAt -gt $latestFeedbackAt) {
+        $reasons.Add("author-activity-after-feedback")
+    }
+    if ($coverage.commit.state -eq "complete" -and $commitAt -gt $latestFeedbackAt) {
+        $reasons.Add("head-commit-after-feedback")
+    }
+    $requestEvidenceIncomplete = $false
+    $laterRequests = @(
+        foreach ($event in @(ConvertTo-Array (Get-PropertyValue (Get-PropertyValue $detail "timelineItems") "nodes"))) {
+            $requested = Get-PropertyValue $event "requestedReviewer"
+            $at = ConvertTo-UtcDateTime (Get-PropertyValue $event "createdAt")
+            $requestActor = Get-LifecycleActor (Get-PropertyValue $event "actor") $author $patterns
+            $targetActor = Get-LifecycleActor $requested $author $patterns
+            $team = (Get-PropertyValue $requested "__typename") -eq "Team" -and (Get-PropertyValue $requested "name")
+            if (-not $at -or $requestActor -in @("unknown", "unestablished-service") -or
+                ($targetActor -in @("unknown", "unestablished-service") -and -not $team) -or
+                (Get-PropertyValue $event "__typename") -ne "ReviewRequestedEvent") {
+                $requestEvidenceIncomplete = $true
+            }
+            if ((Get-PropertyValue $event "__typename") -eq "ReviewRequestedEvent" -and
+                $requestActor -in @("author", "human") -and ($targetActor -eq "human" -or $team) -and
+                $at -and $at -gt $latestFeedbackAt) {
+                [pscustomobject]@{
+                    id = Get-PropertyValue $event "id"; createdAt = $at
+                    actor = Get-PropertyValue (Get-PropertyValue $event "actor") "login"
+                    requestedReviewer = $requested
+                }
+            }
+        }
+    )
+    $assessment.evidence.laterReviewRequests = $laterRequests
+    if ($laterRequests.Count -gt 0) { $reasons.Add("review-request-after-feedback") }
+    if ($reasons.Count -gt 1) {
+        return & $finish "grouped" "review-follow-up-candidates" $null
+    }
+    if ($requestEvidenceIncomplete -or $coverage.timeline.state -ne "complete" -or $coverage.commit.state -ne "complete") {
+        return & $finish "verification-needed" $null "follow-up-activity-incomplete"
+    }
+    return & $finish "not-grouped" $null "no-later-follow-up-observed"
+}
+
+function Get-LifecycleCoverageSummary {
+    param([object[]]$Items)
+
+    $grouped = @($Items | Where-Object { $_.reviewLifecycle.status -eq "grouped" }).Count
+    $notGrouped = @($Items | Where-Object { $_.reviewLifecycle.status -eq "not-grouped" }).Count
+    $blocked = @($Items | Where-Object { $_.reviewLifecycle.status -eq "blocked" }).Count
+    $verificationNeeded = @($Items | Where-Object { $_.reviewLifecycle.status -eq "verification-needed" }).Count
+    $causes = [ordered]@{}
+    foreach ($item in @($Items | Where-Object { $_.reviewLifecycle.status -eq "verification-needed" } | Sort-Object number)) {
+        $reason = $item.reviewLifecycle.primaryUncertaintyReason
+        $causes[$reason] = [int]$causes[$reason] + 1
+    }
+    $sourceCounts = [ordered]@{}
+    foreach ($source in @("identity", "reviews", "comments", "threads", "threadComments", "reviewRequests", "timeline", "commit", "merge")) {
+        $sourceCounts[$source] = [pscustomobject]@{
+            complete = @($Items | Where-Object { $_.reviewLifecycle.coverage.$source.state -eq "complete" }).Count
+            partial = @($Items | Where-Object { $_.reviewLifecycle.coverage.$source.state -eq "partial" }).Count
+            'not-collected' = @($Items | Where-Object { $_.reviewLifecycle.coverage.$source.state -eq "not-collected" }).Count
+        }
+    }
+    return [pscustomobject]@{
+        denominator = $Items.Count; grouped = $grouped; notGrouped = $notGrouped
+        blocked = $blocked; verificationNeeded = $verificationNeeded
+        groupedFraction = if ($Items.Count -gt 0) { $grouped / $Items.Count } else { $null }
+        groupCounts = [pscustomobject]@{
+            'merge-candidates' = @($Items | Where-Object { $_.reviewLifecycle.group -eq "merge-candidates" }).Count
+            'review-follow-up-candidates' = @($Items | Where-Object { $_.reviewLifecycle.group -eq "review-follow-up-candidates" }).Count
+            'initial-review-candidates' = @($Items | Where-Object { $_.reviewLifecycle.group -eq "initial-review-candidates" }).Count
+        }
+        primaryUncertaintyReasons = [pscustomobject]$causes
+        sources = [pscustomobject]$sourceCounts
+    }
+}
+
+function Get-ReviewLifecycleIndex {
+    param([object[]]$Items, [int[]]$ReviewNumbers, [int[]]$DiscussionNumbers, [int[]]$MergeNumbers)
+
+    $order = @("merge-candidates", "review-follow-up-candidates", "initial-review-candidates")
+    $groups = @(
+        foreach ($id in $order) {
+            $members = @($Items | Where-Object { $_.reviewLifecycle.group -eq $id })
+            if ($id -eq "merge-candidates") {
+                $members = @($members | Sort-Object @{ Expression = { $_.idleDays }; Descending = $true },
+                    @{ Expression = { $_.ageDays }; Descending = $true }, number)
+            }
+            else {
+                $members = @($members | Sort-Object @{ Expression = { $_.idleDays }; Descending = $true },
+                    @{ Expression = { if ($_.authorClass -eq "Community") { 1 } else { 0 } }; Descending = $true },
+                    @{ Expression = { $_.ageDays }; Descending = $true }, changedFiles, number)
+            }
+            for ($i = 0; $i -lt $members.Count; $i++) { $members[$i].reviewLifecycle.rank = $i + 1 }
+            [pscustomobject]@{ id = $id; count = $members.Count; numbers = @($members | ForEach-Object number) }
+        }
+    )
+    $reviewItems = @($Items | Where-Object { $_.number -in $ReviewNumbers })
+    $reviewCoverage = Get-LifecycleCoverageSummary $reviewItems
+    $reviewCoverage | Add-Member -NotePropertyName "insideDiscussionBudget" -NotePropertyValue (
+        Get-LifecycleCoverageSummary @($reviewItems | Where-Object { $_.number -in $DiscussionNumbers }))
+    $reviewCoverage | Add-Member -NotePropertyName "outsideDiscussionBudget" -NotePropertyValue (
+        Get-LifecycleCoverageSummary @($reviewItems | Where-Object { $_.number -notin $DiscussionNumbers }))
+    $counts = [ordered]@{}
+    foreach ($status in @("grouped", "not-grouped", "blocked", "verification-needed")) {
+        $counts[$status] = @($Items | Where-Object { $_.reviewLifecycle.status -eq $status }).Count
+    }
+    return [pscustomobject]@{
+        kind = "review-candidates"; groupOrder = $order; groups = $groups; statusCounts = [pscustomobject]$counts
+        coverage = [pscustomobject]@{
+            inventory = Get-LifecycleCoverageSummary $Items
+            reviewWork = $reviewCoverage
+            mergeWork = Get-LifecycleCoverageSummary @($Items | Where-Object { $_.number -in $MergeNumbers })
+        }
+    }
+}
+
 function Get-DisplayMetadata {
     return [pscustomobject]@{
+        reviewLifecycle = [pscustomobject]@{
+            groups = [pscustomobject][ordered]@{
+                'merge-candidates' = [pscustomobject]@{ label = "Merge candidates"; description = "GitHub approval, passing checks and conflict-free evidence are observed. An UNKNOWN merge state is an explicit unresolved gate, not clearance to merge." }
+                'review-follow-up-candidates' = [pscustomobject]@{ label = "Review follow-up candidates"; description = "Human feedback is followed by recorded author, head or review-request activity. This does not establish that feedback was addressed or who must act next." }
+                'initial-review-candidates' = [pscustomobject]@{ label = "Initial review candidates"; description = "Complete collected history contains no non-author human submitted review, inline comment or top-level comment. Comment intent is not interpreted." }
+            }
+            statuses = [pscustomobject][ordered]@{
+                grouped = [pscustomobject]@{ label = "Grouped"; description = "Observable facts meet a candidate-group rule, not a readiness or accuracy certification." }
+                'not-grouped' = [pscustomobject]@{ label = "Existing feedback"; description = "Human feedback is recorded without observed later follow-up activity; no next actor or author obligation is inferred." }
+                blocked = [pscustomobject]@{ label = "Existing gate"; description = "An existing author, draft, rescue, design, CI or exclusion gate prevents candidate grouping." }
+                'verification-needed' = [pscustomobject]@{ label = "Verification needed"; description = "Required identity, publication, actor or source evidence is missing or inconsistent." }
+            }
+            reasons = [pscustomobject]@{
+                'approval-and-passing-checks-observed' = [pscustomobject]@{ label = "Approval and passing checks observed"; description = "GitHub reports APPROVED and MERGEABLE with passing checks on the observed head." }
+                'merge-state-unknown' = [pscustomobject]@{ label = "Merge gate unresolved"; description = "GitHub reports UNKNOWN merge state. The candidate is not cleared to merge; the legacy CLEAN requirement is unchanged." }
+                'human-feedback-observed' = [pscustomobject]@{ label = "Human feedback observed"; description = "A non-author human submitted review or published top-level or inline comment is recorded." }
+                'no-human-feedback-observed' = [pscustomobject]@{ label = "No human feedback observed"; description = "Complete feedback histories contain only author or automation activity, or are empty." }
+                'author-activity-after-feedback' = [pscustomobject]@{ label = "Later author activity"; description = "Published author review/comment activity follows the latest observed human feedback. Its intent is not interpreted." }
+                'head-commit-after-feedback' = [pscustomobject]@{ label = "Later head commit"; description = "The current head commit's recorded date follows the latest human feedback. This is not proof of a fix or of who pushed." }
+                'review-request-after-feedback' = [pscustomobject]@{ label = "Later review request"; description = "A recorded human-originated request for human or team review follows the latest human feedback." }
+                'no-later-follow-up-observed' = [pscustomobject]@{ label = "No later follow-up observed"; description = "No collected author response, head commit or human review request follows the latest human feedback." }
+                'follow-up-activity-incomplete' = [pscustomobject]@{ label = "Follow-up activity incomplete"; description = "No later activity was established, but missing commit or request-history evidence prevents an absence conclusion." }
+                'event-publication-or-actor-unknown' = [pscustomobject]@{ label = "Publication or actor unknown"; description = "A feedback-history record lacks a known publication state, date or typed actor." }
+                'checks-not-collected' = [pscustomobject]@{ label = "Checks unknown"; description = "Missing check evidence is not treated as passing." }
+                'checks-pending' = [pscustomobject]@{ label = "Checks pending"; description = "Existing rules allow concurrent review activity, but pending checks are not reported as passing." }
+                'source-identity-mismatch' = [pscustomobject]@{ label = "Evidence changed"; description = "Collection stages disagree about required head, draft, author or review identity." }
+                'author-policy-unestablished' = [pscustomobject]@{ label = "Ownership policy uncertain"; description = "Typed actor metadata does not establish service-account ownership policy; the PR remains visible." }
+                'author-metadata-incomplete' = [pscustomobject]@{ label = "Author metadata incomplete"; description = "The author's typed actor identity was not collected or is unavailable." }
+                'identity-not-collected' = [pscustomobject]@{ label = "Identity unavailable"; description = "Required head or draft identity was not collected at every required stage." }
+                'source-error' = [pscustomobject]@{ label = "Source failure"; description = "A required per-PR source failed; the original API error is retained in evidence.sourceErrors." }
+                'explicit-queue-exclusion' = [pscustomobject]@{ label = "Explicit exclusion"; description = "A caller-excluded author or unhealthy ancestor prevents queue action without removing the PR record." }
+                'existing-actionability-gate' = [pscustomobject]@{ label = "Existing actionability gate"; description = "The existing draft, design, rescue, author, CI or automation gate applies; its original reasons are retained." }
+                'merge-evidence-incomplete' = [pscustomobject]@{ label = "Merge evidence incomplete"; description = "Current approval, consistent identity or explicit merge facts cannot establish readiness." }
+                'reviews-incomplete' = [pscustomobject]@{ label = "Review history incomplete"; description = "The published review connection lacks complete counts, pages or records." }
+                'comments-incomplete' = [pscustomobject]@{ label = "Comment history incomplete"; description = "Top-level comment counts, pages or records are missing or truncated." }
+                'threads-incomplete' = [pscustomobject]@{ label = "Thread history incomplete"; description = "Inline thread counts, pages or records are missing or truncated." }
+                'thread-comments-incomplete' = [pscustomobject]@{ label = "Thread comments incomplete"; description = "Relevant inline conversations were not fully collected within the bounded source window." }
+            }
+        }
         buckets = [pscustomobject][ordered]@{
             ReviewNow = [pscustomobject]@{
                 label = "Review now"
@@ -3955,6 +4468,25 @@ function Invoke-PRAttentionQueue {
 
     $discussionStopwatch.Stop()
 
+    foreach ($item in $matchedItems) {
+        $item | Add-Member -NotePropertyName "reviewLifecycle" -NotePropertyValue (
+            Get-ReviewLifecycleAssessment `
+                -PullRequest $candidatesByNumber[[int]$item.number].PullRequest `
+                -Item $item `
+                -Settings $configuration.settings
+        )
+    }
+    $lifecycle = Get-ReviewLifecycleIndex `
+        -Items @($matchedItems) `
+        -ReviewNumbers @($reviewNow | ForEach-Object number) `
+        -DiscussionNumbers @($discussionItems | ForEach-Object number) `
+        -MergeNumbers @($matchedItems | Where-Object {
+            ($_.bucket -eq "ReadyToMerge" -or (
+                $_.bucket -eq "WaitingOnCI" -and $_.mergeStateStatus -eq "UNKNOWN" -and
+                $_.checkState -eq "Passing" -and $_.reasonCodes -contains "merge-state-not-clean"
+            )) -and $_.digestExclusionReasons.Count -eq 0
+        } | ForEach-Object number)
+
     $needsRescue = @(
         $matchedItems |
             Where-Object { $_.bucket -eq "NeedsRescue" -and $_.digestExclusionReasons.Count -eq 0 } |
@@ -4096,6 +4628,7 @@ function Invoke-PRAttentionQueue {
     $result = [pscustomobject]@{
         schemaVersion = "1.0.0"
         display = Get-DisplayMetadata
+        reviewLifecycle = $lifecycle
         generatedAt = $Now.ToUniversalTime().ToString("o")
         repository = $Repository
         filter = [pscustomobject]@{

--- a/.github/skills/pr-attention-queue/tests/Test-PRAttentionQueue.ps1
+++ b/.github/skills/pr-attention-queue/tests/Test-PRAttentionQueue.ps1
@@ -691,4 +691,65 @@ foreach ($temporaryPath in @($cachePath, $revalidationCachePath, $pollCachePath)
     }
 }
 
+# Shared detail failures must abort the public collection path before any JSON is emitted.
+Import-Module -Scope Local -Force $modulePath
+$failureModule = Get-Module PRAttentionQueue
+$sharedFailureResults = @(
+    foreach ($failureKind in @("transport", "graphql", "missing-pr", "missing-shared-field", "null-shared-field")) {
+        & $failureModule {
+            param($kind, $now, $fixture)
+            $raw = Get-Content $fixture -Raw | ConvertFrom-Json -Depth 100
+            function Invoke-GhJson {
+                param([string[]]$Arguments)
+                $query = @($Arguments | Where-Object { $_ -like "query=*" }) -join ""
+                if ($Arguments[0] -eq "pr") {
+                    return [pscustomobject]@{
+                        number = 800; title = "Shared source failure"; url = $raw.url
+                        author = $raw.author; headRefOid = $raw.headRefOid; isDraft = $false
+                        createdAt = "2026-09-01T10:00:00Z"; updatedAt = "2026-09-01T10:00:00Z"
+                        labels = @(); files = @(); changedFiles = 0
+                    }
+                }
+                if ($query -like "*pullRequests(states:OPEN)*") {
+                    return [pscustomobject]@{ data = [pscustomobject]@{ repository = [pscustomobject]@{
+                        pullRequests = [pscustomobject]@{ totalCount = 1 }
+                    } } }
+                }
+                if ($query -like "*reviews(last: 50)*") {
+                    switch ($kind) {
+                        "transport" { throw "Deliberate shared-detail transport failure." }
+                        "graphql" {
+                            $raw.reviews = $null
+                            return [pscustomobject]@{
+                                data = [pscustomobject]@{ repository = [pscustomobject]@{ pr800 = $raw } }
+                                errors = @([pscustomobject]@{ message = "Deliberate shared review failure."; path = @("repository", "pr800", "reviews") })
+                            }
+                        }
+                        "missing-pr" { return [pscustomobject]@{ data = [pscustomobject]@{ repository = [pscustomobject]@{} } } }
+                        "missing-shared-field" { $raw.reviews = $null }
+                        "null-shared-field" { $raw.mergeable = $null }
+                    }
+                }
+                return [pscustomobject]@{ data = [pscustomobject]@{ repository = [pscustomobject]@{ pr800 = $raw } } }
+            }
+            $output = [System.Collections.Generic.List[object]]::new()
+            $failure = $null
+            try {
+                Invoke-PRAttentionQueue -AllRepo -DisablePersonalInbox -Now $now -OutputFormat Json |
+                    ForEach-Object { $output.Add($_) }
+            }
+            catch { $failure = $_.Exception.Message }
+            [pscustomobject]@{ kind = $kind; error = $failure; outputCount = $output.Count }
+        } $failureKind $snapshot (Join-Path $PSScriptRoot "fixtures/review-lifecycle.json")
+    }
+)
+foreach ($failure in $sharedFailureResults) {
+    Write-Output "Shared-detail public entry point: $($failure.kind); error=$($failure.error); outputCount=$($failure.outputCount)"
+}
+foreach ($failure in $sharedFailureResults) {
+    Assert-True ($failure.error -and $failure.outputCount -eq 0) "Shared-detail $($failure.kind) failure must throw, not emit a complete actionable public result."
+}
+
+. (Join-Path $PSScriptRoot "Test-ReviewLifecycle.ps1")
+
 Write-Output "All PR attention queue tests passed."

--- a/.github/skills/pr-attention-queue/tests/Test-ReviewLifecycle.ps1
+++ b/.github/skills/pr-attention-queue/tests/Test-ReviewLifecycle.ps1
@@ -1,0 +1,426 @@
+# Invoked by the existing harness. Candidate grouping deliberately does not interpret comment text.
+Import-Module -Scope Local -Force $modulePath
+$candidateModule = Get-Module PRAttentionQueue
+$candidateSettings = (Get-Content (Join-Path $skillRoot "presets.json") -Raw | ConvertFrom-Json).settings
+$candidateRaw = Get-Content (Join-Path $PSScriptRoot "fixtures/review-lifecycle.json") -Raw
+$candidateDisplay = & $candidateModule { Get-DisplayMetadata }
+$candidateChecks = 0
+
+function Sync-CandidateRecord($Pr) {
+    $d = $Pr.lifecycleDetails
+    $Pr.latestReviews = @($d.reviews.nodes)
+    $Pr.comments = @($d.comments.nodes)
+    $Pr.lifecycleDiscussion = $d | ConvertTo-Json -Depth 100 | ConvertFrom-Json -Depth 100
+}
+
+function New-CandidateRecord {
+    $d = $candidateRaw | ConvertFrom-Json -Depth 100
+    $pr = [pscustomobject]@{
+        number = 800; title = $d.title; url = $d.url; author = $d.author
+        createdAt = "2026-08-30T10:00:00Z"; updatedAt = "2026-09-01T12:00:00Z"
+        headRefOid = $d.headRefOid; isDraft = $false
+        labels = @([pscustomobject]@{ name = "area-blazor" }); files = @(); changedFiles = 0
+        mergeable = $d.mergeable; mergeStateStatus = $d.mergeStateStatus; reviewDecision = $d.reviewDecision
+        latestReviews = @(); comments = @()
+        reviewRequests = @([pscustomobject]@{ login = "reviewer"; requestedAt = "2026-09-01T12:30:00Z" })
+        statusCheckRollup = @([pscustomobject]@{ state = "SUCCESS" })
+        lifecycleDetails = $d; lifecycleDiscussion = $null
+    }
+    Sync-CandidateRecord $pr
+    return $pr
+}
+
+function Clear-CandidateFeedback($Pr) {
+    foreach ($name in @("reviews", "comments", "reviewThreads")) {
+        $Pr.lifecycleDetails.$name.nodes = @()
+        $Pr.lifecycleDetails.$name.totalCount = 0
+    }
+    Sync-CandidateRecord $Pr
+}
+
+function Add-CandidateComment($Pr, $Login, $Time, $Body) {
+    $Pr.lifecycleDetails.comments.nodes += [pscustomobject]@{
+        id = "I$($Pr.lifecycleDetails.comments.nodes.Count)"
+        author = [pscustomobject]@{ __typename = "User"; login = $Login }
+        createdAt = $Time; body = $Body; url = "$($Pr.url)#issuecomment-$($Pr.lifecycleDetails.comments.nodes.Count)"
+    }
+    $Pr.lifecycleDetails.comments.totalCount++
+    Sync-CandidateRecord $Pr
+}
+
+function Assert-Candidate($Pr, $Status, $Group, $Message) {
+    $actual = & $candidateModule {
+        param($pr, $settings, $now)
+        $classification = Get-Classification $pr @(Get-LabelNames $pr) (Get-AuthorInfo $pr) $settings $now
+        $item = [pscustomobject]@{
+            bucket = $classification.Bucket; nextActor = $classification.NextActor
+            reasonCodes = $classification.ReasonCodes; digestExclusionReasons = @(); checkState = $classification.CheckState
+        }
+        Get-ReviewLifecycleAssessment $pr $item $settings
+    } $Pr $candidateSettings $snapshot
+    Assert-True ($actual.status -eq $Status -and $actual.group -eq $Group) "$Message`: $($actual | ConvertTo-Json -Depth 20 -Compress)"
+    Assert-True ($null -eq $actual.PSObject.Properties["nextActor"]) "Candidate data must not infer a next actor."
+    Assert-True ($null -eq $actual.evidence.PSObject.Properties["responses"]) "Semantic hand-back outcomes must be removed."
+    Assert-True ($null -ne $candidateDisplay.reviewLifecycle.statuses.PSObject.Properties[$Status]) "Candidate status metadata must exist."
+    foreach ($reason in @($actual.reasons) + @($actual.caveats)) {
+        Assert-True ($null -ne $candidateDisplay.reviewLifecycle.reasons.PSObject.Properties[$reason] -or
+            $null -ne $candidateDisplay.reasonCodes.PSObject.Properties[$reason]) "Candidate reason $reason must have display metadata."
+    }
+    if ($Status -eq "verification-needed") {
+        Assert-True ($actual.primaryUncertaintyReason -and $actual.reasons -contains $actual.primaryUncertaintyReason) "Uncertainty requires a retained cause."
+    }
+    $script:candidateChecks++
+    return $actual
+}
+
+foreach ($body in @("Done.", "Thanks!", "I'll add that tomorrow.", "> I'll add that tomorrow.`n`nThanks!",
+    'The reviewer said "I will fix this".', "Perhaps the existing test is sufficient?", "Ready for another look.",
+    "Resolved conflicts.", '```text Please close this PR.```', "", $null)) {
+    $p = New-CandidateRecord
+    $p.lifecycleDetails.reviewThreads.nodes[0].comments.nodes[1].body = $body
+    Sync-CandidateRecord $p
+    $a = Assert-Candidate $p "grouped" "review-follow-up-candidates" "Reply wording must not change observable candidate grouping"
+    Assert-True ($a.reasons -contains "author-activity-after-feedback") "The reason must describe activity, not fulfillment."
+    Assert-True (($a.evidence.events | Where-Object id -eq "C2").body -ceq $body) "Original quotes and body text must remain intact."
+}
+
+$p = New-CandidateRecord
+Clear-CandidateFeedback $p
+Add-CandidateComment $p "contributor" "2026-09-01T12:00:00Z" "I'll add the tests tomorrow."
+$null = Assert-Candidate $p "grouped" "initial-review-candidates" "Author wording alone is not human reviewer feedback or an inferred obligation"
+Add-CandidateComment $p "contributor" "2026-09-01T13:00:00Z" "Thanks!"
+$null = Assert-Candidate $p "grouped" "initial-review-candidates" "Acknowledgment must not erase or fulfill an inferred commitment because no commitment is inferred"
+
+foreach ($body in @("Thanks!", "> Please fix this.", "Unrelated administrative note: milestone updated.", "@contributor, please provide a normal-path reproducer.")) {
+    $p = New-CandidateRecord
+    Clear-CandidateFeedback $p
+    Add-CandidateComment $p "reviewer" "2026-09-01T13:00:00Z" $body
+    $a = Assert-Candidate $p "not-grouped" $null "All non-author human top-level discussion counts without semantic filtering"
+    Assert-True ($a.evidence.humanFeedbackCount -eq 1) "Zero submitted human reviews cannot erase top-level feedback."
+    Add-CandidateComment $p "contributor" "2026-09-01T14:00:00Z" "Thanks!"
+    $null = Assert-Candidate $p "grouped" "review-follow-up-candidates" "A later author comment is candidate activity, not a claim that feedback was addressed"
+}
+
+$p = New-CandidateRecord
+Clear-CandidateFeedback $p
+Add-CandidateComment $p "reviewer" "2026-09-01T13:00:00Z" "Thanks!"
+foreach ($i in 1..15) {
+    Add-CandidateComment $p "policy" "2026-09-01T14:00:00Z" "Notification"
+    $p.lifecycleDetails.comments.nodes[-1].author.__typename = "Bot"
+}
+Sync-CandidateRecord $p
+$a = Assert-Candidate $p "not-grouped" $null "Human feedback beyond the ten-comment preview must not be lost"
+Assert-True ($a.evidence.events.Count -eq 16 -and $a.evidence.humanFeedbackCount -eq 1) "Assessment uses all normalized events, not preview excerpts."
+
+foreach ($variant in @("inline-only", "newer-inline", "edited-feedback", "partial-reply", "resolved", "outdated",
+    "wrong-reply-target", "wrong-reply-author", "pending-reply", "missing-publication", "unknown-inline-actor",
+    "truncated-comments", "truncated-threads", "truncated-reviews", "missing-count", "missing-source",
+    "head-mismatch", "draft-mismatch", "discussion-head", "discussion-review-count", "source-error",
+    "bot-only", "self-only", "deleted-reviewer", "service-author", "outside-zero", "outside-thread-headers",
+    "changed-sha-no-date", "author-without-head-date", "pending-private-review", "unknown-checks", "null-nodes", "commit-head-mismatch")) {
+    $p = New-CandidateRecord
+    $d = $p.lifecycleDetails
+    $status = "grouped"; $group = "review-follow-up-candidates"
+    switch ($variant) {
+        "inline-only" { $d.reviews.nodes = @(); $d.reviews.totalCount = 0 }
+        "newer-inline" {
+            $c = $d.reviewThreads.nodes[0].comments.nodes[0] | ConvertTo-Json -Depth 20 | ConvertFrom-Json
+            $c.id = "C3"; $c.createdAt = "2026-09-01T13:00:00Z"
+            $d.reviewThreads.nodes[0].comments.nodes += $c; $d.reviewThreads.nodes[0].comments.totalCount++
+            $status = "not-grouped"; $group = $null
+        }
+        "edited-feedback" {
+            $d.reviewThreads.nodes[0].comments.nodes[0] | Add-Member updatedAt "2026-09-01T13:00:00Z"
+            $status = "not-grouped"; $group = $null
+        }
+        "partial-reply" {
+            $t = $d.reviewThreads.nodes[0] | ConvertTo-Json -Depth 20 | ConvertFrom-Json
+            $t.id = "T2"; $t.comments.nodes = @($t.comments.nodes[0]); $t.comments.totalCount = 1
+            $d.reviewThreads.nodes += $t; $d.reviewThreads.totalCount++
+        }
+        "resolved" { $d.reviewThreads.nodes[0].isResolved = $true }
+        "outdated" { $d.reviewThreads.nodes[0].isOutdated = $true }
+        "wrong-reply-target" { $d.reviewThreads.nodes[0].comments.nodes[1].replyTo.id = "another-comment" }
+        "wrong-reply-author" { $d.reviewThreads.nodes[0].comments.nodes[1].author.login = "another-reviewer"; $status = "not-grouped"; $group = $null }
+        "pending-reply" {
+            $d.reviewThreads.nodes[0].comments.nodes[1].state = "PENDING"
+            $d.reviewThreads.nodes[0].comments.nodes[1].pullRequestReview.state = "PENDING"
+            $d.commits.nodes[0].commit.committedDate = "2026-09-01T09:00:00Z"; $status = "not-grouped"; $group = $null
+        }
+        "missing-publication" { $d.reviewThreads.nodes[0].comments.nodes[1].state = $null; $status = "verification-needed"; $group = $null }
+        "unknown-inline-actor" { $d.reviewThreads.nodes[0].comments.nodes[0].author = $null; $status = "verification-needed"; $group = $null }
+        "truncated-comments" { $d.reviewThreads.nodes[0].comments.pageInfo.hasPreviousPage = $true; $status = "verification-needed"; $group = $null }
+        "truncated-threads" { $d.reviewThreads.pageInfo.hasPreviousPage = $true; $status = "verification-needed"; $group = $null }
+        "truncated-reviews" { $d.reviews.pageInfo.hasPreviousPage = $true; $status = "verification-needed"; $group = $null }
+        "missing-count" { $d.comments.PSObject.Properties.Remove("totalCount"); $status = "verification-needed"; $group = $null }
+        "missing-source" { $d.reviewThreads = $null; $status = "verification-needed"; $group = $null }
+        "head-mismatch" { $d.headRefOid = "other-head"; $status = "verification-needed"; $group = $null }
+        "draft-mismatch" { $d.isDraft = $true; $status = "verification-needed"; $group = $null }
+        "discussion-head" { $status = "verification-needed"; $group = $null }
+        "discussion-review-count" { $status = "verification-needed"; $group = $null }
+        "source-error" { $p | Add-Member lifecycleDiscussionError "Deliberate source error"; $status = "verification-needed"; $group = $null }
+        "bot-only" {
+            $d.reviews.nodes[0].author.__typename = "Bot"; $d.reviews.nodes[0].author.login = "Copilot"
+            $d.reviewThreads.nodes[0].comments.nodes[0].author.__typename = "Bot"; $d.reviewThreads.nodes[0].comments.nodes[0].author.login = "Copilot"
+            $group = "initial-review-candidates"
+        }
+        "self-only" {
+            $d.reviews.nodes[0].author.login = "contributor"
+            $d.reviewThreads.nodes[0].comments.nodes[0].author.login = "contributor"
+            $group = "initial-review-candidates"
+        }
+        "deleted-reviewer" { $d.reviews.nodes[0].author = $null; $status = "verification-needed"; $group = $null }
+        "service-author" { Clear-CandidateFeedback $p; $d.author.login = "dotnet-bot"; $status = "verification-needed"; $group = $null }
+        "outside-zero" { Clear-CandidateFeedback $p; $group = "initial-review-candidates" }
+        "outside-thread-headers" { $d.reviewThreads.nodes[0].PSObject.Properties.Remove("comments"); $status = "verification-needed"; $group = $null }
+        "changed-sha-no-date" {
+            $d.reviewThreads.nodes[0].comments.nodes = @($d.reviewThreads.nodes[0].comments.nodes[0]); $d.reviewThreads.nodes[0].comments.totalCount = 1
+            $d.commits.nodes[0].commit.committedDate = $null; $status = "verification-needed"; $group = $null
+        }
+        "author-without-head-date" { $d.commits.nodes[0].commit.committedDate = $null }
+        "pending-private-review" {
+            Clear-CandidateFeedback $p
+            $r = ($candidateRaw | ConvertFrom-Json -Depth 100).reviews.nodes[0]; $r.state = "PENDING"; $r.submittedAt = $null; $r.author = $null
+            $d.reviews.nodes = @($r); $d.reviews.totalCount = 1; $group = "initial-review-candidates"
+        }
+        "unknown-checks" { $p.statusCheckRollup = @(); $status = "verification-needed"; $group = $null }
+        "null-nodes" { Clear-CandidateFeedback $p; $d.reviewThreads.nodes = $null; $status = "verification-needed"; $group = $null }
+        "commit-head-mismatch" { $d.commits.nodes[0].commit.oid = "other-head"; $status = "verification-needed"; $group = $null }
+    }
+    Sync-CandidateRecord $p
+    if ($variant -eq "discussion-head") { $p.lifecycleDiscussion.headRefOid = "other-head" }
+    if ($variant -eq "discussion-review-count") { $p.lifecycleDiscussion.reviews.totalCount++ }
+    if ($variant -in @("outside-zero", "outside-thread-headers")) { $p.lifecycleDiscussion = $null }
+    $null = Assert-Candidate $p $status $group "Observable source case $variant"
+}
+
+foreach ($state in @("COMMENTED", "APPROVED", "CHANGES_REQUESTED", "DISMISSED")) {
+    $p = New-CandidateRecord
+    $p.lifecycleDetails.reviews.nodes[0].state = $state
+    Sync-CandidateRecord $p
+    $null = Assert-Candidate $p "grouped" "review-follow-up-candidates" "Published $state review is historical feedback, not first review"
+}
+
+foreach ($variant in @("human-request", "author-request", "team-request", "before-feedback", "unknown-requester", "bot-requester", "missing-timeline")) {
+    $p = New-CandidateRecord
+    Clear-CandidateFeedback $p
+    $r = ($candidateRaw | ConvertFrom-Json -Depth 100).reviews.nodes[0]; $r.state = "APPROVED"; $r.commit.oid = $p.headRefOid
+    $p.lifecycleDetails.reviews.nodes = @($r); $p.lifecycleDetails.reviews.totalCount = 1
+    $p.lifecycleDetails.commits.nodes[0].commit.committedDate = "2026-09-01T09:00:00Z"
+    $e = [pscustomobject]@{
+        __typename = "ReviewRequestedEvent"; id = "E1"; createdAt = "2026-09-01T13:00:00Z"
+        actor = [pscustomobject]@{ __typename = "User"; login = "reviewer" }
+        requestedReviewer = [pscustomobject]@{ __typename = "User"; login = "second-reviewer" }
+    }
+    $status = "grouped"; $group = "review-follow-up-candidates"
+    switch ($variant) {
+        "author-request" { $e.actor.login = "contributor" }
+        "team-request" { $e.requestedReviewer = [pscustomobject]@{ __typename = "Team"; name = "review-team" } }
+        "before-feedback" { $e.createdAt = "2026-09-01T09:00:00Z"; $status = "not-grouped"; $group = $null }
+        "unknown-requester" { $e.actor = $null; $status = "verification-needed"; $group = $null }
+        "bot-requester" { $e.actor.__typename = "Bot"; $e.actor.login = "automation"; $status = "not-grouped"; $group = $null }
+        "missing-timeline" { $status = "verification-needed"; $group = $null }
+    }
+    $p.lifecycleDetails.timelineItems.nodes = @($e)
+    $p.lifecycleDetails.timelineItems.totalCount = 99
+    $p.lifecycleDetails.timelineItems.filteredCount = 1
+    if ($variant -eq "missing-timeline") { $p.lifecycleDetails.timelineItems = $null }
+    Sync-CandidateRecord $p
+    $a = Assert-Candidate $p $status $group "Additional review request case $variant"
+    if ($group) { Assert-True ($a.reasons -contains "review-request-after-feedback") "An additional request is a follow-up candidate, not merge readiness." }
+}
+
+foreach ($gate in @("CLEAN", "UNKNOWN", "BLOCKED", "BEHIND", "draft", "conflict", "failed", "pending", "unknown-checks", "missing-rollup", "design", "blocked-label", "author", "rescue", "pending-review")) {
+    $p = New-CandidateRecord
+    Clear-CandidateFeedback $p
+    $p.reviewDecision = "APPROVED"; $p.lifecycleDetails.reviewDecision = "APPROVED"
+    $status = "blocked"; $group = $null
+    switch ($gate) {
+        { $_ -in @("CLEAN", "UNKNOWN", "BLOCKED", "BEHIND") } {
+            $p.mergeStateStatus = $gate; $p.lifecycleDetails.mergeStateStatus = $gate
+            if ($gate -in @("CLEAN", "UNKNOWN")) { $status = "grouped"; $group = "merge-candidates" }
+        }
+        "draft" { $p.isDraft = $true; $p.lifecycleDetails.isDraft = $true }
+        "conflict" { $p.mergeable = "CONFLICTING"; $p.lifecycleDetails.mergeable = "CONFLICTING" }
+        "failed" { $p.statusCheckRollup[0].state = "FAILURE" }
+        "pending" { $p.statusCheckRollup[0].state = "PENDING" }
+        "unknown-checks" { $p.statusCheckRollup = @(); $status = "verification-needed" }
+        "missing-rollup" { $p.lifecycleDetails.commits.nodes[0].commit.statusCheckRollup = $null; $status = "verification-needed" }
+        "design" { $p.labels += [pscustomobject]@{ name = "needs-design" } }
+        "blocked-label" { $p.labels += [pscustomobject]@{ name = "do-not-merge" } }
+        "author" { $p = New-CandidateRecord; $p.lifecycleDetails.reviews.nodes[0].commit.oid = $p.headRefOid }
+        "rescue" { $p.reviewDecision = "REVIEW_REQUIRED"; $p.lifecycleDetails.reviewDecision = "REVIEW_REQUIRED"; $p.createdAt = "2026-06-01T10:00:00Z"; $p.reviewRequests = @() }
+        "pending-review" {
+            $p.reviewDecision = "REVIEW_REQUIRED"; $p.lifecycleDetails.reviewDecision = "REVIEW_REQUIRED"
+            $p.statusCheckRollup[0].state = "PENDING"; $status = "grouped"; $group = "initial-review-candidates"
+        }
+    }
+    Sync-CandidateRecord $p
+    $a = Assert-Candidate $p $status $group "Existing gate $gate"
+    if ($gate -eq "UNKNOWN") { Assert-True ($a.caveats -contains "merge-state-unknown") "UNKNOWN is a visible unresolved merge gate." }
+    if ($gate -eq "pending-review") { Assert-True ($a.evidence.checkState -eq "Pending" -and $a.caveats -contains "checks-pending") "Concurrent review does not imply green CI." }
+}
+
+# Exercise the production collectors without another service, a live query or semantic fixture labels.
+$hydrated = & $candidateModule {
+    param($raw, $settings, $now)
+    $queries = [System.Collections.Generic.List[string]]::new()
+    function Invoke-GhJson {
+        param([string[]]$Arguments)
+        $query = @($Arguments | Where-Object { $_ -like "query=*" })[0]; $queries.Add($query)
+        $aliases = [regex]::Matches($query, 'pr(\d+): pullRequest')
+        if ($aliases.Count -gt 5) { throw "At most five PRs per richer batch." }
+        if ($query -notmatch 'headRefOid' -or $query -notmatch 'isDraft' -or $query -notmatch '__typename') { throw "Typed identity is required." }
+        $repository = @{}
+        foreach ($alias in $aliases) {
+            $detail = $raw | ConvertFrom-Json -Depth 100; $detail.number = [int]$alias.Groups[1].Value
+            if ($query -notmatch 'comments\(last: 20\)') {
+                if ($query -notmatch 'filteredCount' -or $query -notmatch 'reviews\(last: 50\)\s*\{\s*totalCount\s*pageInfo') { throw "History completeness is required." }
+                foreach ($thread in $detail.reviewThreads.nodes) { $thread.PSObject.Properties.Remove("comments") }
+            }
+            elseif ($query -notmatch 'replyTo \{ id \}' -or $query -notmatch 'pullRequestReview \{ id state submittedAt url \}') { throw "Publication metadata is required." }
+            $repository["pr$($detail.number)"] = $detail
+        }
+        return [pscustomobject]@{ data = [pscustomobject]@{ repository = [pscustomobject]$repository } }
+    }
+    $candidates = @(foreach ($number in 901..906) {
+        [pscustomobject]@{ PullRequest = [pscustomobject]@{
+            number = $number; headRefOid = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"; isDraft = $false
+            author = [pscustomobject]@{ login = "contributor" }; createdAt = "2026-08-30T10:00:00Z"; updatedAt = "2026-09-01T12:00:00Z"
+        } }
+    })
+    Add-PullRequestDetails "dotnet/aspnetcore" $candidates
+    Add-DiscussionEvidenceDetails "dotnet/aspnetcore" $candidates
+    $p = $candidates[0].PullRequest
+    $c = Get-Classification $p @("area-blazor") (Get-AuthorInfo $p) $settings $now
+    $item = [pscustomobject]@{ bucket = $c.Bucket; reasonCodes = $c.ReasonCodes; checkState = $c.CheckState; digestExclusionReasons = @() }
+    [pscustomobject]@{
+        calls = $queries.Count; assessment = Get-ReviewLifecycleAssessment $p $item $settings
+        legacy = Get-DiscussionAssessment $p (Get-AuthorInfo $p) @($settings.knownBotPatterns)
+    }
+} $candidateRaw $candidateSettings $snapshot
+Assert-True ($hydrated.calls -eq 4 -and $hydrated.assessment.group -eq "review-follow-up-candidates") "Real bounded collector normalization must produce candidate data."
+Assert-True ($hydrated.legacy.State -eq "verification-needed") "Candidate grouping does not change the legacy discussion veto."
+
+$failedDiscussion = & $candidateModule {
+    function Invoke-GhJson { throw "Deliberate lifecycle-only discussion failure." }
+    $candidate = [pscustomobject]@{ PullRequest = [pscustomobject]@{ number = 999 } }
+    Add-DiscussionEvidenceDetails "dotnet/aspnetcore" @($candidate)
+    $candidate.PullRequest
+}
+Assert-True ($failedDiscussion.lifecycleDiscussionError -like "*Deliberate*" -and -not $failedDiscussion.discussionThreadsComplete) "Lifecycle-only failures remain explicit incomplete evidence."
+foreach ($number in @(111, 113)) {
+    $item = $digestControlResult.items | Where-Object number -eq $number
+    Assert-True ($item.reviewLifecycle.status -eq "blocked" -and $null -eq $item.reviewLifecycle.group) "Explicit author/stack exclusion $number remains effective."
+}
+
+$population = @(foreach ($number in 801..825) {
+    $p = New-CandidateRecord; Clear-CandidateFeedback $p; $p.number = $number
+    $p.lifecycleDiscussion = $null
+    $p
+})
+$populationPath = Join-Path ([System.IO.Path]::GetTempPath()) "pr-attention-candidates-$PID.json"
+try {
+    $population | ConvertTo-Json -Depth 100 | Set-Content $populationPath
+    $full = Invoke-PRAttentionQueue -InputPath $populationPath -Now $snapshot -DisablePersonalInbox -OutputFormat Json | ConvertFrom-Json -Depth 100
+    $personal = Invoke-PRAttentionQueue -InputPath $populationPath -Now $snapshot -PersonalLogin "another-user" -OutputFormat Json | ConvertFrom-Json -Depth 100
+    Assert-True (($full.reviewLifecycle | ConvertTo-Json -Depth 30 -Compress) -ceq ($personal.reviewLifecycle | ConvertTo-Json -Depth 30 -Compress)) "Personal identity cannot alter general candidate groups."
+    Assert-True ($full.reviewLifecycle.kind -eq "review-candidates") "The unpublished candidate extension must identify its new semantics."
+    Assert-True (($full.reviewLifecycle.groupOrder -join ",") -eq "merge-candidates,review-follow-up-candidates,initial-review-candidates") "Preserve group priority, not one oldest-first list."
+    $group = $full.reviewLifecycle.groups | Where-Object id -eq "initial-review-candidates"
+    Assert-True ($group.count -eq 25 -and $group.numbers.Count -eq 25) "Candidate inventories have no digest or per-author cap."
+    Assert-True ($full.reviewLifecycle.coverage.reviewWork.denominator -eq 25 -and $full.reviewLifecycle.coverage.reviewWork.outsideDiscussionBudget.grouped -eq 5) "Complete absence beyond twenty remains visible in the fixed denominator."
+    Assert-True (@($full.items | Where-Object shownInDigest).Count -le 2) "Legacy per-author cap stays unchanged."
+    foreach ($i in 0..24) {
+        $item = $full.items | Where-Object number -eq $group.numbers[$i]
+        Assert-True ($item.reviewLifecycle.rank -eq $i + 1 -and $item.number -eq 801 + $i) "Ranks and tie breakers remain stable and contiguous."
+    }
+    foreach ($p in $population) { $p.lifecycleDetails = $null; $p.lifecycleDiscussion = $null }
+    $population | ConvertTo-Json -Depth 100 | Set-Content $populationPath
+    $unknown = Invoke-PRAttentionQueue -InputPath $populationPath -Now $snapshot -DisablePersonalInbox -OutputFormat Json | ConvertFrom-Json -Depth 100
+    Assert-True ($unknown.reviewLifecycle.coverage.inventory.verificationNeeded -eq 25 -and $unknown.reviewLifecycle.coverage.inventory.grouped -eq 0) "Unknown is not initial review."
+    Assert-True (@($unknown.items | Where-Object shownInDigest).Count -gt 0) "New uncertainty does not rewrite legacy digest semantics."
+    $population[0] = New-CandidateRecord; Clear-CandidateFeedback $population[0]; $population[0].number = 801
+    $population[1] = New-CandidateRecord; $population[1].number = 802
+    $population[2] = New-CandidateRecord; Clear-CandidateFeedback $population[2]; $population[2].number = 803
+    Add-CandidateComment $population[2] "reviewer" "2026-09-01T13:00:00Z" "Thanks!"
+    $population[3] = New-CandidateRecord; Clear-CandidateFeedback $population[3]; $population[3].number = 804
+    $population[3].reviewDecision = "APPROVED"; $population[3].lifecycleDetails.reviewDecision = "APPROVED"
+    $population[3].mergeStateStatus = "UNKNOWN"; $population[3].lifecycleDetails.mergeStateStatus = "UNKNOWN"
+    Sync-CandidateRecord $population[3]
+    $population | ConvertTo-Json -Depth 100 | Set-Content $populationPath
+    $mixed = Invoke-PRAttentionQueue -InputPath $populationPath -Now $snapshot -DisablePersonalInbox -OutputFormat Json | ConvertFrom-Json -Depth 100
+    $c = $mixed.reviewLifecycle.coverage.inventory
+    Assert-True ($c.denominator -eq 25 -and $c.grouped -eq 3 -and $c.notGrouped -eq 1 -and $c.verificationNeeded -eq 21) "Coverage counts describe grouping, not confidence or established actors."
+    Assert-True ($null -eq $c.PSObject.Properties["confidentlyRouted"] -and $null -eq $c.PSObject.Properties["establishedOtherNextActor"]) "Remove certification and inferred-actor coverage claims."
+    Assert-True ($mixed.reviewLifecycle.coverage.mergeWork.denominator -eq 1 -and $mixed.reviewLifecycle.coverage.mergeWork.grouped -eq 1) "UNKNOWN merge candidates belong in separate merge coverage."
+    Assert-True (($mixed.items | Where-Object number -eq 804).bucket -eq "WaitingOnCI") "UNKNOWN never becomes legacy ReadyToMerge."
+    Assert-True (($mixed.reviewLifecycle.statusCounts.PSObject.Properties.Value | Measure-Object -Sum).Sum -eq 25) "All statuses reconcile."
+    Assert-True (($c.primaryUncertaintyReasons.PSObject.Properties.Value | Measure-Object -Sum).Sum -eq 21) "One primary uncertainty cause per uncertain PR."
+    foreach ($source in $c.sources.PSObject.Properties.Value) {
+        Assert-True (($source.PSObject.Properties.Value | Measure-Object -Sum).Sum -eq 25) "Each source reconciles every inventory record."
+    }
+    $references = @($mixed.reviewLifecycle.groups | ForEach-Object numbers)
+    Assert-True (($references -join ",") -eq "804,802,801" -and @($references | Select-Object -Unique).Count -eq $references.Count) "Ordered groups retain unique references into items."
+    "[]" | Set-Content $populationPath
+    $empty = Invoke-PRAttentionQueue -InputPath $populationPath -Now $snapshot -DisablePersonalInbox -OutputFormat Json | ConvertFrom-Json -Depth 100
+    Assert-True ($empty.reviewLifecycle.coverage.inventory.denominator -eq 0 -and $null -eq $empty.reviewLifecycle.coverage.inventory.groupedFraction) "Empty cohorts have no grouping percentage."
+}
+finally { if (Test-Path $populationPath) { Remove-Item $populationPath } }
+
+if ($env:PR_ATTENTION_QUEUE_REPLAY_PATH) {
+    $saved = Get-Content $env:PR_ATTENTION_QUEUE_REPLAY_PATH -Raw | ConvertFrom-Json -Depth 100
+    Assert-True ($saved.repository -eq "dotnet/aspnetcore") "Saved replay must be scoped to dotnet/aspnetcore."
+    $replayedItems = @(
+        foreach ($record in $saved.records) {
+            $record.item.reviewLifecycle = & $candidateModule {
+                param($pr, $item, $settings)
+                Get-ReviewLifecycleAssessment $pr $item $settings
+            } $record.pullRequest $record.item $candidateSettings
+            $record.item
+        }
+    )
+    foreach ($number in @(67970, 66968)) {
+        $item = $replayedItems | Where-Object number -eq $number
+        Assert-True ($item -and $item.reviewLifecycle.group -eq "review-follow-up-candidates") "Saved approved example #$number must be an observable follow-up candidate."
+    }
+    $replayedIndex = & $candidateModule {
+        param($items)
+        Get-ReviewLifecycleIndex -Items $items -ReviewNumbers @($items | Where-Object bucket -eq "ReviewNow" | ForEach-Object number) `
+            -DiscussionNumbers @($items | ForEach-Object number) -MergeNumbers @()
+    } $replayedItems
+    if ($env:PR_ATTENTION_QUEUE_REPLAY_OUTPUT) {
+        [pscustomobject]@{
+            kind = "saved-evidence-replay"; repository = $saved.repository; sourceSnapshotAt = $saved.snapshotAt
+            reviewLifecycle = $replayedIndex; items = $replayedItems
+        } | ConvertTo-Json -Depth 100 | Set-Content $env:PR_ATTENTION_QUEUE_REPLAY_OUTPUT
+    }
+    Write-Output "Saved evidence replay passed: $($replayedItems.Count) records; #67970 and #66968 are follow-up candidates."
+}
+
+if ($env:PR_ATTENTION_QUEUE_BASELINE_MODULE) {
+    function Get-LegacyProjection($Value) {
+        $Value.PSObject.Properties.Remove("reviewLifecycle")
+        $Value.display.PSObject.Properties.Remove("reviewLifecycle")
+        foreach ($item in $Value.items) { $item.PSObject.Properties.Remove("reviewLifecycle") }
+        $Value.PSObject.Properties.Remove("timing")
+        $Value.personal.metrics.PSObject.Properties.Remove("elapsedMs")
+        $Value.personal.metrics.PSObject.Properties.Remove("personalMs")
+        return $Value | ConvertTo-Json -Depth 100 -Compress
+    }
+    foreach ($fixture in @("pull-requests", "correctness-pull-requests", "discussion-pull-requests", "inbox-pull-requests")) {
+        $inputPath = Join-Path $PSScriptRoot "fixtures/$fixture.json"
+        $outputs = @()
+        foreach ($sourceModule in @($env:PR_ATTENTION_QUEUE_BASELINE_MODULE, $modulePath)) {
+            Remove-Module PRAttentionQueue -Force -ErrorAction SilentlyContinue
+            Import-Module $sourceModule -Force
+            $json = Invoke-PRAttentionQueue -InputPath $inputPath -Now $snapshot -OutputFormat Json | ConvertFrom-Json -Depth 100
+            $markdown = Invoke-PRAttentionQueue -InputPath $inputPath -Now $snapshot -OutputFormat Markdown
+            $outputs += [pscustomobject]@{ projection = Get-LegacyProjection $json; markdown = $markdown }
+        }
+        Assert-True ($outputs[0].projection -ceq $outputs[1].projection) "Legacy JSON changed: $fixture (excluding timing and candidate additions)."
+        Assert-True ($outputs[0].markdown -ceq $outputs[1].markdown) "Legacy Markdown changed: $fixture."
+        Write-Output "Exact legacy JSON and Markdown match: $fixture"
+    }
+}
+Write-Output "Candidate assertions passed ($candidateChecks observable cases plus public collection, inventory and compatibility checks)."

--- a/.github/skills/pr-attention-queue/tests/fixtures/review-lifecycle.json
+++ b/.github/skills/pr-attention-queue/tests/fixtures/review-lifecycle.json
@@ -1,0 +1,67 @@
+{
+  "number": 800,
+  "title": "Observable review candidate evidence",
+  "url": "https://github.com/dotnet/aspnetcore/pull/800",
+  "state": "OPEN",
+  "isDraft": false,
+  "author": { "__typename": "User", "login": "contributor" },
+  "headRefOid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "mergeable": "MERGEABLE",
+  "mergeStateStatus": "CLEAN",
+  "reviewDecision": "REVIEW_REQUIRED",
+  "reviews": {
+    "totalCount": 1,
+    "pageInfo": { "hasPreviousPage": false },
+    "nodes": [{
+      "id": "R1", "url": "https://github.com/dotnet/aspnetcore/pull/800#pullrequestreview-1",
+      "author": { "__typename": "User", "login": "reviewer" },
+      "state": "COMMENTED", "submittedAt": "2026-09-01T10:00:00Z", "body": "",
+      "commit": { "oid": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" }
+    }]
+  },
+  "reviewRequests": {
+    "totalCount": 1, "pageInfo": { "hasNextPage": false },
+    "nodes": [{ "requestedReviewer": { "__typename": "User", "login": "reviewer" } }]
+  },
+  "comments": { "totalCount": 0, "pageInfo": { "hasPreviousPage": false }, "nodes": [] },
+  "reviewThreads": {
+    "totalCount": 1, "pageInfo": { "hasPreviousPage": false },
+    "nodes": [{
+      "id": "T1", "isResolved": false, "isOutdated": false, "path": "src/Components/example.cs",
+      "comments": {
+        "totalCount": 2, "pageInfo": { "hasPreviousPage": false },
+        "nodes": [{
+          "id": "C1", "url": "https://github.com/dotnet/aspnetcore/pull/800#discussion_r1",
+          "author": { "__typename": "User", "login": "reviewer" },
+          "authorAssociation": "MEMBER", "state": "SUBMITTED",
+          "createdAt": "2026-09-01T10:00:00Z", "body": "Please add the regression test.",
+          "replyTo": null,
+          "pullRequestReview": { "id": "R1", "state": "COMMENTED", "submittedAt": "2026-09-01T10:00:00Z" }
+        }, {
+          "id": "C2", "url": "https://github.com/dotnet/aspnetcore/pull/800#discussion_r2",
+          "author": { "__typename": "User", "login": "contributor" },
+          "authorAssociation": "CONTRIBUTOR", "state": "SUBMITTED",
+          "createdAt": "2026-09-01T12:00:00Z",
+          "body": "Done, added in aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.",
+          "replyTo": { "id": "C1" },
+          "pullRequestReview": { "id": "R2", "state": "COMMENTED", "submittedAt": "2026-09-01T12:00:00Z" }
+        }]
+      }
+    }]
+  },
+  "timelineItems": {
+    "totalCount": 0, "filteredCount": 0, "pageInfo": { "hasPreviousPage": false }, "nodes": []
+  },
+  "commits": {
+    "nodes": [{
+      "commit": {
+        "oid": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "url": "https://github.com/dotnet/aspnetcore/commit/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "committedDate": "2026-09-01T11:00:00Z",
+        "author": { "user": { "__typename": "User", "login": "contributor" } },
+        "committer": { "user": { "__typename": "User", "login": "contributor" } },
+        "statusCheckRollup": { "state": "SUCCESS" }
+      }
+    }]
+  }
+}


### PR DESCRIPTION
Stacked on #69199.

Adds JSON-only merge, follow-up, and initial candidate groups with observable event evidence rather than claiming feedback was addressed. Legacy Markdown, JSON, display, and inbox behavior remains unchanged. Shared-detail failure fails closed. No new live credential or evaluation change.