### PR TITLE
[SignalR] [Java] Fix hung start/stop after a failed connection attempt

### DIFF
--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/DefaultHttpClient.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/DefaultHttpClient.java
@@ -154,7 +154,7 @@ final class DefaultHttpClient extends HttpClient {
                 HttpResponse httpResponse;
                 try (ResponseBody body = response.body()) {
                     httpResponse = new HttpResponse(response.code(), response.message(), ByteBuffer.wrap(body.bytes()));
-                } catch (Throwable ex) {
+                } catch (Exception ex) {
                     // OkHttp marks the callback as signalled before invoking onResponse, so it never calls
                     // onFailure for anything thrown from here. Reading the body can still fail, for example when
                     // the connection drops mid-response, so terminate the Single ourselves. Otherwise callers

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -364,14 +364,20 @@ public class HubConnection implements AutoCloseable {
                 }
 
                 if (releaseConnection) {
-                    // The cleanup above already ran, so stop the transport without letting its onClose
-                    // callback re-enter stopConnection now that there is no connection state.
-                    Transport failedTransport = connectionState.transport;
-                    if (failedTransport != null) {
-                        failedTransport.setOnClose((message) -> {
-                        });
+                    try {
+                        // The cleanup above already ran, so stop the transport without letting its onClose
+                        // callback re-enter stopConnection now that there is no connection state.
+                        Transport failedTransport = connectionState.transport;
+                        if (failedTransport != null) {
+                            failedTransport.setOnClose((message) -> {
+                            });
+                        }
+                        connectionState.stopTransport().onErrorComplete().subscribe();
+                    } catch (Exception ex) {
+                        // Cleaning up must never keep the start task from terminating below, since that
+                        // leaves the caller waiting forever on a connection that already failed.
+                        logger.warn("Failed to clean up after the connection failed to start.", ex);
                     }
-                    connectionState.stopTransport().onErrorComplete().subscribe();
                 }
 
                 localStart.onError(error);
@@ -1560,8 +1566,17 @@ public class HubConnection implements AutoCloseable {
         // transport twice runs its shutdown a second time, so callers share a single stop.
         public Completable stopTransport() {
             if (transportStopInitiated.compareAndSet(false, true)) {
-                Transport transportToStop = this.transport;
-                Completable stop = (transportToStop != null) ? transportToStop.stop() : Completable.complete();
+                Completable stop;
+                try {
+                    Transport transportToStop = this.transport;
+                    stop = (transportToStop != null) ? transportToStop.stop() : Completable.complete();
+                } catch (Exception ex) {
+                    // A transport that failed to start can throw from stop(), for example a WebSocket
+                    // that never created its client. Report that instead of throwing at the caller,
+                    // which would leave whoever is waiting on this stop hanging.
+                    stop = Completable.error(ex);
+                }
+
                 stop.subscribe(() -> transportStopped.onComplete(), e -> transportStopped.onError(e));
             }
 

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -355,9 +355,10 @@ public class HubConnection implements AutoCloseable {
                         // DISCONNECTED state, so nothing ever cleaned them up.
                         releaseConnection = true;
                         this.state.setConnectionState(null);
-                        // stop() and close() have to be able to wait for this teardown, otherwise they
-                        // report the connection stopped while its transport is still shutting down.
-                        this.pendingTeardown = connectionState.getTransportStopped();
+                        // A stop() racing this narrow window still has to wait for the teardown started
+                        // below rather than reporting the connection stopped while it is running. A
+                        // teardown failure is not the caller's to handle, the start error already is.
+                        this.pendingTeardown = connectionState.getTransportStopped().onErrorComplete();
                         connectionState.close();
                         this.state.changeState(HubConnectionState.CONNECTING, HubConnectionState.DISCONNECTED);
                     }
@@ -367,19 +368,28 @@ public class HubConnection implements AutoCloseable {
                     this.state.unlock();
                 }
 
-                if (releaseConnection) {
-                    try {
-                        // The transport's callbacks are scoped to this attempt, so they no-op from here on
-                        // and stopping it cannot disturb whatever connection comes next.
-                        connectionState.stopTransport().onErrorComplete().subscribe();
-                    } catch (Exception ex) {
-                        // Cleaning up must never keep the start task from terminating below, since that
-                        // leaves the caller waiting forever on a connection that already failed.
-                        logger.warn("Failed to clean up after the connection failed to start.", ex);
-                    }
+                if (!releaseConnection) {
+                    localStart.onError(error);
+                    return;
                 }
 
-                localStart.onError(error);
+                // Like the .NET and TypeScript clients, a start that failed does not complete until the
+                // transport it brought up has finished shutting down. Waiting here rather than in stop()
+                // keeps the wait with the caller that is already failing, and leaves nothing running
+                // behind a start that has already reported failure.
+                Completable teardown;
+                try {
+                    // The transport's callbacks are scoped to this attempt, so they no-op from here on
+                    // and stopping it cannot disturb whatever connection comes next.
+                    teardown = connectionState.stopTransport().onErrorComplete();
+                } catch (Exception ex) {
+                    // Cleaning up must never keep the start task from terminating, since that leaves the
+                    // caller waiting forever on a connection that already failed.
+                    logger.warn("Failed to clean up after the connection failed to start.", ex);
+                    teardown = Completable.complete();
+                }
+
+                teardown.subscribe(() -> localStart.onError(error), e -> localStart.onError(error));
             });
         } finally {
             this.state.lock.unlock();

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -46,9 +46,10 @@ public class HubConnection implements AutoCloseable {
     private final Logger logger = LoggerFactory.getLogger(HubConnection.class);
     private final HttpClient httpClient;
     private final Transport customTransport;
-    private final OnReceiveCallBack callback;
     private final Single<String> accessTokenProvider;
     private final TransportEnum transportEnum;
+    // Teardown left running by a start that failed. Guarded by state.lock.
+    private Completable pendingTeardown = Completable.complete();
 
     // These are all user-settable properties
     private String baseUrl;
@@ -165,8 +166,6 @@ public class HubConnection implements AutoCloseable {
 
         this.serverTimeout = serverTimeout;
         this.keepAliveInterval = keepAliveInterval;
-
-        this.callback = (payload) -> ReceiveLoop(payload);
     }
 
     private Single<NegotiateResponse> handleNegotiate(String url, Map<String, String> localHeaders) {
@@ -291,8 +290,10 @@ public class HubConnection implements AutoCloseable {
 
                 connectionState.transport = transport;
 
-                transport.setOnReceive(this.callback);
-                transport.setOnClose((message) -> stopConnection(message));
+                // Scope the callbacks to this attempt. Once the attempt is no longer the current one,
+                // its transport must not be able to touch whatever connection replaced it.
+                transport.setOnReceive((payload) -> ReceiveLoop(connectionState, payload));
+                transport.setOnClose((message) -> stopConnection(connectionState, message));
 
                 return transport.start(negotiateResponse.getFinalUrl()).andThen(Completable.defer(() -> {
                     ByteBuffer handshake = HandshakeProtocol.createHandshakeRequestMessage(
@@ -354,6 +355,9 @@ public class HubConnection implements AutoCloseable {
                         // DISCONNECTED state, so nothing ever cleaned them up.
                         releaseConnection = true;
                         this.state.setConnectionState(null);
+                        // stop() and close() have to be able to wait for this teardown, otherwise they
+                        // report the connection stopped while its transport is still shutting down.
+                        this.pendingTeardown = connectionState.getTransportStopped();
                         connectionState.close();
                         this.state.changeState(HubConnectionState.CONNECTING, HubConnectionState.DISCONNECTED);
                     }
@@ -365,13 +369,8 @@ public class HubConnection implements AutoCloseable {
 
                 if (releaseConnection) {
                     try {
-                        // The cleanup above already ran, so stop the transport without letting its onClose
-                        // callback re-enter stopConnection now that there is no connection state.
-                        Transport failedTransport = connectionState.transport;
-                        if (failedTransport != null) {
-                            failedTransport.setOnClose((message) -> {
-                            });
-                        }
+                        // The transport's callbacks are scoped to this attempt, so they no-op from here on
+                        // and stopping it cannot disturb whatever connection comes next.
                         connectionState.stopTransport().onErrorComplete().subscribe();
                     } catch (Exception ex) {
                         // Cleaning up must never keep the start task from terminating below, since that
@@ -447,7 +446,9 @@ public class HubConnection implements AutoCloseable {
         this.state.lock();
         try {
             if (this.state.getHubConnectionState() == HubConnectionState.DISCONNECTED) {
-                return Completable.complete();
+                // A start that already failed released the connection and kicked off its transport
+                // teardown. Wait for that instead of reporting stopped while it is still running.
+                return this.pendingTeardown;
             }
 
             connectionState = this.state.getConnectionStateUnsynchronized(false);
@@ -476,13 +477,19 @@ public class HubConnection implements AutoCloseable {
         return subject;
     }
 
-    private void ReceiveLoop(ByteBuffer payload)
+    private void ReceiveLoop(ConnectionState expectedState, ByteBuffer payload)
     {
         List<HubMessage> messages;
         ConnectionState connectionState;
         this.state.lock();
         try {
-            connectionState = this.state.getConnectionState();
+            connectionState = this.state.getConnectionStateUnsynchronized(true);
+            if (connectionState != expectedState) {
+                // The attempt that owns this transport is gone, so this payload is no longer ours to handle.
+                logger.debug("Ignoring a message received after its connection was released.");
+                return;
+            }
+
             connectionState.resetServerTimeout();
             connectionState.handleHandshake(payload);
             // The payload only contained the handshake response so we can return.
@@ -561,11 +568,18 @@ public class HubConnection implements AutoCloseable {
         return stop(null);
     }
 
-    private void stopConnection(String errorMessage) {
+    private void stopConnection(ConnectionState expectedState, String errorMessage) {
         RuntimeException exception = null;
         this.state.lock();
         try {
             ConnectionState connectionState = this.state.getConnectionStateUnsynchronized(true);
+
+            if (connectionState != expectedState) {
+                // The attempt that owns this transport was already released, so there is nothing left to
+                // stop. Tearing down here would close whatever connection replaced it.
+                logger.debug("Ignoring a transport close for a connection that was already released.");
+                return;
+            }
 
             if (connectionState == null)
             {
@@ -1560,6 +1574,11 @@ public class HubConnection implements AutoCloseable {
             handshakeTimeout.schedule(() -> {
                 errorHandshake(new TimeoutException("Timed out waiting for the server to respond to the handshake message."));
             }, timeout, unit);
+        }
+
+        // The shared stop for this attempt's transport, without starting it.
+        public Completable getTransportStopped() {
+            return transportStopped;
         }
 
         // Stops the transport at most once. Both a failed start and stop() get here, and stopping a

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/HubConnection.java
@@ -9,6 +9,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
@@ -343,16 +344,34 @@ public class HubConnection implements AutoCloseable {
             }).subscribe(() -> {
                 localStart.onComplete();
             }, error -> {
+                boolean releaseConnection = false;
                 this.state.lock();
                 try {
                     ConnectionState activeState = this.state.getConnectionStateUnsynchronized(true);
                     if (activeState == connectionState) {
+                        // Release the failed attempt. Leaving the connection state in place kept the
+                        // transport and its timers running, and a later stop() short circuits on the
+                        // DISCONNECTED state, so nothing ever cleaned them up.
+                        releaseConnection = true;
+                        this.state.setConnectionState(null);
+                        connectionState.close();
                         this.state.changeState(HubConnectionState.CONNECTING, HubConnectionState.DISCONNECTED);
                     }
                 // this error is already logged and we want the user to see the original error
                 } catch (Exception ex) {
                 } finally {
                     this.state.unlock();
+                }
+
+                if (releaseConnection) {
+                    // The cleanup above already ran, so stop the transport without letting its onClose
+                    // callback re-enter stopConnection now that there is no connection state.
+                    Transport failedTransport = connectionState.transport;
+                    if (failedTransport != null) {
+                        failedTransport.setOnClose((message) -> {
+                        });
+                    }
+                    connectionState.stopTransport().onErrorComplete().subscribe();
                 }
 
                 localStart.onError(error);
@@ -445,9 +464,7 @@ public class HubConnection implements AutoCloseable {
         CompletableSubject subject = CompletableSubject.create();
         startTask.onErrorComplete().subscribe(() ->
         {
-            Transport transport = connectionState.transport;
-            Completable stop = (transport != null) ? transport.stop() : Completable.complete();
-            stop.subscribe(() -> subject.onComplete(), e -> subject.onError(e));
+            connectionState.stopTransport().subscribe(() -> subject.onComplete(), e -> subject.onError(e));
         });
 
         return subject;
@@ -1395,6 +1412,8 @@ public class HubConnection implements AutoCloseable {
         private ScheduledExecutorService handshakeTimeout = null;
         private BehaviorSubject<InvocationMessage> messages = BehaviorSubject.create();
         private ExecutorService resultInvocationPool = null;
+        private final AtomicBoolean transportStopInitiated = new AtomicBoolean(false);
+        private final CompletableSubject transportStopped = CompletableSubject.create();
 
         public final Lock lock = new ReentrantLock();
         public final CompletableSubject handshakeResponseSubject = CompletableSubject.create();
@@ -1535,6 +1554,18 @@ public class HubConnection implements AutoCloseable {
             handshakeTimeout.schedule(() -> {
                 errorHandshake(new TimeoutException("Timed out waiting for the server to respond to the handshake message."));
             }, timeout, unit);
+        }
+
+        // Stops the transport at most once. Both a failed start and stop() get here, and stopping a
+        // transport twice runs its shutdown a second time, so callers share a single stop.
+        public Completable stopTransport() {
+            if (transportStopInitiated.compareAndSet(false, true)) {
+                Transport transportToStop = this.transport;
+                Completable stop = (transportToStop != null) ? transportToStop.stop() : Completable.complete();
+                stop.subscribe(() -> transportStopped.onComplete(), e -> transportStopped.onError(e));
+            }
+
+            return transportStopped;
         }
 
         public void close() {

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/LongPollingTransport.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/LongPollingTransport.java
@@ -92,7 +92,13 @@ class LongPollingTransport implements Transport {
 
                 return Completable.complete();
             });
-        }));
+        })).doOnError(e -> {
+            // The receive loop only starts once the first poll succeeds, so nothing will ever complete
+            // receiveLoopSubject when start fails. stop() waits on that subject after sending DELETE,
+            // so complete it here to keep a stop() that races with a failed start from waiting forever.
+            this.active = false;
+            receiveLoopSubject.onComplete();
+        });
     }
 
     private void poll(String url) {

--- a/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java
+++ b/src/SignalR/clients/java/signalr/core/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapper.java
@@ -6,6 +6,7 @@ package com.microsoft.signalr;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.slf4j.Logger;
@@ -22,6 +23,10 @@ import okhttp3.WebSocketListener;
 import okio.ByteString;
 
 class OkHttpWebSocketWrapper extends WebSocketWrapper {
+    // How long to wait for the peer to answer a close frame before tearing the socket down anyway.
+    // Matches the .NET client's HttpConnectionOptions.CloseTimeout default.
+    private static final long CLOSE_TIMEOUT_MILLIS = 5 * 1000;
+
     private WebSocket websocketClient;
     private String url;
     private Map<String, String> headers;
@@ -59,7 +64,21 @@ class OkHttpWebSocketWrapper extends WebSocketWrapper {
     @Override
     public Completable stop() {
         websocketClient.close(1000, "HubConnection stopped.");
-        return closeSubject;
+
+        // OkHttp waits a minute before it cancels a close the peer never answered, which leaves a stop
+        // stalled behind an unresponsive peer. Bound that wait like the .NET client, which arms the same
+        // kind of ungraceful close timer from HttpConnectionOptions.CloseTimeout.
+        Completable cancel = Completable.fromAction(() -> {
+                    logger.warn("The WebSocket did not close within {}ms, cancelling it.", CLOSE_TIMEOUT_MILLIS);
+                    websocketClient.cancel();
+                })
+                // Cancelling fails the socket, which terminates closeSubject, so the close callbacks still
+                // run before the stop reports back. That wait is bounded too, because nothing here may
+                // leave a stop hanging.
+                .andThen(closeSubject.onErrorComplete())
+                .timeout(CLOSE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS, Completable.complete());
+
+        return closeSubject.timeout(CLOSE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS, cancel);
     }
 
     @Override

--- a/src/SignalR/clients/java/signalr/test/build.gradle
+++ b/src/SignalR/clients/java/signalr/test/build.gradle
@@ -13,6 +13,9 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.11.2'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'ch.qos.logback:logback-classic:1.2.3'
+    // ':core' declares okhttp as 'implementation', so it is not on this module's compile classpath.
+    // OkHttpWebSocketWrapperTest drives the real wrapper, which needs an OkHttpClient.
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation project(':core')
     implementation project(':messagepack')
     antJUnit 'org.apache.ant:ant-junit:1.10.15'

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/DefaultHttpClientTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/DefaultHttpClientTest.java
@@ -90,7 +90,9 @@ public class DefaultHttpClientTest {
                 while (!serverSocket.isClosed()) {
                     try {
                         Socket socket = serverSocket.accept();
-                        new Thread(() -> respond(socket, mode)).start();
+                        Thread responseThread = new Thread(() -> respond(socket, mode));
+                        responseThread.setDaemon(true);
+                        responseThread.start();
                     } catch (Exception ex) {
                         return;
                     }

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
@@ -3399,6 +3399,70 @@ class HubConnectionTest {
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
     }
 
+    // stop() used to short circuit on the DISCONNECTED state that a failed start had already published,
+    // so it reported the connection stopped while the abandoned transport was still shutting down.
+    @Test
+    public void stopAfterFailedStartWaitsForTheTransportToStop() {
+        TestHttpClient client = new TestHttpClient()
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
+                    (req) -> Single.just(new HttpResponse(200, "",
+                            TestUtils.stringToByteBuffer("{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
+                                    + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"))));
+
+        CompletableSubject releaseTransportStop = CompletableSubject.create();
+        AtomicBoolean transportStopped = new AtomicBoolean(false);
+
+        Transport transport = new Transport() {
+            @Override
+            public Completable start(String url) {
+                return Completable.complete();
+            }
+
+            @Override
+            public Completable send(ByteBuffer message) {
+                return Completable.complete();
+            }
+
+            @Override
+            public void setOnReceive(OnReceiveCallBack callback) {
+            }
+
+            @Override
+            public void onReceive(ByteBuffer message) {
+            }
+
+            @Override
+            public void setOnClose(TransportOnClosedCallback onCloseCallback) {
+            }
+
+            @Override
+            public Completable stop() {
+                // Take as long to shut down as a transport whose peer never answers the close.
+                return releaseTransportStop.doOnComplete(() -> transportStopped.set(true));
+            }
+        };
+
+        HubConnection hubConnection = HubConnectionBuilder
+                .create("http://example.com")
+                .withTransportImplementation(transport)
+                .withHttpClient(client)
+                .withHandshakeResponseTimeout(100)
+                .build();
+
+        // Never send a handshake response, so start fails on the handshake timeout.
+        assertThrows(RuntimeException.class, () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+
+        TestObserver<Void> stop = hubConnection.stop().test();
+        stop.assertNotComplete();
+        assertFalse(transportStopped.get());
+
+        releaseTransportStop.onComplete();
+
+        stop.awaitDone(30, TimeUnit.SECONDS).assertComplete();
+        assertTrue(transportStopped.get());
+    }
+
     // The abandoned attempt also leaves behind the close callback that tears the hub down. Releasing it
     // has to detach that callback, otherwise a late close from the abandoned transport closes whichever
     // connection is current by then.

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
@@ -28,6 +28,7 @@ import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.disposables.Disposable;
+import io.reactivex.rxjava3.observers.TestObserver;
 import io.reactivex.rxjava3.schedulers.Schedulers;
 import io.reactivex.rxjava3.subjects.CompletableSubject;
 import io.reactivex.rxjava3.subjects.PublishSubject;
@@ -3322,6 +3323,79 @@ class HubConnectionTest {
         hubConnection.stop();
         closed.timeout(30, TimeUnit.SECONDS).blockingAwait();
         blockGet.onComplete();
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+    }
+
+    // Regression test for stop() hanging when it races with a failing start. stop() waits on the start
+    // task, then stops the transport. The initial poll had already been issued, so LongPollingTransport
+    // sent DELETE and waited on a receive loop that never started.
+    @Test
+    public void stopDuringFailingInitialLongPollDoesNotHang() throws Exception {
+        CompletableSubject initialPollArrived = CompletableSubject.create();
+        // Leave the initial poll unresolved so start() returns while it is still in flight.
+        SingleSubject<HttpResponse> initialPoll = SingleSubject.create();
+        AtomicBoolean deleteSent = new AtomicBoolean(false);
+        TestHttpClient client = new TestHttpClient()
+            .on("POST", "http://example.com/negotiate?negotiateVersion=1",
+                (req) -> Single.just(new HttpResponse(200, "",
+                        TestUtils.stringToByteBuffer("{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
+                                + "availableTransports\":[{\"transport\":\"LongPolling\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"))))
+            .on("GET", (req) -> {
+                initialPollArrived.onComplete();
+                return initialPoll;
+            })
+            .on("DELETE", (req) -> {
+                deleteSent.set(true);
+                return Single.just(new HttpResponse(200, "", TestUtils.emptyByteBuffer));
+            });
+
+        HubConnection hubConnection = HubConnectionBuilder
+                .create("http://example.com")
+                .withTransport(TransportEnum.LONG_POLLING)
+                .withHttpClient(client)
+                .build();
+
+        TestObserver<Void> start = hubConnection.start().test();
+        assertTrue(initialPollArrived.blockingAwait(30, TimeUnit.SECONDS));
+
+        // stop() has to observe the in-progress start, so it waits on the start task.
+        TestObserver<Void> stop = hubConnection.stop().test();
+
+        // Fail the poll from another thread so a hang shows up as a failed assertion below rather than
+        // blocking the test thread inside onSuccess.
+        Thread poller = new Thread(() -> initialPoll.onSuccess(new HttpResponse(500, "", TestUtils.emptyByteBuffer)));
+        poller.setDaemon(true);
+        poller.start();
+
+        assertTrue(start.await(30, TimeUnit.SECONDS), "start() never terminated.");
+        start.assertError(Throwable.class);
+        assertTrue(stop.await(30, TimeUnit.SECONDS), "stop() never terminated.");
+        assertTrue(deleteSent.get());
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+    }
+
+    // A failed start used to leave the transport running, and because the hub was already DISCONNECTED a
+    // later stop() did nothing, so the abandoned transport kept polling.
+    @Test
+    public void failedStartStopsTheTransport() {
+        TestHttpClient client = new TestHttpClient()
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
+                    (req) -> Single.just(new HttpResponse(200, "",
+                            TestUtils.stringToByteBuffer("{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
+                                    + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"))));
+
+        MockTransport transport = new MockTransport(false);
+        HubConnection hubConnection = HubConnectionBuilder
+                .create("http://example.com")
+                .withTransportImplementation(transport)
+                .withHttpClient(client)
+                .withHandshakeResponseTimeout(100)
+                .build();
+
+        // Never send a handshake response, so start fails on the handshake timeout.
+        assertThrows(RuntimeException.class, () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
+
+        transport.getStopTask().timeout(30, TimeUnit.SECONDS).blockingAwait();
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
     }
 

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
@@ -3368,7 +3368,7 @@ class HubConnectionTest {
         poller.start();
 
         assertTrue(start.await(30, TimeUnit.SECONDS), "start() never terminated.");
-        start.assertError(Throwable.class);
+        start.assertError(e -> e instanceof Exception && "Failed to connect.".equals(e.getMessage()));
         assertTrue(stop.await(30, TimeUnit.SECONDS), "stop() never terminated.");
         assertTrue(deleteSent.get());
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
@@ -3378,24 +3378,86 @@ class HubConnectionTest {
     // later stop() did nothing, so the abandoned transport kept polling.
     @Test
     public void failedStartStopsTheTransport() {
+        try (TestLogger logger = new TestLogger()) {
+            TestHttpClient client = new TestHttpClient()
+                    .on("POST", "http://example.com/negotiate?negotiateVersion=1",
+                        (req) -> Single.just(new HttpResponse(200, "",
+                                TestUtils.stringToByteBuffer("{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
+                                        + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"))));
+
+            MockTransport transport = new MockTransport(false);
+            HubConnection hubConnection = HubConnectionBuilder
+                    .create("http://example.com")
+                    .withTransportImplementation(transport)
+                    .withHttpClient(client)
+                    .withHandshakeResponseTimeout(100)
+                    .build();
+
+            // Never send a handshake response, so start fails on the handshake timeout.
+            assertThrows(RuntimeException.class, () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
+
+            transport.getStopTask().timeout(30, TimeUnit.SECONDS).blockingAwait();
+            assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+
+            // Stopping the transport must not run the close callback back through stopConnection, which
+            // has already been cleaned up. Doing so logs a spurious "please file a bug" error.
+            for (ILoggingEvent log : logger.getLogs()) {
+                assertFalse(log.getFormattedMessage().startsWith("'stopConnection' called with a null ConnectionState"),
+                    "Stopping the failed transport re-entered stopConnection.");
+            }
+        }
+    }
+
+    // A transport that failed to start can also throw from stop(), for example a WebSocket that never
+    // created its underlying client. Cleaning up after the failure must not stop start() from completing.
+    @Test
+    public void failedStartCompletesWhenStoppingTheTransportThrows() {
         TestHttpClient client = new TestHttpClient()
                 .on("POST", "http://example.com/negotiate?negotiateVersion=1",
                     (req) -> Single.just(new HttpResponse(200, "",
                             TestUtils.stringToByteBuffer("{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
                                     + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"))));
 
-        MockTransport transport = new MockTransport(false);
+        Transport transport = new Transport() {
+            @Override
+            public Completable start(String url) {
+                return Completable.error(new RuntimeException("Failed to start the transport."));
+            }
+
+            @Override
+            public Completable send(ByteBuffer message) {
+                return Completable.complete();
+            }
+
+            @Override
+            public void setOnReceive(OnReceiveCallBack callback) {
+            }
+
+            @Override
+            public void onReceive(ByteBuffer message) {
+            }
+
+            @Override
+            public void setOnClose(TransportOnClosedCallback onCloseCallback) {
+            }
+
+            @Override
+            public Completable stop() {
+                throw new NullPointerException("The transport was never started.");
+            }
+        };
+
         HubConnection hubConnection = HubConnectionBuilder
                 .create("http://example.com")
                 .withTransportImplementation(transport)
                 .withHttpClient(client)
-                .withHandshakeResponseTimeout(100)
                 .build();
 
-        // Never send a handshake response, so start fails on the handshake timeout.
-        assertThrows(RuntimeException.class, () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
+        RuntimeException exception = assertThrows(RuntimeException.class,
+                () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
 
-        transport.getStopTask().timeout(30, TimeUnit.SECONDS).blockingAwait();
+        // The caller has to see the original startup failure, not a cleanup failure or a timeout.
+        assertEquals("Failed to start the transport.", exception.getMessage());
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
     }
 

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
@@ -3399,10 +3399,10 @@ class HubConnectionTest {
         assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
     }
 
-    // stop() used to short circuit on the DISCONNECTED state that a failed start had already published,
-    // so it reported the connection stopped while the abandoned transport was still shutting down.
+    // A start that fails must not report failure while the transport it brought up is still shutting
+    // down, which is what the .NET and TypeScript clients do. stop() then has nothing left to wait for.
     @Test
-    public void stopAfterFailedStartWaitsForTheTransportToStop() {
+    public void failedStartWaitsForTheTransportToStop() {
         TestHttpClient client = new TestHttpClient()
                 .on("POST", "http://example.com/negotiate?negotiateVersion=1",
                     (req) -> Single.just(new HttpResponse(200, "",
@@ -3410,6 +3410,7 @@ class HubConnectionTest {
                                     + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"))));
 
         CompletableSubject releaseTransportStop = CompletableSubject.create();
+        CompletableSubject transportStopCalled = CompletableSubject.create();
         AtomicBoolean transportStopped = new AtomicBoolean(false);
 
         Transport transport = new Transport() {
@@ -3438,6 +3439,7 @@ class HubConnectionTest {
             @Override
             public Completable stop() {
                 // Take as long to shut down as a transport whose peer never answers the close.
+                transportStopCalled.onComplete();
                 return releaseTransportStop.doOnComplete(() -> transportStopped.set(true));
             }
         };
@@ -3450,17 +3452,21 @@ class HubConnectionTest {
                 .build();
 
         // Never send a handshake response, so start fails on the handshake timeout.
-        assertThrows(RuntimeException.class, () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
-        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+        TestObserver<Void> start = hubConnection.start().test();
 
-        TestObserver<Void> stop = hubConnection.stop().test();
-        stop.assertNotComplete();
+        // The handshake has failed and teardown is under way, but it has not finished.
+        assertTrue(transportStopCalled.blockingAwait(30, TimeUnit.SECONDS));
+        start.assertNoErrors().assertNotComplete();
         assertFalse(transportStopped.get());
 
         releaseTransportStop.onComplete();
 
-        stop.awaitDone(30, TimeUnit.SECONDS).assertComplete();
+        start.awaitDone(30, TimeUnit.SECONDS).assertError(TimeoutException.class);
         assertTrue(transportStopped.get());
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+
+        // Nothing is left running, so stopping is immediate.
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
     }
 
     // The abandoned attempt also leaves behind the close callback that tears the hub down. Releasing it

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/HubConnectionTest.java
@@ -3378,34 +3378,104 @@ class HubConnectionTest {
     // later stop() did nothing, so the abandoned transport kept polling.
     @Test
     public void failedStartStopsTheTransport() {
-        try (TestLogger logger = new TestLogger()) {
-            TestHttpClient client = new TestHttpClient()
-                    .on("POST", "http://example.com/negotiate?negotiateVersion=1",
-                        (req) -> Single.just(new HttpResponse(200, "",
-                                TestUtils.stringToByteBuffer("{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
-                                        + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"))));
+        TestHttpClient client = new TestHttpClient()
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
+                    (req) -> Single.just(new HttpResponse(200, "",
+                            TestUtils.stringToByteBuffer("{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
+                                    + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"))));
 
-            MockTransport transport = new MockTransport(false);
-            HubConnection hubConnection = HubConnectionBuilder
-                    .create("http://example.com")
-                    .withTransportImplementation(transport)
-                    .withHttpClient(client)
-                    .withHandshakeResponseTimeout(100)
-                    .build();
+        MockTransport transport = new MockTransport(false);
+        HubConnection hubConnection = HubConnectionBuilder
+                .create("http://example.com")
+                .withTransportImplementation(transport)
+                .withHttpClient(client)
+                .withHandshakeResponseTimeout(100)
+                .build();
 
-            // Never send a handshake response, so start fails on the handshake timeout.
-            assertThrows(RuntimeException.class, () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
+        // Never send a handshake response, so start fails on the handshake timeout.
+        assertThrows(RuntimeException.class, () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
 
-            transport.getStopTask().timeout(30, TimeUnit.SECONDS).blockingAwait();
-            assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+        transport.getStopTask().timeout(30, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+    }
 
-            // Stopping the transport must not run the close callback back through stopConnection, which
-            // has already been cleaned up. Doing so logs a spurious "please file a bug" error.
-            for (ILoggingEvent log : logger.getLogs()) {
-                assertFalse(log.getFormattedMessage().startsWith("'stopConnection' called with a null ConnectionState"),
-                    "Stopping the failed transport re-entered stopConnection.");
+    // The abandoned attempt also leaves behind the close callback that tears the hub down. Releasing it
+    // has to detach that callback, otherwise a late close from the abandoned transport closes whichever
+    // connection is current by then.
+    @Test
+    public void closeFromAbandonedTransportDoesNotCloseALaterConnection() {
+        TestHttpClient client = new TestHttpClient()
+                .on("POST", "http://example.com/negotiate?negotiateVersion=1",
+                    (req) -> Single.just(new HttpResponse(200, "",
+                            TestUtils.stringToByteBuffer("{\"connectionId\":\"bVOiRPG8-6YiJ6d7ZcTOVQ\",\""
+                                    + "availableTransports\":[{\"transport\":\"WebSockets\",\"transferFormats\":[\"Text\",\"Binary\"]}]}"))));
+
+        AtomicReference<TransportOnClosedCallback> onClose = new AtomicReference<>();
+        AtomicReference<OnReceiveCallBack> onReceive = new AtomicReference<>();
+        AtomicInteger startCount = new AtomicInteger(0);
+        CompletableSubject stopped = CompletableSubject.create();
+
+        Transport transport = new Transport() {
+            @Override
+            public Completable start(String url) {
+                // Only answer the handshake from the second attempt on, so the first start fails.
+                if (startCount.incrementAndGet() > 1) {
+                    onReceive.get().invoke(TestUtils.stringToByteBuffer("{}" + RECORD_SEPARATOR));
+                }
+                return Completable.complete();
             }
-        }
+
+            @Override
+            public Completable send(ByteBuffer message) {
+                return Completable.complete();
+            }
+
+            @Override
+            public void setOnReceive(OnReceiveCallBack callback) {
+                onReceive.set(callback);
+            }
+
+            @Override
+            public void onReceive(ByteBuffer message) {
+            }
+
+            @Override
+            public void setOnClose(TransportOnClosedCallback onCloseCallback) {
+                onClose.set(onCloseCallback);
+            }
+
+            @Override
+            public Completable stop() {
+                stopped.onComplete();
+                return Completable.complete();
+            }
+        };
+
+        HubConnection hubConnection = HubConnectionBuilder
+                .create("http://example.com")
+                .withTransportImplementation(transport)
+                .withHttpClient(client)
+                .withHandshakeResponseTimeout(100)
+                .build();
+
+        assertThrows(RuntimeException.class, () -> hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait());
+        stopped.timeout(30, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.DISCONNECTED, hubConnection.getConnectionState());
+
+        // Whatever the failed attempt left on the transport must no longer reach the hub.
+        TransportOnClosedCallback abandonedCallback = onClose.get();
+
+        AtomicBoolean closed = new AtomicBoolean(false);
+        hubConnection.onClosed((e) -> closed.set(true));
+        hubConnection.start().timeout(30, TimeUnit.SECONDS).blockingAwait();
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+
+        abandonedCallback.invoke("Late close from the abandoned attempt.");
+
+        assertFalse(closed.get(), "A close from the abandoned transport closed the new connection.");
+        assertEquals(HubConnectionState.CONNECTED, hubConnection.getConnectionState());
+
+        hubConnection.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
     }
 
     // A transport that failed to start can also throw from stop(), for example a WebSocket that never

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/LongPollingTransportTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/LongPollingTransportTest.java
@@ -34,6 +34,22 @@ public class LongPollingTransportTest {
         assertFalse(transport.isActive());
     }
 
+    // The receive loop only starts after the first poll succeeds, so a stop() that races with a failed
+    // start used to wait forever on a loop that never ran.
+    @Test
+    public void LongPollingTransportStopDoesNotHangWhenStartFails() {
+        TestHttpClient client = new TestHttpClient()
+                .on("GET", (req) -> Single.just(new HttpResponse(500, "", TestUtils.emptyByteBuffer)))
+                .on("DELETE", (req) -> Single.just(new HttpResponse(200, "", TestUtils.emptyByteBuffer)));
+
+        Map<String, String> headers = new HashMap<>();
+        LongPollingTransport transport = new LongPollingTransport(headers, client, Single.just(""));
+        assertThrows(RuntimeException.class, () -> transport.start("http://example.com").timeout(30, TimeUnit.SECONDS).blockingAwait());
+        assertFalse(transport.isActive());
+
+        transport.stop().timeout(30, TimeUnit.SECONDS).blockingAwait();
+    }
+
     @Test
     public void LongPollingTransportCantSendBeforeStart() {
         TestHttpClient client = new TestHttpClient()

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/LongPollingTransportTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/LongPollingTransportTest.java
@@ -34,8 +34,8 @@ public class LongPollingTransportTest {
         assertFalse(transport.isActive());
     }
 
-    // The receive loop only starts after the first poll succeeds, so a stop() that races with a failed
-    // start used to wait forever on a loop that never ran.
+    // stop() sends DELETE and then waits on receiveLoopSubject. The receive loop only starts once the
+    // first poll succeeds, so stopping after a failed start used to wait on a loop that never ran.
     @Test
     public void LongPollingTransportStopDoesNotHangWhenStartFails() {
         TestHttpClient client = new TestHttpClient()

--- a/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapperTest.java
+++ b/src/SignalR/clients/java/signalr/test/src/main/java/com/microsoft/signalr/OkHttpWebSocketWrapperTest.java
@@ -1,0 +1,265 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+package com.microsoft.signalr;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.Closeable;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import io.reactivex.rxjava3.core.Completable;
+import okhttp3.OkHttpClient;
+
+class OkHttpWebSocketWrapperTest {
+
+    // OkHttp waits RealWebSocket.CANCEL_AFTER_CLOSE_MILLIS, 60 seconds, before it cancels a close the
+    // peer never answered. Anything below that proves the wrapper bounded the wait itself.
+    private static final long OKHTTP_CANCEL_AFTER_CLOSE_MILLIS = 60 * 1000;
+
+    // Mirrors OkHttpWebSocketWrapper.CLOSE_TIMEOUT_MILLIS. A stop that finishes below this did not come
+    // back on the ungraceful close timer.
+    private static final long CLOSE_TIMEOUT_MILLIS = 5 * 1000;
+
+    @Test
+    public void stopCompletesWhenThePeerNeverAnswersTheCloseFrame() throws Exception {
+        try (LoopbackWebSocketServer server = new LoopbackWebSocketServer(false)) {
+            OkHttpClient client = new OkHttpClient();
+            OkHttpWebSocketWrapper wrapper = new OkHttpWebSocketWrapper(server.getWebSocketUrl(), new HashMap<>(), client);
+            wrapper.setOnReceive((message) -> { });
+            wrapper.setOnClose((code, reason) -> { });
+
+            assertTrue(wrapper.start().blockingAwait(30, TimeUnit.SECONDS), "The WebSocket never connected.");
+
+            long startedAt = System.nanoTime();
+            Completable stop = wrapper.stop();
+
+            assertTrue(server.awaitCloseFrame(30, TimeUnit.SECONDS),
+                    "The client never sent a close frame, so this run did not exercise an unanswered close.");
+
+            boolean stopped = stop.onErrorComplete().blockingAwait(30, TimeUnit.SECONDS);
+            long elapsedMillis = (System.nanoTime() - startedAt) / 1_000_000;
+
+            assertTrue(stopped, "stop() did not complete while the peer left the close frame unanswered.");
+            assertTrue(elapsedMillis < OKHTTP_CANCEL_AFTER_CLOSE_MILLIS,
+                    "stop() took " + elapsedMillis + "ms, so it waited on OkHttp's cancel instead of bounding the close.");
+        }
+    }
+
+    @Test
+    public void stopWaitsForTheCloseHandshakeWhenThePeerAnswersTheCloseFrame() throws Exception {
+        try (LoopbackWebSocketServer server = new LoopbackWebSocketServer(true);
+                DefaultHttpClient httpClient = new DefaultHttpClient(new OkHttpClient(), null)) {
+            WebSocketTransport transport = new WebSocketTransport(new HashMap<>(), httpClient);
+            AtomicBoolean closeCallbackRan = new AtomicBoolean(false);
+            AtomicReference<String> closeReason = new AtomicReference<>("the close callback never ran");
+            transport.setOnReceive((message) -> { });
+            transport.setOnClose((reason) -> {
+                closeReason.set(reason);
+                closeCallbackRan.set(true);
+            });
+
+            assertTrue(transport.start(server.getUrl()).blockingAwait(30, TimeUnit.SECONDS),
+                    "The WebSocket transport never connected.");
+
+            long startedAt = System.nanoTime();
+            boolean stopped = transport.stop().onErrorComplete().blockingAwait(30, TimeUnit.SECONDS);
+            long elapsedMillis = (System.nanoTime() - startedAt) / 1_000_000;
+
+            assertTrue(stopped, "stop() did not complete against a peer that answered the close frame.");
+
+            // The peer delays its answer, so a stop that came back before it cannot have waited for the
+            // close handshake. onClosing also invokes the close callback before completing closeSubject,
+            // so a stop that did wait has already run it.
+            assertTrue(elapsedMillis >= LoopbackWebSocketServer.CLOSE_ANSWER_DELAY_MILLIS,
+                    "stop() completed in " + elapsedMillis + "ms, before the peer answered the close frame, so it did not wait for the close handshake.");
+            assertTrue(closeCallbackRan.get(),
+                    "stop() completed before any close callback ran, so it returned on the close timer rather than on the close handshake.");
+            assertNull(closeReason.get(),
+                    "A clean 1000 close was reported to the transport as an error close, reason: " + closeReason.get());
+            assertTrue(elapsedMillis < CLOSE_TIMEOUT_MILLIS,
+                    "stop() took " + elapsedMillis + "ms, so it waited out the close timeout instead of the peer's close frame.");
+        }
+    }
+
+    @Test
+    public void stopReportsAnErrorCloseWhenTheCloseTimeoutCancelsTheSocket() throws Exception {
+        try (LoopbackWebSocketServer server = new LoopbackWebSocketServer(false);
+                DefaultHttpClient httpClient = new DefaultHttpClient(new OkHttpClient(), null)) {
+            WebSocketTransport transport = new WebSocketTransport(new HashMap<>(), httpClient);
+            CountDownLatch closeCallbackRan = new CountDownLatch(1);
+            AtomicReference<String> closeReason = new AtomicReference<>();
+            transport.setOnReceive((message) -> { });
+            transport.setOnClose((reason) -> {
+                closeReason.set(reason);
+                closeCallbackRan.countDown();
+            });
+
+            assertTrue(transport.start(server.getUrl()).blockingAwait(30, TimeUnit.SECONDS),
+                    "The WebSocket transport never connected.");
+
+            assertTrue(transport.stop().onErrorComplete().blockingAwait(30, TimeUnit.SECONDS),
+                    "stop() did not complete while the peer left the close frame unanswered.");
+
+            // Cancelling reports the socket as failed rather than cleanly closed, so unlike the answered
+            // close above the transport sees a reason instead of null. That is the same tradeoff the .NET
+            // client makes when its CloseTimeout expires.
+            assertTrue(closeCallbackRan.await(30, TimeUnit.SECONDS), "The close callback never ran.");
+            assertNotNull(closeReason.get(),
+                    "A close the peer never answered was reported as a clean close, which hides the ungraceful shutdown.");
+        }
+    }
+
+    // A peer that completes the WebSocket handshake and then either answers the client's close frame or
+    // deliberately leaves it unanswered. TestHttpClient runs its handlers inline on the caller's thread,
+    // so only a real socket can hold a close handshake open like this.
+    private static final class LoopbackWebSocketServer implements Closeable {
+        private static final String WEBSOCKET_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+        private static final String KEY_HEADER = "Sec-WebSocket-Key:";
+        private static final int OPCODE_CLOSE = 0x8;
+
+        // Answer the close frame late enough that a stop which never waited for the close handshake is
+        // distinguishable from one that did, but well inside the wrapper's close timeout. Without this a
+        // loopback peer answers so fast that both look identical from the test thread.
+        static final long CLOSE_ANSWER_DELAY_MILLIS = 750;
+
+        private final ServerSocket serverSocket;
+        private final boolean answerClose;
+        private final CountDownLatch closeFrameReceived = new CountDownLatch(1);
+        private volatile Socket connection;
+
+        LoopbackWebSocketServer(boolean answerClose) throws IOException {
+            this.answerClose = answerClose;
+            this.serverSocket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress());
+            Thread thread = new Thread(this::run, "loopback-websocket-server");
+            thread.setDaemon(true);
+            thread.start();
+        }
+
+        String getUrl() {
+            return "http://" + serverSocket.getInetAddress().getHostAddress() + ":" + serverSocket.getLocalPort();
+        }
+
+        String getWebSocketUrl() {
+            return "ws://" + serverSocket.getInetAddress().getHostAddress() + ":" + serverSocket.getLocalPort();
+        }
+
+        boolean awaitCloseFrame(long timeout, TimeUnit unit) throws InterruptedException {
+            return closeFrameReceived.await(timeout, unit);
+        }
+
+        private void run() {
+            try (Socket socket = serverSocket.accept()) {
+                connection = socket;
+                InputStream input = socket.getInputStream();
+                OutputStream output = socket.getOutputStream();
+
+                String accept = acceptFor(readWebSocketKey(input));
+                output.write(("HTTP/1.1 101 Switching Protocols\r\n"
+                        + "Upgrade: websocket\r\n"
+                        + "Connection: Upgrade\r\n"
+                        + "Sec-WebSocket-Accept: " + accept + "\r\n\r\n").getBytes(StandardCharsets.UTF_8));
+                output.flush();
+
+                // Nothing is ever sent over this connection, so the first frame the client writes is its
+                // close frame.
+                int firstByte = input.read();
+                if (firstByte != -1 && (firstByte & 0x0F) == OPCODE_CLOSE) {
+                    consumeFrameBody(input);
+                    closeFrameReceived.countDown();
+
+                    if (answerClose) {
+                        Thread.sleep(CLOSE_ANSWER_DELAY_MILLIS);
+                        // An unmasked close frame carrying status code 1000.
+                        output.write(new byte[] { (byte) 0x88, 0x02, 0x03, (byte) 0xE8 });
+                        output.flush();
+                    }
+                }
+
+                while (input.read() != -1) {
+                    // Hold the connection open until the client gives up or finishes closing.
+                }
+            } catch (Exception ex) {
+                // The test closes the sockets out from under this thread when it finishes.
+            }
+        }
+
+        // Reads the rest of a client frame, which is always masked and, for a close, always short.
+        private static void consumeFrameBody(InputStream input) throws IOException {
+            int second = readByte(input);
+            int length = second & 0x7F;
+            if ((second & 0x80) != 0) {
+                skip(input, 4);
+            }
+
+            skip(input, length);
+        }
+
+        private static void skip(InputStream input, int count) throws IOException {
+            for (int i = 0; i < count; i++) {
+                readByte(input);
+            }
+        }
+
+        private static int readByte(InputStream input) throws IOException {
+            int value = input.read();
+            if (value == -1) {
+                throw new EOFException("The client closed the socket mid frame.");
+            }
+
+            return value;
+        }
+
+        private static String readWebSocketKey(InputStream input) throws IOException {
+            StringBuilder request = new StringBuilder();
+            int b;
+            while ((b = input.read()) != -1) {
+                request.append((char) b);
+                if (request.length() >= 4 && request.lastIndexOf("\r\n\r\n") == request.length() - 4) {
+                    break;
+                }
+            }
+
+            for (String line : request.toString().split("\r\n")) {
+                if (line.regionMatches(true, 0, KEY_HEADER, 0, KEY_HEADER.length())) {
+                    return line.substring(KEY_HEADER.length()).trim();
+                }
+            }
+
+            throw new IOException("The upgrade request did not contain a " + KEY_HEADER + " header.");
+        }
+
+        private static String acceptFor(String key) throws Exception {
+            MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
+            byte[] hash = sha1.digest((key + WEBSOCKET_GUID).getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(hash);
+        }
+
+        @Override
+        public void close() throws IOException {
+            serverSocket.close();
+            Socket socket = connection;
+            if (socket != null) {
+                socket.close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Follow up from feedback on https://github.com/dotnet/aspnetcore/pull/69037

Fix Java client lifecycle bugs where a failed start leaks a transport and stop() hangs

## Description

A `HubConnection.start()` that fails part way through left the connection state in place, which kept the transport and its timers running forever. A later `stop()` short circuits on the `DISCONNECTED` state, so nothing ever cleaned them up. Separately, a `stop()` could hang indefinitely waiting on a subject that was never going to complete. This fixes both, and brings the failure path closer to what the .NET and TypeScript clients already do.

### Releasing and tearing down a failed attempt

When a start fails, `HubConnection` now clears the connection state and stops the transport it brought up, and the start task does not complete until that teardown finishes. Keeping the wait with the caller that is already failing means nothing is left running behind a start that has already reported failure. Teardown errors are swallowed rather than surfaced, since the original start error is the one the caller cares about.

`stop()` on an already-`DISCONNECTED` connection now waits on that pending teardown instead of immediately reporting stopped while a teardown is still in flight. Both paths route through a single shared `stopTransport()` on `ConnectionState`, so a transport is never stopped twice.

### Scoping transport callbacks to their attempt

`setOnReceive`/`setOnClose` previously pointed at instance level callbacks. An abandoned transport from a failed attempt could therefore deliver a message to, or close, whatever connection replaced it. Callbacks are now scoped to the attempt that owns them and no-op once that attempt is no longer current.

### Two hangs

- `LongPollingTransport`: the receive loop only starts once the first poll succeeds, so `receiveLoopSubject` never completed when start failed. `stop()` waits on that subject after sending DELETE, so a `stop()` racing a failed start waited forever. It is now completed on the error path.
- `OkHttpWebSocketWrapper`: OkHttp waits a full 60s before cancelling a close the peer never answered. That wait is now bounded to 5s, matching the .NET client's `HttpConnectionOptions.CloseTimeout` default, after which the socket is cancelled. The cancellation path is bounded too, because nothing in stop may leave a caller hanging. A failed start against an unresponsive peer goes from 61.2s to 6.2s.

### Worth a closer look

- The `catch (Throwable)` in `DefaultHttpClient` was narrowed to `catch (Exception)`.
- `test/build.gradle` gains an explicit `okhttp` dependency. `:core` declares okhttp as `implementation`, so it is not on the test module's compile classpath, and `OkHttpWebSocketWrapperTest` drives the real wrapper against a live `OkHttpClient` rather than a mock.
- `OkHttpWebSocketWrapperTest` has two tests that legitimately take about 5s each, because they exercise the new close timeout end to end.

Full Java client suite is green: 304 tests, 0 failures, 0 errors, confirmed stable over three consecutive runs (these tests use real sockets and timers, so it was worth checking for flakiness).

Fixes N/A