### PR TITLE
feat(components): add BL0020 analyzer for code after NavigationManager.NavigateTo

### DIFF
--- a/docs/list-of-diagnostics.md
+++ b/docs/list-of-diagnostics.md
@@ -67,7 +67,7 @@
 |  __`MVC1005`__ | Cannot use UseMvc with Endpoint Routing |
 |  __`MVC1006`__ | Methods containing TagHelpers must be async and return Task |
 
-### BL  (`BL0001-BL0019`)
+### BL  (`BL0001-BL0020`)
 
 | Diagnostic ID     | Description |
 | :---------------- | :---------- |
@@ -90,6 +90,7 @@
 |  __`BL0017`__ | Component declares `Dispose()` but does not implement `IDisposable`  |
 |  __`BL0018`__ | Component declares `DisposeAsync()` but does not implement `IAsyncDisposable` |
 |  __`BL0019`__ | Virtualize uses an invalid spacer element |
+|  __`BL0020`__ | Code after NavigationManager.NavigateTo will still execute |
 
 ### Request Delegate Generator  (`RDG001-RDG014`)
 

--- a/src/Components/Analyzers/src/DiagnosticDescriptors.cs
+++ b/src/Components/Analyzers/src/DiagnosticDescriptors.cs
@@ -183,4 +183,13 @@ internal static class DiagnosticDescriptors
         DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: CreateLocalizableResourceString(nameof(Resources.VirtualizeSpacerElementIsInvalid_Description)));
+
+    public static readonly DiagnosticDescriptor CodeAfterNavigateToWillExecute = new(
+        "BL0020",
+        CreateLocalizableResourceString(nameof(Resources.CodeAfterNavigateToWillExecute_Title)),
+        CreateLocalizableResourceString(nameof(Resources.CodeAfterNavigateToWillExecute_Format)),
+        Usage,
+        DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: CreateLocalizableResourceString(nameof(Resources.CodeAfterNavigateToWillExecute_Description)));
 }

--- a/src/Components/Analyzers/src/NavigateToReturnAnalyzer.cs
+++ b/src/Components/Analyzers/src/NavigateToReturnAnalyzer.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -12,7 +13,7 @@ using Microsoft.CodeAnalysis.Operations;
 namespace Microsoft.AspNetCore.Components.Analyzers;
 
 /// <summary>
-/// Analyzer that warns when code follows a <c>NavigationManager.NavigateTo</c> call in the same block.
+/// Analyzer that warns when code follows a <c>NavigationManager.NavigateTo</c> call in the same statement list.
 /// In server-side (static SSR) contexts <c>NavigateTo</c> only signals the navigation; it no longer
 /// stops execution, so the statements after it still run. Adding a <c>return</c> makes the intent explicit.
 /// </summary>
@@ -21,6 +22,7 @@ public sealed class NavigateToReturnAnalyzer : DiagnosticAnalyzer
 {
     private const string NavigationManagerTypeName = "Microsoft.AspNetCore.Components.NavigationManager";
     private const string NavigateToMethodName = "NavigateTo";
+    private const string DisableThrowNavigationExceptionProperty = "build_property.BlazorDisableThrowNavigationException";
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(DiagnosticDescriptors.CodeAfterNavigateToWillExecute);
@@ -48,15 +50,21 @@ public sealed class NavigateToReturnAnalyzer : DiagnosticAnalyzer
                     return;
                 }
 
-                // Only expression statements can be followed by unreachable-looking code in the same block.
-                if (invocation.Syntax is not InvocationExpressionSyntax invocationSyntax ||
-                    invocationSyntax.Parent is not ExpressionStatementSyntax statement ||
-                    statement.Parent is not BlockSyntax block)
+                var analyzerOptions = operationContext.Options.AnalyzerConfigOptionsProvider.GetOptions(invocation.Syntax.SyntaxTree);
+                if (!analyzerOptions.TryGetValue(DisableThrowNavigationExceptionProperty, out var disableThrowNavigationException) ||
+                    !string.Equals(disableThrowNavigationException, bool.TrueString, StringComparison.OrdinalIgnoreCase))
                 {
                     return;
                 }
 
