### PR TITLE
[ResponseCaching] Correctly handle Vary: * in delimited or multi-value headers (RFC 9111)

### DIFF
--- a/src/Middleware/ResponseCaching/src/ResponseCachingPolicyProvider.cs
+++ b/src/Middleware/ResponseCaching/src/ResponseCachingPolicyProvider.cs
@@ -9,6 +9,8 @@ namespace Microsoft.AspNetCore.ResponseCaching;
 
 internal sealed class ResponseCachingPolicyProvider : IResponseCachingPolicyProvider
 {
+    private static readonly char[] HeaderDelimiters = [','];
+
     public bool AttemptResponseCaching(ResponseCachingContext context)
     {
         var request = context.HttpContext.Request;
@@ -99,10 +101,23 @@ internal sealed class ResponseCachingPolicyProvider : IResponseCachingPolicyProv
 
         // Do not cache responses varying by *
         var varyHeader = response.Headers.Vary;
-        if (varyHeader.Count == 1 && string.Equals(varyHeader, "*", StringComparison.OrdinalIgnoreCase))
+        for (var i = 0; i < varyHeader.Count; i++)
         {
-            context.Logger.ResponseWithVaryStarNotCacheable();
-            return false;
+            var rawHeader = varyHeader[i];
+            if (string.IsNullOrEmpty(rawHeader))
+            {
+                continue;
+            }
+
+            var tokenizer = new StringTokenizer(rawHeader, HeaderDelimiters);
+            foreach (var segment in tokenizer)
+            {
+                if (segment.Trim().Equals("*", StringComparison.Ordinal))
+                {
+                    context.Logger.ResponseWithVaryStarNotCacheable();
+                    return false;
+                }
+            }
         }
 
         // Check private

--- a/src/Middleware/ResponseCaching/src/ResponseCachingPolicyProvider.cs
+++ b/src/Middleware/ResponseCaching/src/ResponseCachingPolicyProvider.cs
@@ -102,7 +102,7 @@ internal sealed class ResponseCachingPolicyProvider : IResponseCachingPolicyProv
         for (var i = 0; i < varyHeader.Count; i++)
         {
             var rawHeader = varyHeader[i].AsSpan();
-            if (rawHeader.Length == 0)
+            if (rawHeader.IsEmpty)
             {
                 continue;
             }

--- a/src/Middleware/ResponseCaching/src/ResponseCachingPolicyProvider.cs
+++ b/src/Middleware/ResponseCaching/src/ResponseCachingPolicyProvider.cs
@@ -9,8 +9,6 @@ namespace Microsoft.AspNetCore.ResponseCaching;
 
 internal sealed class ResponseCachingPolicyProvider : IResponseCachingPolicyProvider
 {
-    private static readonly char[] HeaderDelimiters = [','];
-
     public bool AttemptResponseCaching(ResponseCachingContext context)
     {
         var request = context.HttpContext.Request;
@@ -103,16 +101,15 @@ internal sealed class ResponseCachingPolicyProvider : IResponseCachingPolicyProv
         var varyHeader = response.Headers.Vary;
         for (var i = 0; i < varyHeader.Count; i++)
         {
-            var rawHeader = varyHeader[i];
-            if (string.IsNullOrEmpty(rawHeader))
+            var rawHeader = varyHeader[i].AsSpan();
+            if (rawHeader.Length == 0)
             {
                 continue;
             }
 
-            var tokenizer = new StringTokenizer(rawHeader, HeaderDelimiters);
-            foreach (var segment in tokenizer)
+            foreach (var segment in rawHeader.Split(','))
             {
-                if (segment.Trim().Equals("*", StringComparison.Ordinal))
+                if (rawHeader[segment].Trim().SequenceEqual("*"))
                 {
                     context.Logger.ResponseWithVaryStarNotCacheable();
                     return false;

--- a/src/Middleware/ResponseCaching/src/ResponseCachingPolicyProvider.cs
+++ b/src/Middleware/ResponseCaching/src/ResponseCachingPolicyProvider.cs
@@ -109,7 +109,7 @@ internal sealed class ResponseCachingPolicyProvider : IResponseCachingPolicyProv
 
             foreach (var segment in rawHeader.Split(','))
             {
-                if (rawHeader[segment].Trim().SequenceEqual("*"))
+                if (rawHeader[segment].Trim() is ['*'])
                 {
                     context.Logger.ResponseWithVaryStarNotCacheable();
                     return false;

--- a/src/Middleware/ResponseCaching/test/ResponseCachingMiddlewareTests.cs
+++ b/src/Middleware/ResponseCaching/test/ResponseCachingMiddlewareTests.cs
@@ -1,10 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Net.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.InternalTesting;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Testing;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Extensions.Time.Testing;
@@ -1050,5 +1056,68 @@ public class ResponseCachingMiddlewareTests
         var normalizedStrings = ResponseCachingMiddleware.GetOrderCasingNormalizedStringValues(originalStrings);
 
         Assert.Equal(originalStrings, normalizedStrings);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ResponseWithVaryStar_AndDownstreamMiddlewareAppendedVaryHeader_IsNotServedFromCache(bool appendStarFirst)
+    {
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                    .UseTestServer()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddResponseCaching();
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseResponseCaching();
+                        app.Use(async (context, next) =>
+                        {
+                            if (!appendStarFirst)
+                            {
+                                context.Response.Headers.Append("Vary", "Accept-Encoding");
+                            }
+                            await next(context);
+                        });
+                        app.Run(async context =>
+                        {
+                            context.Response.Headers.CacheControl = new CacheControlHeaderValue
+                            {
+                                Public = true,
+                                MaxAge = TimeSpan.FromSeconds(10)
+                            }.ToString();
+                            if (appendStarFirst)
+                            {
+                                context.Response.Headers.Vary = "*";
+                                context.Response.Headers.Append("Vary", "Accept-Encoding");
+                            }
+                            else
+                            {
+                                context.Response.Headers.Append("Vary", "*");
+                            }
+                            await context.Response.WriteAsync(Guid.NewGuid().ToString());
+                        });
+                    });
+            })
+            .Build();
+
+        await host.StartAsync();
+
+        using var server = host.GetTestServer();
+        var client = server.CreateClient();
+        var initialResponse = await client.GetAsync("");
+        var subsequentResponse = await client.GetAsync("");
+
+        initialResponse.EnsureSuccessStatusCode();
+        subsequentResponse.EnsureSuccessStatusCode();
+
+        Assert.False(subsequentResponse.Headers.Contains(HeaderNames.Age));
+        var initialContent = await initialResponse.Content.ReadAsStringAsync();
+        var subsequentContent = await subsequentResponse.Content.ReadAsStringAsync();
+        Assert.NotEqual(initialContent, subsequentContent);
     }
 }

--- a/src/Middleware/ResponseCaching/test/ResponseCachingPolicyProviderTests.cs
+++ b/src/Middleware/ResponseCaching/test/ResponseCachingPolicyProviderTests.cs
@@ -1,8 +1,9 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging.Testing;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 
 namespace Microsoft.AspNetCore.ResponseCaching.Tests;
@@ -229,8 +230,24 @@ public class ResponseCachingPolicyProviderTests
             LoggedMessage.ResponseWithSetCookieNotCacheable);
     }
 
-    [Fact]
-    public void IsResponseCacheable_VaryHeaderByStar_NotAllowed()
+    public static TheoryData<StringValues> VaryHeaderWithStarData
+    {
+        get
+        {
+            return new TheoryData<StringValues>
+            {
+                "*",
+                new StringValues(["*", "Accept-Encoding"]),
+                "*, Accept-Encoding",
+                "Accept-Encoding, *",
+                "gzip, *, br"
+            };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(VaryHeaderWithStarData))]
+    public void IsResponseCacheable_VaryHeaderByStar_NotAllowed(StringValues vary)
     {
         var sink = new TestSink();
         var context = TestUtils.CreateTestContext(sink);
@@ -238,12 +255,27 @@ public class ResponseCachingPolicyProviderTests
         {
             Public = true
         }.ToString();
-        context.HttpContext.Response.Headers.Vary = "*";
+        context.HttpContext.Response.Headers.Vary = vary;
 
         Assert.False(new ResponseCachingPolicyProvider().IsResponseCacheable(context));
         TestUtils.AssertLoggedMessages(
             sink.Writes,
             LoggedMessage.ResponseWithVaryStarNotCacheable);
+    }
+
+    [Fact]
+    public void IsResponseCacheable_ValidVaryHeaderWithoutAsterisk_Allowed()
+    {
+        var sink = new TestSink();
+        var context = TestUtils.CreateTestContext(sink);
+        context.HttpContext.Response.Headers.CacheControl = new CacheControlHeaderValue()
+        {
+            Public = true
+        }.ToString();
+        context.HttpContext.Response.Headers.Vary = "Accept-Encoding, User-Agent";
+
+        Assert.True(new ResponseCachingPolicyProvider().IsResponseCacheable(context));
+        Assert.Empty(sink.Writes);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #69192.

Per RFC 9111 § 4.1, a response containing `*` anywhere as a member of the `Vary` header field MUST NOT be used to satisfy a subsequent request. Previously, `ResponseCachingPolicyProvider` performed an exact match on `varyHeader.Count == 1 && string.Equals(varyHeader, "*", ...)` which failed when:
1. Downstream middleware (e.g., Response Compression) appended headers, resulting in `varyHeader.Count > 1`.
2. The `Vary` header contained comma-delimited tokens (e.g., `*, Accept-Encoding`).

### Changes
* **Output Caching Audit**: Verified that `OutputCaching` determines vary behavior via explicit cache key rules (`IOutputCachePolicy`, `CacheVaryByRules`) rather than reading `context.Response.Headers.Vary`. No changes required there.
* **Response Caching**:
  * Replaced the exact-match check with span-based token inspection using `MemoryExtensions.Split(',')` on `rawHeader.AsSpan()`.
  * Iterated over `StringValues` directly by index to avoid `string.Join` allocations.
  * Trimmed each segment span and verified equality via `SequenceEqual("*")` without heap allocations.
* **Tests**:
  * Expanded unit test `IsResponseCacheable_VaryHeaderByStar_NotAllowed` to a `[Theory]` covering single strings, multi-entry `StringValues`, and delimited values with spaces.
  * Added unit test asserting valid headers without `*` remain cacheable.
  * Added an integration test in `ResponseCachingMiddlewareTests` with downstream appended headers to verify subsequent requests are not served from cache.

### Customer Impact
Prevents incorrectly caching responses that vary by `*` when response compression or other middleware appends headers to `Vary`.

### Regression?
No.

### Risk
Low. Restricts caching behavior to strictly adhere to RFC 9111 without allocating heap strings.