### PR TITLE
[ResponseCaching] Include retained cache key bytes in MemoryCacheEntryOptions.Size

### DIFF
--- a/src/Middleware/ResponseCaching/src/MemoryResponseCache.cs
+++ b/src/Middleware/ResponseCaching/src/MemoryResponseCache.cs
@@ -36,10 +36,12 @@ internal sealed class MemoryResponseCache : IResponseCache
 
     public void Set(string key, IResponseCacheEntry entry, TimeSpan validFor)
     {
+        var keyBytes = (long)(key?.Length ?? 0) * sizeof(char);
+
         if (entry is CachedResponse cachedResponse)
         {
             _cache.Set(
-                key,
+                key!,
                 new MemoryCachedResponse
                 {
                     Created = cachedResponse.Created,
@@ -50,18 +52,18 @@ internal sealed class MemoryResponseCache : IResponseCache
                 new MemoryCacheEntryOptions
                 {
                     AbsoluteExpirationRelativeToNow = validFor,
-                    Size = CacheEntryHelpers.EstimateCachedResponseSize(cachedResponse)
+                    Size = checked(CacheEntryHelpers.EstimateCachedResponseSize(cachedResponse) + keyBytes)
                 });
         }
         else
         {
             _cache.Set(
-                key,
+                key!,
                 entry,
                 new MemoryCacheEntryOptions
                 {
                     AbsoluteExpirationRelativeToNow = validFor,
-                    Size = CacheEntryHelpers.EstimateCachedVaryByRulesySize(entry as CachedVaryByRules)
+                    Size = checked(CacheEntryHelpers.EstimateCachedVaryByRulesySize(entry as CachedVaryByRules) + keyBytes)
                 });
         }
     }

--- a/src/Middleware/ResponseCaching/src/ResponseCachingOptions.cs
+++ b/src/Middleware/ResponseCaching/src/ResponseCachingOptions.cs
@@ -9,10 +9,14 @@ namespace Microsoft.AspNetCore.ResponseCaching;
 public class ResponseCachingOptions
 {
     /// <summary>
-    /// The size limit for the response cache middleware in bytes. The default is set to 100 MB.
-    /// When this limit is exceeded, no new responses will be cached until older entries are
-    /// evicted.
+    /// The size limit for the response cache middleware in bytes. The default is set to 100MB (104,857,600 bytes).
+    /// When set, cache size estimation includes the UTF-16 byte content of retained cache keys in addition to
+    /// cached response headers, body payloads, and vary-by rules.
     /// </summary>
+    /// <remarks>
+    /// Because cache keys are included in size estimation, caches configured with a <see cref="SizeLimit"/>
+    /// may reach capacity earlier and retain fewer entries than in previous versions.
+    /// </remarks>
     public long SizeLimit { get; set; } = 100 * 1024 * 1024;
 
     /// <summary>

--- a/src/Middleware/ResponseCaching/test/MemoryResponseCacheTests.cs
+++ b/src/Middleware/ResponseCaching/test/MemoryResponseCacheTests.cs
@@ -1,0 +1,229 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
+
+#nullable enable
+
+namespace Microsoft.AspNetCore.ResponseCaching.Tests;
+
+public class MemoryResponseCacheTests
+{
+    private sealed class TestCacheEntry : ICacheEntry
+    {
+        public TestCacheEntry(object key)
+        {
+            Key = key;
+        }
+
+        public object Key { get; }
+        public object? Value { get; set; }
+        public DateTimeOffset? AbsoluteExpiration { get; set; }
+        public TimeSpan? AbsoluteExpirationRelativeToNow { get; set; }
+        public TimeSpan? SlidingExpiration { get; set; }
+        public IList<IChangeToken> ExpirationTokens { get; } = new List<IChangeToken>();
+        public IList<PostEvictionCallbackRegistration> PostEvictionCallbacks { get; } = new List<PostEvictionCallbackRegistration>();
+        public CacheItemPriority Priority { get; set; }
+        public long? Size { get; set; }
+
+        public void Dispose() { }
+    }
+
+    private sealed class TestMemoryCache : IMemoryCache
+    {
+        public TestCacheEntry? LastCreatedEntry { get; private set; }
+
+        public ICacheEntry CreateEntry(object key)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+            LastCreatedEntry = new TestCacheEntry(key);
+            return LastCreatedEntry;
+        }
+
+        public void Remove(object key) { }
+
+        public bool TryGetValue(object key, out object? value)
+        {
+            value = null;
+            return false;
+        }
+
+        public void Dispose() { }
+    }
+
+    private sealed class DummyResponseCacheEntry : IResponseCacheEntry
+    {
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("a")]
+    [InlineData("key")]
+    [InlineData("a-much-longer-cache-key-string-for-testing")]
+    public void Set_CachedResponse_IncludesKeyByteContentInSize(string key)
+    {
+        var stubCache = new TestMemoryCache();
+        var cache = new MemoryResponseCache(stubCache);
+        var response = new CachedResponse
+        {
+            StatusCode = StatusCodes.Status200OK,
+            Headers = new HeaderDictionary
+            {
+                { "Content-Type", "text/plain" },
+                { "Custom-Header", "CustomValue" }
+            },
+            Body = new CachedResponseBody(new List<byte[]> { new byte[64] }, 64)
+        };
+
+        var expectedValueSize = CacheEntryHelpers.EstimateCachedResponseSize(response);
+        var expectedKeyBytes = (long)key.Length * sizeof(char);
+
+        cache.Set(key, response, TimeSpan.FromMinutes(1));
+
+        Assert.NotNull(stubCache.LastCreatedEntry);
+        Assert.Equal(key, stubCache.LastCreatedEntry.Key);
+        Assert.Equal(expectedValueSize + expectedKeyBytes, stubCache.LastCreatedEntry.Size);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("vary-key")]
+    [InlineData("vary-key-with-a-longer-name-to-verify-accounting")]
+    public void Set_CachedVaryByRules_IncludesKeyByteContentInSize(string key)
+    {
+        var stubCache = new TestMemoryCache();
+        var cache = new MemoryResponseCache(stubCache);
+        var rules = new CachedVaryByRules
+        {
+            VaryByKeyPrefix = "prefix",
+            Headers = new StringValues(new[] { "Accept", "Accept-Encoding" }),
+            QueryKeys = new StringValues(new[] { "q", "page" })
+        };
+
+        var expectedValueSize = CacheEntryHelpers.EstimateCachedVaryByRulesySize(rules);
+        var expectedKeyBytes = (long)key.Length * sizeof(char);
+
+        cache.Set(key, rules, TimeSpan.FromMinutes(1));
+
+        Assert.NotNull(stubCache.LastCreatedEntry);
+        Assert.Equal(key, stubCache.LastCreatedEntry.Key);
+        Assert.Equal(expectedValueSize + expectedKeyBytes, stubCache.LastCreatedEntry.Size);
+    }
+
+    [Fact]
+    public void Set_UTF16CharacterHandling_UsesCodeUnitsWithoutTranscoding()
+    {
+        var stubCache = new TestMemoryCache();
+        var cache = new MemoryResponseCache(stubCache);
+        var response = new CachedResponse
+        {
+            StatusCode = StatusCodes.Status200OK,
+            Headers = new HeaderDictionary(),
+            Body = new CachedResponseBody(new List<byte[]> { new byte[10] }, 10)
+        };
+        var expectedValueSize = CacheEntryHelpers.EstimateCachedResponseSize(response);
+
+        // 1. ASCII: 5 characters = 5 UTF-16 code units = 10 bytes
+        var asciiKey = "hello";
+        cache.Set(asciiKey, response, TimeSpan.FromMinutes(1));
+        Assert.Equal(expectedValueSize + (5 * sizeof(char)), stubCache.LastCreatedEntry!.Size);
+
+        // 2. BMP (Basic Multilingual Plane): "\u4e2d\u6587" (Chinese characters) = 2 characters = 4 bytes
+        var bmpKey = "\u4e2d\u6587";
+        Assert.Equal(2, bmpKey.Length);
+        cache.Set(bmpKey, response, TimeSpan.FromMinutes(1));
+        Assert.Equal(expectedValueSize + 4, stubCache.LastCreatedEntry!.Size);
+
+        // 3. Surrogate pair emoji: "🚀" (\uD83D\uDE80) = 2 code units = 4 bytes in UTF-16
+        var emojiKey = "🚀";
+        Assert.Equal(2, emojiKey.Length);
+        cache.Set(emojiKey, response, TimeSpan.FromMinutes(1));
+        Assert.Equal(expectedValueSize + 4, stubCache.LastCreatedEntry!.Size);
+
+        // 4. Multiple surrogate pairs: "🚀🎉" = 4 code units = 8 bytes in UTF-16
+        var multiEmojiKey = "🚀🎉";
+        Assert.Equal(4, multiEmojiKey.Length);
+        cache.Set(multiEmojiKey, response, TimeSpan.FromMinutes(1));
+        Assert.Equal(expectedValueSize + 8, stubCache.LastCreatedEntry!.Size);
+    }
+
+    [Fact]
+    public void Set_EmptyKey_SizeMatchesValueEstimateAlone()
+    {
+        var stubCache = new TestMemoryCache();
+        var cache = new MemoryResponseCache(stubCache);
+        var response = new CachedResponse
+        {
+            StatusCode = StatusCodes.Status200OK,
+            Headers = new HeaderDictionary(),
+            Body = new CachedResponseBody(new List<byte[]> { new byte[32] }, 32)
+        };
+
+        var expectedValueSize = CacheEntryHelpers.EstimateCachedResponseSize(response);
+        cache.Set("", response, TimeSpan.FromMinutes(1));
+
+        Assert.NotNull(stubCache.LastCreatedEntry);
+        Assert.Equal(expectedValueSize, stubCache.LastCreatedEntry.Size);
+    }
+
+    [Fact]
+    public void Set_NullKey_ThrowsArgumentNullExceptionFromBackingCache()
+    {
+        var stubCache = new TestMemoryCache();
+        var cacheWithStub = new MemoryResponseCache(stubCache);
+        var response = new CachedResponse
+        {
+            StatusCode = StatusCodes.Status200OK,
+            Headers = new HeaderDictionary(),
+            Body = new CachedResponseBody(new List<byte[]>(), 0)
+        };
+
+        // Stub cache verification
+        Assert.Throws<ArgumentNullException>(() => cacheWithStub.Set(null!, response, TimeSpan.FromMinutes(1)));
+
+        // Real MemoryCache verification
+        using var realMemoryCache = new MemoryCache(new MemoryCacheOptions());
+        var cacheWithReal = new MemoryResponseCache(realMemoryCache);
+        Assert.Throws<ArgumentNullException>(() => cacheWithReal.Set(null!, response, TimeSpan.FromMinutes(1)));
+    }
+
+    [Fact]
+    public void Set_FallbackEntry_ChargesFallbackEstimatePlusKeyBytes()
+    {
+        var stubCache = new TestMemoryCache();
+        var cache = new MemoryResponseCache(stubCache);
+        var dummyEntry = new DummyResponseCacheEntry();
+        var key = "fallback-test-key";
+        var expectedKeyBytes = (long)key.Length * sizeof(char);
+
+        cache.Set(key, dummyEntry, TimeSpan.FromMinutes(1));
+
+        Assert.NotNull(stubCache.LastCreatedEntry);
+        // Fallback estimate for non-CachedVaryByRules is EstimateCachedVaryByRulesySize(null) == 0
+        Assert.Equal(expectedKeyBytes, stubCache.LastCreatedEntry.Size);
+    }
+
+    [Fact]
+    public void Set_CheckedArithmeticOverflow_ThrowsOverflowException()
+    {
+        var stubCache = new TestMemoryCache();
+        var cache = new MemoryResponseCache(stubCache);
+
+        // Zero-allocation overflow: CachedResponseBody with length near long.MaxValue
+        // EstimateCachedResponseSize computes: sizeof(int) [4] + Body.Length
+        // With Body.Length = long.MaxValue - 10, EstimateCachedResponseSize returns long.MaxValue - 6
+        var response = new CachedResponse
+        {
+            StatusCode = StatusCodes.Status200OK,
+            Headers = new HeaderDictionary(),
+            Body = new CachedResponseBody(new List<byte[]>(), long.MaxValue - 10)
+        };
+
+        // Key length 10 = 20 bytes. (long.MaxValue - 6) + 20 overflows long.MaxValue
+        var key = new string('x', 10);
+
+        Assert.Throws<OverflowException>(() => cache.Set(key, response, TimeSpan.FromMinutes(1)));
+    }
+}

--- a/src/Middleware/ResponseCaching/test/ResponseCachingMiddlewareTests.cs
+++ b/src/Middleware/ResponseCaching/test/ResponseCachingMiddlewareTests.cs
@@ -1120,4 +1120,200 @@ public class ResponseCachingMiddlewareTests
         var subsequentContent = await subsequentResponse.Content.ReadAsStringAsync();
         Assert.NotEqual(initialContent, subsequentContent);
     }
