### PR TITLE
[Authorization] Make middleware marker endpoint-specific

### DIFF
--- a/src/Http/Routing/src/EndpointMiddleware.cs
+++ b/src/Http/Routing/src/EndpointMiddleware.cs
@@ -37,7 +37,8 @@ internal sealed partial class EndpointMiddleware
             if (!_routeOptions.SuppressCheckForUnhandledSecurityMetadata)
             {
                 if (AuthorizationMetadataHelper.HasAuthorizationMetadata(endpoint) &&
-                    !httpContext.Items.ContainsKey(AuthorizationMiddlewareInvokedKey))
+                    (!httpContext.Items.TryGetValue(AuthorizationMiddlewareInvokedKey, out var authorizationEndpoint) ||
+                        !ReferenceEquals(authorizationEndpoint, endpoint)))
                 {
                     ThrowMissingAuthMiddlewareException(endpoint);
                 }

--- a/src/Http/Routing/test/FunctionalTests/EndpointRoutingIntegrationTest.cs
+++ b/src/Http/Routing/test/FunctionalTests/EndpointRoutingIntegrationTest.cs
@@ -123,6 +123,46 @@ public class EndpointRoutingIntegrationTest
     }
 
     [Fact]
+    public async Task AuthorizationMiddleware_EndpointChangedAfterAuthorization_Throws()
+    {
+        // Arrange
+        using var host = new HostBuilder()
+            .ConfigureWebHost(webHostBuilder =>
+            {
+                webHostBuilder
+                    .Configure(app =>
+                    {
+                        app.UseRouting();
+                        app.UseAuthorization();
+                        app.Use((context, next) =>
+                        {
+                            context.SetEndpoint(new Endpoint(
+                                TestDelegate,
+                                new EndpointMetadataCollection(new AuthorizeAttribute()),
+                                "Changed endpoint"));
+
+                            return next(context);
+                        });
+                        app.UseEndpoints(b => b.Map("/", TestDelegate).RequireAuthorization());
+                    })
+                    .UseTestServer();
+            })
+            .ConfigureServices(services =>
+            {
+                services.AddAuthorization(options => options.DefaultPolicy = new AuthorizationPolicyBuilder().RequireAssertion(_ => true).Build());
+                services.AddRouting();
+            })
+            .Build();
+
+        using var server = host.GetTestServer();
+
+        await host.StartAsync();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => server.CreateRequest("/").SendAsync("GET"));
+        Assert.StartsWith("Endpoint Changed endpoint contains authorization metadata, but a middleware was not found that supports authorization.", ex.Message);
+    }
+
+    [Fact]
     public async Task AuthorizationMiddleware_NotConfigured_Throws()
     {
         // Arrange

--- a/src/Http/Routing/test/UnitTests/EndpointMiddlewareTest.cs
+++ b/src/Http/Routing/test/UnitTests/EndpointMiddlewareTest.cs
@@ -218,7 +218,7 @@ public class EndpointMiddlewareTest
     }
 
     [Fact]
-    public async Task Invoke_WithEndpoint_WorksIfAuthAttributesWereFound_AndAuthMiddlewareInvoked()
+    public async Task Invoke_WithEndpoint_WorksIfAuthAttributesWereFound_AndAuthMiddlewareInvokedForEndpoint()
     {
         // Arrange
         var httpContext = new DefaultHttpContext
@@ -233,9 +233,10 @@ public class EndpointMiddlewareTest
             return Task.CompletedTask;
         };
 
-        httpContext.SetEndpoint(new Endpoint(endpointFunc, new EndpointMetadataCollection(Mock.Of<IAuthorizeData>()), "Test"));
+        var endpoint = new Endpoint(endpointFunc, new EndpointMetadataCollection(Mock.Of<IAuthorizeData>()), "Test");
+        httpContext.SetEndpoint(endpoint);
 
-        httpContext.Items[EndpointMiddleware.AuthorizationMiddlewareInvokedKey] = true;
+        httpContext.Items[EndpointMiddleware.AuthorizationMiddlewareInvokedKey] = endpoint;
 
         RequestDelegate next = (c) =>
         {

--- a/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs
+++ b/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs
@@ -32,7 +32,6 @@ public class AuthorizationMiddleware
 
     // Property key is used by Endpoint routing to determine if Authorization has run
     private const string AuthorizationMiddlewareInvokedWithEndpointKey = "__AuthorizationMiddlewareWithEndpointInvoked";
-    private static readonly object AuthorizationMiddlewareWithEndpointInvokedValue = new object();
 
     private readonly RequestDelegate _next;
     private readonly IAuthorizationPolicyProvider _policyProvider;
@@ -98,9 +97,9 @@ public class AuthorizationMiddleware
         var endpoint = context.GetEndpoint();
         if (endpoint != null)
         {
-            // EndpointRoutingMiddleware uses this flag to check if the Authorization middleware processed auth metadata on the endpoint.
+            // EndpointMiddleware uses this flag to check if the Authorization middleware processed auth metadata on the endpoint.
             // The Authorization middleware can only make this claim if it observes an actual endpoint.
-            context.Items[AuthorizationMiddlewareInvokedWithEndpointKey] = AuthorizationMiddlewareWithEndpointInvokedValue;
+            context.Items[AuthorizationMiddlewareInvokedWithEndpointKey] = endpoint;
         }
 
         // Use the computed policy for this endpoint if we can


### PR DESCRIPTION
## Overview

Makes the existing authorization middleware safeguard endpoint-specific. Authorization running for one endpoint can no longer satisfy the safety check for a different endpoint selected later in the same request, preserving the intended fail-closed behavior without changing public API or normal middleware behavior.

Fixes #68582

## Design

The existing private `HttpContext.Items` key remains unchanged, but its internal contract is strengthened: the value now identifies the exact `Endpoint` observed by authorization middleware. `EndpointMiddleware` accepts the marker only when that value is reference-equal to the endpoint about to execute; a missing or different value follows the existing missing-authorization-middleware failure path.

This is deliberately narrower than relying on every current and future rerouting path to replay authorization correctly. The endpoint-specific check remains an independent defense-in-depth safeguard.

## Implementation

```csharp
// src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs
// Record the endpoint whose authorization metadata was actually processed.
context.Items[AuthorizationMiddlewareInvokedWithEndpointKey] = endpoint;
```

```csharp
// src/Http/Routing/src/EndpointMiddleware.cs
// Presence alone is insufficient: the proof must belong to this endpoint instance.
if (AuthorizationMetadataHelper.HasAuthorizationMetadata(endpoint) &&
    (!httpContext.Items.TryGetValue(AuthorizationMiddlewareInvokedKey, out var authorizationEndpoint) ||
        !ReferenceEquals(authorizationEndpoint, endpoint)))
{
    ThrowMissingAuthMiddlewareException(endpoint);
}
```

The existing matching-endpoint unit test now stores the endpoint instance as the marker value. A focused `TestServer` regression runs `UseRouting` and `UseAuthorization` for endpoint A, replaces it downstream with authorized endpoint B, and verifies endpoint execution throws because B was never evaluated by authorization middleware.

## Outcome

Red/green validation:
- before the fix, the faithful endpoint-replacement regression failed with `Assert.Throws() Failure: No exception was thrown`
- after the fix, routing authorization integration tests passed 8/8
- focused endpoint middleware unit tests passed 15/15
- authorization middleware tests passed 45/45

Environment limitation: the repository-local SDK and generated web assets were initially absent, so `restore.cmd` and `npm run build` were required. Focused unit and security test runs used `/p:UseIisNativeAssets=false` because native ANCM had not been built; the full repository suite was not run.