### PR TITLE
Fix RouteHandlerAnalyzer Crash On Method Groups From Referenced Assemblies

### DIFF
--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DisallowNonParsableComplexTypesOnParameters.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/DisallowNonParsableComplexTypesOnParameters.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.Analyzers.Infrastructure;
 using Microsoft.AspNetCore.Analyzers.RouteEmbeddedLanguage.Infrastructure;
 using Microsoft.AspNetCore.App.Analyzers.Infrastructure;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.AspNetCore.Analyzers.RouteHandlers;
@@ -19,7 +18,8 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
         in OperationAnalysisContext context,
         WellKnownTypes wellKnownTypes,
         RouteUsageModel routeUsage,
-        IMethodSymbol methodSymbol)
+        IMethodSymbol methodSymbol,
+        SyntaxNode delegateCreationSyntax)
     {
         foreach (var handlerDelegateParameter in methodSymbol.Parameters)
         {
@@ -44,8 +44,10 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            var syntax = (ParameterSyntax)handlerDelegateParameter.DeclaringSyntaxReferences[0].GetSyntax(context.CancellationToken);
-            var location = syntax.GetLocation();
+            // Parameters of a method group declared in a referenced assembly have no declaring syntax
+            // in the current compilation. Fall back to reporting on the delegate passed to the Map method.
+            var location = handlerDelegateParameter.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax(context.CancellationToken).GetLocation()
+                ?? delegateCreationSyntax.GetLocation();
 
             if (ReportFromAttributeDiagnostic(
                 context,

--- a/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
+++ b/src/Framework/AspNetCoreAnalyzers/src/Analyzers/RouteHandlers/RouteHandlerAnalyzer.cs
@@ -106,7 +106,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
                 {
                     var lambda = (IAnonymousFunctionOperation)delegateCreation.Target;
                     DisallowMvcBindArgumentsOnParameters(in context, wellKnownTypes, invocation, lambda.Symbol);
-                    DisallowNonParsableComplexTypesOnParameters(in context, wellKnownTypes, routeUsage, lambda.Symbol);
+                    DisallowNonParsableComplexTypesOnParameters(in context, wellKnownTypes, routeUsage, lambda.Symbol, delegateCreation.Syntax);
                     DisallowReturningActionResultFromMapMethods(in context, wellKnownTypes, invocation, lambda, delegateCreation.Syntax);
                     DetectMisplacedLambdaAttribute(context, lambda);
                     DetectMismatchedParameterOptionality(in context, routeUsage, lambda.Symbol);
@@ -116,7 +116,7 @@ public partial class RouteHandlerAnalyzer : DiagnosticAnalyzer
                 {
                     var methodReference = (IMethodReferenceOperation)delegateCreation.Target;
                     DisallowMvcBindArgumentsOnParameters(in context, wellKnownTypes, invocation, methodReference.Method);
-                    DisallowNonParsableComplexTypesOnParameters(in context, wellKnownTypes, routeUsage, methodReference.Method);
+                    DisallowNonParsableComplexTypesOnParameters(in context, wellKnownTypes, routeUsage, methodReference.Method, delegateCreation.Syntax);
                     DetectMismatchedParameterOptionality(in context, routeUsage, methodReference.Method);
                     AtMostOneFromBodyAttribute(in context, wellKnownTypes, methodReference.Method);
 

--- a/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/DisallowNonParsableComplexTypesOnParametersTest.cs
+++ b/src/Framework/AspNetCoreAnalyzers/test/RouteHandlers/DisallowNonParsableComplexTypesOnParametersTest.cs
@@ -1,6 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+using Microsoft.AspNetCore.Analyzer.Testing;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Testing;
 using VerifyCS = Microsoft.AspNetCore.Analyzers.Verifiers.CSharpAnalyzerVerifier<Microsoft.AspNetCore.Analyzers.RouteHandlers.RouteHandlerAnalyzer>;
 
@@ -761,5 +765,90 @@ public class CommercialCustomer : ICustomer
         // Act
         await VerifyCS.VerifyAnalyzerAsync(source);
     }
-}
 
+    [Fact]
+    public async Task Handler_MethodGroup_FromReferencedAssembly_WithParsableParameter_Works()
+    {
+        // Arrange
+        // Regression test for https://github.com/dotnet/aspnetcore/issues/68976. Parameters of a method
+        // declared in a referenced assembly have no declaring syntax references in the current compilation.
+        var referencedAssemblySource = """
+            using Microsoft.AspNetCore.Http;
+
+            namespace Lib;
+
+            public static class Handlers
+            {
+                public static IResult GetById(string id) => Results.Ok(id);
+            }
+            """;
+        var source = """
+            using Lib;
+            using Microsoft.AspNetCore.Builder;
+
+            var app = WebApplication.Create();
+            app.MapGet("/items/{id}", Handlers.GetById);
+            """;
+
+        // Act
+        var diagnostics = await GetDiagnosticsWithReferencedAssemblyAsync(referencedAssemblySource, source);
+
+        // Assert
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
+    public async Task Handler_MethodGroup_FromReferencedAssembly_WithNonParsableRouteParameter_ReportsOnMethodGroup()
+    {
+        // Arrange
+        var referencedAssemblySource = """
+            using Microsoft.AspNetCore.Http;
+
+            namespace Lib;
+
+            public class Customer
+            {
+            }
+
+            public static class Handlers
+            {
+                public static IResult GetCustomer(Customer customer) => Results.Ok();
+            }
+            """;
+        var source = TestSource.Read("""
+            using Lib;
+            using Microsoft.AspNetCore.Builder;
+
+            var app = WebApplication.Create();
+            app.MapGet("/customers/{customer}", /*MM*/Handlers.GetCustomer);
+            """);
+
+        // Act
+        var diagnostics = await GetDiagnosticsWithReferencedAssemblyAsync(referencedAssemblySource, source.Source);
+
+        // Assert
+        var diagnostic = Assert.Single(diagnostics);
+        Assert.Same(DiagnosticDescriptors.RouteParameterComplexTypeIsNotParsable, diagnostic.Descriptor);
+        AnalyzerAssert.DiagnosticLocation(source.DefaultMarkerLocation, diagnostic.Location);
+        Assert.Equal("Parameter 'customer' of type Customer should define a bool TryParse(string, IFormatProvider, out Customer) method, or implement IParsable<Customer>", diagnostic.GetMessage(CultureInfo.InvariantCulture));
+    }
+
+    private async Task<Diagnostic[]> GetDiagnosticsWithReferencedAssemblyAsync(string referencedAssemblySource, string source)
+    {
+        var project = TestDiagnosticAnalyzerRunner.CreateProjectWithReferencesInBinDir(typeof(DisallowNonParsableComplexTypesOnParametersTest).Assembly, source);
+
+        // Compile the referenced code into a separate assembly so the analyzer sees metadata symbols
+        // rather than source symbols, matching a handler declared in a ProjectReference.
+        var referencedCompilation = CSharpCompilation.Create(
+            "ReferencedAssembly",
+            [CSharpSyntaxTree.ParseText(referencedAssemblySource)],
+            project.MetadataReferences,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var stream = new MemoryStream();
+        var emitResult = referencedCompilation.Emit(stream);
+        Assert.True(emitResult.Success, string.Join(Environment.NewLine, emitResult.Diagnostics));
+
+        project = project.AddMetadataReference(MetadataReference.CreateFromImage(stream.ToArray()));
+        return await Runner.GetDiagnosticsAsync(project);
+    }
+}


### PR DESCRIPTION
`RouteHandlerAnalyzer` threw `IndexOutOfRangeException` (surfaced as `AD0001`) whenever a minimal API route handler was passed as a method group declared in a referenced assembly:

```csharp
// Handlers.GetById lives in a ProjectReference
app.MapGet("/items/{id}", Handlers.GetById);

The crash disabled the analyzer for the rest of the compilation and failed builds using TreatWarningsAsErrors.

Root cause

DisallowNonParsableComplexTypesOnParameters read handlerDelegateParameter.DeclaringSyntaxReferences[0] for every parameter. Parameters of a method from another assembly are metadata symbols with no declaring syntax in the current compilation, so the array is empty and the index throws. The sibling checks (AtMostOneFromBodyAttribute, DisallowMvcBindArgumentsOnParameters) already guarded this case.

Fix

- Use FirstOrDefault() for the parameter's declaring syntax.
- When it is absent, report on the delegate expression passed to the Map* call. ASP0020 still points at Handlers.GetById instead of the analyzer crashing or the diagnostic being lost.
- RouteHandlerAnalyzer passes delegateCreation.Syntax through at both call sites.

Tests

Added two tests to DisallowNonParsableComplexTypesOnParametersTest. A helper compiles the handler source into a separate in-memory assembly and adds it as a MetadataReference, so the analyzer sees metadata symbols exactly as with a ProjectReference:

- Parsable string route parameter from a referenced assembly: no diagnostics (the reporter's scenario).
- Non-parsable complex route parameter from a referenced assembly: one ASP0020 located on the method group expression.

Both tests fail with AD0001 without the fix and pass with it. The full RouteHandlers analyzer suite (111 tests) passes.

Fixes #68976
```