### PR TITLE
[Caching] Distinguish absent and empty cache key values

### DIFF
--- a/src/Middleware/OutputCaching/src/OutputCacheKeyProvider.cs
+++ b/src/Middleware/OutputCaching/src/OutputCacheKeyProvider.cs
@@ -16,7 +16,7 @@ internal sealed class OutputCacheKeyProvider : IOutputCacheKeyProvider
     private const char KeyDelimiter = '\x1e';
     // Use the unit separator for delimiting subcomponents of the cache key to avoid possible collisions
     private const char KeySubDelimiter = '\x1f';
-    // Use the group separator for delimiting a name from its value to avoid possible collisions.
+    // Use the group separator for delimiting a name from its value and representing empty values to avoid possible collisions.
     // A literal '=' cannot be used because it can legitimately appear in decoded header/query names and values.
     private const char KeyNameValueDelimiter = '\x1d';
 
@@ -185,12 +185,10 @@ internal sealed class OutputCacheKeyProvider : IOutputCacheKeyProvider
                         builder.Append(KeySubDelimiter);
                     }
 
-                    if (ContainsDelimiters(headerValuesArray[j]))
+                    if (!TryAppendValue(builder, headerValuesArray[j]))
                     {
                         return false;
                     }
-
-                    builder.Append(headerValuesArray[j]);
                 }
             }
         }
@@ -231,12 +229,10 @@ internal sealed class OutputCacheKeyProvider : IOutputCacheKeyProvider
                             builder.Append(KeySubDelimiter);
                         }
 
-                        if (ContainsDelimiters(queryValueArray[j]))
+                        if (!TryAppendValue(builder, queryValueArray[j]))
                         {
                             return false;
                         }
-
-                        builder.Append(queryValueArray[j]);
                     }
                 }
             }
@@ -264,12 +260,10 @@ internal sealed class OutputCacheKeyProvider : IOutputCacheKeyProvider
                             builder.Append(KeySubDelimiter);
                         }
 
-                        if (ContainsDelimiters(queryValueArray[j]))
+                        if (!TryAppendValue(builder, queryValueArray[j]))
                         {
                             return false;
                         }
-
-                        builder.Append(queryValueArray[j]);
                     }
                 }
             }
@@ -339,6 +333,25 @@ internal sealed class OutputCacheKeyProvider : IOutputCacheKeyProvider
                     .Append(KeyNameValueDelimiter)
                     .Append(value);
             }
+        }
+
+        return true;
+    }
+
+    private static bool TryAppendValue(StringBuilder builder, string? value)
+    {
+        if (ContainsDelimiters(value))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrEmpty(value))
+        {
+            builder.Append(KeyNameValueDelimiter);
+        }
+        else
+        {
+            builder.Append(value);
         }
 
         return true;

--- a/src/Middleware/OutputCaching/test/OutputCacheKeyProviderTests.cs
+++ b/src/Middleware/OutputCaching/test/OutputCacheKeyProviderTests.cs
@@ -208,6 +208,19 @@ public class OutputCacheKeyProviderTests
     }
 
     [Fact]
+    public void OutputCachingKeyProvider_CreateStorageKey_EmptyHeaderValueDoesNotCollideWithAbsentHeader()
+    {
+        var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
+        var absentContext = TestUtils.CreateTestContext();
+        absentContext.CacheVaryByRules.HeaderNames = new string[] { "HeaderA" };
+        var emptyContext = TestUtils.CreateTestContext();
+        emptyContext.HttpContext.Request.Headers["HeaderA"] = string.Empty;
+        emptyContext.CacheVaryByRules.HeaderNames = new string[] { "HeaderA" };
+
+        Assert.NotEqual(cacheKeyProvider.CreateStorageKey(absentContext), cacheKeyProvider.CreateStorageKey(emptyContext));
+    }
+
+    [Fact]
     public void OutputCachingKeyProvider_CreateStorageKey_IncludesListedQueryKeysOnly()
     {
         var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
@@ -289,6 +302,19 @@ public class OutputCacheKeyProviderTests
         // Explicit query keys uses the casing specified in the setting.
         Assert.Equal($"{context.CacheVaryByRules.CacheKeyPrefix}{KeyDelimiter}{EmptyBaseKey}{KeyDelimiter}Q{KeyDelimiter}QUERYA{KeyNameValueDelimiter}ValueB{KeySubDelimiter}ValueA",
             cacheKeyProvider.CreateStorageKey(context));
+    }
+
+    [Fact]
+    public void OutputCachingKeyProvider_CreateStorageKey_EmptyQueryValueDoesNotCollideWithAbsentQuery()
+    {
+        var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
+        var absentContext = TestUtils.CreateTestContext();
+        absentContext.CacheVaryByRules.QueryKeys = new string[] { "QueryA" };
+        var emptyContext = TestUtils.CreateTestContext();
+        emptyContext.HttpContext.Request.QueryString = new QueryString("?QueryA=");
+        emptyContext.CacheVaryByRules.QueryKeys = new string[] { "QueryA" };
+
+        Assert.NotEqual(cacheKeyProvider.CreateStorageKey(absentContext), cacheKeyProvider.CreateStorageKey(emptyContext));
     }
 
     [Fact]

