### PR TITLE
[Identity] Validate RSA passkey public keys

### DIFF
--- a/src/Identity/Core/src/Passkeys/CredentialPublicKey.cs
+++ b/src/Identity/Core/src/Passkeys/CredentialPublicKey.cs
@@ -143,7 +143,41 @@ internal sealed class CredentialPublicKey
 
         reader.ReadEndMap();
 
+        ValidateRSAParameters(rsaParams);
+
         return RSA.Create(rsaParams);
+    }
+
+    private static void ValidateRSAParameters(in RSAParameters parameters)
+    {
+        const int MinimumModulusSizeInBytes = 2048 / 8;
+
+        var modulus = parameters.Modulus.AsSpan();
+        var exponent = parameters.Exponent.AsSpan();
+
+        if (modulus.IsEmpty || modulus[0] == 0)
+        {
+            throw new CborContentException("The RSA modulus is not minimally encoded.");
+        }
+
+        if (modulus.Length < MinimumModulusSizeInBytes ||
+            (modulus.Length == MinimumModulusSizeInBytes && modulus[0] < 0x80))
+        {
+            throw new CborContentException("The RSA modulus must be at least 2048 bits.");
+        }
+
+        if (exponent.IsEmpty || exponent[0] == 0)
+        {
+            throw new CborContentException("The RSA exponent is not minimally encoded.");
+        }
+
+        if ((exponent[^1] & 1) == 0 ||
+            (exponent.Length == 1 && exponent[0] < 3) ||
+            exponent.Length > modulus.Length ||
+            (exponent.Length == modulus.Length && exponent.SequenceCompareTo(modulus) >= 0))
+        {
+            throw new CborContentException("The RSA exponent must be an odd integer between 3 and the modulus.");
+        }
     }
 
     private static ECDsa ParseECDsa(COSEKeyType kty, Ctap2CborReader reader)