-                var statements = block.Statements;
+                // Only expression statements can be followed by unreachable-looking code in the same statement list.
+                if (invocation.Syntax is not InvocationExpressionSyntax invocationSyntax ||
+                    invocationSyntax.Parent is not ExpressionStatementSyntax statement ||
+                    !TryGetContainingStatements(statement, out var statements))
+                {
+                    return;
+                }
+
                 var index = statements.IndexOf(statement);
                 if (index < 0 || index == statements.Count - 1)
                 {
@@ -75,6 +83,22 @@ public sealed class NavigateToReturnAnalyzer : DiagnosticAnalyzer
                     invocationSyntax.GetLocation()));
             }, OperationKind.Invocation);
         });
+    }
+
+    private static bool TryGetContainingStatements(ExpressionStatementSyntax statement, out SyntaxList<StatementSyntax> statements)
+    {
+        switch (statement.Parent)
+        {
+            case BlockSyntax block:
+                statements = block.Statements;
+                return true;
+            case SwitchSectionSyntax switchSection:
+                statements = switchSection.Statements;
+                return true;
+            default:
+                statements = default;
+                return false;
+        }
     }
 
     private static bool InheritsFromOrEquals(ITypeSymbol? type, INamedTypeSymbol baseType)

--- a/src/Components/Analyzers/src/NavigateToReturnAnalyzer.cs
+++ b/src/Components/Analyzers/src/NavigateToReturnAnalyzer.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+#nullable enable
+
+namespace Microsoft.AspNetCore.Components.Analyzers;
+
+/// <summary>
+/// Analyzer that warns when code follows a <c>NavigationManager.NavigateTo</c> call in the same block.
+/// In server-side (static SSR) contexts <c>NavigateTo</c> only signals the navigation; it no longer
+/// stops execution, so the statements after it still run. Adding a <c>return</c> makes the intent explicit.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class NavigateToReturnAnalyzer : DiagnosticAnalyzer
+{
+    private const string NavigationManagerTypeName = "Microsoft.AspNetCore.Components.NavigationManager";
+    private const string NavigateToMethodName = "NavigateTo";
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(DiagnosticDescriptors.CodeAfterNavigateToWillExecute);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
+
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var navigationManagerType = compilationContext.Compilation.GetTypeByMetadataName(NavigationManagerTypeName);
+            if (navigationManagerType is null)
+            {
+                // NavigationManager is not available in this compilation.
+                return;
+            }
+
+            compilationContext.RegisterOperationAction(operationContext =>
+            {
+                var invocation = (IInvocationOperation)operationContext.Operation;
+                if (invocation.TargetMethod.Name != NavigateToMethodName ||
+                    !InheritsFromOrEquals(invocation.TargetMethod.ContainingType, navigationManagerType))
+                {
+                    return;
+                }
+
+                // Only expression statements can be followed by unreachable-looking code in the same block.
+                if (invocation.Syntax is not InvocationExpressionSyntax invocationSyntax ||
+                    invocationSyntax.Parent is not ExpressionStatementSyntax statement ||
+                    statement.Parent is not BlockSyntax block)
+                {
+                    return;
+                }
+
+                var statements = block.Statements;
+                var index = statements.IndexOf(statement);
+                if (index < 0 || index == statements.Count - 1)
+                {
+                    // Last statement in the block: nothing runs after NavigateTo here.
+                    return;
+                }
+
+                // A trailing return/throw is the recommended pattern, so it should not be flagged.
+                if (statements[index + 1] is ReturnStatementSyntax or ThrowStatementSyntax)
+                {
+                    return;
+                }
+
+                operationContext.ReportDiagnostic(Diagnostic.Create(
+                    DiagnosticDescriptors.CodeAfterNavigateToWillExecute,
+                    invocationSyntax.GetLocation()));
+            }, OperationKind.Invocation);
+        });
+    }
+
+    private static bool InheritsFromOrEquals(ITypeSymbol? type, INamedTypeSymbol baseType)
+    {
+        for (var current = type; current is not null; current = current.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, baseType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Components/Analyzers/src/Resources.resx
+++ b/src/Components/Analyzers/src/Resources.resx
@@ -228,6 +228,15 @@
   <data name="VirtualizeSpacerElementIsInvalid_Title" xml:space="preserve">
     <value>Virtualize uses an invalid spacer element</value>
   </data>
+  <data name="CodeAfterNavigateToWillExecute_Description" xml:space="preserve">
+    <value>In server-side (static SSR) contexts, NavigationManager.NavigateTo signals the navigation and stops rendering after the current batch, but it does not stop execution. Code placed after the NavigateTo call still runs. Add a return statement after NavigateTo if the following code should not execute.</value>
+  </data>
+  <data name="CodeAfterNavigateToWillExecute_Format" xml:space="preserve">
+    <value>Code after this 'NavigateTo' call will still execute because 'NavigateTo' does not stop execution. Add a 'return' statement after 'NavigateTo' if the following code should not run.</value>
+  </data>
+  <data name="CodeAfterNavigateToWillExecute_Title" xml:space="preserve">
+    <value>Code after NavigationManager.NavigateTo will still execute</value>
+  </data>
   <data name="UnnecessaryStateHasChangedCall_Description" xml:space="preserve">
     <value>StateHasChanged is unnecessary in synchronous component lifecycle methods or event handlers. In async lifecycle methods or event handlers, it is unnecessary before the first await and after the final await because ComponentBase already schedules renders at those points.</value>
   </data>

--- a/src/Components/Analyzers/src/build/netstandard2.0/Microsoft.AspNetCore.Components.Analyzers.targets
+++ b/src/Components/Analyzers/src/build/netstandard2.0/Microsoft.AspNetCore.Components.Analyzers.targets
@@ -1,4 +1,8 @@
 <Project>
+  <ItemGroup>
+    <CompilerVisibleProperty Include="BlazorDisableThrowNavigationException" />
+  </ItemGroup>
+
   <!--
   The Web.SDK unconditionally adds the components analyzer to all qualifying Web projects. A project qualifiies if it targets netcoreapp3.0 or later and does not have a flag that
   prevents the implicit analyzer from being added. We want to ensure that when a Web project also references this package, typically as the result of referencing a component class library,

--- a/src/Components/Analyzers/test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/src/Components/Analyzers/test/Helpers/DiagnosticVerifier.Helper.cs
@@ -41,6 +41,11 @@ public abstract partial class DiagnosticVerifier
         return GetSortedDiagnosticsFromDocuments(analyzer, GetDocuments(sources, language));
     }
 
+    private static Diagnostic[] GetSortedDiagnostics(string[] sources, string language, DiagnosticAnalyzer analyzer, AnalyzerOptions analyzerOptions)
+    {
+        return GetSortedDiagnosticsFromDocuments(analyzer, GetDocuments(sources, language), analyzerOptions);
+    }
+
     /// <summary>
     /// Given an analyzer and a document to apply it to, run the analyzer and gather an array of diagnostics found in it.
     /// The returned diagnostics are then ordered by location in the source document.
@@ -48,7 +53,7 @@ public abstract partial class DiagnosticVerifier
     /// <param name="analyzer">The analyzer to run on the documents</param>
     /// <param name="documents">The Documents that the analyzer will be run on</param>
     /// <returns>An IEnumerable of Diagnostics that surfaced in the source code, sorted by Location</returns>
-    protected static Diagnostic[] GetSortedDiagnosticsFromDocuments(DiagnosticAnalyzer analyzer, Document[] documents)
+    protected static Diagnostic[] GetSortedDiagnosticsFromDocuments(DiagnosticAnalyzer analyzer, Document[] documents, AnalyzerOptions analyzerOptions = null)
     {
         var projects = new HashSet<Project>();
         foreach (var document in documents)
@@ -59,7 +64,10 @@ public abstract partial class DiagnosticVerifier
         var diagnostics = new List<Diagnostic>();
         foreach (var project in projects)
         {
-            var compilationWithAnalyzers = project.GetCompilationAsync().Result.WithAnalyzers(ImmutableArray.Create(analyzer));
+            var compilation = project.GetCompilationAsync().Result;
+            var compilationWithAnalyzers = analyzerOptions is null
+                ? compilation.WithAnalyzers(ImmutableArray.Create(analyzer))
+                : compilation.WithAnalyzers(ImmutableArray.Create(analyzer), analyzerOptions);
             var diags = compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().Result;
             foreach (var diag in diags)
             {
@@ -168,4 +176,3 @@ public abstract partial class DiagnosticVerifier
     }
     #endregion
 }
-

--- a/src/Components/Analyzers/test/NavigateToReturnAnalyzerTest.cs
+++ b/src/Components/Analyzers/test/NavigateToReturnAnalyzerTest.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using TestHelper;
+
+namespace Microsoft.AspNetCore.Components.Analyzers.Test;
+
+public class NavigateToReturnAnalyzerTest : DiagnosticVerifier
+{
+    protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new NavigateToReturnAnalyzer();
+
+    private static readonly string NavigationManagerDeclaration = @"
+    namespace Microsoft.AspNetCore.Components
+    {
+        public class NavigationManager
+        {
+            public void NavigateTo(string uri, bool forceLoad = false) { }
+        }
+    }
+";
+
+    [Fact]
+    public void DiagnosticForCodeAfterNavigateTo()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestClass
+        {
+            private NavigationManager Navigation;
+
+            public void Handle()
+            {
+                Navigation.NavigateTo(""/"");
+                System.Console.WriteLine(""this still runs"");
+            }
+        }
+    }" + NavigationManagerDeclaration;
+
+        var expected = new DiagnosticResult
+        {
+            Id = DiagnosticDescriptors.CodeAfterNavigateToWillExecute.Id,
+            Message = "Code after this 'NavigateTo' call will still execute because 'NavigateTo' does not stop execution. Add a 'return' statement after 'NavigateTo' if the following code should not run.",
+            Severity = DiagnosticSeverity.Warning,
+            Locations = new[]
+            {
+                new DiagnosticResultLocation("Test0.cs", 12, 17)
+            }
+        };
+
+        VerifyCSharpDiagnostic(test, expected);
+    }
+
+    [Fact]
+    public void NoDiagnosticWhenReturnFollowsNavigateTo()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestClass
+        {
+            private NavigationManager Navigation;
+
+            public void Handle()
+            {
+                Navigation.NavigateTo(""/"");
+                return;
+            }
+        }
+    }" + NavigationManagerDeclaration;
+
+        VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
+    public void NoDiagnosticWhenNavigateToIsLastStatement()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestClass
+        {
+            private NavigationManager Navigation;
+
+            public void Handle()
+            {
+                Navigation.NavigateTo(""/"");
+            }
+        }
+    }" + NavigationManagerDeclaration;
+
+        VerifyCSharpDiagnostic(test);
+    }
+
+    [Fact]
+    public void NoDiagnosticForUnrelatedNavigateTo()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        class NavigationManager
+        {
+            public void NavigateTo(string uri) { }
+        }
+
+        class TestClass
+        {
+            private NavigationManager Navigation;
+
+            public void Handle()
+            {
+                Navigation.NavigateTo(""/"");
+                System.Console.WriteLine(""this still runs"");
+            }
+        }
+    }";
+
+        VerifyCSharpDiagnostic(test);
+    }
+}