+
+    [Fact]
+    public async Task KeyDrivenRejection_UnvariedResponse_AdmittedWhenKeyShort_RejectedWhenKeyLong()
+    {
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                    .UseTestServer()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddResponseCaching(options =>
+                        {
+                            options.SizeLimit = 350;
+                        });
+                    })
+                    .Configure(app =>
+                    {
+                        app.UseResponseCaching();
+                        app.Run(async context =>
+                        {
+                            context.Response.Headers.CacheControl = new CacheControlHeaderValue
+                            {
+                                Public = true,
+                                MaxAge = TimeSpan.FromSeconds(10)
+                            }.ToString();
+                            await context.Response.WriteAsync(Guid.NewGuid().ToString());
+                        });
+                    });
+            })
+            .Build();
+
+        await host.StartAsync();
+
+        using var server = host.GetTestServer();
+        var client = server.CreateClient();
+
+        // 1. Short path: fits within SizeLimit (350 bytes)
+        var shortInitial = await client.GetAsync("/short");
+        var shortSubsequent = await client.GetAsync("/short");
+
+        shortInitial.EnsureSuccessStatusCode();
+        shortSubsequent.EnsureSuccessStatusCode();
+        Assert.True(shortSubsequent.Headers.Contains(HeaderNames.Age));
+        Assert.Equal(await shortInitial.Content.ReadAsStringAsync(), await shortSubsequent.Content.ReadAsStringAsync());
+
+        // 2. Long path: response body and headers are identical, but key bytes push total size over SizeLimit
+        var longPath = "/long/" + new string('a', 150);
+        var longInitial = await client.GetAsync(longPath);
+        var longSubsequent = await client.GetAsync(longPath);
+
+        longInitial.EnsureSuccessStatusCode();
+        longSubsequent.EnsureSuccessStatusCode();
+        Assert.False(longSubsequent.Headers.Contains(HeaderNames.Age));
+        Assert.NotEqual(await longInitial.Content.ReadAsStringAsync(), await longSubsequent.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task DecoupledVaryBy_BaseKeyAdmitted_VariedResponseRejectedDueToSize()
+    {
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions { SizeLimit = 350 });
+        var responseCache = new MemoryResponseCache(memoryCache);
+
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                    .UseTestServer()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddResponseCaching(options =>
+                        {
+                            options.SizeLimit = 350;
+                        });
+                    })
+                    .Configure(app =>
+                    {
+                        app.Use((context, next) =>
+                        {
+                            var middleware = TestUtils.CreateTestMiddleware(
+                                next,
+                                cache: responseCache,
+                                options: new ResponseCachingOptions { SizeLimit = 350 },
+                                policyProvider: new ResponseCachingPolicyProvider());
+                            return middleware.Invoke(context);
+                        });
+                        app.Run(async context =>
+                        {
+                            context.Response.Headers.CacheControl = new CacheControlHeaderValue
+                            {
+                                Public = true,
+                                MaxAge = TimeSpan.FromSeconds(10)
+                            }.ToString();
+                            context.Response.Headers.Vary = "X-Custom";
+                            // Large payload (500 bytes) ensures response size exceeds SizeLimit (350),
+                            // while base key + CachedVaryByRules fits (~160 bytes)
+                            await context.Response.WriteAsync(Guid.NewGuid().ToString() + new string('x', 500));
+                        });
+                    });
+            })
+            .Build();
+
+        await host.StartAsync();
+
+        using var server = host.GetTestServer();
+        var client = server.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Custom", "value1");
+
+        // Initial request: base key + CachedVaryByRules is admitted, but varied response is rejected
+        var initialResponse = await client.GetAsync("/vary-short");
+        initialResponse.EnsureSuccessStatusCode();
+
+        // Exactly one entry in the cache: CachedVaryByRules under the base key
+        Assert.Equal(1, memoryCache.Count);
+
+        // Subsequent request with the same vary header:
+        // Decoupled admission failure must not throw or terminate the pipeline
+        var subsequentResponse = await client.GetAsync("/vary-short");
+        subsequentResponse.EnsureSuccessStatusCode();
+
+        // Fresh response served because the varied response was rejected due to size
+        Assert.False(subsequentResponse.Headers.Contains(HeaderNames.Age));
+        Assert.NotEqual(await initialResponse.Content.ReadAsStringAsync(), await subsequentResponse.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task DecoupledVaryBy_BaseKeyRejectedDueToSize_VariedResponseAdmitted()
+    {
+        using var memoryCache = new MemoryCache(new MemoryCacheOptions { SizeLimit = 350 });
+        var responseCache = new MemoryResponseCache(memoryCache);
+
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                    .UseTestServer()
+                    .ConfigureServices(services =>
+                    {
+                        services.AddResponseCaching(options =>
+                        {
+                            options.SizeLimit = 350;
+                        });
+                    })
+                    .Configure(app =>
+                    {
+                        app.Use((context, next) =>
+                        {
+                            var middleware = TestUtils.CreateTestMiddleware(
+                                next,
+                                cache: responseCache,
+                                options: new ResponseCachingOptions { SizeLimit = 350 },
+                                policyProvider: new ResponseCachingPolicyProvider());
+                            return middleware.Invoke(context);
+                        });
+                        app.Run(async context =>
+                        {
+                            context.Response.Headers.CacheControl = new CacheControlHeaderValue
+                            {
+                                Public = true,
+                                MaxAge = TimeSpan.FromSeconds(10)
+                            }.ToString();
+                            context.Response.Headers.Vary = "X-Custom";
+                            // Small payload ensures varied response + short storage vary key fits in SizeLimit (350),
+                            // while the long base key (> 180 chars -> > 360 bytes) pushes CachedVaryByRules over SizeLimit
+                            await context.Response.WriteAsync(Guid.NewGuid().ToString());
+                        });
+                    });
+            })
+            .Build();
+
+        await host.StartAsync();
+
+        using var server = host.GetTestServer();
+        var client = server.CreateClient();
+        client.DefaultRequestHeaders.Add("X-Custom", "value1");
+
+        // Long path makes base key (> 360 bytes) exceed SizeLimit (350), so CachedVaryByRules is rejected.
+        // But storage vary key (which does not include the path) + small response body fits in SizeLimit, so CachedResponse is admitted.
+        var longPath = "/vary-long/" + new string('k', 180);
+
+        var initialResponse = await client.GetAsync(longPath);
+        initialResponse.EnsureSuccessStatusCode();
+
+        // Exactly one entry in the cache: the varied CachedResponse (CachedVaryByRules was rejected)
+        Assert.Equal(1, memoryCache.Count);
+
+        // Subsequent request:
+        // Middleware does not find CachedVaryByRules under base key, so it cannot look up the varied response.
+        // Independent admission failure must not throw or terminate the pipeline.
+        var subsequentResponse = await client.GetAsync(longPath);
+        subsequentResponse.EnsureSuccessStatusCode();
+
+        // Fresh response served because CachedVaryByRules was rejected
+        Assert.False(subsequentResponse.Headers.Contains(HeaderNames.Age));
+        Assert.NotEqual(await initialResponse.Content.ReadAsStringAsync(), await subsequentResponse.Content.ReadAsStringAsync());
+    }
 }


