### PR TITLE
Fix OpenAPI property-level [JsonConverter] on [AsParameters] enum ignored with request body

### DIFF
--- a/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
+++ b/src/OpenApi/src/Extensions/JsonNodeSchemaExtensions.cs
@@ -3,12 +3,14 @@
 
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Schema;
+using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
@@ -349,6 +351,22 @@ internal static class JsonNodeSchemaExtensions
             schema.ApplyRouteConstraints(constraints);
         }
 
+        // Enum parameters generated from the bare type have no property-level converter context
+        // and surface as "type": "integer". When the property on the container type has a
+        // converter that serializes enums as strings, drop the type so the block below applies
+        // the string enum values instead.
+        var forceStringEnum = parameterDescription.Source is { } converterSource && IsNonBodyBindingSource(converterSource)
+            && parameterDescription.Type is { } converterParamType
+            && (Nullable.GetUnderlyingType(converterParamType) ?? converterParamType) is { IsEnum: true }
+            && schema[OpenApiSchemaKeywords.EnumKeyword] is not JsonArray
+            && parameterDescription.ModelMetadata is { ContainerType: { } containerType, PropertyName: { } propertyName }
+            && GetPropertyJsonConverterType(containerType, propertyName) is { } converterType
+            && IsStringEnumConverterType(converterType);
+        if (forceStringEnum && schema is JsonObject schemaObject)
+        {
+            schemaObject.Remove(OpenApiSchemaKeywords.TypeKeyword);
+        }
+
         // Parameters sourced from query, path, header, and form are bound via Enum.TryParse,
         // which only accepts the original C# member names — not names transformed by a JSON
         // naming policy (e.g. KebabCaseLower). Replace the schema's enum values and default
@@ -358,7 +376,7 @@ internal static class JsonNodeSchemaExtensions
             && parameterDescription.Type is { } paramType)
         {
             var enumType = Nullable.GetUnderlyingType(paramType) ?? paramType;
-            if (enumType.IsEnum && schema[OpenApiSchemaKeywords.EnumKeyword] is JsonArray)
+            if (enumType.IsEnum && (schema[OpenApiSchemaKeywords.EnumKeyword] is JsonArray || forceStringEnum))
             {
                 var memberNames = Enum.GetNames(enumType);
                 var enumArray = new JsonArray();
@@ -416,6 +434,16 @@ internal static class JsonNodeSchemaExtensions
             || bindingSource == BindingSource.Path
             || bindingSource == BindingSource.Form
             || bindingSource == BindingSource.FormFile;
+
+        static bool IsStringEnumConverterType(Type converterType) =>
+            typeof(JsonStringEnumConverter).IsAssignableFrom(converterType)
+            || (converterType.IsGenericType && converterType.GetGenericTypeDefinition() == typeof(JsonStringEnumConverter<>));
+
+        [UnconditionalSuppressMessage("Trimming", "IL2070",
+            Justification = "Container types for [AsParameters] are preserved by the model binding infrastructure.")]
+        static Type? GetPropertyJsonConverterType(Type containerType, string propertyName) =>
+            containerType.GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance)
+                ?.GetCustomAttribute<JsonConverterAttribute>()?.ConverterType;
     }
 
     /// <summary>

--- a/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ParameterSchemas.cs
+++ b/src/OpenApi/test/Microsoft.AspNetCore.OpenApi.Tests/Services/OpenApiSchemaService/OpenApiSchemaService.ParameterSchemas.cs
@@ -1294,5 +1294,289 @@ public partial class OpenApiSchemaServiceTests : OpenApiDocumentServiceTestBase
         [FromQuery(Name = "id")]
         public int? Id { get; set; }
     }