--- a/src/Components/Analyzers/test/NavigateToReturnAnalyzerTest.cs
+++ b/src/Components/Analyzers/test/NavigateToReturnAnalyzerTest.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using TestHelper;
@@ -9,7 +11,11 @@ namespace Microsoft.AspNetCore.Components.Analyzers.Test;
 
 public class NavigateToReturnAnalyzerTest : DiagnosticVerifier
 {
+    private const string DisableThrowNavigationExceptionProperty = "build_property.BlazorDisableThrowNavigationException";
+
     protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer() => new NavigateToReturnAnalyzer();
+
+    private static AnalyzerOptions EnabledAnalyzerOptions { get; } = CreateAnalyzerOptions("true");
 
     private static readonly string NavigationManagerDeclaration = @"
     namespace Microsoft.AspNetCore.Components
@@ -41,18 +47,7 @@ public class NavigateToReturnAnalyzerTest : DiagnosticVerifier
         }
     }" + NavigationManagerDeclaration;
 
-        var expected = new DiagnosticResult
-        {
-            Id = DiagnosticDescriptors.CodeAfterNavigateToWillExecute.Id,
-            Message = "Code after this 'NavigateTo' call will still execute because 'NavigateTo' does not stop execution. Add a 'return' statement after 'NavigateTo' if the following code should not run.",
-            Severity = DiagnosticSeverity.Warning,
-            Locations = new[]
-            {
-                new DiagnosticResultLocation("Test0.cs", 12, 17)
-            }
-        };
-
-        VerifyCSharpDiagnostic(test, expected);
+        VerifyCSharpDiagnostic(test, EnabledAnalyzerOptions, CreateExpectedDiagnostic(12, 17));
     }
 
     [Fact]
