### PR TITLE
Fix flaky HTTP/3 request trailer validation test

### DIFF
--- a/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
+++ b/src/Servers/Kestrel/test/InMemory.FunctionalTests/Http3/Http3StreamTests.cs
@@ -2099,7 +2099,7 @@ public class Http3StreamTests : Http3TestBase
             new KeyValuePair<string, string>("contains-newlines", newlineChars),
         };
 
-        var requestStream = await Http3Api.InitializeConnectionAndStreamsAsync(_noopApplication, headers, endStream: false);
+        var requestStream = await Http3Api.InitializeConnectionAndStreamsAsync(_echoApplication, headers, endStream: false);
         await requestStream.SendHeadersAsync(trailerWithNewlines, endStream: true);
 
         await requestStream.WaitForStreamErrorAsync(


### PR DESCRIPTION
# Fix flaky HTTP/3 request trailer validation test

Keep the request application active while invalid HTTP/3 trailers are parsed.

## Description

`RequestTrailers_ContainsNewlines` used the no-op application, which could complete the response before the request trailers were parsed. `WaitForStreamErrorAsync` could then observe the completed response stream before `MessageError` was assigned and fail with an error code of `-1`.

Use the echo application so it continues reading the request body while the trailers are processed. This keeps the test synchronized with the real request-processing path without changing the shared HTTP/3 test helper.

Fixes: https://github.com/dotnet/aspnetcore/issues/69224