--- a/src/Middleware/ResponseCaching/src/ResponseCachingKeyProvider.cs
+++ b/src/Middleware/ResponseCaching/src/ResponseCachingKeyProvider.cs
@@ -15,7 +15,7 @@ internal sealed class ResponseCachingKeyProvider : IResponseCachingKeyProvider
     private const char KeyDelimiter = '\x1e';
     // Use the unit separator for delimiting subcomponents of the cache key to avoid possible collisions
     private const char KeySubDelimiter = '\x1f';
-    // Use the group separator for delimiting a name from its value to avoid possible collisions.
+    // Use the group separator for delimiting a name from its value and representing empty values to avoid possible collisions.
     // A literal '=' cannot be used because it can legitimately appear in decoded header/query names and values.
     private const char KeyNameValueDelimiter = '\x1d';
 
@@ -130,8 +130,7 @@ internal sealed class ResponseCachingKeyProvider : IResponseCachingKeyProvider
                             builder.Append(KeySubDelimiter);
                         }
 
-                        ThrowIfContainsDelimiters(headerValuesArray[j]);
-                        builder.Append(headerValuesArray[j]);
+                        AppendValue(builder, headerValuesArray[j]);
                     }
                 }
             }
@@ -167,8 +166,7 @@ internal sealed class ResponseCachingKeyProvider : IResponseCachingKeyProvider
                                 builder.Append(KeySubDelimiter);
                             }
 
-                            ThrowIfContainsDelimiters(queryValueArray[j]);
-                            builder.Append(queryValueArray[j]);
+                            AppendValue(builder, queryValueArray[j]);
                         }
                     }
                 }
@@ -191,8 +189,7 @@ internal sealed class ResponseCachingKeyProvider : IResponseCachingKeyProvider
                                 builder.Append(KeySubDelimiter);
                             }
 
-                            ThrowIfContainsDelimiters(queryValueArray[j]);
-                            builder.Append(queryValueArray[j]);
+                            AppendValue(builder, queryValueArray[j]);
                         }
                     }
                 }
@@ -203,6 +200,19 @@ internal sealed class ResponseCachingKeyProvider : IResponseCachingKeyProvider
         finally
         {
             _builderPool.Return(builder);
+        }
+    }
+
+    private static void AppendValue(StringBuilder builder, string? value)
+    {
+        ThrowIfContainsDelimiters(value);
+        if (string.IsNullOrEmpty(value))
+        {
+            builder.Append(KeyNameValueDelimiter);
+        }
+        else
+        {
+            builder.Append(value);
         }
     }
 

--- a/src/Middleware/ResponseCaching/test/ResponseCachingKeyProviderTests.cs
+++ b/src/Middleware/ResponseCaching/test/ResponseCachingKeyProviderTests.cs
@@ -140,6 +140,25 @@ public class ResponseCachingKeyProviderTests
     }
 
     [Fact]