@@ -75,7 +70,7 @@ public class NavigateToReturnAnalyzerTest : DiagnosticVerifier
         }
     }" + NavigationManagerDeclaration;
 
-        VerifyCSharpDiagnostic(test);
+        VerifyCSharpDiagnostic(test, EnabledAnalyzerOptions);
     }
 
     [Fact]
@@ -97,7 +92,7 @@ public class NavigateToReturnAnalyzerTest : DiagnosticVerifier
         }
     }" + NavigationManagerDeclaration;
 
-        VerifyCSharpDiagnostic(test);
+        VerifyCSharpDiagnostic(test, EnabledAnalyzerOptions);
     }
 
     [Fact]
@@ -123,6 +118,190 @@ public class NavigateToReturnAnalyzerTest : DiagnosticVerifier
         }
     }";
 
-        VerifyCSharpDiagnostic(test);
+        VerifyCSharpDiagnostic(test, EnabledAnalyzerOptions);
+    }
+
+    [Fact]
+    public void DiagnosticForCodeAfterNavigateToInSwitchSection()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestClass
+        {
+            private NavigationManager Navigation;
+
+            public void Handle(int value)
+            {
+                switch (value)
+                {
+                    case 0:
+                        Navigation.NavigateTo(""/"");
+                        System.Console.WriteLine(""this still runs"");
+                        break;
+                }
+            }
+        }
+    }" + NavigationManagerDeclaration;
+
+        VerifyCSharpDiagnostic(test, EnabledAnalyzerOptions, CreateExpectedDiagnostic(15, 25));
+    }
+
+    [Fact]
+    public void OneDiagnosticForMultipleStatementsAfterNavigateTo()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestClass
+        {
+            private NavigationManager Navigation;
+
+            public void Handle()
+            {
+                Navigation.NavigateTo(""/"");
+                System.Console.WriteLine(""first"");
+                System.Console.WriteLine(""second"");
+            }
+        }
+    }" + NavigationManagerDeclaration;
+
+        VerifyCSharpDiagnostic(test, EnabledAnalyzerOptions, CreateExpectedDiagnostic(12, 17));
+    }
+
+    [Fact]
+    public void DiagnosticWhenCodeBeforeTrailingReturn()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestClass
+        {
+            private NavigationManager Navigation;
+
+            public void Handle()
+            {
+                Navigation.NavigateTo(""/"");
+                System.Console.WriteLine(""this still runs"");
+                return;
+            }
+        }
+    }" + NavigationManagerDeclaration;
+
+        VerifyCSharpDiagnostic(test, EnabledAnalyzerOptions, CreateExpectedDiagnostic(12, 17));
+    }
+
+    [Fact]
+    public void DiagnosticForNavigateToReceiverExpressions()
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestClass
+        {
+            private NavigationManager Navigation;
+
+            private NavigationManager GetNavigationManager() => Navigation;
+
+            public void Handle()
+            {
+                GetNavigationManager().NavigateTo(""/first"");
+                System.Console.WriteLine(""first still runs"");
+                this.Navigation.NavigateTo(""/second"");
+                System.Console.WriteLine(""second still runs"");
+            }
+        }
+    }" + NavigationManagerDeclaration;
+
+        VerifyCSharpDiagnostic(
+            test,
+            EnabledAnalyzerOptions,
+            CreateExpectedDiagnostic(14, 17),
+            CreateExpectedDiagnostic(16, 17));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("false")]
+    public void NoDiagnosticWhenNavigateToStillThrows(string propertyValue)
+    {
+        var test = @"
+    namespace ConsoleApplication1
+    {
+        using Microsoft.AspNetCore.Components;
+
+        class TestClass
+        {
+            private NavigationManager Navigation;
+
+            public void Handle()
+            {
+                Navigation.NavigateTo(""/"");
+                System.Console.WriteLine(""unreachable when NavigateTo throws"");
+            }
+        }
+    }" + NavigationManagerDeclaration;
+
+        VerifyCSharpDiagnostic(test, CreateAnalyzerOptions(propertyValue));
+    }
+
+    private static DiagnosticResult CreateExpectedDiagnostic(int line, int column) => new()
+    {
+        Id = DiagnosticDescriptors.CodeAfterNavigateToWillExecute.Id,
+        Message = "Code after this 'NavigateTo' call will still execute because 'NavigateTo' does not stop execution. Add a 'return' statement after 'NavigateTo' if the following code should not run.",
+        Severity = DiagnosticSeverity.Warning,
+        Locations = new[]
+        {
+            new DiagnosticResultLocation("Test0.cs", line, column)
+        }
+    };
+
+    private static AnalyzerOptions CreateAnalyzerOptions(string propertyValue)
+    {
+        var options = new Dictionary<string, string>();
+        if (propertyValue is not null)
+        {
+            options.Add(DisableThrowNavigationExceptionProperty, propertyValue);
+        }
+
+        return new AnalyzerOptions(
+            ImmutableArray<AdditionalText>.Empty,
+            new TestAnalyzerConfigOptionsProvider(options));
+    }
+
+    private sealed class TestAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
+    {
+        private readonly TestAnalyzerConfigOptions _globalOptions;
+
+        public TestAnalyzerConfigOptionsProvider(IReadOnlyDictionary<string, string> globalOptions)
+        {
+            _globalOptions = new TestAnalyzerConfigOptions(globalOptions);
+        }
+
+        public override AnalyzerConfigOptions GlobalOptions => _globalOptions;
+
+        public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => _globalOptions;
+
+        public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => _globalOptions;
+    }
+
+    private sealed class TestAnalyzerConfigOptions : AnalyzerConfigOptions
+    {
+        private readonly IReadOnlyDictionary<string, string> _options;
+
+        public TestAnalyzerConfigOptions(IReadOnlyDictionary<string, string> options)
+        {
+            _options = options;
+        }
+
+        public override bool TryGetValue(string key, out string value) => _options.TryGetValue(key, out value);
     }
 }