### PR DESCRIPTION
Fixes #69214.

### Description
The built-in Response Caching memory store previously omitted retained storage keys from `MemoryCacheEntryOptions.Size`. While `ResponseCachingOptions.SizeLimit` is budgeted in bytes, `MemoryResponseCache.Set` only charged the estimated payload value (headers, status, body, or vary rules) to the backing cache, leading to under-reported memory usage against the configured limit.

### Changes
- **Key Byte Accounting**: Updated `MemoryResponseCache.Set` to calculate `(long)(key?.Length ?? 0) * sizeof(char)` and add it to `MemoryCacheEntryOptions.Size` within `checked(...)` arithmetic across both the `CachedResponse` and `CachedVaryByRules` branches.
- **Null Key & Contract Safety**: Passed `key!` to `_cache.Set(key!, ...)` to preserve compile-time nullability contracts while ensuring null keys continue to trigger `ArgumentNullException` inside the backing cache. Left `CacheEntryHelpers` unmodified.
- **XML Documentation**: Clarified `ResponseCachingOptions.SizeLimit` XML documentation to explicitly state that cache size estimation includes the UTF-16 byte content of retained keys, noting the capacity impact on configured caches.
- **Unit Tests**: Added `MemoryResponseCacheTests` with a test stub capturing `ICacheEntry.Size` directly:
  - Verified size estimates across varying key lengths for responses and vary-by rules.
  - Asserted UTF-16 code-unit counting across ASCII, BMP (multilingual), and surrogate-pair characters (e.g. emojis).
  - Verified edge cases: empty strings, null keys, and fallback entries.
  - Verified `OverflowException` via a custom stream length without allocating large memory buffers.
- **Integration Tests**: Added tests in `ResponseCachingMiddlewareTests` against bounded caches (`SizeLimit = 350`):
  - Verified key-driven rejection where an identical response payload is cached on a short URI (`/short`), but rejected when a long URI exceeds `SizeLimit`.
  - Verified independent vary-by admission (rules admitted while response rejected, and rules rejected while response admitted) without terminating or throwing in the pipeline.

### Customer Impact
Prevents under-counting memory consumption against `ResponseCachingOptions.SizeLimit`. Caches configured with a `SizeLimit` will more accurately reflect retained memory and may reach capacity earlier.

### Regression?
No.

### Risk
Low. Tightens byte accounting for cache entries to align with the documented contract without altering key generation, value estimators, or public API signatures.