### PR TITLE
[Kestrel] Tighten HTTP/2 and HTTP/3 path validation

### DIFF
--- a/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http2/Http2Stream.cs
@@ -448,7 +448,7 @@ internal abstract partial class Http2Stream : HttpProtocol, IThreadPoolWorkItem,
             for (var i = 0; i < pathSegment.Length; i++)
             {
                 var ch = pathSegment[i];
-                if (ch > byte.MaxValue)
+                if (ch < 0x20 || ch > 0x7E)
                 {
                     ResetAndAbort(new ConnectionAbortedException(CoreStrings.FormatHttp2StreamErrorPathInvalid(RawTarget)), Http2ErrorCode.PROTOCOL_ERROR);
                     return false;

--- a/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
+++ b/src/Servers/Kestrel/Core/src/Internal/Http3/Http3Stream.cs
@@ -1275,7 +1275,7 @@ internal abstract partial class Http3Stream : HttpProtocol, IHttp3Stream, IHttpS
             for (var i = 0; i < pathSegment.Length; i++)
             {
                 var ch = pathSegment[i];
-                if (ch > byte.MaxValue)
+                if (ch < 0x20 || ch > 0x7E)
                 {
                     Abort(new ConnectionAbortedException(CoreStrings.FormatHttp3StreamErrorPathInvalid(RawTarget)), Http3ErrorCode.ProtocolError);
                     return false;

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http2/Http2StreamTests.cs
@@ -863,7 +863,11 @@ public class Http2StreamTests : Http2TestBase
     [InlineData("/a\u0161")]
     [InlineData("/\u0161a")]
     [InlineData("/a\u0161a")]
-    public async Task HEADERS_Received_CharacterLargerThanByte_Reset(string path)
+    [InlineData("/a%2F\u00C2\u0080")]
+    [InlineData("/a%2F\u00C2\u00A9")]
+    [InlineData("/a%2F\u00C3\u00A9")]
+    [InlineData("/a%2F\u00E9\u0080\u0080")]
+    public async Task HEADERS_Received_NonAsciiPath_Reset(string path)
     {
         var pathBytes = Encoding.UTF8.GetBytes(path);
         var headerBlock = new byte[4 + pathBytes.Length];

--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -313,6 +313,10 @@ public class Http3StreamTests : Http3TestBase
     [InlineData("/\u0161dmin?x=1")]  // U+0161 (353), truncates to 0x61 = 'a' → "/admin?x=1"
     [InlineData("/\u0170ser")]        // U+0170 (368), truncates to 0x70 = 'p' → "/pser"
     [InlineData("/caf\u0165?q=1")]   // U+0165 (357), truncates to 0x65 = 'e' → "/cafe?q=1
+    [InlineData("/a%2F\u00C2\u0080")]
+    [InlineData("/a%2F\u00C2\u00A9")]
+    [InlineData("/a%2F\u00C3\u00A9")]
+    [InlineData("/a%2F\u00E9\u0080\u0080")]
     public async Task NonAsciiPath_Reset(string path)
     {
         var pathBytes = Encoding.UTF8.GetBytes(path);


### PR DESCRIPTION
Fixes #68270

## Overview

Tightens Kestrel's HTTP/2 and HTTP/3 `:path` validation to the printable-ASCII range. Values in U+0080-U+00FF were previously narrowed to bytes before decoding, allowing selected sequences to reconstruct valid UTF-8 and reach the application instead of producing a protocol error.

## Design

None. This changes no public API or configuration; it aligns both protocol implementations with HTTP/1's printable-ASCII handling while preserving their existing stream-error behavior.

## Implementation

```csharp
// Http2Stream.cs; Http3Stream.cs applies the equivalent guard.
// Reject before narrowing char to byte, so values such as U+00C2/U+00A9
// cannot become the UTF-8 byte sequence C2 A9 during path decoding.
var ch = pathSegment[i];
if (ch < 0x20 || ch > 0x7E)
{
    ResetAndAbort(..., Http2ErrorCode.PROTOCOL_ERROR);
    return false;
}
pathBuffer[i] = (byte)ch;
```

HTTP/2 retains `RST_STREAM` with `PROTOCOL_ERROR`; HTTP/3 retains its stream abort with `ProtocolError`. Focused HPACK and QPACK regressions cover U+0080, U+00A9, U+00C3, and U+00E9 in percent-decoding paths that previously reconstructed valid UTF-8.

## Outcome

After activating the repository environment with `. .\activate.ps1`:

- **Red baseline, tests added before implementation:**
  ```powershell
  dotnet test .\src\Servers\Kestrel\test\InMemory.FunctionalTests\InMemory.FunctionalTests.csproj --filter "FullyQualifiedName~NonAsciiPath_Reset" --logger "console;verbosity=normal"
  ```
  **Result:** 15 total, 7 passed, 8 failed. All four new cases failed for both HTTP/2 and HTTP/3 because Kestrel returned normal response `HEADERS` instead of the expected stream protocol error.
- **Green validation:**
  ```powershell
  dotnet test .\src\Servers\Kestrel\test\InMemory.FunctionalTests\InMemory.FunctionalTests.csproj --filter "FullyQualifiedName~NonAsciiPath_Reset|FullyQualifiedName~Path_DecodedAndNormalized" --logger "console;verbosity=normal"
  ```
  **Result:** 31/31 passed, covering every new rejection case and existing printable/percent-encoded normalization behavior for both protocols.
- `git diff --check` passed.

**Broader-build limitation:** `.\src\Servers\Kestrel\build.cmd -test` was attempted after activation, but failed before managed tests in unrelated IIS native projects because this worktree lacks `src\submodules\googletest\googlemock\src\gmock-all.cc` and `src\submodules\googletest\googletest\src\gtest-all.cc` (six C1083 errors, zero warnings).