--- a/src/Components/Analyzers/test/Verifiers/DiagnosticVerifier.cs
+++ b/src/Components/Analyzers/test/Verifiers/DiagnosticVerifier.cs
@@ -47,6 +47,17 @@ public abstract partial class DiagnosticVerifier
     }
 
     /// <summary>
+    /// Called to test a C# DiagnosticAnalyzer with the specified analyzer options.
+    /// </summary>
+    /// <param name="source">A class in the form of a string to run the analyzer on</param>
+    /// <param name="analyzerOptions">The analyzer options to use</param>
+    /// <param name="expected">DiagnosticResults that should appear after the analyzer is run on the source</param>
+    protected void VerifyCSharpDiagnostic(string source, AnalyzerOptions analyzerOptions, params DiagnosticResult[] expected)
+    {
+        VerifyDiagnostics(new[] { source }, LanguageNames.CSharp, GetCSharpDiagnosticAnalyzer(), analyzerOptions, expected);
+    }
+
+    /// <summary>
     /// Called to test a VB DiagnosticAnalyzer when applied on the single inputted string as a source
     /// Note: input a DiagnosticResult for each Diagnostic expected
     /// </summary>
@@ -90,6 +101,12 @@ public abstract partial class DiagnosticVerifier
     private void VerifyDiagnostics(string[] sources, string language, DiagnosticAnalyzer analyzer, params DiagnosticResult[] expected)
     {
         var diagnostics = GetSortedDiagnostics(sources, language, analyzer);
+        VerifyDiagnosticResults(diagnostics, analyzer, expected);
+    }
+
+    private void VerifyDiagnostics(string[] sources, string language, DiagnosticAnalyzer analyzer, AnalyzerOptions analyzerOptions, params DiagnosticResult[] expected)
+    {
+        var diagnostics = GetSortedDiagnostics(sources, language, analyzer, analyzerOptions);
         VerifyDiagnosticResults(diagnostics, analyzer, expected);
     }
 


### PR DESCRIPTION
Adds analyzer BL0020 for code that follows `NavigationManager.NavigateTo` when static SSR navigation exceptions are disabled.

The analyzer:

- runs only when `BlazorDisableThrowNavigationException=true`, avoiding warnings in applications that retain the throwing behavior;
- handles statements in method blocks and `switch` sections;
- recognizes `NavigateTo` calls through different `NavigationManager` receiver expressions;
- reports one warning per call when executable statements follow it, while allowing an immediate `return` or `throw`.

## Validation

- Regression tests fail before the review fix for `switch` sections and for projects where the opt-in property is absent or `false`.
- `./.dotnet/dotnet test src/Components/Analyzers/test/Microsoft.AspNetCore.Components.Analyzers.Tests.csproj -p:BuildNodeJS=false --no-restore` — 232 passed.

Fixes #69195