--- a/src/Identity/test/Identity.Test/Passkeys/CredentialPublicKeyTest.cs
+++ b/src/Identity/test/Identity.Test/Passkeys/CredentialPublicKeyTest.cs
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Formats.Cbor;
+using System.Security.Cryptography;
+
+namespace Microsoft.AspNetCore.Identity.Test;
+
+public class CredentialPublicKeyTest
+{
+    [Theory]
+    [InlineData(2048)]
+    [InlineData(3072)]
+    public void Decode_AcceptsValidRsaKey(int keySize)
+    {
+        using var rsa = RSA.Create(keySize);
+        var parameters = rsa.ExportParameters(false);
+        var encodedKey = EncodeRsaKey(parameters.Modulus!, parameters.Exponent!);
+
+        var key = CredentialPublicKey.Decode(encodedKey);
+
+        Assert.Equal(encodedKey, key.AsMemory());
+    }
+
+    [Fact]
+    public void Decode_RejectsRsaModulusBelowMinimumKeySize()
+    {
+        using var rsa = RSA.Create(1024);
+        var parameters = rsa.ExportParameters(false);
+        var encodedKey = EncodeRsaKey(parameters.Modulus!, parameters.Exponent!);
+
+        var exception = Assert.Throws<PasskeyException>(() => CredentialPublicKey.Decode(encodedKey));
+
+        Assert.IsType<CborContentException>(exception.InnerException);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Decode_RejectsRsaParameterWithLeadingZero(bool addLeadingZeroToModulus)
+    {
+        using var rsa = RSA.Create(2048);
+        var parameters = rsa.ExportParameters(false);
+        var modulus = parameters.Modulus!;
+        var exponent = parameters.Exponent!;
+
+        if (addLeadingZeroToModulus)
+        {
+            modulus = [0, .. modulus];
+        }
+        else
+        {
+            exponent = [0, .. exponent];
+        }
+
+        var exception = Assert.Throws<PasskeyException>(
+            () => CredentialPublicKey.Decode(EncodeRsaKey(modulus, exponent)));
+
+        Assert.IsType<CborContentException>(exception.InnerException);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(4)]
+    public void Decode_RejectsInvalidRsaExponent(byte exponent)
+    {
+        using var rsa = RSA.Create(2048);
+        var modulus = rsa.ExportParameters(false).Modulus!;
+
+        var exception = Assert.Throws<PasskeyException>(
+            () => CredentialPublicKey.Decode(EncodeRsaKey(modulus, [exponent])));
+
+        Assert.IsType<CborContentException>(exception.InnerException);
+    }
+
+    [Fact]
+    public void Decode_RejectsRsaExponentNotLessThanModulus()
+    {
+        using var rsa = RSA.Create(2048);
+        var modulus = rsa.ExportParameters(false).Modulus!;
+
+        var exception = Assert.Throws<PasskeyException>(
+            () => CredentialPublicKey.Decode(EncodeRsaKey(modulus, modulus)));
+
+        Assert.IsType<CborContentException>(exception.InnerException);
+    }
+
+    private static byte[] EncodeRsaKey(byte[] modulus, byte[] exponent)
+    {
+        var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
+        writer.WriteStartMap(4);
+        writer.WriteInt32(1);
+        writer.WriteInt32(3);
+        writer.WriteInt32(3);
+        writer.WriteInt32((int)COSEAlgorithmIdentifier.RS256);
+        writer.WriteInt32(-1);
+        writer.WriteByteString(modulus);
+        writer.WriteInt32(-2);
+        writer.WriteByteString(exponent);
+        writer.WriteEndMap();
+
+        return writer.Encode();
+    }
+}


### PR DESCRIPTION
Fixes #68367

## Overview

Validates RSA parameters while decoding a passkey `CredentialPublicKey`, before handing the key to the platform cryptography provider. The change is limited to RSA COSE-key parsing and focused unit tests; ECDSA curves and supported-algorithm policy are unchanged. The governing constraint is to reject malformed or insecure encodings without imposing an artificial maximum on valid, OS-supported RSA keys.

## Design

None. `CredentialPublicKey` and the new validation helper are internal, so this changes no public or protected API, signature, default, or convention. API review is not required.

The validation follows RFC 8230 sections 4 and 6.1 and RFC 8017 section 3.1:

- `n` and `e` must be minimally encoded unsigned big-endian byte strings
- `n` must represent a modulus of at least 2048 bits
- `e` must be odd and satisfy `3 <= e < n`
- no maximum modulus size or allowlist of common exponents is introduced

## Implementation

```csharp
// src/Identity/Core/src/Passkeys/CredentialPublicKey.cs
// Validate the untrusted encoded components before RSA.Create performs provider-specific import.
reader.ReadEndMap();
ValidateRSAParameters(rsaParams);
return RSA.Create(rsaParams);
```

```csharp
// src/Identity/Core/src/Passkeys/CredentialPublicKey.cs
// Leading zero bytes violate RFC 8230's minimum-octet representation.
// For example, 65537 must be 0x01_00_01, not 0x00_01_00_01.
if (modulus.IsEmpty || modulus[0] == 0)
{
    throw new CborContentException("The RSA modulus is not minimally encoded.");
}

if (modulus.Length < MinimumModulusSizeInBytes ||
    (modulus.Length == MinimumModulusSizeInBytes && modulus[0] < 0x80))
{
    throw new CborContentException("The RSA modulus must be at least 2048 bits.");
}

// An even exponent cannot be coprime to lambda(n) for an RSA modulus made from odd primes.
// Sequence comparison enforces the remaining public-key bound e < n without integer allocation.
if ((exponent[^1] & 1) == 0 ||
    (exponent.Length == 1 && exponent[0] < 3) ||
    exponent.Length > modulus.Length ||
    (exponent.Length == modulus.Length && exponent.SequenceCompareTo(modulus) >= 0))
{
    throw new CborContentException("The RSA exponent must be an odd integer between 3 and the modulus.");
}
```

The checks operate on spans and preserve `RSA.Create` as the final authority for deeper platform/provider-specific key support.

## Outcome

| Validation | Result |
|---|---|
| Red baseline | 8 malformed-key cases were accepted before the fix: a 1024-bit modulus, leading-zero `n` and `e`, exponents 0/1/2/4, and `e == n` |
| Focused tests | 11/11 pass after the fix, including valid exponent 3 and valid 2048- and 3072-bit controls |
| Broader passkey tests | 256/256 pass |

Limitation: decoding public components cannot cheaply prove that `n` has the required prime factorization or fully establish `gcd(e, lambda(n)) = 1`. Those deeper checks remain with the cryptographic provider; this change intentionally avoids expensive factorization analysis and does not add an application-level maximum key size.