### PR TITLE
[release/9.0] Scope sections E2E assertions to mounted app

### DIFF
--- a/src/Components/test/E2ETest/Tests/SectionsWithCascadingParametersTest.cs
+++ b/src/Components/test/E2ETest/Tests/SectionsWithCascadingParametersTest.cs
@@ -14,6 +14,8 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests;
 
 public class SectionsWithCascadingParametersTest : ServerTestBase<ToggleExecutionModeServerFixture<Program>>
 {
+    private IWebElement _appElement;
+
     public SectionsWithCascadingParametersTest
         (BrowserFixture browserFixture,
         ToggleExecutionModeServerFixture<Program> serverFixture,
@@ -25,7 +27,7 @@ public class SectionsWithCascadingParametersTest : ServerTestBase<ToggleExecutio
     protected override void InitializeAsyncCore()
     {
         Navigate(ServerPathBase);
-        Browser.MountTestComponent<BasicTestApp.SectionsTest.SectionsWithCascadingParameters>();
+        _appElement = Browser.MountTestComponent<BasicTestApp.SectionsTest.SectionsWithCascadingParameters>();
     }
 
     [Fact]
@@ -35,7 +37,7 @@ public class SectionsWithCascadingParametersTest : ServerTestBase<ToggleExecutio
         Browser.FindElement(By.Id("render-section-outlet")).Click();
         Browser.FindElement(By.Id("render-second-section-content")).Click();
 
-        Browser.Equal("Second Section with additional text for second section", () => Browser.Exists(By.TagName("p")).Text);
+        Browser.Equal("Second Section with additional text for second section", () => _appElement.FindElement(By.TagName("p")).Text);
     }
 
     [Fact]
@@ -46,7 +48,7 @@ public class SectionsWithCascadingParametersTest : ServerTestBase<ToggleExecutio
 
         Browser.FindElement(By.Id("change-cascading-value")).Click();
 
-        Browser.Equal("First Section with additional text for second section", () => Browser.Exists(By.TagName("p")).Text);
+        Browser.Equal("First Section with additional text for second section", () => _appElement.FindElement(By.TagName("p")).Text);
     }
 
     [Fact]
@@ -56,7 +58,7 @@ public class SectionsWithCascadingParametersTest : ServerTestBase<ToggleExecutio
         Browser.FindElement(By.Id("render-first-section-content")).Click();
         Browser.FindElement(By.Id("render-section-outlet")).Click();
 
-        Browser.Equal("First Section with additional text for first section", () => Browser.Exists(By.TagName("p")).Text);
+        Browser.Equal("First Section with additional text for first section", () => _appElement.FindElement(By.TagName("p")).Text);
     }
 
     [Fact]
@@ -68,7 +70,7 @@ public class SectionsWithCascadingParametersTest : ServerTestBase<ToggleExecutio
 
         Browser.FindElement(By.Id("change-second-section-content-id")).Click();
 
-        Browser.Equal("First Section with additional text for first section", () => Browser.Exists(By.TagName("p")).Text);
+        Browser.Equal("First Section with additional text for first section", () => _appElement.FindElement(By.TagName("p")).Text);
     }
 
     [Fact]
@@ -80,7 +82,7 @@ public class SectionsWithCascadingParametersTest : ServerTestBase<ToggleExecutio
 
         Browser.FindElement(By.Id("dispose-second-section-content")).Click();
 
-        Browser.Equal("First Section with additional text for first section", () => Browser.Exists(By.TagName("p")).Text);
+        Browser.Equal("First Section with additional text for first section", () => _appElement.FindElement(By.TagName("p")).Text);
     }
 
     [Fact]
@@ -92,7 +94,7 @@ public class SectionsWithCascadingParametersTest : ServerTestBase<ToggleExecutio
         Browser.FindElement(By.Id("dispose-first-section-content")).Click();
         Browser.FindElement(By.Id("render-second-section-content")).Click();
 
-        Browser.Equal("Second Section with additional text for second section", () => Browser.Exists(By.TagName("p")).Text);
+        Browser.Equal("Second Section with additional text for second section", () => _appElement.FindElement(By.TagName("p")).Text);
     }
 
     [Fact]
@@ -105,6 +107,6 @@ public class SectionsWithCascadingParametersTest : ServerTestBase<ToggleExecutio
 
         Browser.FindElement(By.Id("change-section-outlet-id")).Click();
 
-        Browser.Equal("Second Section with additional text for second section", () => Browser.Exists(By.TagName("p")).Text);
+        Browser.Equal("Second Section with additional text for second section", () => _appElement.FindElement(By.TagName("p")).Text);
     }
 }

--- a/src/Components/test/E2ETest/Tests/SectionsWithErrorBoundaryTest.cs
+++ b/src/Components/test/E2ETest/Tests/SectionsWithErrorBoundaryTest.cs
@@ -14,6 +14,8 @@ namespace Microsoft.AspNetCore.Components.E2ETests.Tests;
 
 public class SectionsWithErrorBoundaryTest : ServerTestBase<ToggleExecutionModeServerFixture<Program>>
 {
+    private IWebElement _appElement;
+
     public SectionsWithErrorBoundaryTest
         (BrowserFixture browserFixture,
         ToggleExecutionModeServerFixture<Program> serverFixture,
@@ -25,7 +27,7 @@ public class SectionsWithErrorBoundaryTest : ServerTestBase<ToggleExecutionModeS
     protected override void InitializeAsyncCore()
     {
         Navigate(ServerPathBase);
-        Browser.MountTestComponent<BasicTestApp.SectionsTest.SectionsWithErrorBoundary>();
+        _appElement = Browser.MountTestComponent<BasicTestApp.SectionsTest.SectionsWithErrorBoundary>();
     }
 
     [Fact]
@@ -37,7 +39,7 @@ public class SectionsWithErrorBoundaryTest : ServerTestBase<ToggleExecutionModeS
 
         Browser.FindElement(By.Id("error-button")).Click();
 
-        Browser.Equal("Sorry!", () => Browser.Exists(By.TagName("p")).Text);
+        Browser.Equal("Sorry!", () => _appElement.FindElement(By.TagName("p")).Text);
     }
 
     [Fact]
@@ -88,7 +90,7 @@ public class SectionsWithErrorBoundaryTest : ServerTestBase<ToggleExecutionModeS
         Browser.FindElement(By.Id("render-second-section-content")).Click();
         Browser.FindElement(By.Id("error-button")).Click();
 
-        Browser.Equal("Sorry!", () => Browser.Exists(By.TagName("p")).Text);
+        Browser.Equal("Sorry!", () => _appElement.FindElement(By.TagName("p")).Text);
     }
 
     [Fact]
@@ -102,6 +104,6 @@ public class SectionsWithErrorBoundaryTest : ServerTestBase<ToggleExecutionModeS
         Browser.FindElement(By.Id("change-section-outlet-id")).Click();
         Browser.FindElement(By.Id("error-button")).Click();
 
-        Browser.Equal("Sorry!", () => Browser.Exists(By.TagName("p")).Text);
+        Browser.Equal("Sorry!", () => _appElement.FindElement(By.TagName("p")).Text);
     }
 }


### PR DESCRIPTION
## Description

The recent JavaScript root component servicing change added a top-level `<p>` to `BasicTestApp`. The sections E2E tests used a document-wide paragraph selector, so they started reading that unrelated element instead of the content rendered by the mounted test component.

Capture the mounted app element and scope paragraph lookups to it. This follows the existing pattern in `SectionsTest` and fixes the deterministic failures affecting the release/9.0 Components E2E pipeline.