+    public void ResponseCachingKeyProvider_CreateStorageVaryKey_EmptyHeaderValueDoesNotCollideWithAbsentHeader()
+    {
+        var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
+        var absentContext = TestUtils.CreateTestContext();
+        absentContext.CachedVaryByRules = new CachedVaryByRules()
+        {
+            Headers = new string[] { "HeaderA" }
+        };
+        var emptyContext = TestUtils.CreateTestContext();
+        emptyContext.HttpContext.Request.Headers["HeaderA"] = string.Empty;
+        emptyContext.CachedVaryByRules = new CachedVaryByRules()
+        {
+            Headers = new string[] { "HeaderA" }
+        };
+
+        Assert.NotEqual(cacheKeyProvider.CreateStorageVaryByKey(absentContext), cacheKeyProvider.CreateStorageVaryByKey(emptyContext));
+    }
+
+    [Fact]
     public void ResponseCachingKeyProvider_CreateStorageVaryKey_IncludesListedQueryKeysOnly()
     {
         var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
@@ -223,6 +242,25 @@ public class ResponseCachingKeyProviderTests
         // Explicit query keys uses the casing specified in the setting.
         Assert.Equal($"{context.CachedVaryByRules.VaryByKeyPrefix}{KeyDelimiter}Q{KeyDelimiter}QUERYA{KeyNameValueDelimiter}ValueB{KeySubDelimiter}ValueA",
             cacheKeyProvider.CreateStorageVaryByKey(context));
+    }
+
+    [Fact]
+    public void ResponseCachingKeyProvider_CreateStorageVaryKey_EmptyQueryValueDoesNotCollideWithAbsentQuery()
+    {
+        var cacheKeyProvider = TestUtils.CreateTestKeyProvider();
+        var absentContext = TestUtils.CreateTestContext();
+        absentContext.CachedVaryByRules = new CachedVaryByRules()
+        {
+            QueryKeys = new string[] { "QueryA" }
+        };
+        var emptyContext = TestUtils.CreateTestContext();
+        emptyContext.HttpContext.Request.QueryString = new QueryString("?QueryA=");
+        emptyContext.CachedVaryByRules = new CachedVaryByRules()
+        {
+            QueryKeys = new string[] { "QueryA" }
+        };
+
+        Assert.NotEqual(cacheKeyProvider.CreateStorageVaryByKey(absentContext), cacheKeyProvider.CreateStorageVaryByKey(emptyContext));
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #68943

## Overview

Output Caching and Response Caching previously serialized an absent configured query/header value identically to a present empty value, even though application code can distinguish them with `ContainsKey`. This changes the four affected configured paths and their shared wildcard/multi-value query serialization so cache keys represent presence and value boundaries injectively. The change is limited to the two internal key providers and focused tests; no public API changes.

## Design

None (no public contract change).

The existing ASCII group separator (`\x1d`) remains the name/value delimiter and now also marks each empty value. This was preferred over introducing another reserved character: delimiter validation already prevents user values from containing `\x1d`, so the representation is unambiguous and composes with the existing record (`\x1e`) and unit (`\x1f`) separators.

- Absent configured value: `Name\x1d`
- One empty value: `Name\x1d\x1d`
- Empty then non-empty: `Name\x1d\x1d\x1fValue`

## Implementation

```csharp
// src/Middleware/OutputCaching/src/OutputCacheKeyProvider.cs
// All header, configured-query, and wildcard-query loops use this helper.
// Delimiter-bearing values still disable caching; only empty values gain a marker.
private static bool TryAppendValue(StringBuilder builder, string? value)
{
    if (ContainsDelimiters(value))
    {
        return false;
    }

    if (string.IsNullOrEmpty(value))
    {
        builder.Append(KeyNameValueDelimiter);
    }
    else
    {
        builder.Append(value);
    }

    return true;
}
```

Response Caching applies the same encoding through `AppendValue`, preserving its existing behavior of throwing `CacheKeyDelimiterException` for unsafe values. The affected equivalence classes are:

- Output Caching: varied headers, configured query keys, wildcard query values, and empty elements in multi-value sequences.
- Response Caching: varied headers, configured query keys, wildcard query values, and empty elements in multi-value sequences.

Existing non-empty serialization, original value ordering, wildcard query-key discovery/sorting, and delimiter rejection are unchanged.

## Outcome

| Case | Before | After |
|---|---|---|
| Output Caching configured header: absent vs present-empty | Failed: identical keys | Passed |
| Output Caching configured query: absent vs `?QueryA=` | Failed: identical keys | Passed |
| Response Caching varied header: absent vs present-empty | Failed: identical keys | Passed |
| Response Caching configured query: absent vs `?QueryA=` | Failed: identical keys | Passed |

Each regression was observed failing for the expected identical-key reason before the production change and passing afterward. Additional focused coverage protects wildcard empty query values and empty elements in multi-value query/header sequences. Full validation passed:

- `Microsoft.AspNetCore.OutputCaching.Tests`: 399 passed
- `Microsoft.AspNetCore.ResponseCaching.Tests`: 283 passed

Compatibility: absent and non-empty keys remain byte-for-byte unchanged. Present-empty values intentionally move to corrected keys, causing a one-time miss and safe cache repopulation. Existing distributed cache entries are not proactively purged and continue to expire or be evicted normally.