+
+    private enum PropertyConverterSort { A, B, C }
+
+    private record QueryWithPropertyConverter
+    {
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public PropertyConverterSort? Sort { get; init; }
+    }
+
+    private class PropertyConverterRequestBody
+    {
+        public string? Term { get; init; }
+    }
+
+    [Fact]
+    public async Task GetOpenApiParameters_HandlesPropertyLevelJsonStringEnumConverterWithRequestBody()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/with-body", ([AsParameters] QueryWithPropertyConverter query, PropertyConverterRequestBody body) => body);
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/with-body"].Operations![HttpMethod.Post];
+            var sortParam = Assert.Single(operation.Parameters!, p => p.Name == "Sort");
+            var schema = sortParam.Schema!;
+            Assert.Null(schema.Type);
+            Assert.NotNull(schema.Enum);
+            Assert.Collection(schema.Enum!,
+                value => Assert.Equal("A", value.GetValue<string>()),
+                value => Assert.Equal("B", value.GetValue<string>()),
+                value => Assert.Equal("C", value.GetValue<string>()));
+        });
+    }
+
+    [Fact]
+    public async Task GetOpenApiParameters_HandlesPropertyLevelJsonStringEnumConverterWithoutRequestBody()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapGet("/without-body", ([AsParameters] QueryWithPropertyConverter query) => query);
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/without-body"].Operations![HttpMethod.Get];
+            var sortParam = Assert.Single(operation.Parameters!, p => p.Name == "Sort");
+            var schema = sortParam.Schema!;
+            Assert.Null(schema.Type);
+            Assert.NotNull(schema.Enum);
+            Assert.Collection(schema.Enum!,
+                value => Assert.Equal("A", value.GetValue<string>()),
+                value => Assert.Equal("B", value.GetValue<string>()),
+                value => Assert.Equal("C", value.GetValue<string>()));
+        });
+    }
+
+    private record QueryWithGenericPropertyConverter
+    {
+        [JsonConverter(typeof(JsonStringEnumConverter<PropertyConverterSort>))]
+        public PropertyConverterSort? Sort { get; init; }
+    }
+
+    private sealed class DerivedStringEnumConverter : JsonStringEnumConverter
+    {
+    }
+
+    private record QueryWithDerivedPropertyConverter
+    {
+        [JsonConverter(typeof(DerivedStringEnumConverter))]
+        public PropertyConverterSort? Sort { get; init; }
+    }
+
+    private sealed class NumericSortConverter : JsonConverter<PropertyConverterSort>
+    {
+        public override PropertyConverterSort Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => (PropertyConverterSort)reader.GetInt32();
+
+        public override void Write(Utf8JsonWriter writer, PropertyConverterSort value, JsonSerializerOptions options)
+            => writer.WriteNumberValue((int)value);
+    }
+
+    private record QueryWithNumericPropertyConverter
+    {
+        [JsonConverter(typeof(NumericSortConverter))]
+        public PropertyConverterSort Sort { get; init; }
+    }
+
+    private record QueryWithNonNullablePropertyConverter
+    {
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public PropertyConverterSort Sort { get; init; }
+    }
+
+    private record QueryWithHeaderPropertyConverter
+    {
+        [FromHeader(Name = "X-Sort")]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public PropertyConverterSort? Sort { get; init; }
+    }
+
+    [Fact]
+    public async Task GetOpenApiParameters_HandlesGenericJsonStringEnumConverterWithRequestBody()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/generic-converter", ([AsParameters] QueryWithGenericPropertyConverter query, PropertyConverterRequestBody body) => body);
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/generic-converter"].Operations![HttpMethod.Post];
+            var sortParam = Assert.Single(operation.Parameters!, p => p.Name == "Sort");
+            var schema = sortParam.Schema!;
+            Assert.Null(schema.Type);
+            Assert.NotNull(schema.Enum);
+            Assert.Collection(schema.Enum!,
+                value => Assert.Equal("A", value.GetValue<string>()),
+                value => Assert.Equal("B", value.GetValue<string>()),
+                value => Assert.Equal("C", value.GetValue<string>()));
+        });
+    }
+
+    [Fact]
+    public async Task GetOpenApiParameters_HandlesDerivedJsonStringEnumConverterWithRequestBody()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/derived-converter", ([AsParameters] QueryWithDerivedPropertyConverter query, PropertyConverterRequestBody body) => body);
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/derived-converter"].Operations![HttpMethod.Post];
+            var sortParam = Assert.Single(operation.Parameters!, p => p.Name == "Sort");
+            var schema = sortParam.Schema!;
+            Assert.Null(schema.Type);
+            Assert.NotNull(schema.Enum);
+            Assert.Collection(schema.Enum!,
+                value => Assert.Equal("A", value.GetValue<string>()),
+                value => Assert.Equal("B", value.GetValue<string>()),
+                value => Assert.Equal("C", value.GetValue<string>()));
+        });
+    }
+
+    [Fact]
+    public async Task GetOpenApiParameters_HandlesNonNullablePropertyLevelJsonStringEnumConverterWithRequestBody()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/non-nullable-converter", ([AsParameters] QueryWithNonNullablePropertyConverter query, PropertyConverterRequestBody body) => body);
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/non-nullable-converter"].Operations![HttpMethod.Post];
+            var sortParam = Assert.Single(operation.Parameters!, p => p.Name == "Sort");
+            var schema = sortParam.Schema!;
+            Assert.Null(schema.Type);
+            Assert.NotNull(schema.Enum);
+            Assert.Collection(schema.Enum!,
+                value => Assert.Equal("A", value.GetValue<string>()),
+                value => Assert.Equal("B", value.GetValue<string>()),
+                value => Assert.Equal("C", value.GetValue<string>()));
+        });
+    }
+
+    [Fact]
+    public async Task GetOpenApiParameters_HandlesHeaderBoundPropertyLevelJsonStringEnumConverterWithRequestBody()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/header-converter", ([AsParameters] QueryWithHeaderPropertyConverter query, PropertyConverterRequestBody body) => body);
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/header-converter"].Operations![HttpMethod.Post];
+            var sortParam = Assert.Single(operation.Parameters!, p => p.Name == "X-Sort");
+            var schema = sortParam.Schema!;
+            Assert.Null(schema.Type);
+            Assert.NotNull(schema.Enum);
+            Assert.Collection(schema.Enum!,
+                value => Assert.Equal("A", value.GetValue<string>()),
+                value => Assert.Equal("B", value.GetValue<string>()),
+                value => Assert.Equal("C", value.GetValue<string>()));
+        });
+    }
+
+    [Fact]
+    public async Task GetOpenApiParameters_IgnoresNonStringEnumPropertyLevelConverterWithRequestBody()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/numeric-converter", ([AsParameters] QueryWithNumericPropertyConverter query, PropertyConverterRequestBody body) => body);
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/numeric-converter"].Operations![HttpMethod.Post];
+            var sortParam = Assert.Single(operation.Parameters!, p => p.Name == "Sort");
+            var schema = sortParam.Schema!;
+            // Converters that do not serialize enums as strings are left alone.
+            Assert.Equal(JsonSchemaType.Integer, schema.Type);
+            Assert.Null(schema.Enum);
+        });
+    }
+
+    private record QueryWithPathPropertyConverter
+    {
+        [FromRoute(Name = "Sort")]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public PropertyConverterSort Sort { get; init; }
+    }
+
+    private record QueryWithFormPropertyConverter
+    {
+        [FromForm(Name = "Sort")]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public PropertyConverterSort? Sort { get; init; }
+    }
+
+    [Fact]
+    public async Task GetOpenApiParameters_HandlesRouteBoundPropertyLevelJsonStringEnumConverterWithRequestBody()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/path-converter/{Sort}", ([AsParameters] QueryWithPathPropertyConverter query, PropertyConverterRequestBody body) => body);
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/path-converter/{Sort}"].Operations![HttpMethod.Post];
+            var sortParam = Assert.Single(operation.Parameters!, p => p.Name == "Sort");
+            var schema = sortParam.Schema!;
+            Assert.Null(schema.Type);
+            Assert.NotNull(schema.Enum);
+            Assert.Collection(schema.Enum!,
+                value => Assert.Equal("A", value.GetValue<string>()),
+                value => Assert.Equal("B", value.GetValue<string>()),
+                value => Assert.Equal("C", value.GetValue<string>()));
+        });
+    }
+
+    [Fact]
+    public async Task GetOpenApiParameters_HandlesFormBoundPropertyLevelJsonStringEnumConverter()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+
+        // Act
+        builder.MapPost("/form-converter", ([AsParameters] QueryWithFormPropertyConverter query) => Results.Ok());
+
+        // Assert
+        await VerifyOpenApiDocument(builder, document =>
+        {
+            var operation = document.Paths["/form-converter"].Operations![HttpMethod.Post];
+            var schema = operation.RequestBody!.Content!["application/x-www-form-urlencoded"].Schema!;
+            var sortSchema = schema.Properties!["Sort"];
+            Assert.Null(sortSchema.Type);
+            Assert.NotNull(sortSchema.Enum);
+            Assert.Collection(sortSchema.Enum!,
+                value => Assert.Equal("A", value.GetValue<string>()),
+                value => Assert.Equal("B", value.GetValue<string>()),
+                value => Assert.Equal("C", value.GetValue<string>()));
+        });
+    }
 #nullable restore
 }


### PR DESCRIPTION
## Summary

Fixes #69156

- When an `[AsParameters]` DTO has an enum property with a **property-level** `[JsonConverter(typeof(JsonStringEnumConverter))]`, the generated schema emits `{ "type": "integer" }` instead of string enum values — but only when the endpoint also has a request body parameter.
- Root cause: `CreateSchema(Type)` generates schemas for bare types without property-level converter context. When the response type doesn't reference the enum, it is first registered as an integer component during parameter processing — before the property-level converter is seen.
- Fix: detect property-level `JsonStringEnumConverter` attributes in `ApplyParameterInfo` and inject string enum values before the schema is componentized.

## Test plan

- [x] Added `GetOpenApiParameters_HandlesPropertyLevelJsonStringEnumConverterWithRequestBody` — the exact bug scenario (enum + body param)
- [x] Added `GetOpenApiParameters_HandlesPropertyLevelJsonStringEnumConverterWithoutRequestBody` — confirms the already-working path stays correct
- [x] All 1035 existing OpenApi tests pass (0 failures, 5 pre-existing skips)
- [x] All 19 enum-related tests pass